### PR TITLE
Remove remants of the old .tk field

### DIFF
--- a/src/extraction/FStar.Extraction.ML.Modul.fs
+++ b/src/extraction/FStar.Extraction.ML.Modul.fs
@@ -53,9 +53,7 @@ let fail_exp (lid:lident) (t:typ) =
                ; S.as_arg <|
                  mk (Tm_constant
                       (Const_string ("Not yet implemented:"^(Print.lid_to_string lid), Range.dummyRange)))
-                    None
                     Range.dummyRange]))
-        None
         Range.dummyRange
 
 let always_fail lid t =
@@ -504,7 +502,7 @@ let extract_reifiable_effect g ed
         let lbname = Inl (S.new_bv (Some a.action_defn.pos) tun) in
         let lb = mk_lb (lbname, a.action_univs, PC.effect_Tot_lid, a.action_typ, a.action_defn, [], a.action_defn.pos) in
         let lbs = (false, [lb]) in
-        let action_lb = mk (Tm_let(lbs, U.exp_false_bool)) None a.action_defn.pos in
+        let action_lb = mk (Tm_let(lbs, U.exp_false_bool)) a.action_defn.pos in
         let a_let, _, ty = Term.term_as_mlexpr g action_lb in
         let exp, tysc = match a_let.expr with
             | MLE_Let((_, [mllb]), _) ->
@@ -855,7 +853,7 @@ let rec extract_sig (g:env_t) (se:sigelt) : env_t * list<mlmodule1> =
           let ml_let, _, _ =
             Term.term_as_mlexpr
                     g
-                    (mk (Tm_let(lbs, U.exp_false_bool)) None se.sigrng)
+                    (mk (Tm_let(lbs, U.exp_false_bool)) se.sigrng)
           in
           begin
           match ml_let.expr with

--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -709,7 +709,7 @@ let rec translate_term_to_mlty (g:uenv) (t0:term) : mlty =
                   fv_app_as_mlty env fv args
 
                 | Tm_app (head, args') ->
-                  translate_term_to_mlty env (S.mk (Tm_app(head, args'@args)) None t.pos)
+                  translate_term_to_mlty env (S.mk (Tm_app(head, args'@args)) t.pos)
 
                 | _ -> MLTY_Top in
             res
@@ -1095,7 +1095,7 @@ let extract_lb_sig (g:uenv) (lbs:letbindings) =
                        let polytype = tbinders |> List.map (fun (x, _) -> (UEnv.lookup_ty env x).ty_b_name), expected_t in
                        //In this case, an eta expansion is safe
                        let args = tbinders |> List.map (fun (bv, _) -> S.bv_to_name bv |> as_arg) in
-                       let e = mk (Tm_app(lbdef, args)) None lbdef.pos in
+                       let e = mk (Tm_app(lbdef, args)) lbdef.pos in
                        (lbname_, f_e, (lbtyp, (tbinders, polytype)), false, e)
 
                      | _ ->
@@ -1349,7 +1349,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
 
             | Tm_constant Const_reify ->
               let e = TcUtil.reify_body_with_arg (tcenv_of_uenv g) [TcEnv.Inlining; TcEnv.Unascribe] head (List.hd args) in
-              let tm = S.mk_Tm_app (TcUtil.remove_reify e) (List.tl args) None t.pos in
+              let tm = S.mk_Tm_app (TcUtil.remove_reify e) (List.tl args) t.pos in
               term_as_mlexpr g tm
 
             | _ ->

--- a/src/extraction/FStar.Extraction.ML.Util.fs
+++ b/src/extraction/FStar.Extraction.ML.Util.fs
@@ -549,8 +549,8 @@ let interpret_plugin_as_term_fun (env:UEnv.uenv) (fv:fv) (t:typ) (arity_opt:opti
           emb_arrow l (mk_embedding l env t0) (mk_embedding l env t1)
 
         | Tm_arrow(b::more::bs, c) ->
-          let tail = S.mk (Tm_arrow(more::bs, c)) None t.pos in
-          let t = S.mk (Tm_arrow([b], S.mk_Total tail)) None t.pos in
+          let tail = S.mk (Tm_arrow(more::bs, c)) t.pos in
+          let t = S.mk (Tm_arrow([b], S.mk_Total tail)) t.pos in
           mk_embedding l env t
 
         | Tm_fvar _

--- a/src/fstar/FStar.CheckedFiles.fs
+++ b/src/fstar/FStar.CheckedFiles.fs
@@ -42,7 +42,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It need to be kept in sync with prims.fst
  *)
-let cache_version_number = 24
+let cache_version_number = 25
 
 type tc_result = {
   checked_module: Syntax.modul; //persisted

--- a/src/fstar/FStar.Interactive.Ide.fs
+++ b/src/fstar/FStar.Interactive.Ide.fs
@@ -915,7 +915,7 @@ let sc_typ tcenv sc = // Memoized version of sc_typ
    match !sc.sc_typ with
    | Some t -> t
    | None -> let typ = match try_lookup_lid tcenv sc.sc_lid with
-                       | None -> SS.mk SS.Tm_unknown None Range.dummyRange
+                       | None -> SS.mk SS.Tm_unknown Range.dummyRange
                        | Some ((_, typ), _) -> typ in
              sc.sc_typ := Some typ; typ
 

--- a/src/ocaml-output/FStar_CheckedFiles.ml
+++ b/src/ocaml-output/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (24)) 
+let (cache_version_number : Prims.int) = (Prims.of_int (25)) 
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -8,41 +8,33 @@ let (fail_exp :
   fun lid  ->
     fun t  ->
       let uu____25 =
-        let uu____32 =
-          let uu____33 =
-            let uu____50 =
-              FStar_Syntax_Syntax.fvar FStar_Parser_Const.failwith_lid
-                FStar_Syntax_Syntax.delta_constant
-                FStar_Pervasives_Native.None
-               in
-            let uu____53 =
-              let uu____64 = FStar_Syntax_Syntax.iarg t  in
-              let uu____73 =
-                let uu____84 =
-                  let uu____93 =
-                    let uu____94 =
-                      let uu____101 =
-                        let uu____102 =
-                          let uu____103 =
-                            let uu____109 =
-                              let uu____111 =
-                                FStar_Syntax_Print.lid_to_string lid  in
-                              Prims.op_Hat "Not yet implemented:" uu____111
-                               in
-                            (uu____109, FStar_Range.dummyRange)  in
-                          FStar_Const.Const_string uu____103  in
-                        FStar_Syntax_Syntax.Tm_constant uu____102  in
-                      FStar_Syntax_Syntax.mk uu____101  in
-                    uu____94 FStar_Pervasives_Native.None
-                      FStar_Range.dummyRange
-                     in
-                  FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____93  in
-                [uu____84]  in
-              uu____64 :: uu____73  in
-            (uu____50, uu____53)  in
-          FStar_Syntax_Syntax.Tm_app uu____33  in
-        FStar_Syntax_Syntax.mk uu____32  in
-      uu____25 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____26 =
+          let uu____43 =
+            FStar_Syntax_Syntax.fvar FStar_Parser_Const.failwith_lid
+              FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
+             in
+          let uu____46 =
+            let uu____57 = FStar_Syntax_Syntax.iarg t  in
+            let uu____66 =
+              let uu____77 =
+                let uu____86 =
+                  let uu____87 =
+                    let uu____88 =
+                      let uu____89 =
+                        let uu____95 =
+                          let uu____97 = FStar_Syntax_Print.lid_to_string lid
+                             in
+                          Prims.op_Hat "Not yet implemented:" uu____97  in
+                        (uu____95, FStar_Range.dummyRange)  in
+                      FStar_Const.Const_string uu____89  in
+                    FStar_Syntax_Syntax.Tm_constant uu____88  in
+                  FStar_Syntax_Syntax.mk uu____87 FStar_Range.dummyRange  in
+                FStar_All.pipe_left FStar_Syntax_Syntax.as_arg uu____86  in
+              [uu____77]  in
+            uu____57 :: uu____66  in
+          (uu____43, uu____46)  in
+        FStar_Syntax_Syntax.Tm_app uu____26  in
+      FStar_Syntax_Syntax.mk uu____25 FStar_Range.dummyRange
   
 let (always_fail :
   FStar_Ident.lident ->
@@ -52,30 +44,30 @@ let (always_fail :
   fun lid  ->
     fun t  ->
       let imp =
-        let uu____177 = FStar_Syntax_Util.arrow_formals t  in
-        match uu____177 with
+        let uu____163 = FStar_Syntax_Util.arrow_formals t  in
+        match uu____163 with
         | ([],t1) ->
             let b =
-              let uu____204 =
+              let uu____190 =
                 FStar_Syntax_Syntax.gen_bv "_" FStar_Pervasives_Native.None
                   t1
                  in
-              FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____204  in
-            let uu____212 = fail_exp lid t1  in
-            FStar_Syntax_Util.abs [b] uu____212 FStar_Pervasives_Native.None
+              FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____190  in
+            let uu____198 = fail_exp lid t1  in
+            FStar_Syntax_Util.abs [b] uu____198 FStar_Pervasives_Native.None
         | (bs,t1) ->
-            let uu____233 = fail_exp lid t1  in
-            FStar_Syntax_Util.abs bs uu____233 FStar_Pervasives_Native.None
+            let uu____219 = fail_exp lid t1  in
+            FStar_Syntax_Util.abs bs uu____219 FStar_Pervasives_Native.None
          in
       let lb =
-        let uu____237 =
-          let uu____242 =
+        let uu____223 =
+          let uu____228 =
             FStar_Syntax_Syntax.lid_as_fv lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
              in
-          FStar_Util.Inr uu____242  in
+          FStar_Util.Inr uu____228  in
         {
-          FStar_Syntax_Syntax.lbname = uu____237;
+          FStar_Syntax_Syntax.lbname = uu____223;
           FStar_Syntax_Syntax.lbunivs = [];
           FStar_Syntax_Syntax.lbtyp = t;
           FStar_Syntax_Syntax.lbeff = FStar_Parser_Const.effect_ML_lid;
@@ -85,41 +77,41 @@ let (always_fail :
         }  in
       lb
   
-let as_pair : 'uuuuuu250 . 'uuuuuu250 Prims.list -> ('uuuuuu250 * 'uuuuuu250)
+let as_pair : 'uuuuuu236 . 'uuuuuu236 Prims.list -> ('uuuuuu236 * 'uuuuuu236)
   =
-  fun uu___0_261  ->
-    match uu___0_261 with
+  fun uu___0_247  ->
+    match uu___0_247 with
     | a::b::[] -> (a, b)
-    | uu____266 -> failwith "Expected a list with 2 elements"
+    | uu____252 -> failwith "Expected a list with 2 elements"
   
 let (flag_of_qual :
   FStar_Syntax_Syntax.qualifier ->
     FStar_Extraction_ML_Syntax.meta FStar_Pervasives_Native.option)
   =
-  fun uu___1_281  ->
-    match uu___1_281 with
+  fun uu___1_267  ->
+    match uu___1_267 with
     | FStar_Syntax_Syntax.Assumption  ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Assumed
     | FStar_Syntax_Syntax.Private  ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Private
     | FStar_Syntax_Syntax.NoExtract  ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.NoExtract
-    | uu____284 -> FStar_Pervasives_Native.None
+    | uu____270 -> FStar_Pervasives_Native.None
   
 let rec (extract_meta :
   FStar_Syntax_Syntax.term ->
     FStar_Extraction_ML_Syntax.meta FStar_Pervasives_Native.option)
   =
   fun x  ->
-    let uu____293 = FStar_Syntax_Subst.compress x  in
-    match uu____293 with
+    let uu____279 = FStar_Syntax_Subst.compress x  in
+    match uu____279 with
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-        FStar_Syntax_Syntax.pos = uu____297;
-        FStar_Syntax_Syntax.vars = uu____298;_} ->
-        let uu____301 =
-          let uu____303 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____303  in
-        (match uu____301 with
+        FStar_Syntax_Syntax.pos = uu____283;
+        FStar_Syntax_Syntax.vars = uu____284;_} ->
+        let uu____287 =
+          let uu____289 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          FStar_Ident.string_of_lid uu____289  in
+        (match uu____287 with
          | "FStar.Pervasives.PpxDerivingShow" ->
              FStar_Pervasives_Native.Some
                FStar_Extraction_ML_Syntax.PpxDerivingShow
@@ -143,27 +135,27 @@ let rec (extract_meta :
          | "Prims.deprecated" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.Deprecated "")
-         | uu____316 -> FStar_Pervasives_Native.None)
+         | uu____302 -> FStar_Pervasives_Native.None)
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____319;
-             FStar_Syntax_Syntax.vars = uu____320;_},({
+             FStar_Syntax_Syntax.pos = uu____305;
+             FStar_Syntax_Syntax.vars = uu____306;_},({
                                                         FStar_Syntax_Syntax.n
                                                           =
                                                           FStar_Syntax_Syntax.Tm_constant
                                                           (FStar_Const.Const_string
-                                                          (s,uu____322));
+                                                          (s,uu____308));
                                                         FStar_Syntax_Syntax.pos
-                                                          = uu____323;
+                                                          = uu____309;
                                                         FStar_Syntax_Syntax.vars
-                                                          = uu____324;_},uu____325)::[]);
-        FStar_Syntax_Syntax.pos = uu____326;
-        FStar_Syntax_Syntax.vars = uu____327;_} ->
-        let uu____370 =
-          let uu____372 = FStar_Syntax_Syntax.lid_of_fv fv  in
-          FStar_Ident.string_of_lid uu____372  in
-        (match uu____370 with
+                                                          = uu____310;_},uu____311)::[]);
+        FStar_Syntax_Syntax.pos = uu____312;
+        FStar_Syntax_Syntax.vars = uu____313;_} ->
+        let uu____356 =
+          let uu____358 = FStar_Syntax_Syntax.lid_of_fv fv  in
+          FStar_Ident.string_of_lid uu____358  in
+        (match uu____356 with
          | "FStar.Pervasives.PpxDerivingShowConstant" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.PpxDerivingShowConstant s)
@@ -185,38 +177,38 @@ let rec (extract_meta :
          | "Prims.deprecated" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.Deprecated s)
-         | uu____382 -> FStar_Pervasives_Native.None)
+         | uu____368 -> FStar_Pervasives_Native.None)
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-          (FStar_Const.Const_string ("KremlinPrivate",uu____384));
-        FStar_Syntax_Syntax.pos = uu____385;
-        FStar_Syntax_Syntax.vars = uu____386;_} ->
+          (FStar_Const.Const_string ("KremlinPrivate",uu____370));
+        FStar_Syntax_Syntax.pos = uu____371;
+        FStar_Syntax_Syntax.vars = uu____372;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Private
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-          (FStar_Const.Const_string ("c_inline",uu____391));
-        FStar_Syntax_Syntax.pos = uu____392;
-        FStar_Syntax_Syntax.vars = uu____393;_} ->
+          (FStar_Const.Const_string ("c_inline",uu____377));
+        FStar_Syntax_Syntax.pos = uu____378;
+        FStar_Syntax_Syntax.vars = uu____379;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.CInline
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-          (FStar_Const.Const_string ("substitute",uu____398));
-        FStar_Syntax_Syntax.pos = uu____399;
-        FStar_Syntax_Syntax.vars = uu____400;_} ->
+          (FStar_Const.Const_string ("substitute",uu____384));
+        FStar_Syntax_Syntax.pos = uu____385;
+        FStar_Syntax_Syntax.vars = uu____386;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Substitute
-    | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_meta (x1,uu____406);
-        FStar_Syntax_Syntax.pos = uu____407;
-        FStar_Syntax_Syntax.vars = uu____408;_} -> extract_meta x1
-    | uu____415 -> FStar_Pervasives_Native.None
+    | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_meta (x1,uu____392);
+        FStar_Syntax_Syntax.pos = uu____393;
+        FStar_Syntax_Syntax.vars = uu____394;_} -> extract_meta x1
+    | uu____401 -> FStar_Pervasives_Native.None
   
 let (extract_metadata :
   FStar_Syntax_Syntax.term Prims.list ->
     FStar_Extraction_ML_Syntax.meta Prims.list)
   = fun metas  -> FStar_List.choose extract_meta metas 
 let binders_as_mlty_binders :
-  'uuuuuu435 .
+  'uuuuuu421 .
     FStar_Extraction_ML_UEnv.uenv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu435) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu421) Prims.list ->
         (FStar_Extraction_ML_UEnv.uenv * FStar_Extraction_ML_Syntax.mlident
           Prims.list)
   =
@@ -224,18 +216,18 @@ let binders_as_mlty_binders :
     fun bs  ->
       FStar_Util.fold_map
         (fun env1  ->
-           fun uu____477  ->
-             match uu____477 with
-             | (bv,uu____488) ->
+           fun uu____463  ->
+             match uu____463 with
+             | (bv,uu____474) ->
                  let env2 = FStar_Extraction_ML_UEnv.extend_ty env1 bv false
                     in
                  let name =
-                   let uu____493 = FStar_Extraction_ML_UEnv.lookup_bv env2 bv
+                   let uu____479 = FStar_Extraction_ML_UEnv.lookup_bv env2 bv
                       in
-                   match uu____493 with
+                   match uu____479 with
                    | FStar_Util.Inl ty ->
                        ty.FStar_Extraction_ML_UEnv.ty_b_name
-                   | uu____496 -> failwith "Impossible"  in
+                   | uu____482 -> failwith "Impossible"  in
                  (env2, name)) env bs
   
 type data_constructor =
@@ -301,24 +293,24 @@ let (__proj__Mkinductive_family__item__imetadata :
   
 let (print_ifamily : inductive_family -> unit) =
   fun i  ->
-    let uu____698 = FStar_Syntax_Print.lid_to_string i.iname  in
-    let uu____700 = FStar_Syntax_Print.binders_to_string " " i.iparams  in
-    let uu____703 = FStar_Syntax_Print.term_to_string i.ityp  in
-    let uu____705 =
-      let uu____707 =
+    let uu____684 = FStar_Syntax_Print.lid_to_string i.iname  in
+    let uu____686 = FStar_Syntax_Print.binders_to_string " " i.iparams  in
+    let uu____689 = FStar_Syntax_Print.term_to_string i.ityp  in
+    let uu____691 =
+      let uu____693 =
         FStar_All.pipe_right i.idatas
           (FStar_List.map
              (fun d  ->
-                let uu____721 = FStar_Syntax_Print.lid_to_string d.dname  in
-                let uu____723 =
-                  let uu____725 = FStar_Syntax_Print.term_to_string d.dtyp
+                let uu____707 = FStar_Syntax_Print.lid_to_string d.dname  in
+                let uu____709 =
+                  let uu____711 = FStar_Syntax_Print.term_to_string d.dtyp
                      in
-                  Prims.op_Hat " : " uu____725  in
-                Prims.op_Hat uu____721 uu____723))
+                  Prims.op_Hat " : " uu____711  in
+                Prims.op_Hat uu____707 uu____709))
          in
-      FStar_All.pipe_right uu____707 (FStar_String.concat "\n\t\t")  in
-    FStar_Util.print4 "\n\t%s %s : %s { %s }\n" uu____698 uu____700 uu____703
-      uu____705
+      FStar_All.pipe_right uu____693 (FStar_String.concat "\n\t\t")  in
+    FStar_Util.print4 "\n\t%s %s : %s { %s }\n" uu____684 uu____686 uu____689
+      uu____691
   
 let (bundle_as_inductive_families :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -329,20 +321,20 @@ let (bundle_as_inductive_families :
   fun env  ->
     fun ses  ->
       fun quals  ->
-        let uu____770 =
+        let uu____756 =
           FStar_Util.fold_map
             (fun env1  ->
                fun se  ->
                  match se.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_inductive_typ
                      (l,us,bs,t,_mut_i,datas) ->
-                     let uu____823 = FStar_Syntax_Subst.open_univ_vars us t
+                     let uu____809 = FStar_Syntax_Subst.open_univ_vars us t
                         in
-                     (match uu____823 with
+                     (match uu____809 with
                       | (_us,t1) ->
-                          let uu____836 = FStar_Syntax_Subst.open_term bs t1
+                          let uu____822 = FStar_Syntax_Subst.open_term bs t1
                              in
-                          (match uu____836 with
+                          (match uu____822 with
                            | (bs1,t2) ->
                                let datas1 =
                                  FStar_All.pipe_right ses
@@ -351,71 +343,71 @@ let (bundle_as_inductive_families :
                                          match se1.FStar_Syntax_Syntax.sigel
                                          with
                                          | FStar_Syntax_Syntax.Sig_datacon
-                                             (d,us1,t3,l',nparams,uu____882)
+                                             (d,us1,t3,l',nparams,uu____868)
                                              when FStar_Ident.lid_equals l l'
                                              ->
-                                             let uu____889 =
+                                             let uu____875 =
                                                FStar_Syntax_Subst.open_univ_vars
                                                  us1 t3
                                                 in
-                                             (match uu____889 with
+                                             (match uu____875 with
                                               | (_us1,t4) ->
-                                                  let uu____898 =
+                                                  let uu____884 =
                                                     FStar_Syntax_Util.arrow_formals
                                                       t4
                                                      in
-                                                  (match uu____898 with
+                                                  (match uu____884 with
                                                    | (bs',body) ->
-                                                       let uu____913 =
+                                                       let uu____899 =
                                                          FStar_Util.first_N
                                                            (FStar_List.length
                                                               bs1) bs'
                                                           in
-                                                       (match uu____913 with
+                                                       (match uu____899 with
                                                         | (bs_params,rest) ->
                                                             let subst =
                                                               FStar_List.map2
                                                                 (fun
-                                                                   uu____1004
-                                                                    ->
+                                                                   uu____990 
+                                                                   ->
                                                                    fun
-                                                                    uu____1005
+                                                                    uu____991
                                                                      ->
                                                                     match 
-                                                                    (uu____1004,
-                                                                    uu____1005)
+                                                                    (uu____990,
+                                                                    uu____991)
                                                                     with
                                                                     | 
-                                                                    ((b',uu____1031),
-                                                                    (b,uu____1033))
+                                                                    ((b',uu____1017),
+                                                                    (b,uu____1019))
                                                                     ->
-                                                                    let uu____1054
+                                                                    let uu____1040
                                                                     =
-                                                                    let uu____1061
+                                                                    let uu____1047
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     b  in
                                                                     (b',
-                                                                    uu____1061)
+                                                                    uu____1047)
                                                                      in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____1054)
+                                                                    uu____1040)
                                                                 bs_params bs1
                                                                in
                                                             let t5 =
-                                                              let uu____1067
+                                                              let uu____1053
                                                                 =
-                                                                let uu____1068
+                                                                let uu____1054
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_Total
                                                                     body
                                                                    in
                                                                 FStar_Syntax_Util.arrow
                                                                   rest
-                                                                  uu____1068
+                                                                  uu____1054
                                                                  in
                                                               FStar_All.pipe_right
-                                                                uu____1067
+                                                                uu____1053
                                                                 (FStar_Syntax_Subst.subst
                                                                    subst)
                                                                in
@@ -423,27 +415,27 @@ let (bundle_as_inductive_families :
                                                                dname = d;
                                                                dtyp = t5
                                                              }])))
-                                         | uu____1071 -> []))
+                                         | uu____1057 -> []))
                                   in
                                let metadata =
-                                 let uu____1075 =
+                                 let uu____1061 =
                                    extract_metadata
                                      se.FStar_Syntax_Syntax.sigattrs
                                     in
-                                 let uu____1078 =
+                                 let uu____1064 =
                                    FStar_List.choose flag_of_qual quals  in
-                                 FStar_List.append uu____1075 uu____1078  in
+                                 FStar_List.append uu____1061 uu____1064  in
                                let fv =
                                  FStar_Syntax_Syntax.lid_as_fv l
                                    FStar_Syntax_Syntax.delta_constant
                                    FStar_Pervasives_Native.None
                                   in
-                               let uu____1082 =
+                               let uu____1068 =
                                  FStar_Extraction_ML_UEnv.extend_type_name
                                    env1 fv
                                   in
-                               (match uu____1082 with
-                                | (uu____1093,env2) ->
+                               (match uu____1068 with
+                                | (uu____1079,env2) ->
                                     (env2,
                                       [{
                                          ifv = fv;
@@ -455,9 +447,9 @@ let (bundle_as_inductive_families :
                                            (se.FStar_Syntax_Syntax.sigquals);
                                          imetadata = metadata
                                        }]))))
-                 | uu____1097 -> (env1, [])) env ses
+                 | uu____1083 -> (env1, [])) env ses
            in
-        match uu____770 with
+        match uu____756 with
         | (env1,ifams) -> (env1, (FStar_List.flatten ifams))
   
 type iface =
@@ -515,29 +507,29 @@ let (iface_of_bindings :
     -> iface)
   =
   fun fvs  ->
-    let uu___221_1309 = empty_iface  in
+    let uu___221_1295 = empty_iface  in
     {
-      iface_module_name = (uu___221_1309.iface_module_name);
+      iface_module_name = (uu___221_1295.iface_module_name);
       iface_bindings = fvs;
-      iface_tydefs = (uu___221_1309.iface_tydefs);
-      iface_type_names = (uu___221_1309.iface_type_names)
+      iface_tydefs = (uu___221_1295.iface_tydefs);
+      iface_type_names = (uu___221_1295.iface_type_names)
     }
   
 let (iface_of_tydefs : FStar_Extraction_ML_UEnv.tydef Prims.list -> iface) =
   fun tds  ->
-    let uu___224_1320 = empty_iface  in
-    let uu____1321 =
+    let uu___224_1306 = empty_iface  in
+    let uu____1307 =
       FStar_List.map
         (fun td  ->
-           let uu____1336 = FStar_Extraction_ML_UEnv.tydef_fv td  in
-           let uu____1337 = FStar_Extraction_ML_UEnv.tydef_mlpath td  in
-           (uu____1336, uu____1337)) tds
+           let uu____1322 = FStar_Extraction_ML_UEnv.tydef_fv td  in
+           let uu____1323 = FStar_Extraction_ML_UEnv.tydef_mlpath td  in
+           (uu____1322, uu____1323)) tds
        in
     {
-      iface_module_name = (uu___224_1320.iface_module_name);
-      iface_bindings = (uu___224_1320.iface_bindings);
+      iface_module_name = (uu___224_1306.iface_module_name);
+      iface_bindings = (uu___224_1306.iface_bindings);
       iface_tydefs = tds;
-      iface_type_names = uu____1321
+      iface_type_names = uu____1307
     }
   
 let (iface_of_type_names :
@@ -545,23 +537,23 @@ let (iface_of_type_names :
     iface)
   =
   fun fvs  ->
-    let uu___228_1356 = empty_iface  in
+    let uu___228_1342 = empty_iface  in
     {
-      iface_module_name = (uu___228_1356.iface_module_name);
-      iface_bindings = (uu___228_1356.iface_bindings);
-      iface_tydefs = (uu___228_1356.iface_tydefs);
+      iface_module_name = (uu___228_1342.iface_module_name);
+      iface_bindings = (uu___228_1342.iface_bindings);
+      iface_tydefs = (uu___228_1342.iface_tydefs);
       iface_type_names = fvs
     }
   
 let (iface_union : iface -> iface -> iface) =
   fun if1  ->
     fun if2  ->
-      let uu____1368 =
+      let uu____1354 =
         if if1.iface_module_name <> if1.iface_module_name
         then failwith "Union not defined"
         else if1.iface_module_name  in
       {
-        iface_module_name = uu____1368;
+        iface_module_name = uu____1354;
         iface_bindings =
           (FStar_List.append if1.iface_bindings if2.iface_bindings);
         iface_tydefs = (FStar_List.append if1.iface_tydefs if2.iface_tydefs);
@@ -578,9 +570,9 @@ let (mlpath_to_string : FStar_Extraction_ML_Syntax.mlpath -> Prims.string) =
          [FStar_Pervasives_Native.snd p])
   
 let tscheme_to_string :
-  'uuuuuu1417 .
+  'uuuuuu1403 .
     FStar_Extraction_ML_Syntax.mlpath ->
-      ('uuuuuu1417 * FStar_Extraction_ML_Syntax.mlty) -> Prims.string
+      ('uuuuuu1403 * FStar_Extraction_ML_Syntax.mlty) -> Prims.string
   =
   fun cm  ->
     fun ts  ->
@@ -593,15 +585,15 @@ let (print_exp_binding :
   =
   fun cm  ->
     fun e  ->
-      let uu____1449 =
+      let uu____1435 =
         FStar_Extraction_ML_Code.string_of_mlexpr cm
           e.FStar_Extraction_ML_UEnv.exp_b_expr
          in
-      let uu____1451 =
+      let uu____1437 =
         tscheme_to_string cm e.FStar_Extraction_ML_UEnv.exp_b_tscheme  in
       FStar_Util.format3
         "{\n\texp_b_name = %s\n\texp_b_expr = %s\n\texp_b_tscheme = %s }"
-        e.FStar_Extraction_ML_UEnv.exp_b_name uu____1449 uu____1451
+        e.FStar_Extraction_ML_UEnv.exp_b_name uu____1435 uu____1437
   
 let (print_binding :
   FStar_Extraction_ML_Syntax.mlpath ->
@@ -609,12 +601,12 @@ let (print_binding :
       Prims.string)
   =
   fun cm  ->
-    fun uu____1469  ->
-      match uu____1469 with
+    fun uu____1455  ->
+      match uu____1455 with
       | (fv,exp_binding) ->
-          let uu____1477 = FStar_Syntax_Print.fv_to_string fv  in
-          let uu____1479 = print_exp_binding cm exp_binding  in
-          FStar_Util.format2 "(%s, %s)" uu____1477 uu____1479
+          let uu____1463 = FStar_Syntax_Print.fv_to_string fv  in
+          let uu____1465 = print_exp_binding cm exp_binding  in
+          FStar_Util.format2 "(%s, %s)" uu____1463 uu____1465
   
 let (print_tydef :
   FStar_Extraction_ML_Syntax.mlpath ->
@@ -622,52 +614,52 @@ let (print_tydef :
   =
   fun cm  ->
     fun tydef  ->
-      let uu____1494 =
-        let uu____1496 = FStar_Extraction_ML_UEnv.tydef_fv tydef  in
-        FStar_Syntax_Print.fv_to_string uu____1496  in
-      let uu____1497 =
-        let uu____1499 = FStar_Extraction_ML_UEnv.tydef_def tydef  in
-        tscheme_to_string cm uu____1499  in
-      FStar_Util.format2 "(%s, %s)" uu____1494 uu____1497
+      let uu____1480 =
+        let uu____1482 = FStar_Extraction_ML_UEnv.tydef_fv tydef  in
+        FStar_Syntax_Print.fv_to_string uu____1482  in
+      let uu____1483 =
+        let uu____1485 = FStar_Extraction_ML_UEnv.tydef_def tydef  in
+        tscheme_to_string cm uu____1485  in
+      FStar_Util.format2 "(%s, %s)" uu____1480 uu____1483
   
 let (iface_to_string : iface -> Prims.string) =
   fun iface1  ->
     let cm = iface1.iface_module_name  in
-    let print_type_name uu____1523 =
-      match uu____1523 with
-      | (tn,uu____1530) -> FStar_Syntax_Print.fv_to_string tn  in
-    let uu____1531 =
-      let uu____1533 =
+    let print_type_name uu____1509 =
+      match uu____1509 with
+      | (tn,uu____1516) -> FStar_Syntax_Print.fv_to_string tn  in
+    let uu____1517 =
+      let uu____1519 =
         FStar_List.map (print_binding cm) iface1.iface_bindings  in
-      FStar_All.pipe_right uu____1533 (FStar_String.concat "\n")  in
-    let uu____1547 =
-      let uu____1549 = FStar_List.map (print_tydef cm) iface1.iface_tydefs
+      FStar_All.pipe_right uu____1519 (FStar_String.concat "\n")  in
+    let uu____1533 =
+      let uu____1535 = FStar_List.map (print_tydef cm) iface1.iface_tydefs
          in
-      FStar_All.pipe_right uu____1549 (FStar_String.concat "\n")  in
-    let uu____1559 =
-      let uu____1561 = FStar_List.map print_type_name iface1.iface_type_names
+      FStar_All.pipe_right uu____1535 (FStar_String.concat "\n")  in
+    let uu____1545 =
+      let uu____1547 = FStar_List.map print_type_name iface1.iface_type_names
          in
-      FStar_All.pipe_right uu____1561 (FStar_String.concat "\n")  in
+      FStar_All.pipe_right uu____1547 (FStar_String.concat "\n")  in
     FStar_Util.format4
       "Interface %s = {\niface_bindings=\n%s;\n\niface_tydefs=\n%s;\n\niface_type_names=%s;\n}"
-      (mlpath_to_string iface1.iface_module_name) uu____1531 uu____1547
-      uu____1559
+      (mlpath_to_string iface1.iface_module_name) uu____1517 uu____1533
+      uu____1545
   
 let (gamma_to_string : FStar_Extraction_ML_UEnv.uenv -> Prims.string) =
   fun env  ->
     let cm = FStar_Extraction_ML_UEnv.current_module_of_uenv env  in
     let gamma =
-      let uu____1591 = FStar_Extraction_ML_UEnv.bindings_of_uenv env  in
+      let uu____1577 = FStar_Extraction_ML_UEnv.bindings_of_uenv env  in
       FStar_List.collect
-        (fun uu___2_1601  ->
-           match uu___2_1601 with
+        (fun uu___2_1587  ->
+           match uu___2_1587 with
            | FStar_Extraction_ML_UEnv.Fv (b,e) -> [(b, e)]
-           | uu____1618 -> []) uu____1591
+           | uu____1604 -> []) uu____1577
        in
-    let uu____1623 =
-      let uu____1625 = FStar_List.map (print_binding cm) gamma  in
-      FStar_All.pipe_right uu____1625 (FStar_String.concat "\n")  in
-    FStar_Util.format1 "Gamma = {\n %s }" uu____1623
+    let uu____1609 =
+      let uu____1611 = FStar_List.map (print_binding cm) gamma  in
+      FStar_All.pipe_right uu____1611 (FStar_String.concat "\n")  in
+    FStar_Util.format1 "Gamma = {\n %s }" uu____1609
   
 let (extract_typ_abbrev :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -680,18 +672,18 @@ let (extract_typ_abbrev :
     fun quals  ->
       fun attrs  ->
         fun lb  ->
-          let uu____1685 =
-            let uu____1694 =
-              let uu____1703 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
-              FStar_TypeChecker_Env.open_universes_in uu____1703
+          let uu____1671 =
+            let uu____1680 =
+              let uu____1689 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
+              FStar_TypeChecker_Env.open_universes_in uu____1689
                 lb.FStar_Syntax_Syntax.lbunivs
                 [lb.FStar_Syntax_Syntax.lbdef; lb.FStar_Syntax_Syntax.lbtyp]
                in
-            match uu____1694 with
-            | (tcenv,uu____1713,def_typ) ->
-                let uu____1719 = as_pair def_typ  in (tcenv, uu____1719)
+            match uu____1680 with
+            | (tcenv,uu____1699,def_typ) ->
+                let uu____1705 = as_pair def_typ  in (tcenv, uu____1705)
              in
-          match uu____1685 with
+          match uu____1671 with
           | (tcenv,(lbdef,lbtyp)) ->
               let lbtyp1 =
                 FStar_TypeChecker_Normalize.normalize
@@ -707,79 +699,79 @@ let (extract_typ_abbrev :
               let lid =
                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
               let def =
-                let uu____1750 =
-                  let uu____1751 = FStar_Syntax_Subst.compress lbdef1  in
-                  FStar_All.pipe_right uu____1751 FStar_Syntax_Util.unmeta
+                let uu____1736 =
+                  let uu____1737 = FStar_Syntax_Subst.compress lbdef1  in
+                  FStar_All.pipe_right uu____1737 FStar_Syntax_Util.unmeta
                    in
-                FStar_All.pipe_right uu____1750 FStar_Syntax_Util.un_uinst
+                FStar_All.pipe_right uu____1736 FStar_Syntax_Util.un_uinst
                  in
               let def1 =
                 match def.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_abs uu____1759 ->
+                | FStar_Syntax_Syntax.Tm_abs uu____1745 ->
                     FStar_Extraction_ML_Term.normalize_abs def
-                | uu____1778 -> def  in
-              let uu____1779 =
+                | uu____1764 -> def  in
+              let uu____1765 =
                 match def1.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1790) ->
+                | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____1776) ->
                     FStar_Syntax_Subst.open_term bs body
-                | uu____1815 -> ([], def1)  in
-              (match uu____1779 with
+                | uu____1801 -> ([], def1)  in
+              (match uu____1765 with
                | (bs,body) ->
                    let assumed =
                      FStar_Util.for_some
-                       (fun uu___3_1835  ->
-                          match uu___3_1835 with
+                       (fun uu___3_1821  ->
+                          match uu___3_1821 with
                           | FStar_Syntax_Syntax.Assumption  -> true
-                          | uu____1838 -> false) quals
+                          | uu____1824 -> false) quals
                       in
-                   let uu____1840 = binders_as_mlty_binders env bs  in
-                   (match uu____1840 with
+                   let uu____1826 = binders_as_mlty_binders env bs  in
+                   (match uu____1826 with
                     | (env1,ml_bs) ->
                         let body1 =
-                          let uu____1867 =
+                          let uu____1853 =
                             FStar_Extraction_ML_Term.term_as_mlty env1 body
                              in
-                          FStar_All.pipe_right uu____1867
+                          FStar_All.pipe_right uu____1853
                             (FStar_Extraction_ML_Util.eraseTypeDeep
                                (FStar_Extraction_ML_Util.udelta_unfold env1))
                            in
                         let metadata =
-                          let uu____1871 = extract_metadata attrs  in
-                          let uu____1874 =
+                          let uu____1857 = extract_metadata attrs  in
+                          let uu____1860 =
                             FStar_List.choose flag_of_qual quals  in
-                          FStar_List.append uu____1871 uu____1874  in
+                          FStar_List.append uu____1857 uu____1860  in
                         let tyscheme = (ml_bs, body1)  in
-                        let uu____1882 =
-                          let uu____1897 =
+                        let uu____1868 =
+                          let uu____1883 =
                             FStar_All.pipe_right quals
                               (FStar_Util.for_some
-                                 (fun uu___4_1903  ->
-                                    match uu___4_1903 with
+                                 (fun uu___4_1889  ->
+                                    match uu___4_1889 with
                                     | FStar_Syntax_Syntax.Assumption  -> true
                                     | FStar_Syntax_Syntax.New  -> true
-                                    | uu____1907 -> false))
+                                    | uu____1893 -> false))
                              in
-                          if uu____1897
+                          if uu____1883
                           then
-                            let uu____1924 =
+                            let uu____1910 =
                               FStar_Extraction_ML_UEnv.extend_type_name env
                                 fv
                                in
-                            match uu____1924 with
+                            match uu____1910 with
                             | (mlp,env2) ->
                                 (mlp, (iface_of_type_names [(fv, mlp)]),
                                   env2)
                           else
-                            (let uu____1963 =
+                            (let uu____1949 =
                                FStar_Extraction_ML_UEnv.extend_tydef env fv
                                  tyscheme
                                 in
-                             match uu____1963 with
+                             match uu____1949 with
                              | (td,mlp,env2) ->
-                                 let uu____1987 = iface_of_tydefs [td]  in
-                                 (mlp, uu____1987, env2))
+                                 let uu____1973 = iface_of_tydefs [td]  in
+                                 (mlp, uu____1973, env2))
                            in
-                        (match uu____1882 with
+                        (match uu____1868 with
                          | (mlpath,iface1,env2) ->
                              let td =
                                (assumed,
@@ -791,17 +783,17 @@ let (extract_typ_abbrev :
                                        body1)))
                                 in
                              let def2 =
-                               let uu____2058 =
-                                 let uu____2059 =
-                                   let uu____2060 =
+                               let uu____2044 =
+                                 let uu____2045 =
+                                   let uu____2046 =
                                      FStar_Ident.range_of_lid lid  in
                                    FStar_Extraction_ML_Util.mlloc_of_range
-                                     uu____2060
+                                     uu____2046
                                     in
                                  FStar_Extraction_ML_Syntax.MLM_Loc
-                                   uu____2059
+                                   uu____2045
                                   in
-                               [uu____2058;
+                               [uu____2044;
                                FStar_Extraction_ML_Syntax.MLM_Ty [td]]  in
                              (env2, iface1, def2))))
   
@@ -817,20 +809,20 @@ let (extract_let_rec_type :
       fun attrs  ->
         fun lb  ->
           let lbtyp =
-            let uu____2109 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
+            let uu____2095 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta;
               FStar_TypeChecker_Env.AllowUnboundUniverses;
               FStar_TypeChecker_Env.EraseUniverses;
               FStar_TypeChecker_Env.UnfoldUntil
-                FStar_Syntax_Syntax.delta_constant] uu____2109
+                FStar_Syntax_Syntax.delta_constant] uu____2095
               lb.FStar_Syntax_Syntax.lbtyp
              in
-          let uu____2110 = FStar_Syntax_Util.arrow_formals lbtyp  in
-          match uu____2110 with
-          | (bs,uu____2126) ->
-              let uu____2131 = binders_as_mlty_binders env bs  in
-              (match uu____2131 with
+          let uu____2096 = FStar_Syntax_Util.arrow_formals lbtyp  in
+          match uu____2096 with
+          | (bs,uu____2112) ->
+              let uu____2117 = binders_as_mlty_binders env bs  in
+              (match uu____2117 with
                | (env1,ml_bs) ->
                    let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                       in
@@ -839,15 +831,15 @@ let (extract_let_rec_type :
                       in
                    let body = FStar_Extraction_ML_Syntax.MLTY_Top  in
                    let metadata =
-                     let uu____2163 = extract_metadata attrs  in
-                     let uu____2166 = FStar_List.choose flag_of_qual quals
+                     let uu____2149 = extract_metadata attrs  in
+                     let uu____2152 = FStar_List.choose flag_of_qual quals
                         in
-                     FStar_List.append uu____2163 uu____2166  in
+                     FStar_List.append uu____2149 uu____2152  in
                    let assumed = false  in
                    let tscheme = (ml_bs, body)  in
-                   let uu____2177 =
+                   let uu____2163 =
                      FStar_Extraction_ML_UEnv.extend_tydef env fv tscheme  in
-                   (match uu____2177 with
+                   (match uu____2163 with
                     | (tydef,mlp,env2) ->
                         let td =
                           (assumed, (FStar_Pervasives_Native.snd mlp),
@@ -856,15 +848,15 @@ let (extract_let_rec_type :
                                (FStar_Extraction_ML_Syntax.MLTD_Abbrev body)))
                            in
                         let def =
-                          let uu____2230 =
-                            let uu____2231 =
-                              let uu____2232 = FStar_Ident.range_of_lid lid
+                          let uu____2216 =
+                            let uu____2217 =
+                              let uu____2218 = FStar_Ident.range_of_lid lid
                                  in
                               FStar_Extraction_ML_Util.mlloc_of_range
-                                uu____2232
+                                uu____2218
                                in
-                            FStar_Extraction_ML_Syntax.MLM_Loc uu____2231  in
-                          [uu____2230;
+                            FStar_Extraction_ML_Syntax.MLM_Loc uu____2217  in
+                          [uu____2216;
                           FStar_Extraction_ML_Syntax.MLM_Ty [td]]  in
                         let iface1 = iface_of_tydefs [tydef]  in
                         (env2, iface1, def)))
@@ -877,53 +869,53 @@ let (extract_bundle_iface :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____2299 =
+          let uu____2285 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____2299
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____2285
            in
         let tys = (ml_tyvars, mlt)  in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        let uu____2306 =
+        let uu____2292 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false  in
-        match uu____2306 with | (env2,uu____2324,b) -> (env2, (fvv, b))  in
+        match uu____2292 with | (env2,uu____2310,b) -> (env2, (fvv, b))  in
       let extract_one_family env1 ind =
-        let uu____2363 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____2363 with
+        let uu____2349 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____2349 with
         | (env_iparams,vars) ->
-            let uu____2391 =
+            let uu____2377 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____2391 with
+            (match uu____2377 with
              | (env2,ctors) ->
                  let env3 =
-                   let uu____2443 =
+                   let uu____2429 =
                      FStar_Util.find_opt
-                       (fun uu___5_2448  ->
-                          match uu___5_2448 with
-                          | FStar_Syntax_Syntax.RecordType uu____2450 -> true
-                          | uu____2460 -> false) ind.iquals
+                       (fun uu___5_2434  ->
+                          match uu___5_2434 with
+                          | FStar_Syntax_Syntax.RecordType uu____2436 -> true
+                          | uu____2446 -> false) ind.iquals
                       in
-                   match uu____2443 with
+                   match uu____2429 with
                    | FStar_Pervasives_Native.Some
                        (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
                        let g =
                          FStar_List.fold_right
                            (fun id  ->
                               fun g  ->
-                                let uu____2480 =
+                                let uu____2466 =
                                   FStar_Extraction_ML_UEnv.extend_record_field_name
                                     g ((ind.iname), id)
                                    in
-                                match uu____2480 with | (mlp,g1) -> g1) ids
+                                match uu____2466 with | (mlp,g1) -> g1) ids
                            env2
                           in
                        g
-                   | uu____2487 -> env2  in
+                   | uu____2473 -> env2  in
                  (env3, ctors))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
@@ -932,49 +924,49 @@ let (extract_bundle_iface :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____2503,t,uu____2505,uu____2506,uu____2507);
-            FStar_Syntax_Syntax.sigrng = uu____2508;
-            FStar_Syntax_Syntax.sigquals = uu____2509;
-            FStar_Syntax_Syntax.sigmeta = uu____2510;
-            FStar_Syntax_Syntax.sigattrs = uu____2511;
-            FStar_Syntax_Syntax.sigopts = uu____2512;_}::[],uu____2513),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____2489,t,uu____2491,uu____2492,uu____2493);
+            FStar_Syntax_Syntax.sigrng = uu____2494;
+            FStar_Syntax_Syntax.sigquals = uu____2495;
+            FStar_Syntax_Syntax.sigmeta = uu____2496;
+            FStar_Syntax_Syntax.sigattrs = uu____2497;
+            FStar_Syntax_Syntax.sigopts = uu____2498;_}::[],uu____2499),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____2534 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____2520 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____2534 with
+          (match uu____2520 with
            | (env1,ctor) -> (env1, (iface_of_bindings [ctor])))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2567),quals) ->
-          let uu____2581 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____2553),quals) ->
+          let uu____2567 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr
              in
-          if uu____2581
+          if uu____2567
           then (env, empty_iface)
           else
-            (let uu____2590 = bundle_as_inductive_families env ses quals  in
-             match uu____2590 with
+            (let uu____2576 = bundle_as_inductive_families env ses quals  in
+             match uu____2576 with
              | (env1,ifams) ->
-                 let uu____2607 =
+                 let uu____2593 =
                    FStar_Util.fold_map extract_one_family env1 ifams  in
-                 (match uu____2607 with
+                 (match uu____2593 with
                   | (env2,td) ->
-                      let uu____2648 =
-                        let uu____2649 =
-                          let uu____2650 =
+                      let uu____2634 =
+                        let uu____2635 =
+                          let uu____2636 =
                             FStar_List.map
                               (fun x  ->
-                                 let uu____2664 =
+                                 let uu____2650 =
                                    FStar_Extraction_ML_UEnv.mlpath_of_lident
                                      env2 x.iname
                                     in
-                                 ((x.ifv), uu____2664)) ifams
+                                 ((x.ifv), uu____2650)) ifams
                              in
-                          iface_of_type_names uu____2650  in
-                        iface_union uu____2649
+                          iface_of_type_names uu____2636  in
+                        iface_union uu____2635
                           (iface_of_bindings (FStar_List.flatten td))
                          in
-                      (env2, uu____2648)))
-      | uu____2669 -> failwith "Unexpected signature element"
+                      (env2, uu____2634)))
+      | uu____2655 -> failwith "Unexpected signature element"
   
 let (extract_type_declaration :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -992,29 +984,29 @@ let (extract_type_declaration :
         fun attrs  ->
           fun univs  ->
             fun t  ->
-              let uu____2744 =
-                let uu____2746 =
+              let uu____2730 =
+                let uu____2732 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
-                       (fun uu___6_2752  ->
-                          match uu___6_2752 with
+                       (fun uu___6_2738  ->
+                          match uu___6_2738 with
                           | FStar_Syntax_Syntax.Assumption  -> true
-                          | uu____2755 -> false))
+                          | uu____2741 -> false))
                    in
-                Prims.op_Negation uu____2746  in
-              if uu____2744
+                Prims.op_Negation uu____2732  in
+              if uu____2730
               then (g, empty_iface, [])
               else
-                (let uu____2770 = FStar_Syntax_Util.arrow_formals t  in
-                 match uu____2770 with
-                 | (bs,uu____2786) ->
+                (let uu____2756 = FStar_Syntax_Util.arrow_formals t  in
+                 match uu____2756 with
+                 | (bs,uu____2772) ->
                      let fv =
                        FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None
                         in
                      let lb =
-                       let uu____2793 =
+                       let uu____2779 =
                          FStar_Syntax_Util.abs bs FStar_Syntax_Syntax.t_unit
                            FStar_Pervasives_Native.None
                           in
@@ -1024,7 +1016,7 @@ let (extract_type_declaration :
                          FStar_Syntax_Syntax.lbtyp = t;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_Tot_lid;
-                         FStar_Syntax_Syntax.lbdef = uu____2793;
+                         FStar_Syntax_Syntax.lbdef = uu____2779;
                          FStar_Syntax_Syntax.lbattrs = attrs;
                          FStar_Syntax_Syntax.lbpos =
                            (t.FStar_Syntax_Syntax.pos)
@@ -1060,78 +1052,78 @@ let (extract_reifiable_effect :
              (FStar_Extraction_ML_Syntax.NonRec, [lb])))
          in
       let rec extract_fv tm =
-        (let uu____2897 =
-           let uu____2899 =
-             let uu____2905 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-             FStar_TypeChecker_Env.debug uu____2905  in
-           FStar_All.pipe_left uu____2899
+        (let uu____2883 =
+           let uu____2885 =
+             let uu____2891 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+             FStar_TypeChecker_Env.debug uu____2891  in
+           FStar_All.pipe_left uu____2885
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2897
+         if uu____2883
          then
-           let uu____2909 = FStar_Syntax_Print.term_to_string tm  in
-           FStar_Util.print1 "extract_fv term: %s\n" uu____2909
+           let uu____2895 = FStar_Syntax_Print.term_to_string tm  in
+           FStar_Util.print1 "extract_fv term: %s\n" uu____2895
          else ());
-        (let uu____2914 =
-           let uu____2915 = FStar_Syntax_Subst.compress tm  in
-           uu____2915.FStar_Syntax_Syntax.n  in
-         match uu____2914 with
-         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2923) -> extract_fv tm1
+        (let uu____2900 =
+           let uu____2901 = FStar_Syntax_Subst.compress tm  in
+           uu____2901.FStar_Syntax_Syntax.n  in
+         match uu____2900 with
+         | FStar_Syntax_Syntax.Tm_uinst (tm1,uu____2909) -> extract_fv tm1
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              let mlp =
                FStar_Extraction_ML_UEnv.mlpath_of_lident g
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             let uu____2930 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
-             (match uu____2930 with
-              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2935;
-                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2936;
+             let uu____2916 = FStar_Extraction_ML_UEnv.lookup_fv g fv  in
+             (match uu____2916 with
+              | { FStar_Extraction_ML_UEnv.exp_b_name = uu____2921;
+                  FStar_Extraction_ML_UEnv.exp_b_expr = uu____2922;
                   FStar_Extraction_ML_UEnv.exp_b_tscheme = tysc;_} ->
-                  let uu____2939 =
+                  let uu____2925 =
                     FStar_All.pipe_left
                       (FStar_Extraction_ML_Syntax.with_ty
                          FStar_Extraction_ML_Syntax.MLTY_Top)
                       (FStar_Extraction_ML_Syntax.MLE_Name mlp)
                      in
-                  (uu____2939, tysc))
-         | uu____2940 ->
-             let uu____2941 =
-               let uu____2943 =
+                  (uu____2925, tysc))
+         | uu____2926 ->
+             let uu____2927 =
+               let uu____2929 =
                  FStar_Range.string_of_range tm.FStar_Syntax_Syntax.pos  in
-               let uu____2945 = FStar_Syntax_Print.term_to_string tm  in
-               FStar_Util.format2 "(%s) Not an fv: %s" uu____2943 uu____2945
+               let uu____2931 = FStar_Syntax_Print.term_to_string tm  in
+               FStar_Util.format2 "(%s) Not an fv: %s" uu____2929 uu____2931
                 in
-             failwith uu____2941)
+             failwith uu____2927)
          in
       let extract_action g1 a =
-        (let uu____2973 =
-           let uu____2975 =
-             let uu____2981 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
-             FStar_TypeChecker_Env.debug uu____2981  in
-           FStar_All.pipe_left uu____2975
+        (let uu____2959 =
+           let uu____2961 =
+             let uu____2967 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
+             FStar_TypeChecker_Env.debug uu____2967  in
+           FStar_All.pipe_left uu____2961
              (FStar_Options.Other "ExtractionReify")
             in
-         if uu____2973
+         if uu____2959
          then
-           let uu____2985 =
+           let uu____2971 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_typ
               in
-           let uu____2987 =
+           let uu____2973 =
              FStar_Syntax_Print.term_to_string
                a.FStar_Syntax_Syntax.action_defn
               in
-           FStar_Util.print2 "Action type %s and term %s\n" uu____2985
-             uu____2987
+           FStar_Util.print2 "Action type %s and term %s\n" uu____2971
+             uu____2973
          else ());
         (let lbname =
-           let uu____2997 =
+           let uu____2983 =
              FStar_Syntax_Syntax.new_bv
                (FStar_Pervasives_Native.Some
                   ((a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos))
                FStar_Syntax_Syntax.tun
               in
-           FStar_Util.Inl uu____2997  in
+           FStar_Util.Inl uu____2983  in
          let lb =
            FStar_Syntax_Syntax.mk_lb
              (lbname, (a.FStar_Syntax_Syntax.action_univs),
@@ -1145,137 +1137,136 @@ let (extract_reifiable_effect :
            FStar_Syntax_Syntax.mk
              (FStar_Syntax_Syntax.Tm_let
                 (lbs, FStar_Syntax_Util.exp_false_bool))
-             FStar_Pervasives_Native.None
              (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
             in
-         let uu____3027 =
+         let uu____3013 =
            FStar_Extraction_ML_Term.term_as_mlexpr g1 action_lb  in
-         match uu____3027 with
-         | (a_let,uu____3043,ty) ->
-             let uu____3045 =
+         match uu____3013 with
+         | (a_let,uu____3029,ty) ->
+             let uu____3031 =
                match a_let.FStar_Extraction_ML_Syntax.expr with
                | FStar_Extraction_ML_Syntax.MLE_Let
-                   ((uu____3062,mllb::[]),uu____3064) ->
+                   ((uu____3048,mllb::[]),uu____3050) ->
                    (match mllb.FStar_Extraction_ML_Syntax.mllb_tysc with
                     | FStar_Pervasives_Native.Some tysc ->
                         ((mllb.FStar_Extraction_ML_Syntax.mllb_def), tysc)
                     | FStar_Pervasives_Native.None  ->
                         failwith "No type scheme")
-               | uu____3095 -> failwith "Impossible"  in
-             (match uu____3045 with
+               | uu____3081 -> failwith "Impossible"  in
+             (match uu____3031 with
               | (exp,tysc) ->
-                  let uu____3123 =
+                  let uu____3109 =
                     FStar_Extraction_ML_UEnv.extend_with_action_name g1 ed a
                       tysc
                      in
-                  (match uu____3123 with
+                  (match uu____3109 with
                    | (a_nm,a_lid,exp_b,g2) ->
-                       ((let uu____3145 =
-                           let uu____3147 =
-                             let uu____3153 =
+                       ((let uu____3131 =
+                           let uu____3133 =
+                             let uu____3139 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv g2  in
-                             FStar_TypeChecker_Env.debug uu____3153  in
-                           FStar_All.pipe_left uu____3147
+                             FStar_TypeChecker_Env.debug uu____3139  in
+                           FStar_All.pipe_left uu____3133
                              (FStar_Options.Other "ExtractionReify")
                             in
-                         if uu____3145
+                         if uu____3131
                          then
-                           let uu____3157 =
+                           let uu____3143 =
                              FStar_Extraction_ML_Code.string_of_mlexpr a_nm
                                a_let
                               in
                            FStar_Util.print1 "Extracted action term: %s\n"
-                             uu____3157
+                             uu____3143
                          else ());
-                        (let uu____3163 =
-                           let uu____3165 =
-                             let uu____3171 =
+                        (let uu____3149 =
+                           let uu____3151 =
+                             let uu____3157 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv g2  in
-                             FStar_TypeChecker_Env.debug uu____3171  in
-                           FStar_All.pipe_left uu____3165
+                             FStar_TypeChecker_Env.debug uu____3157  in
+                           FStar_All.pipe_left uu____3151
                              (FStar_Options.Other "ExtractionReify")
                             in
-                         if uu____3163
+                         if uu____3149
                          then
-                           ((let uu____3176 =
+                           ((let uu____3162 =
                                FStar_Extraction_ML_Code.string_of_mlty a_nm
                                  (FStar_Pervasives_Native.snd tysc)
                                 in
                              FStar_Util.print1 "Extracted action type: %s\n"
-                               uu____3176);
+                               uu____3162);
                             FStar_List.iter
                               (fun x  ->
                                  FStar_Util.print1 "and binders: %s\n" x)
                               (FStar_Pervasives_Native.fst tysc))
                          else ());
-                        (let uu____3186 = extend_iface a_lid a_nm exp exp_b
+                        (let uu____3172 = extend_iface a_lid a_nm exp exp_b
                             in
-                         match uu____3186 with
+                         match uu____3172 with
                          | (iface1,impl) -> (g2, (iface1, impl)))))))
          in
-      let uu____3205 =
-        let uu____3212 =
-          let uu____3217 =
-            let uu____3220 =
-              let uu____3229 =
+      let uu____3191 =
+        let uu____3198 =
+          let uu____3203 =
+            let uu____3206 =
+              let uu____3215 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_return_repr  in
-              FStar_All.pipe_right uu____3229 FStar_Util.must  in
-            FStar_All.pipe_right uu____3220 FStar_Pervasives_Native.snd  in
-          extract_fv uu____3217  in
-        match uu____3212 with
+              FStar_All.pipe_right uu____3215 FStar_Util.must  in
+            FStar_All.pipe_right uu____3206 FStar_Pervasives_Native.snd  in
+          extract_fv uu____3203  in
+        match uu____3198 with
         | (return_tm,ty_sc) ->
-            let uu____3298 =
+            let uu____3284 =
               FStar_Extraction_ML_UEnv.extend_with_monad_op_name g ed
                 "return" ty_sc
                in
-            (match uu____3298 with
+            (match uu____3284 with
              | (return_nm,return_lid,return_b,g1) ->
-                 let uu____3318 =
+                 let uu____3304 =
                    extend_iface return_lid return_nm return_tm return_b  in
-                 (match uu____3318 with | (iface1,impl) -> (g1, iface1, impl)))
+                 (match uu____3304 with | (iface1,impl) -> (g1, iface1, impl)))
          in
-      match uu____3205 with
+      match uu____3191 with
       | (g1,return_iface,return_decl) ->
-          let uu____3342 =
-            let uu____3349 =
-              let uu____3354 =
-                let uu____3357 =
-                  let uu____3366 =
+          let uu____3328 =
+            let uu____3335 =
+              let uu____3340 =
+                let uu____3343 =
+                  let uu____3352 =
                     FStar_All.pipe_right ed FStar_Syntax_Util.get_bind_repr
                      in
-                  FStar_All.pipe_right uu____3366 FStar_Util.must  in
-                FStar_All.pipe_right uu____3357 FStar_Pervasives_Native.snd
+                  FStar_All.pipe_right uu____3352 FStar_Util.must  in
+                FStar_All.pipe_right uu____3343 FStar_Pervasives_Native.snd
                  in
-              extract_fv uu____3354  in
-            match uu____3349 with
+              extract_fv uu____3340  in
+            match uu____3335 with
             | (bind_tm,ty_sc) ->
-                let uu____3435 =
+                let uu____3421 =
                   FStar_Extraction_ML_UEnv.extend_with_monad_op_name g1 ed
                     "bind" ty_sc
                    in
-                (match uu____3435 with
+                (match uu____3421 with
                  | (bind_nm,bind_lid,bind_b,g2) ->
-                     let uu____3455 =
+                     let uu____3441 =
                        extend_iface bind_lid bind_nm bind_tm bind_b  in
-                     (match uu____3455 with
+                     (match uu____3441 with
                       | (iface1,impl) -> (g2, iface1, impl)))
              in
-          (match uu____3342 with
+          (match uu____3328 with
            | (g2,bind_iface,bind_decl) ->
-               let uu____3479 =
+               let uu____3465 =
                  FStar_Util.fold_map extract_action g2
                    ed.FStar_Syntax_Syntax.actions
                   in
-               (match uu____3479 with
+               (match uu____3465 with
                 | (g3,actions) ->
-                    let uu____3516 = FStar_List.unzip actions  in
-                    (match uu____3516 with
+                    let uu____3502 = FStar_List.unzip actions  in
+                    (match uu____3502 with
                      | (actions_iface,actions1) ->
-                         let uu____3543 =
+                         let uu____3529 =
                            iface_union_l (return_iface :: bind_iface ::
                              actions_iface)
                             in
-                         (g3, uu____3543, (return_decl :: bind_decl ::
+                         (g3, uu____3529, (return_decl :: bind_decl ::
                            actions1)))))
   
 let (extract_let_rec_types :
@@ -1288,55 +1279,55 @@ let (extract_let_rec_types :
   fun se  ->
     fun env  ->
       fun lbs  ->
-        let uu____3574 =
+        let uu____3560 =
           FStar_Util.for_some
             (fun lb  ->
-               let uu____3579 =
+               let uu____3565 =
                  FStar_Extraction_ML_Term.is_arity env
                    lb.FStar_Syntax_Syntax.lbtyp
                   in
-               Prims.op_Negation uu____3579) lbs
+               Prims.op_Negation uu____3565) lbs
            in
-        if uu____3574
+        if uu____3560
         then
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExtractionUnsupported,
               "Mutually recursively defined typed and terms cannot yet be extracted")
             se.FStar_Syntax_Syntax.sigrng
         else
-          (let uu____3602 =
+          (let uu____3588 =
              FStar_List.fold_left
-               (fun uu____3637  ->
+               (fun uu____3623  ->
                   fun lb  ->
-                    match uu____3637 with
+                    match uu____3623 with
                     | (env1,iface_opt,impls) ->
-                        let uu____3678 =
+                        let uu____3664 =
                           extract_let_rec_type env1
                             se.FStar_Syntax_Syntax.sigquals
                             se.FStar_Syntax_Syntax.sigattrs lb
                            in
-                        (match uu____3678 with
+                        (match uu____3664 with
                          | (env2,iface1,impl) ->
                              let iface_opt1 =
                                match iface_opt with
                                | FStar_Pervasives_Native.None  ->
                                    FStar_Pervasives_Native.Some iface1
                                | FStar_Pervasives_Native.Some iface' ->
-                                   let uu____3712 = iface_union iface' iface1
+                                   let uu____3698 = iface_union iface' iface1
                                       in
-                                   FStar_Pervasives_Native.Some uu____3712
+                                   FStar_Pervasives_Native.Some uu____3698
                                 in
                              (env2, iface_opt1, (impl :: impls))))
                (env, FStar_Pervasives_Native.None, []) lbs
               in
-           match uu____3602 with
+           match uu____3588 with
            | (env1,iface_opt,impls) ->
-               let uu____3752 = FStar_Option.get iface_opt  in
-               let uu____3753 =
+               let uu____3738 = FStar_Option.get iface_opt  in
+               let uu____3739 =
                  FStar_All.pipe_right (FStar_List.rev impls)
                    FStar_List.flatten
                   in
-               (env1, uu____3752, uu____3753))
+               (env1, uu____3738, uu____3739))
   
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1345,87 +1336,87 @@ let (extract_sigelt_iface :
   fun g  ->
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu____3785 ->
+      | FStar_Syntax_Syntax.Sig_bundle uu____3771 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3794 ->
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3780 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu____3811 ->
+      | FStar_Syntax_Syntax.Sig_datacon uu____3797 ->
           extract_bundle_iface g se
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs,t) when
           FStar_Extraction_ML_Term.is_arity g t ->
-          let uu____3830 =
+          let uu____3816 =
             extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs univs t
              in
-          (match uu____3830 with | (env,iface1,uu____3845) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3851) when
+          (match uu____3816 with | (env,iface1,uu____3831) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____3837) when
           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu____3860 =
+          let uu____3846 =
             extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs lb
              in
-          (match uu____3860 with | (env,iface1,uu____3875) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3881) when
+          (match uu____3846 with | (env,iface1,uu____3861) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____3867) when
           FStar_Util.for_some
             (fun lb  ->
                FStar_Extraction_ML_Term.is_arity g
                  lb.FStar_Syntax_Syntax.lbtyp) lbs
           ->
-          let uu____3894 = extract_let_rec_types se g lbs  in
-          (match uu____3894 with | (env,iface1,uu____3909) -> (env, iface1))
+          let uu____3880 = extract_let_rec_types se g lbs  in
+          (match uu____3880 with | (env,iface1,uu____3895) -> (env, iface1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,_univs,t) ->
           let quals = se.FStar_Syntax_Syntax.sigquals  in
-          let uu____3920 =
+          let uu____3906 =
             (FStar_All.pipe_right quals
                (FStar_List.contains FStar_Syntax_Syntax.Assumption))
               &&
-              (let uu____3926 =
-                 let uu____3928 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+              (let uu____3912 =
+                 let uu____3914 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                     in
-                 FStar_TypeChecker_Util.must_erase_for_extraction uu____3928
+                 FStar_TypeChecker_Util.must_erase_for_extraction uu____3914
                    t
                   in
-               Prims.op_Negation uu____3926)
+               Prims.op_Negation uu____3912)
              in
-          if uu____3920
+          if uu____3906
           then
-            let uu____3934 =
-              let uu____3945 =
-                let uu____3946 =
-                  let uu____3949 = always_fail lid t  in [uu____3949]  in
-                (false, uu____3946)  in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu____3945  in
-            (match uu____3934 with
+            let uu____3920 =
+              let uu____3931 =
+                let uu____3932 =
+                  let uu____3935 = always_fail lid t  in [uu____3935]  in
+                (false, uu____3932)  in
+              FStar_Extraction_ML_Term.extract_lb_iface g uu____3931  in
+            (match uu____3920 with
              | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
           else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3975) ->
-          let uu____3980 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
+      | FStar_Syntax_Syntax.Sig_let (lbs,uu____3961) ->
+          let uu____3966 = FStar_Extraction_ML_Term.extract_lb_iface g lbs
              in
-          (match uu____3980 with
+          (match uu____3966 with
            | (g1,bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_assume uu____4009 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu____4016 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4017 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____4030 ->
+      | FStar_Syntax_Syntax.Sig_assume uu____3995 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_sub_effect uu____4002 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4003 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____4016 ->
           (g, empty_iface)
       | FStar_Syntax_Syntax.Sig_pragma p ->
           (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
            (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu____4043 ->
+      | FStar_Syntax_Syntax.Sig_splice uu____4029 ->
           failwith "impossible: trying to extract splice"
-      | FStar_Syntax_Syntax.Sig_fail uu____4055 ->
+      | FStar_Syntax_Syntax.Sig_fail uu____4041 ->
           failwith "impossible: trying to extract Sig_fail"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____4074 =
-            (let uu____4078 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-             FStar_TypeChecker_Env.is_reifiable_effect uu____4078
+          let uu____4060 =
+            (let uu____4064 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+             FStar_TypeChecker_Env.is_reifiable_effect uu____4064
                ed.FStar_Syntax_Syntax.mname)
               && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders)
              in
-          if uu____4074
+          if uu____4060
           then
-            let uu____4090 = extract_reifiable_effect g ed  in
-            (match uu____4090 with | (env,iface1,uu____4105) -> (env, iface1))
+            let uu____4076 = extract_reifiable_effect g ed  in
+            (match uu____4076 with | (env,iface1,uu____4091) -> (env, iface1))
           else (g, empty_iface)
   
 let (extract_iface' :
@@ -1434,36 +1425,36 @@ let (extract_iface' :
   =
   fun g  ->
     fun modul  ->
-      let uu____4127 = FStar_Options.interactive ()  in
-      if uu____4127
+      let uu____4113 = FStar_Options.interactive ()  in
+      if uu____4113
       then (g, empty_iface)
       else
-        (let uu____4136 = FStar_Options.restore_cmd_line_options true  in
+        (let uu____4122 = FStar_Options.restore_cmd_line_options true  in
          let decls = modul.FStar_Syntax_Syntax.declarations  in
          let iface1 =
-           let uu___647_4140 = empty_iface  in
-           let uu____4141 = FStar_Extraction_ML_UEnv.current_module_of_uenv g
+           let uu___647_4126 = empty_iface  in
+           let uu____4127 = FStar_Extraction_ML_UEnv.current_module_of_uenv g
               in
            {
-             iface_module_name = uu____4141;
-             iface_bindings = (uu___647_4140.iface_bindings);
-             iface_tydefs = (uu___647_4140.iface_tydefs);
-             iface_type_names = (uu___647_4140.iface_type_names)
+             iface_module_name = uu____4127;
+             iface_bindings = (uu___647_4126.iface_bindings);
+             iface_tydefs = (uu___647_4126.iface_tydefs);
+             iface_type_names = (uu___647_4126.iface_type_names)
            }  in
          let res =
            FStar_List.fold_left
-             (fun uu____4159  ->
+             (fun uu____4145  ->
                 fun se  ->
-                  match uu____4159 with
+                  match uu____4145 with
                   | (g1,iface2) ->
-                      let uu____4171 = extract_sigelt_iface g1 se  in
-                      (match uu____4171 with
+                      let uu____4157 = extract_sigelt_iface g1 se  in
+                      (match uu____4157 with
                        | (g2,iface') ->
-                           let uu____4182 = iface_union iface2 iface'  in
-                           (g2, uu____4182))) (g, iface1) decls
+                           let uu____4168 = iface_union iface2 iface'  in
+                           (g2, uu____4168))) (g, iface1) decls
             in
-         (let uu____4184 = FStar_Options.restore_cmd_line_options true  in
-          FStar_All.pipe_left (fun uu____4186  -> ()) uu____4184);
+         (let uu____4170 = FStar_Options.restore_cmd_line_options true  in
+          FStar_All.pipe_left (fun uu____4172  -> ()) uu____4170);
          res)
   
 let (extract_iface :
@@ -1472,26 +1463,26 @@ let (extract_iface :
   =
   fun g  ->
     fun modul  ->
-      let uu____4202 =
+      let uu____4188 =
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____4214  ->
-             let uu____4215 = FStar_Options.debug_any ()  in
-             if uu____4215
+          (fun uu____4200  ->
+             let uu____4201 = FStar_Options.debug_any ()  in
+             if uu____4201
              then
-               let uu____4222 =
-                 let uu____4224 =
+               let uu____4208 =
+                 let uu____4210 =
                    FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name
                     in
-                 FStar_Util.format1 "Extracted interface of %s" uu____4224
+                 FStar_Util.format1 "Extracted interface of %s" uu____4210
                   in
-               FStar_Util.measure_execution_time uu____4222
-                 (fun uu____4232  -> extract_iface' g modul)
+               FStar_Util.measure_execution_time uu____4208
+                 (fun uu____4218  -> extract_iface' g modul)
              else extract_iface' g modul)
          in
-      match uu____4202 with
+      match uu____4188 with
       | (g1,iface1) ->
-          let uu____4241 = FStar_Extraction_ML_UEnv.exit_module g1  in
-          (uu____4241, iface1)
+          let uu____4227 = FStar_Extraction_ML_UEnv.exit_module g1  in
+          (uu____4227, iface1)
   
 let (extract_bundle :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1503,10 +1494,10 @@ let (extract_bundle :
     fun se  ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____4319 =
+          let uu____4305 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp  in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4319
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____4305
            in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
@@ -1515,128 +1506,128 @@ let (extract_bundle :
           FStar_TypeChecker_Env.EraseUniverses;
           FStar_TypeChecker_Env.AllowUnboundUniverses]  in
         let names =
-          let uu____4327 =
-            let uu____4328 =
-              let uu____4331 =
-                let uu____4332 =
+          let uu____4313 =
+            let uu____4314 =
+              let uu____4317 =
+                let uu____4318 =
                   FStar_Extraction_ML_UEnv.tcenv_of_uenv env_iparams  in
-                FStar_TypeChecker_Normalize.normalize steps uu____4332
+                FStar_TypeChecker_Normalize.normalize steps uu____4318
                   ctor.dtyp
                  in
-              FStar_Syntax_Subst.compress uu____4331  in
-            uu____4328.FStar_Syntax_Syntax.n  in
-          match uu____4327 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4337) ->
+              FStar_Syntax_Subst.compress uu____4317  in
+            uu____4314.FStar_Syntax_Syntax.n  in
+          match uu____4313 with
+          | FStar_Syntax_Syntax.Tm_arrow (bs,uu____4323) ->
               FStar_List.map
-                (fun uu____4370  ->
-                   match uu____4370 with
+                (fun uu____4356  ->
+                   match uu____4356 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____4379;
-                        FStar_Syntax_Syntax.sort = uu____4380;_},uu____4381)
+                        FStar_Syntax_Syntax.index = uu____4365;
+                        FStar_Syntax_Syntax.sort = uu____4366;_},uu____4367)
                        -> FStar_Ident.text_of_id ppname) bs
-          | uu____4389 -> []  in
+          | uu____4375 -> []  in
         let tys = (ml_tyvars, mlt)  in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
            in
-        let uu____4397 =
+        let uu____4383 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false  in
-        match uu____4397 with
-        | (env2,mls,uu____4424) ->
-            let uu____4427 =
-              let uu____4440 =
-                let uu____4448 = FStar_Extraction_ML_Util.argTypes mlt  in
-                FStar_List.zip names uu____4448  in
-              (mls, uu____4440)  in
-            (env2, uu____4427)
+        match uu____4383 with
+        | (env2,mls,uu____4410) ->
+            let uu____4413 =
+              let uu____4426 =
+                let uu____4434 = FStar_Extraction_ML_Util.argTypes mlt  in
+                FStar_List.zip names uu____4434  in
+              (mls, uu____4426)  in
+            (env2, uu____4413)
          in
       let extract_one_family env1 ind =
-        let uu____4509 = binders_as_mlty_binders env1 ind.iparams  in
-        match uu____4509 with
+        let uu____4495 = binders_as_mlty_binders env1 ind.iparams  in
+        match uu____4495 with
         | (env_iparams,vars) ->
-            let uu____4553 =
+            let uu____4539 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1)
                in
-            (match uu____4553 with
+            (match uu____4539 with
              | (env2,ctors) ->
-                 let uu____4660 = FStar_Syntax_Util.arrow_formals ind.ityp
+                 let uu____4646 = FStar_Syntax_Util.arrow_formals ind.ityp
                     in
-                 (match uu____4660 with
-                  | (indices,uu____4694) ->
+                 (match uu____4646 with
+                  | (indices,uu____4680) ->
                       let ml_params =
-                        let uu____4703 =
+                        let uu____4689 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i  ->
-                                  fun uu____4729  ->
-                                    let uu____4737 =
+                                  fun uu____4715  ->
+                                    let uu____4723 =
                                       FStar_Util.string_of_int i  in
-                                    Prims.op_Hat "'dummyV" uu____4737))
+                                    Prims.op_Hat "'dummyV" uu____4723))
                            in
-                        FStar_List.append vars uu____4703  in
-                      let uu____4741 =
-                        let uu____4748 =
+                        FStar_List.append vars uu____4689  in
+                      let uu____4727 =
+                        let uu____4734 =
                           FStar_Util.find_opt
-                            (fun uu___7_4753  ->
-                               match uu___7_4753 with
-                               | FStar_Syntax_Syntax.RecordType uu____4755 ->
+                            (fun uu___7_4739  ->
+                               match uu___7_4739 with
+                               | FStar_Syntax_Syntax.RecordType uu____4741 ->
                                    true
-                               | uu____4765 -> false) ind.iquals
+                               | uu____4751 -> false) ind.iquals
                            in
-                        match uu____4748 with
+                        match uu____4734 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns,ids)) ->
-                            let uu____4783 = FStar_List.hd ctors  in
-                            (match uu____4783 with
-                             | (uu____4814,c_ty) ->
-                                 let uu____4833 =
+                            let uu____4769 = FStar_List.hd ctors  in
+                            (match uu____4769 with
+                             | (uu____4800,c_ty) ->
+                                 let uu____4819 =
                                    FStar_List.fold_right2
                                      (fun id  ->
-                                        fun uu____4872  ->
-                                          fun uu____4873  ->
-                                            match (uu____4872, uu____4873)
+                                        fun uu____4858  ->
+                                          fun uu____4859  ->
+                                            match (uu____4858, uu____4859)
                                             with
-                                            | ((uu____4917,ty),(fields,g)) ->
-                                                let uu____4953 =
+                                            | ((uu____4903,ty),(fields,g)) ->
+                                                let uu____4939 =
                                                   FStar_Extraction_ML_UEnv.extend_record_field_name
                                                     g ((ind.iname), id)
                                                    in
-                                                (match uu____4953 with
+                                                (match uu____4939 with
                                                  | (mlp,g1) ->
                                                      ((((FStar_Pervasives_Native.snd
                                                            mlp), ty) ::
                                                        fields), g1))) ids
                                      c_ty ([], env2)
                                     in
-                                 (match uu____4833 with
+                                 (match uu____4819 with
                                   | (fields,g) ->
                                       ((FStar_Pervasives_Native.Some
                                           (FStar_Extraction_ML_Syntax.MLTD_Record
                                              fields)), g)))
-                        | uu____5024 when
+                        | uu____5010 when
                             (FStar_List.length ctors) = Prims.int_zero ->
                             (FStar_Pervasives_Native.None, env2)
-                        | uu____5043 ->
+                        | uu____5029 ->
                             ((FStar_Pervasives_Native.Some
                                 (FStar_Extraction_ML_Syntax.MLTD_DType ctors)),
                               env2)
                          in
-                      (match uu____4741 with
+                      (match uu____4727 with
                        | (tbody,env3) ->
-                           let uu____5080 =
-                             let uu____5103 =
-                               let uu____5105 =
+                           let uu____5066 =
+                             let uu____5089 =
+                               let uu____5091 =
                                  FStar_Extraction_ML_UEnv.mlpath_of_lident
                                    env3 ind.iname
                                   in
-                               FStar_Pervasives_Native.snd uu____5105  in
-                             (false, uu____5103,
+                               FStar_Pervasives_Native.snd uu____5091  in
+                             (false, uu____5089,
                                FStar_Pervasives_Native.None, ml_params,
                                (ind.imetadata), tbody)
                               in
-                           (env3, uu____5080))))
+                           (env3, uu____5066))))
          in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
@@ -1644,34 +1635,34 @@ let (extract_bundle :
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l,uu____5161,t,uu____5163,uu____5164,uu____5165);
-            FStar_Syntax_Syntax.sigrng = uu____5166;
-            FStar_Syntax_Syntax.sigquals = uu____5167;
-            FStar_Syntax_Syntax.sigmeta = uu____5168;
-            FStar_Syntax_Syntax.sigattrs = uu____5169;
-            FStar_Syntax_Syntax.sigopts = uu____5170;_}::[],uu____5171),(FStar_Syntax_Syntax.ExceptionConstructor
+              (l,uu____5147,t,uu____5149,uu____5150,uu____5151);
+            FStar_Syntax_Syntax.sigrng = uu____5152;
+            FStar_Syntax_Syntax.sigquals = uu____5153;
+            FStar_Syntax_Syntax.sigmeta = uu____5154;
+            FStar_Syntax_Syntax.sigattrs = uu____5155;
+            FStar_Syntax_Syntax.sigopts = uu____5156;_}::[],uu____5157),(FStar_Syntax_Syntax.ExceptionConstructor
          )::[]) ->
-          let uu____5192 = extract_ctor env [] env { dname = l; dtyp = t }
+          let uu____5178 = extract_ctor env [] env { dname = l; dtyp = t }
              in
-          (match uu____5192 with
+          (match uu____5178 with
            | (env1,ctor) -> (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____5245),quals) ->
-          let uu____5259 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses,uu____5231),quals) ->
+          let uu____5245 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr
              in
-          if uu____5259
+          if uu____5245
           then (env, [])
           else
-            (let uu____5272 = bundle_as_inductive_families env ses quals  in
-             match uu____5272 with
+            (let uu____5258 = bundle_as_inductive_families env ses quals  in
+             match uu____5258 with
              | (env1,ifams) ->
-                 let uu____5291 =
+                 let uu____5277 =
                    FStar_Util.fold_map extract_one_family env1 ifams  in
-                 (match uu____5291 with
+                 (match uu____5277 with
                   | (env2,td) ->
                       (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____5400 -> failwith "Unexpected signature element"
+      | uu____5386 -> failwith "Unexpected signature element"
   
 let (maybe_register_plugin :
   env_t ->
@@ -1687,43 +1678,43 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t  ->
-             let uu____5458 = FStar_Syntax_Util.head_and_args t  in
-             match uu____5458 with
+             let uu____5444 = FStar_Syntax_Util.head_and_args t  in
+             match uu____5444 with
              | (head,args) ->
-                 let uu____5506 =
-                   let uu____5508 =
+                 let uu____5492 =
+                   let uu____5494 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head
                       in
-                   Prims.op_Negation uu____5508  in
-                 if uu____5506
+                   Prims.op_Negation uu____5494  in
+                 if uu____5492
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s,uu____5527));
-                         FStar_Syntax_Syntax.pos = uu____5528;
-                         FStar_Syntax_Syntax.vars = uu____5529;_},uu____5530)::[]
+                           (FStar_Const.Const_int (s,uu____5513));
+                         FStar_Syntax_Syntax.pos = uu____5514;
+                         FStar_Syntax_Syntax.vars = uu____5515;_},uu____5516)::[]
                         ->
-                        let uu____5569 =
-                          let uu____5573 = FStar_Util.int_of_string s  in
-                          FStar_Pervasives_Native.Some uu____5573  in
-                        FStar_Pervasives_Native.Some uu____5569
-                    | uu____5579 ->
+                        let uu____5555 =
+                          let uu____5559 = FStar_Util.int_of_string s  in
+                          FStar_Pervasives_Native.Some uu____5559  in
+                        FStar_Pervasives_Native.Some uu____5555
+                    | uu____5565 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None))
          in
-      let uu____5594 =
-        let uu____5596 = FStar_Options.codegen ()  in
-        uu____5596 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
-      if uu____5594
+      let uu____5580 =
+        let uu____5582 = FStar_Options.codegen ()  in
+        uu____5582 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin)  in
+      if uu____5580
       then []
       else
-        (let uu____5606 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
+        (let uu____5592 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs
             in
-         match uu____5606 with
+         match uu____5592 with
          | FStar_Pervasives_Native.None  -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1736,18 +1727,18 @@ let (maybe_register_plugin :
                        in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp  in
                     let ml_name_str =
-                      let uu____5648 =
-                        let uu____5649 = FStar_Ident.string_of_lid fv_lid  in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____5649  in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____5648  in
-                    let uu____5651 =
+                      let uu____5634 =
+                        let uu____5635 = FStar_Ident.string_of_lid fv_lid  in
+                        FStar_Extraction_ML_Syntax.MLC_String uu____5635  in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu____5634  in
+                    let uu____5637 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun g
                         fv fv_t arity_opt ml_name_str
                        in
-                    match uu____5651 with
+                    match uu____5637 with
                     | FStar_Pervasives_Native.Some
                         (interp,nbe_interp,arity,plugin) ->
-                        let uu____5684 =
+                        let uu____5670 =
                           if plugin
                           then
                             ((["FStar_Tactics_Native"], "register_plugin"),
@@ -1756,7 +1747,7 @@ let (maybe_register_plugin :
                             ((["FStar_Tactics_Native"], "register_tactic"),
                               [interp])
                            in
-                        (match uu____5684 with
+                        (match uu____5670 with
                          | (register,args) ->
                              let h =
                                FStar_All.pipe_left
@@ -1766,17 +1757,17 @@ let (maybe_register_plugin :
                                     register)
                                 in
                              let arity1 =
-                               let uu____5730 =
-                                 let uu____5731 =
-                                   let uu____5743 =
+                               let uu____5716 =
+                                 let uu____5717 =
+                                   let uu____5729 =
                                      FStar_Util.string_of_int arity  in
-                                   (uu____5743, FStar_Pervasives_Native.None)
+                                   (uu____5729, FStar_Pervasives_Native.None)
                                     in
                                  FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____5731
+                                   uu____5717
                                   in
                                FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____5730
+                                 uu____5716
                                 in
                              let app =
                                FStar_All.pipe_left
@@ -1791,7 +1782,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None  -> []  in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____5772 -> []))
+              | uu____5758 -> []))
   
 let rec (extract_sig :
   env_t ->
@@ -1802,61 +1793,61 @@ let rec (extract_sig :
     fun se  ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u  ->
-           let uu____5800 = FStar_Syntax_Print.sigelt_to_string se  in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5800);
+           let uu____5786 = FStar_Syntax_Print.sigelt_to_string se  in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5786);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____5809 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5818 ->
+       | FStar_Syntax_Syntax.Sig_bundle uu____5795 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5804 ->
            extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____5835 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu____5821 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
-           let uu____5852 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-           FStar_TypeChecker_Env.is_reifiable_effect uu____5852
+           let uu____5838 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
+           FStar_TypeChecker_Env.is_reifiable_effect uu____5838
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____5853 = extract_reifiable_effect g ed  in
-           (match uu____5853 with | (env,_iface,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____5877 ->
+           let uu____5839 = extract_reifiable_effect g ed  in
+           (match uu____5839 with | (env,_iface,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu____5863 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_fail uu____5891 ->
+       | FStar_Syntax_Syntax.Sig_fail uu____5877 ->
            failwith "impossible: trying to extract Sig_fail"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____5911 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu____5897 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid,univs,t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____5917 =
+           let uu____5903 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs t
               in
-           (match uu____5917 with | (env,uu____5933,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5942) when
+           (match uu____5903 with | (env,uu____5919,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5928) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____5951 =
+           let uu____5937 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb
               in
-           (match uu____5951 with | (env,uu____5967,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5976) when
+           (match uu____5937 with | (env,uu____5953,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true ,lbs),uu____5962) when
            FStar_Util.for_some
              (fun lb  ->
                 FStar_Extraction_ML_Term.is_arity g
                   lb.FStar_Syntax_Syntax.lbtyp) lbs
            ->
-           let uu____5989 = extract_let_rec_types se g lbs  in
-           (match uu____5989 with | (env,uu____6005,impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____6014) ->
+           let uu____5975 = extract_let_rec_types se g lbs  in
+           (match uu____5975 with | (env,uu____5991,impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____6000) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____6025 =
-             let uu____6034 =
+           let uu____6011 =
+             let uu____6020 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs
                 in
-             match uu____6034 with
+             match uu____6020 with
              | FStar_Pervasives_Native.None  ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats,(tau,FStar_Pervasives_Native.None )::uu____6063) ->
+                 (ats,(tau,FStar_Pervasives_Native.None )::uu____6049) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats,args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
@@ -1864,34 +1855,34 @@ let rec (extract_sig :
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None))
               in
-           (match uu____6025 with
+           (match uu____6011 with
             | (attrs1,post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
-                    let uu____6149 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                    let uu____6135 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                        in
-                    FStar_TypeChecker_Env.postprocess uu____6149 tau
+                    FStar_TypeChecker_Env.postprocess uu____6135 tau
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  let uu___909_6150 = lb  in
+                  let uu___909_6136 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___909_6150.FStar_Syntax_Syntax.lbname);
+                      (uu___909_6136.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___909_6150.FStar_Syntax_Syntax.lbunivs);
+                      (uu___909_6136.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___909_6150.FStar_Syntax_Syntax.lbtyp);
+                      (uu___909_6136.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___909_6150.FStar_Syntax_Syntax.lbeff);
+                      (uu___909_6136.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___909_6150.FStar_Syntax_Syntax.lbattrs);
+                      (uu___909_6136.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___909_6150.FStar_Syntax_Syntax.lbpos)
+                      (uu___909_6136.FStar_Syntax_Syntax.lbpos)
                   }  in
                 let lbs1 =
-                  let uu____6159 =
+                  let uu____6145 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
@@ -1899,324 +1890,323 @@ let rec (extract_sig :
                     | FStar_Pervasives_Native.None  ->
                         FStar_Pervasives_Native.snd lbs
                      in
-                  ((FStar_Pervasives_Native.fst lbs), uu____6159)  in
-                let uu____6177 =
-                  let uu____6184 =
+                  ((FStar_Pervasives_Native.fst lbs), uu____6145)  in
+                let uu____6163 =
+                  let uu____6170 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
-                      FStar_Pervasives_Native.None
                       se.FStar_Syntax_Syntax.sigrng
                      in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____6184  in
-                (match uu____6177 with
-                 | (ml_let,uu____6201,uu____6202) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____6170  in
+                (match uu____6163 with
+                 | (ml_let,uu____6187,uu____6188) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor,bindings),uu____6211) ->
+                          ((flavor,bindings),uu____6197) ->
                           let flags = FStar_List.choose flag_of_qual quals
                              in
                           let flags' = extract_metadata attrs1  in
-                          let uu____6228 =
+                          let uu____6214 =
                             FStar_List.fold_left2
-                              (fun uu____6254  ->
+                              (fun uu____6240  ->
                                  fun ml_lb  ->
-                                   fun uu____6256  ->
-                                     match (uu____6254, uu____6256) with
+                                   fun uu____6242  ->
+                                     match (uu____6240, uu____6242) with
                                      | ((env,ml_lbs),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbname;
                                                        FStar_Syntax_Syntax.lbunivs
-                                                         = uu____6278;
+                                                         = uu____6264;
                                                        FStar_Syntax_Syntax.lbtyp
                                                          = t;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____6280;
+                                                         = uu____6266;
                                                        FStar_Syntax_Syntax.lbdef
-                                                         = uu____6281;
+                                                         = uu____6267;
                                                        FStar_Syntax_Syntax.lbattrs
-                                                         = uu____6282;
+                                                         = uu____6268;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____6283;_})
+                                                         = uu____6269;_})
                                          ->
-                                         let uu____6308 =
+                                         let uu____6294 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased)
                                             in
-                                         if uu____6308
+                                         if uu____6294
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____6325 =
-                                                let uu____6328 =
+                                              let uu____6311 =
+                                                let uu____6314 =
                                                   FStar_Util.right lbname  in
-                                                uu____6328.FStar_Syntax_Syntax.fv_name
+                                                uu____6314.FStar_Syntax_Syntax.fv_name
                                                  in
-                                              uu____6325.FStar_Syntax_Syntax.v
+                                              uu____6311.FStar_Syntax_Syntax.v
                                                in
                                             let flags'' =
-                                              let uu____6332 =
-                                                let uu____6333 =
+                                              let uu____6318 =
+                                                let uu____6319 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____6333.FStar_Syntax_Syntax.n
+                                                uu____6319.FStar_Syntax_Syntax.n
                                                  in
-                                              match uu____6332 with
+                                              match uu____6318 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____6338,{
+                                                  (uu____6324,{
                                                                 FStar_Syntax_Syntax.n
                                                                   =
                                                                   FStar_Syntax_Syntax.Comp
                                                                   {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____6339;
+                                                                    uu____6325;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     = e;
                                                                     FStar_Syntax_Syntax.result_typ
                                                                     =
-                                                                    uu____6341;
+                                                                    uu____6327;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____6342;
+                                                                    uu____6328;
                                                                     FStar_Syntax_Syntax.flags
                                                                     =
-                                                                    uu____6343;_};
+                                                                    uu____6329;_};
                                                                 FStar_Syntax_Syntax.pos
                                                                   =
-                                                                  uu____6344;
+                                                                  uu____6330;
                                                                 FStar_Syntax_Syntax.vars
                                                                   =
-                                                                  uu____6345;_})
+                                                                  uu____6331;_})
                                                   when
-                                                  let uu____6380 =
+                                                  let uu____6366 =
                                                     FStar_Ident.string_of_lid
                                                       e
                                                      in
-                                                  uu____6380 =
+                                                  uu____6366 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____6384 -> []  in
+                                              | uu____6370 -> []  in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'')
                                                in
                                             let ml_lb1 =
-                                              let uu___957_6389 = ml_lb  in
+                                              let uu___957_6375 = ml_lb  in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___957_6389.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___957_6375.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___957_6389.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___957_6375.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___957_6389.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___957_6375.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___957_6389.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___957_6375.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___957_6389.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___957_6375.FStar_Extraction_ML_Syntax.print_typ)
                                               }  in
-                                            let uu____6390 =
-                                              let uu____6395 =
+                                            let uu____6376 =
+                                              let uu____6381 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_6402  ->
-                                                        match uu___8_6402
+                                                     (fun uu___8_6388  ->
+                                                        match uu___8_6388
                                                         with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____6404 ->
+                                                            uu____6390 ->
                                                             true
-                                                        | uu____6410 -> false))
+                                                        | uu____6396 -> false))
                                                  in
-                                              if uu____6395
+                                              if uu____6381
                                               then
-                                                let uu____6417 =
-                                                  let uu____6425 =
+                                                let uu____6403 =
+                                                  let uu____6411 =
                                                     FStar_Util.right lbname
                                                      in
-                                                  let uu____6426 =
+                                                  let uu____6412 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                      in
                                                   FStar_Extraction_ML_UEnv.extend_fv
-                                                    env uu____6425 uu____6426
+                                                    env uu____6411 uu____6412
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                    in
-                                                match uu____6417 with
-                                                | (env1,mls,uu____6433) ->
+                                                match uu____6403 with
+                                                | (env1,mls,uu____6419) ->
                                                     (env1,
-                                                      (let uu___969_6437 =
+                                                      (let uu___969_6423 =
                                                          ml_lb1  in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
                                                            = mls;
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___969_6437.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___969_6423.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___969_6437.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___969_6423.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___969_6437.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___969_6423.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___969_6437.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___969_6423.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___969_6437.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___969_6423.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____6440 =
-                                                   let uu____6448 =
+                                                (let uu____6426 =
+                                                   let uu____6434 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc
                                                       in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____6448
+                                                     env lbname t uu____6434
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit
                                                     in
-                                                 match uu____6440 with
-                                                 | (env1,uu____6454,uu____6455)
+                                                 match uu____6426 with
+                                                 | (env1,uu____6440,uu____6441)
                                                      -> (env1, ml_lb1))
                                                in
-                                            match uu____6390 with
+                                            match uu____6376 with
                                             | (g1,ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1)
                              in
-                          (match uu____6228 with
+                          (match uu____6214 with
                            | (g1,ml_lbs') ->
-                               let uu____6485 =
-                                 let uu____6488 =
-                                   let uu____6491 =
-                                     let uu____6492 =
+                               let uu____6471 =
+                                 let uu____6474 =
+                                   let uu____6477 =
+                                     let uu____6478 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng
                                         in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____6492
+                                       uu____6478
                                       in
-                                   [uu____6491;
+                                   [uu____6477;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))]
                                     in
-                                 let uu____6495 = maybe_register_plugin g1 se
+                                 let uu____6481 = maybe_register_plugin g1 se
                                     in
-                                 FStar_List.append uu____6488 uu____6495  in
-                               (g1, uu____6485))
-                      | uu____6500 ->
-                          let uu____6501 =
-                            let uu____6503 =
-                              let uu____6505 =
+                                 FStar_List.append uu____6474 uu____6481  in
+                               (g1, uu____6471))
+                      | uu____6486 ->
+                          let uu____6487 =
+                            let uu____6489 =
+                              let uu____6491 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
                               FStar_Extraction_ML_Code.string_of_mlexpr
-                                uu____6505 ml_let
+                                uu____6491 ml_let
                                in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____6503
+                              uu____6489
                              in
-                          failwith uu____6501)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____6514,t) ->
+                          failwith uu____6487)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____6500,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
-           let uu____6519 =
+           let uu____6505 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____6525 =
-                  let uu____6527 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+               (let uu____6511 =
+                  let uu____6513 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                      in
-                  FStar_TypeChecker_Util.must_erase_for_extraction uu____6527
+                  FStar_TypeChecker_Util.must_erase_for_extraction uu____6513
                     t
                    in
-                Prims.op_Negation uu____6525)
+                Prims.op_Negation uu____6511)
               in
-           if uu____6519
+           if uu____6505
            then
              let always_fail1 =
-               let uu___989_6536 = se  in
-               let uu____6537 =
-                 let uu____6538 =
-                   let uu____6545 =
-                     let uu____6546 =
-                       let uu____6549 = always_fail lid t  in [uu____6549]
+               let uu___989_6522 = se  in
+               let uu____6523 =
+                 let uu____6524 =
+                   let uu____6531 =
+                     let uu____6532 =
+                       let uu____6535 = always_fail lid t  in [uu____6535]
                         in
-                     (false, uu____6546)  in
-                   (uu____6545, [])  in
-                 FStar_Syntax_Syntax.Sig_let uu____6538  in
+                     (false, uu____6532)  in
+                   (uu____6531, [])  in
+                 FStar_Syntax_Syntax.Sig_let uu____6524  in
                {
-                 FStar_Syntax_Syntax.sigel = uu____6537;
+                 FStar_Syntax_Syntax.sigel = uu____6523;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___989_6536.FStar_Syntax_Syntax.sigrng);
+                   (uu___989_6522.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___989_6536.FStar_Syntax_Syntax.sigquals);
+                   (uu___989_6522.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___989_6536.FStar_Syntax_Syntax.sigmeta);
+                   (uu___989_6522.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___989_6536.FStar_Syntax_Syntax.sigattrs);
+                   (uu___989_6522.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___989_6536.FStar_Syntax_Syntax.sigopts)
+                   (uu___989_6522.FStar_Syntax_Syntax.sigopts)
                }  in
-             let uu____6556 = extract_sig g always_fail1  in
-             (match uu____6556 with
+             let uu____6542 = extract_sig g always_fail1  in
+             (match uu____6542 with
               | (g1,mlm) ->
-                  let uu____6575 =
+                  let uu____6561 =
                     FStar_Util.find_map quals
-                      (fun uu___9_6580  ->
-                         match uu___9_6580 with
+                      (fun uu___9_6566  ->
+                         match uu___9_6566 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____6584 -> FStar_Pervasives_Native.None)
+                         | uu____6570 -> FStar_Pervasives_Native.None)
                      in
-                  (match uu____6575 with
+                  (match uu____6561 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____6592 =
-                         let uu____6595 =
-                           let uu____6596 =
+                       let uu____6578 =
+                         let uu____6581 =
+                           let uu____6582 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng
                               in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6596  in
-                         let uu____6597 =
-                           let uu____6600 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6582  in
+                         let uu____6583 =
+                           let uu____6586 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l
                               in
-                           [uu____6600]  in
-                         uu____6595 :: uu____6597  in
-                       (g1, uu____6592)
-                   | uu____6603 ->
-                       let uu____6606 =
+                           [uu____6586]  in
+                         uu____6581 :: uu____6583  in
+                       (g1, uu____6578)
+                   | uu____6589 ->
+                       let uu____6592 =
                          FStar_Util.find_map quals
-                           (fun uu___10_6612  ->
-                              match uu___10_6612 with
-                              | FStar_Syntax_Syntax.Projector (l,uu____6616)
+                           (fun uu___10_6598  ->
+                              match uu___10_6598 with
+                              | FStar_Syntax_Syntax.Projector (l,uu____6602)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____6617 -> FStar_Pervasives_Native.None)
+                              | uu____6603 -> FStar_Pervasives_Native.None)
                           in
-                       (match uu____6606 with
-                        | FStar_Pervasives_Native.Some uu____6624 -> (g1, [])
-                        | uu____6627 -> (g1, mlm))))
+                       (match uu____6592 with
+                        | FStar_Pervasives_Native.Some uu____6610 -> (g1, [])
+                        | uu____6613 -> (g1, mlm))))
            else (g, [])
-       | FStar_Syntax_Syntax.Sig_assume uu____6636 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____6645 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6648 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6663 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_assume uu____6622 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____6631 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6634 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6649 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2229,75 +2219,75 @@ let (extract' :
   =
   fun g  ->
     fun m  ->
-      let uu____6703 = FStar_Options.restore_cmd_line_options true  in
-      let uu____6705 =
+      let uu____6689 = FStar_Options.restore_cmd_line_options true  in
+      let uu____6691 =
         FStar_Extraction_ML_UEnv.extend_with_module_name g
           m.FStar_Syntax_Syntax.name
          in
-      match uu____6705 with
+      match uu____6691 with
       | (name,g1) ->
           let g2 =
-            let uu____6719 =
-              let uu____6720 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
-              FStar_TypeChecker_Env.set_current_module uu____6720
+            let uu____6705 =
+              let uu____6706 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1  in
+              FStar_TypeChecker_Env.set_current_module uu____6706
                 m.FStar_Syntax_Syntax.name
                in
-            FStar_Extraction_ML_UEnv.set_tcenv g1 uu____6719  in
+            FStar_Extraction_ML_UEnv.set_tcenv g1 uu____6705  in
           let g3 = FStar_Extraction_ML_UEnv.set_current_module g2 name  in
-          let uu____6722 =
+          let uu____6708 =
             FStar_Util.fold_map
               (fun g4  ->
                  fun se  ->
-                   let uu____6741 =
-                     let uu____6743 =
+                   let uu____6727 =
+                     let uu____6729 =
                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
                         in
-                     FStar_Options.debug_module uu____6743  in
-                   if uu____6741
+                     FStar_Options.debug_module uu____6729  in
+                   if uu____6727
                    then
                      let nm =
-                       let uu____6754 =
+                       let uu____6740 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.lids_of_sigelt se)
                            (FStar_List.map FStar_Ident.string_of_lid)
                           in
-                       FStar_All.pipe_right uu____6754
+                       FStar_All.pipe_right uu____6740
                          (FStar_String.concat ", ")
                         in
                      (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                      (let uu____6771 =
+                      (let uu____6757 =
                          FStar_Util.format1 "---Extracted {%s}" nm  in
-                       FStar_Util.measure_execution_time uu____6771
-                         (fun uu____6781  -> extract_sig g4 se)))
+                       FStar_Util.measure_execution_time uu____6757
+                         (fun uu____6767  -> extract_sig g4 se)))
                    else extract_sig g4 se) g3
               m.FStar_Syntax_Syntax.declarations
              in
-          (match uu____6722 with
+          (match uu____6708 with
            | (g4,sigs) ->
                let mlm = FStar_List.flatten sigs  in
                let is_kremlin =
-                 let uu____6803 = FStar_Options.codegen ()  in
-                 uu____6803 =
+                 let uu____6789 = FStar_Options.codegen ()  in
+                 uu____6789 =
                    (FStar_Pervasives_Native.Some FStar_Options.Kremlin)
                   in
-               let uu____6808 =
-                 (let uu____6812 =
+               let uu____6794 =
+                 (let uu____6798 =
                     FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-                  uu____6812 <> "Prims") &&
+                  uu____6798 <> "Prims") &&
                    (is_kremlin ||
                       (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
                   in
-               if uu____6808
+               if uu____6794
                then
-                 ((let uu____6824 =
-                     let uu____6826 = FStar_Options.silent ()  in
-                     Prims.op_Negation uu____6826  in
-                   if uu____6824
+                 ((let uu____6810 =
+                     let uu____6812 = FStar_Options.silent ()  in
+                     Prims.op_Negation uu____6812  in
+                   if uu____6810
                    then
-                     let uu____6829 =
+                     let uu____6815 =
                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
                         in
-                     FStar_Util.print1 "Extracted module %s\n" uu____6829
+                     FStar_Util.print1 "Extracted module %s\n" uu____6815
                    else ());
                   (g4,
                     (FStar_Pervasives_Native.Some
@@ -2314,50 +2304,50 @@ let (extract :
   =
   fun g  ->
     fun m  ->
-      (let uu____6904 = FStar_Options.restore_cmd_line_options true  in
-       FStar_All.pipe_left (fun uu____6906  -> ()) uu____6904);
-      (let uu____6908 =
-         let uu____6910 =
-           let uu____6912 =
+      (let uu____6890 = FStar_Options.restore_cmd_line_options true  in
+       FStar_All.pipe_left (fun uu____6892  -> ()) uu____6890);
+      (let uu____6894 =
+         let uu____6896 =
+           let uu____6898 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-           FStar_Options.should_extract uu____6912  in
-         Prims.op_Negation uu____6910  in
-       if uu____6908
+           FStar_Options.should_extract uu____6898  in
+         Prims.op_Negation uu____6896  in
+       if uu____6894
        then
-         let uu____6915 =
-           let uu____6917 =
+         let uu____6901 =
+           let uu____6903 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____6917
+             uu____6903
             in
-         failwith uu____6915
+         failwith uu____6901
        else ());
-      (let uu____6922 = FStar_Options.interactive ()  in
-       if uu____6922
+      (let uu____6908 = FStar_Options.interactive ()  in
+       if uu____6908
        then (g, FStar_Pervasives_Native.None)
        else
-         (let uu____6935 =
+         (let uu____6921 =
             FStar_Syntax_Unionfind.with_uf_enabled
-              (fun uu____6951  ->
-                 let uu____6952 = FStar_Options.debug_any ()  in
-                 if uu____6952
+              (fun uu____6937  ->
+                 let uu____6938 = FStar_Options.debug_any ()  in
+                 if uu____6938
                  then
                    let msg =
-                     let uu____6963 =
+                     let uu____6949 =
                        FStar_Syntax_Print.lid_to_string
                          m.FStar_Syntax_Syntax.name
                         in
-                     FStar_Util.format1 "Extracting module %s" uu____6963  in
+                     FStar_Util.format1 "Extracting module %s" uu____6949  in
                    FStar_Util.measure_execution_time msg
-                     (fun uu____6973  -> extract' g m)
+                     (fun uu____6959  -> extract' g m)
                  else extract' g m)
              in
-          match uu____6935 with
+          match uu____6921 with
           | (g1,mllib) ->
-              ((let uu____6989 = FStar_Options.restore_cmd_line_options true
+              ((let uu____6975 = FStar_Options.restore_cmd_line_options true
                    in
-                FStar_All.pipe_left (fun uu____6991  -> ()) uu____6989);
-               (let uu____6992 = FStar_Extraction_ML_UEnv.exit_module g1  in
-                (uu____6992, mllib)))))
+                FStar_All.pipe_left (fun uu____6977  -> ()) uu____6975);
+               (let uu____6978 = FStar_Extraction_ML_UEnv.exit_module g1  in
+                (uu____6978, mllib)))))
   

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -1163,7 +1163,7 @@ let rec (translate_term_to_mlty :
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_app
                          (head1, (FStar_List.append args' args)))
-                      FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
+                      t1.FStar_Syntax_Syntax.pos
                      in
                   translate_term_to_mlty env uu____3856
               | uu____3877 -> FStar_Extraction_ML_Syntax.MLTY_Top  in
@@ -2265,7 +2265,6 @@ let (extract_lb_sig :
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_app
                                          (lbdef1, args))
-                                      FStar_Pervasives_Native.None
                                       lbdef1.FStar_Syntax_Syntax.pos
                                      in
                                   (lbname_, f_e,
@@ -2313,7 +2312,6 @@ let (extract_lb_sig :
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_app
                                          (lbdef1, args))
-                                      FStar_Pervasives_Native.None
                                       lbdef1.FStar_Syntax_Syntax.pos
                                      in
                                   (lbname_, f_e,
@@ -2361,7 +2359,6 @@ let (extract_lb_sig :
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_app
                                          (lbdef1, args))
-                                      FStar_Pervasives_Native.None
                                       lbdef1.FStar_Syntax_Syntax.pos
                                      in
                                   (lbname_, f_e,
@@ -2959,21 +2956,18 @@ and (term_as_mlexpr' :
                     FStar_TypeChecker_Env.Unascribe] head uu____10355
                    in
                 let tm =
-                  let uu____10367 =
-                    let uu____10372 = FStar_TypeChecker_Util.remove_reify e
-                       in
-                    let uu____10373 = FStar_List.tl args  in
-                    FStar_Syntax_Syntax.mk_Tm_app uu____10372 uu____10373  in
-                  uu____10367 FStar_Pervasives_Native.None
+                  let uu____10365 = FStar_TypeChecker_Util.remove_reify e  in
+                  let uu____10366 = FStar_List.tl args  in
+                  FStar_Syntax_Syntax.mk_Tm_app uu____10365 uu____10366
                     t.FStar_Syntax_Syntax.pos
                    in
                 term_as_mlexpr g tm
-            | uu____10382 ->
-                let rec extract_app is_data uu____10431 uu____10432 restArgs
+            | uu____10375 ->
+                let rec extract_app is_data uu____10424 uu____10425 restArgs
                   =
-                  match (uu____10431, uu____10432) with
+                  match (uu____10424, uu____10425) with
                   | ((mlhead,mlargs_f),(f,t1)) ->
-                      let mk_head uu____10513 =
+                      let mk_head uu____10506 =
                         let mlargs =
                           FStar_All.pipe_right (FStar_List.rev mlargs_f)
                             (FStar_List.map FStar_Pervasives_Native.fst)
@@ -2984,89 +2978,89 @@ and (term_as_mlexpr' :
                              (mlhead, mlargs))
                          in
                       (FStar_Extraction_ML_UEnv.debug g
-                         (fun uu____10540  ->
-                            let uu____10541 =
-                              let uu____10543 =
+                         (fun uu____10533  ->
+                            let uu____10534 =
+                              let uu____10536 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
-                              let uu____10544 = mk_head ()  in
+                              let uu____10537 = mk_head ()  in
                               FStar_Extraction_ML_Code.string_of_mlexpr
-                                uu____10543 uu____10544
+                                uu____10536 uu____10537
                                in
-                            let uu____10545 =
-                              let uu____10547 =
+                            let uu____10538 =
+                              let uu____10540 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
                               FStar_Extraction_ML_Code.string_of_mlty
-                                uu____10547 t1
+                                uu____10540 t1
                                in
-                            let uu____10548 =
+                            let uu____10541 =
                               match restArgs with
                               | [] -> "none"
-                              | (hd,uu____10559)::uu____10560 ->
+                              | (hd,uu____10552)::uu____10553 ->
                                   FStar_Syntax_Print.term_to_string hd
                                in
                             FStar_Util.print3
                               "extract_app ml_head=%s type of head = %s, next arg = %s\n"
-                              uu____10541 uu____10545 uu____10548);
+                              uu____10534 uu____10538 uu____10541);
                        (match (restArgs, t1) with
-                        | ([],uu____10594) ->
+                        | ([],uu____10587) ->
                             let app =
-                              let uu____10610 = mk_head ()  in
+                              let uu____10603 = mk_head ()  in
                               maybe_eta_data_and_project_record g is_data t1
-                                uu____10610
+                                uu____10603
                                in
                             (app, f, t1)
-                        | ((arg,uu____10612)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                        | ((arg,uu____10605)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (formal_t,f',t2)) when
                             (is_type g arg) &&
                               (type_leq g formal_t
                                  FStar_Extraction_ML_Syntax.ml_unit_ty)
                             ->
-                            let uu____10643 =
-                              let uu____10648 =
+                            let uu____10636 =
+                              let uu____10641 =
                                 FStar_Extraction_ML_Util.join
                                   arg.FStar_Syntax_Syntax.pos f f'
                                  in
-                              (uu____10648, t2)  in
+                              (uu____10641, t2)  in
                             extract_app is_data
                               (mlhead,
                                 ((FStar_Extraction_ML_Syntax.ml_unit,
                                    FStar_Extraction_ML_Syntax.E_PURE) ::
-                                mlargs_f)) uu____10643 rest
-                        | ((e0,uu____10660)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                mlargs_f)) uu____10636 rest
+                        | ((e0,uu____10653)::rest,FStar_Extraction_ML_Syntax.MLTY_Fun
                            (tExpected,f',t2)) ->
                             let r = e0.FStar_Syntax_Syntax.pos  in
                             let expected_effect =
-                              let uu____10693 =
+                              let uu____10686 =
                                 (FStar_Options.lax ()) &&
                                   (FStar_TypeChecker_Util.short_circuit_head
                                      head)
                                  in
-                              if uu____10693
+                              if uu____10686
                               then FStar_Extraction_ML_Syntax.E_IMPURE
                               else FStar_Extraction_ML_Syntax.E_PURE  in
-                            let uu____10698 =
+                            let uu____10691 =
                               check_term_as_mlexpr g e0 expected_effect
                                 tExpected
                                in
-                            (match uu____10698 with
+                            (match uu____10691 with
                              | (e01,tInferred) ->
-                                 let uu____10711 =
-                                   let uu____10716 =
+                                 let uu____10704 =
+                                   let uu____10709 =
                                      FStar_Extraction_ML_Util.join_l r
                                        [f; f']
                                       in
-                                   (uu____10716, t2)  in
+                                   (uu____10709, t2)  in
                                  extract_app is_data
                                    (mlhead, ((e01, expected_effect) ::
-                                     mlargs_f)) uu____10711 rest)
-                        | uu____10727 ->
-                            let uu____10740 =
+                                     mlargs_f)) uu____10704 rest)
+                        | uu____10720 ->
+                            let uu____10733 =
                               FStar_Extraction_ML_Util.udelta_unfold g t1  in
-                            (match uu____10740 with
+                            (match uu____10733 with
                              | FStar_Pervasives_Native.Some t2 ->
                                  extract_app is_data (mlhead, mlargs_f)
                                    (f, t2) restArgs
@@ -3110,7 +3104,7 @@ and (term_as_mlexpr' :
                                          in
                                       extract_app is_data (mlhead1, [])
                                         (f, t2) restArgs
-                                  | uu____10812 ->
+                                  | uu____10805 ->
                                       let mlhead1 =
                                         let mlargs =
                                           FStar_All.pipe_right
@@ -3134,128 +3128,128 @@ and (term_as_mlexpr' :
                                       err_ill_typed_application g top1
                                         mlhead1 restArgs t1))))
                    in
-                let extract_app_maybe_projector is_data mlhead uu____10883
+                let extract_app_maybe_projector is_data mlhead uu____10876
                   args1 =
-                  match uu____10883 with
+                  match uu____10876 with
                   | (f,t1) ->
                       (match is_data with
                        | FStar_Pervasives_Native.Some
-                           (FStar_Syntax_Syntax.Record_projector uu____10913)
+                           (FStar_Syntax_Syntax.Record_projector uu____10906)
                            ->
                            let rec remove_implicits args2 f1 t2 =
                              match (args2, t2) with
                              | ((a0,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____10997))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
-                                (uu____10999,f',t3)) ->
-                                 let uu____11037 =
+                                 (FStar_Syntax_Syntax.Implicit uu____10990))::args3,FStar_Extraction_ML_Syntax.MLTY_Fun
+                                (uu____10992,f',t3)) ->
+                                 let uu____11030 =
                                    FStar_Extraction_ML_Util.join
                                      a0.FStar_Syntax_Syntax.pos f1 f'
                                     in
-                                 remove_implicits args3 uu____11037 t3
-                             | uu____11038 -> (args2, f1, t2)  in
-                           let uu____11063 = remove_implicits args1 f t1  in
-                           (match uu____11063 with
+                                 remove_implicits args3 uu____11030 t3
+                             | uu____11031 -> (args2, f1, t2)  in
+                           let uu____11056 = remove_implicits args1 f t1  in
+                           (match uu____11056 with
                             | (args2,f1,t2) ->
                                 extract_app is_data (mlhead, []) (f1, t2)
                                   args2)
-                       | uu____11119 ->
+                       | uu____11112 ->
                            extract_app is_data (mlhead, []) (f, t1) args1)
                    in
-                let extract_app_with_instantiations uu____11143 =
+                let extract_app_with_instantiations uu____11136 =
                   let head1 = FStar_Syntax_Util.un_uinst head  in
                   match head1.FStar_Syntax_Syntax.n with
-                  | FStar_Syntax_Syntax.Tm_name uu____11151 ->
-                      let uu____11152 =
-                        let uu____11167 =
+                  | FStar_Syntax_Syntax.Tm_name uu____11144 ->
+                      let uu____11145 =
+                        let uu____11160 =
                           FStar_Extraction_ML_UEnv.lookup_term g head1  in
-                        match uu____11167 with
+                        match uu____11160 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____11199  ->
-                                  let uu____11200 =
+                               (fun uu____11192  ->
+                                  let uu____11193 =
                                     FStar_Syntax_Print.term_to_string head1
                                      in
-                                  let uu____11202 =
-                                    let uu____11204 =
+                                  let uu____11195 =
+                                    let uu____11197 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlexpr
-                                      uu____11204
+                                      uu____11197
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____11205 =
-                                    let uu____11207 =
+                                  let uu____11198 =
+                                    let uu____11200 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlty
-                                      uu____11207
+                                      uu____11200
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
                                   FStar_Util.print3
                                     "@@@looked up %s: got %s at %s\n"
-                                    uu____11200 uu____11202 uu____11205);
+                                    uu____11193 uu____11195 uu____11198);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)),
                                q))
-                        | uu____11223 -> failwith "FIXME Ty"  in
-                      (match uu____11152 with
+                        | uu____11216 -> failwith "FIXME Ty"  in
+                      (match uu____11145 with
                        | ((head_ml,(vars,t1)),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____11275)::uu____11276 -> is_type g a
-                             | uu____11303 -> false  in
-                           let uu____11315 =
+                             | (a,uu____11268)::uu____11269 -> is_type g a
+                             | uu____11296 -> false  in
+                           let uu____11308 =
                              let n = FStar_List.length vars  in
-                             let uu____11332 =
+                             let uu____11325 =
                                if (FStar_List.length args) <= n
                                then
-                                 let uu____11370 =
+                                 let uu____11363 =
                                    FStar_List.map
-                                     (fun uu____11382  ->
-                                        match uu____11382 with
-                                        | (x,uu____11390) -> term_as_mlty g x)
+                                     (fun uu____11375  ->
+                                        match uu____11375 with
+                                        | (x,uu____11383) -> term_as_mlty g x)
                                      args
                                     in
-                                 (uu____11370, [])
+                                 (uu____11363, [])
                                else
-                                 (let uu____11413 = FStar_Util.first_N n args
+                                 (let uu____11406 = FStar_Util.first_N n args
                                      in
-                                  match uu____11413 with
+                                  match uu____11406 with
                                   | (prefix,rest) ->
-                                      let uu____11502 =
+                                      let uu____11495 =
                                         FStar_List.map
-                                          (fun uu____11514  ->
-                                             match uu____11514 with
-                                             | (x,uu____11522) ->
+                                          (fun uu____11507  ->
+                                             match uu____11507 with
+                                             | (x,uu____11515) ->
                                                  term_as_mlty g x) prefix
                                          in
-                                      (uu____11502, rest))
+                                      (uu____11495, rest))
                                 in
-                             match uu____11332 with
+                             match uu____11325 with
                              | (provided_type_args,rest) ->
-                                 let uu____11573 =
+                                 let uu____11566 =
                                    match head_ml.FStar_Extraction_ML_Syntax.expr
                                    with
                                    | FStar_Extraction_ML_Syntax.MLE_Name
-                                       uu____11582 ->
-                                       let uu____11583 =
+                                       uu____11575 ->
+                                       let uu____11576 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____11583 with
-                                        | (head2,uu____11595,t2) ->
+                                       (match uu____11576 with
+                                        | (head2,uu____11588,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_Var
-                                       uu____11597 ->
-                                       let uu____11599 =
+                                       uu____11590 ->
+                                       let uu____11592 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____11599 with
-                                        | (head2,uu____11611,t2) ->
+                                       (match uu____11592 with
+                                        | (head2,uu____11604,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_App
                                        (head2,{
@@ -3265,17 +3259,17 @@ and (term_as_mlexpr' :
                                                   (FStar_Extraction_ML_Syntax.MLC_Unit
                                                   );
                                                 FStar_Extraction_ML_Syntax.mlty
-                                                  = uu____11614;
+                                                  = uu____11607;
                                                 FStar_Extraction_ML_Syntax.loc
-                                                  = uu____11615;_}::[])
+                                                  = uu____11608;_}::[])
                                        ->
-                                       let uu____11618 =
+                                       let uu____11611 =
                                          instantiate_maybe_partial g head2
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____11618 with
-                                        | (head3,uu____11630,t2) ->
-                                            let uu____11632 =
+                                       (match uu____11611 with
+                                        | (head3,uu____11623,t2) ->
+                                            let uu____11625 =
                                               FStar_All.pipe_right
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
@@ -3283,122 +3277,122 @@ and (term_as_mlexpr' :
                                                 (FStar_Extraction_ML_Syntax.with_ty
                                                    t2)
                                                in
-                                            (uu____11632, t2))
-                                   | uu____11635 ->
+                                            (uu____11625, t2))
+                                   | uu____11628 ->
                                        failwith
                                          "Impossible: Unexpected head term"
                                     in
-                                 (match uu____11573 with
+                                 (match uu____11566 with
                                   | (head2,t2) -> (head2, t2, rest))
                               in
-                           (match uu____11315 with
+                           (match uu____11308 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____11702 =
+                                     let uu____11695 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____11702,
+                                     (uu____11695,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____11703 ->
+                                 | uu____11696 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | FStar_Syntax_Syntax.Tm_fvar uu____11712 ->
-                      let uu____11713 =
-                        let uu____11728 =
+                  | FStar_Syntax_Syntax.Tm_fvar uu____11705 ->
+                      let uu____11706 =
+                        let uu____11721 =
                           FStar_Extraction_ML_UEnv.lookup_term g head1  in
-                        match uu____11728 with
+                        match uu____11721 with
                         | (FStar_Util.Inr exp_b,q) ->
                             (FStar_Extraction_ML_UEnv.debug g
-                               (fun uu____11760  ->
-                                  let uu____11761 =
+                               (fun uu____11753  ->
+                                  let uu____11754 =
                                     FStar_Syntax_Print.term_to_string head1
                                      in
-                                  let uu____11763 =
-                                    let uu____11765 =
+                                  let uu____11756 =
+                                    let uu____11758 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlexpr
-                                      uu____11765
+                                      uu____11758
                                       exp_b.FStar_Extraction_ML_UEnv.exp_b_expr
                                      in
-                                  let uu____11766 =
-                                    let uu____11768 =
+                                  let uu____11759 =
+                                    let uu____11761 =
                                       FStar_Extraction_ML_UEnv.current_module_of_uenv
                                         g
                                        in
                                     FStar_Extraction_ML_Code.string_of_mlty
-                                      uu____11768
+                                      uu____11761
                                       (FStar_Pervasives_Native.snd
                                          exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)
                                      in
                                   FStar_Util.print3
                                     "@@@looked up %s: got %s at %s\n"
-                                    uu____11761 uu____11763 uu____11766);
+                                    uu____11754 uu____11756 uu____11759);
                              (((exp_b.FStar_Extraction_ML_UEnv.exp_b_expr),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme)),
                                q))
-                        | uu____11784 -> failwith "FIXME Ty"  in
-                      (match uu____11713 with
+                        | uu____11777 -> failwith "FIXME Ty"  in
+                      (match uu____11706 with
                        | ((head_ml,(vars,t1)),qual) ->
                            let has_typ_apps =
                              match args with
-                             | (a,uu____11836)::uu____11837 -> is_type g a
-                             | uu____11864 -> false  in
-                           let uu____11876 =
+                             | (a,uu____11829)::uu____11830 -> is_type g a
+                             | uu____11857 -> false  in
+                           let uu____11869 =
                              let n = FStar_List.length vars  in
-                             let uu____11893 =
+                             let uu____11886 =
                                if (FStar_List.length args) <= n
                                then
-                                 let uu____11931 =
+                                 let uu____11924 =
                                    FStar_List.map
-                                     (fun uu____11943  ->
-                                        match uu____11943 with
-                                        | (x,uu____11951) -> term_as_mlty g x)
+                                     (fun uu____11936  ->
+                                        match uu____11936 with
+                                        | (x,uu____11944) -> term_as_mlty g x)
                                      args
                                     in
-                                 (uu____11931, [])
+                                 (uu____11924, [])
                                else
-                                 (let uu____11974 = FStar_Util.first_N n args
+                                 (let uu____11967 = FStar_Util.first_N n args
                                      in
-                                  match uu____11974 with
+                                  match uu____11967 with
                                   | (prefix,rest) ->
-                                      let uu____12063 =
+                                      let uu____12056 =
                                         FStar_List.map
-                                          (fun uu____12075  ->
-                                             match uu____12075 with
-                                             | (x,uu____12083) ->
+                                          (fun uu____12068  ->
+                                             match uu____12068 with
+                                             | (x,uu____12076) ->
                                                  term_as_mlty g x) prefix
                                          in
-                                      (uu____12063, rest))
+                                      (uu____12056, rest))
                                 in
-                             match uu____11893 with
+                             match uu____11886 with
                              | (provided_type_args,rest) ->
-                                 let uu____12134 =
+                                 let uu____12127 =
                                    match head_ml.FStar_Extraction_ML_Syntax.expr
                                    with
                                    | FStar_Extraction_ML_Syntax.MLE_Name
-                                       uu____12143 ->
-                                       let uu____12144 =
+                                       uu____12136 ->
+                                       let uu____12137 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____12144 with
-                                        | (head2,uu____12156,t2) ->
+                                       (match uu____12137 with
+                                        | (head2,uu____12149,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_Var
-                                       uu____12158 ->
-                                       let uu____12160 =
+                                       uu____12151 ->
+                                       let uu____12153 =
                                          instantiate_maybe_partial g head_ml
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____12160 with
-                                        | (head2,uu____12172,t2) ->
+                                       (match uu____12153 with
+                                        | (head2,uu____12165,t2) ->
                                             (head2, t2))
                                    | FStar_Extraction_ML_Syntax.MLE_App
                                        (head2,{
@@ -3408,17 +3402,17 @@ and (term_as_mlexpr' :
                                                   (FStar_Extraction_ML_Syntax.MLC_Unit
                                                   );
                                                 FStar_Extraction_ML_Syntax.mlty
-                                                  = uu____12175;
+                                                  = uu____12168;
                                                 FStar_Extraction_ML_Syntax.loc
-                                                  = uu____12176;_}::[])
+                                                  = uu____12169;_}::[])
                                        ->
-                                       let uu____12179 =
+                                       let uu____12172 =
                                          instantiate_maybe_partial g head2
                                            (vars, t1) provided_type_args
                                           in
-                                       (match uu____12179 with
-                                        | (head3,uu____12191,t2) ->
-                                            let uu____12193 =
+                                       (match uu____12172 with
+                                        | (head3,uu____12184,t2) ->
+                                            let uu____12186 =
                                               FStar_All.pipe_right
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
@@ -3426,93 +3420,93 @@ and (term_as_mlexpr' :
                                                 (FStar_Extraction_ML_Syntax.with_ty
                                                    t2)
                                                in
-                                            (uu____12193, t2))
-                                   | uu____12196 ->
+                                            (uu____12186, t2))
+                                   | uu____12189 ->
                                        failwith
                                          "Impossible: Unexpected head term"
                                     in
-                                 (match uu____12134 with
+                                 (match uu____12127 with
                                   | (head2,t2) -> (head2, t2, rest))
                               in
-                           (match uu____11876 with
+                           (match uu____11869 with
                             | (head_ml1,head_t,args1) ->
                                 (match args1 with
                                  | [] ->
-                                     let uu____12263 =
+                                     let uu____12256 =
                                        maybe_eta_data_and_project_record g
                                          qual head_t head_ml1
                                         in
-                                     (uu____12263,
+                                     (uu____12256,
                                        FStar_Extraction_ML_Syntax.E_PURE,
                                        head_t)
-                                 | uu____12264 ->
+                                 | uu____12257 ->
                                      extract_app_maybe_projector qual
                                        head_ml1
                                        (FStar_Extraction_ML_Syntax.E_PURE,
                                          head_t) args1)))
-                  | uu____12273 ->
-                      let uu____12274 = term_as_mlexpr g head1  in
-                      (match uu____12274 with
+                  | uu____12266 ->
+                      let uu____12267 = term_as_mlexpr g head1  in
+                      (match uu____12267 with
                        | (head2,f,t1) ->
                            extract_app_maybe_projector
                              FStar_Pervasives_Native.None head2 (f, t1) args)
                    in
-                let uu____12290 = is_type g t  in
-                if uu____12290
+                let uu____12283 = is_type g t  in
+                if uu____12283
                 then
                   (FStar_Extraction_ML_Syntax.ml_unit,
                     FStar_Extraction_ML_Syntax.E_PURE,
                     FStar_Extraction_ML_Syntax.ml_unit_ty)
                 else
-                  (let uu____12301 =
-                     let uu____12302 = FStar_Syntax_Util.un_uinst head  in
-                     uu____12302.FStar_Syntax_Syntax.n  in
-                   match uu____12301 with
+                  (let uu____12294 =
+                     let uu____12295 = FStar_Syntax_Util.un_uinst head  in
+                     uu____12295.FStar_Syntax_Syntax.n  in
+                   match uu____12294 with
                    | FStar_Syntax_Syntax.Tm_fvar fv ->
-                       let uu____12312 =
+                       let uu____12305 =
                          FStar_Extraction_ML_UEnv.try_lookup_fv g fv  in
-                       (match uu____12312 with
+                       (match uu____12305 with
                         | FStar_Pervasives_Native.None  ->
                             (FStar_Extraction_ML_Syntax.ml_unit,
                               FStar_Extraction_ML_Syntax.E_PURE,
                               FStar_Extraction_ML_Syntax.MLTY_Erased)
-                        | uu____12321 -> extract_app_with_instantiations ())
-                   | uu____12324 -> extract_app_with_instantiations ()))
-       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____12327),f) ->
+                        | uu____12314 -> extract_app_with_instantiations ())
+                   | uu____12317 -> extract_app_with_instantiations ()))
+       | FStar_Syntax_Syntax.Tm_ascribed (e0,(tc,uu____12320),f) ->
            let t1 =
              match tc with
              | FStar_Util.Inl t1 -> term_as_mlty g t1
              | FStar_Util.Inr c ->
-                 let uu____12392 =
-                   let uu____12393 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
+                 let uu____12385 =
+                   let uu____12386 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g
                       in
-                   maybe_reify_comp g uu____12393 c  in
-                 term_as_mlty g uu____12392
+                   maybe_reify_comp g uu____12386 c  in
+                 term_as_mlty g uu____12385
               in
            let f1 =
              match f with
              | FStar_Pervasives_Native.None  ->
                  failwith "Ascription node with an empty effect label"
              | FStar_Pervasives_Native.Some l -> effect_as_etag g l  in
-           let uu____12397 = check_term_as_mlexpr g e0 f1 t1  in
-           (match uu____12397 with | (e,t2) -> (e, f1, t2))
+           let uu____12390 = check_term_as_mlexpr g e0 f1 t1  in
+           (match uu____12390 with | (e,t2) -> (e, f1, t2))
        | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e') when
-           (let uu____12429 = FStar_Syntax_Syntax.is_top_level [lb]  in
-            Prims.op_Negation uu____12429) &&
-             (let uu____12432 =
+           (let uu____12422 = FStar_Syntax_Syntax.is_top_level [lb]  in
+            Prims.op_Negation uu____12422) &&
+             (let uu____12425 =
                 FStar_Syntax_Util.get_attribute
                   FStar_Parser_Const.rename_let_attr
                   lb.FStar_Syntax_Syntax.lbattrs
                  in
-              FStar_Util.is_some uu____12432)
+              FStar_Util.is_some uu____12425)
            ->
            let b =
-             let uu____12442 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname
+             let uu____12435 = FStar_Util.left lb.FStar_Syntax_Syntax.lbname
                 in
-             (uu____12442, FStar_Pervasives_Native.None)  in
-           let uu____12445 = FStar_Syntax_Subst.open_term_1 b e'  in
-           (match uu____12445 with
-            | ((x,uu____12457),body) ->
+             (uu____12435, FStar_Pervasives_Native.None)  in
+           let uu____12438 = FStar_Syntax_Subst.open_term_1 b e'  in
+           (match uu____12438 with
+            | ((x,uu____12450),body) ->
                 let suggested_name =
                   let attr =
                     FStar_Syntax_Util.get_attribute
@@ -3520,19 +3514,19 @@ and (term_as_mlexpr' :
                       lb.FStar_Syntax_Syntax.lbattrs
                      in
                   match attr with
-                  | FStar_Pervasives_Native.Some ((str,uu____12472)::[]) ->
-                      let uu____12497 =
-                        let uu____12498 = FStar_Syntax_Subst.compress str  in
-                        uu____12498.FStar_Syntax_Syntax.n  in
-                      (match uu____12497 with
+                  | FStar_Pervasives_Native.Some ((str,uu____12465)::[]) ->
+                      let uu____12490 =
+                        let uu____12491 = FStar_Syntax_Subst.compress str  in
+                        uu____12491.FStar_Syntax_Syntax.n  in
+                      (match uu____12490 with
                        | FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_string (s,uu____12504)) ->
+                           (FStar_Const.Const_string (s,uu____12497)) ->
                            let id =
-                             let uu____12508 =
-                               let uu____12514 =
+                             let uu____12501 =
+                               let uu____12507 =
                                  FStar_Syntax_Syntax.range_of_bv x  in
-                               (s, uu____12514)  in
-                             FStar_Ident.mk_ident uu____12508  in
+                               (s, uu____12507)  in
+                             FStar_Ident.mk_ident uu____12501  in
                            let bv =
                              {
                                FStar_Syntax_Syntax.ppname = id;
@@ -3542,8 +3536,8 @@ and (term_as_mlexpr' :
                              }  in
                            let bv1 = FStar_Syntax_Syntax.freshen_bv bv  in
                            FStar_Pervasives_Native.Some bv1
-                       | uu____12519 -> FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some uu____12520 ->
+                       | uu____12512 -> FStar_Pervasives_Native.None)
+                  | FStar_Pervasives_Native.Some uu____12513 ->
                       (FStar_Errors.log_issue top1.FStar_Syntax_Syntax.pos
                          (FStar_Errors.Warning_UnrecognizedAttribute,
                            "Ill-formed application of `rename_let`");
@@ -3552,18 +3546,18 @@ and (term_as_mlexpr' :
                       FStar_Pervasives_Native.None
                    in
                 let remove_attr attrs =
-                  let uu____12540 =
+                  let uu____12533 =
                     FStar_List.partition
                       (fun attr  ->
-                         let uu____12552 =
+                         let uu____12545 =
                            FStar_Syntax_Util.get_attribute
                              FStar_Parser_Const.rename_let_attr [attr]
                             in
-                         FStar_Util.is_some uu____12552)
+                         FStar_Util.is_some uu____12545)
                       lb.FStar_Syntax_Syntax.lbattrs
                      in
-                  match uu____12540 with
-                  | (uu____12557,other_attrs) -> other_attrs  in
+                  match uu____12533 with
+                  | (uu____12550,other_attrs) -> other_attrs  in
                 let maybe_rewritten_let =
                   match suggested_name with
                   | FStar_Pervasives_Native.None  ->
@@ -3571,98 +3565,98 @@ and (term_as_mlexpr' :
                         remove_attr lb.FStar_Syntax_Syntax.lbattrs  in
                       FStar_Syntax_Syntax.Tm_let
                         ((false,
-                           [(let uu___1774_12585 = lb  in
+                           [(let uu___1774_12578 = lb  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1774_12585.FStar_Syntax_Syntax.lbname);
+                                 (uu___1774_12578.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1774_12585.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___1774_12578.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___1774_12585.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___1774_12578.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1774_12585.FStar_Syntax_Syntax.lbeff);
+                                 (uu___1774_12578.FStar_Syntax_Syntax.lbeff);
                                FStar_Syntax_Syntax.lbdef =
-                                 (uu___1774_12585.FStar_Syntax_Syntax.lbdef);
+                                 (uu___1774_12578.FStar_Syntax_Syntax.lbdef);
                                FStar_Syntax_Syntax.lbattrs = other_attrs;
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1774_12585.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1774_12578.FStar_Syntax_Syntax.lbpos)
                              })]), e')
                   | FStar_Pervasives_Native.Some y ->
                       let other_attrs =
                         remove_attr lb.FStar_Syntax_Syntax.lbattrs  in
                       let rename =
-                        let uu____12593 =
-                          let uu____12594 =
-                            let uu____12601 =
+                        let uu____12586 =
+                          let uu____12587 =
+                            let uu____12594 =
                               FStar_Syntax_Syntax.bv_to_name y  in
-                            (x, uu____12601)  in
-                          FStar_Syntax_Syntax.NT uu____12594  in
-                        [uu____12593]  in
+                            (x, uu____12594)  in
+                          FStar_Syntax_Syntax.NT uu____12587  in
+                        [uu____12586]  in
                       let body1 =
-                        let uu____12607 =
+                        let uu____12600 =
                           FStar_Syntax_Subst.subst rename body  in
                         FStar_Syntax_Subst.close
-                          [(y, FStar_Pervasives_Native.None)] uu____12607
+                          [(y, FStar_Pervasives_Native.None)] uu____12600
                          in
                       let lb1 =
-                        let uu___1781_12623 = lb  in
+                        let uu___1781_12616 = lb  in
                         {
                           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl y);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___1781_12623.FStar_Syntax_Syntax.lbunivs);
+                            (uu___1781_12616.FStar_Syntax_Syntax.lbunivs);
                           FStar_Syntax_Syntax.lbtyp =
-                            (uu___1781_12623.FStar_Syntax_Syntax.lbtyp);
+                            (uu___1781_12616.FStar_Syntax_Syntax.lbtyp);
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___1781_12623.FStar_Syntax_Syntax.lbeff);
+                            (uu___1781_12616.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef =
-                            (uu___1781_12623.FStar_Syntax_Syntax.lbdef);
+                            (uu___1781_12616.FStar_Syntax_Syntax.lbdef);
                           FStar_Syntax_Syntax.lbattrs = other_attrs;
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___1781_12623.FStar_Syntax_Syntax.lbpos)
+                            (uu___1781_12616.FStar_Syntax_Syntax.lbpos)
                         }  in
                       FStar_Syntax_Syntax.Tm_let ((false, [lb1]), body1)
                    in
                 let top2 =
-                  let uu___1785_12640 = top1  in
+                  let uu___1785_12633 = top1  in
                   {
                     FStar_Syntax_Syntax.n = maybe_rewritten_let;
                     FStar_Syntax_Syntax.pos =
-                      (uu___1785_12640.FStar_Syntax_Syntax.pos);
+                      (uu___1785_12633.FStar_Syntax_Syntax.pos);
                     FStar_Syntax_Syntax.vars =
-                      (uu___1785_12640.FStar_Syntax_Syntax.vars)
+                      (uu___1785_12633.FStar_Syntax_Syntax.vars)
                   }  in
                 term_as_mlexpr' g top2)
        | FStar_Syntax_Syntax.Tm_let ((is_rec,lbs),e') ->
            let top_level = FStar_Syntax_Syntax.is_top_level lbs  in
-           let uu____12663 =
+           let uu____12656 =
              if is_rec
              then FStar_Syntax_Subst.open_let_rec lbs e'
              else
-               (let uu____12679 = FStar_Syntax_Syntax.is_top_level lbs  in
-                if uu____12679
+               (let uu____12672 = FStar_Syntax_Syntax.is_top_level lbs  in
+                if uu____12672
                 then (lbs, e')
                 else
                   (let lb = FStar_List.hd lbs  in
                    let x =
-                     let uu____12694 =
+                     let uu____12687 =
                        FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                     FStar_Syntax_Syntax.freshen_bv uu____12694  in
+                     FStar_Syntax_Syntax.freshen_bv uu____12687  in
                    let lb1 =
-                     let uu___1799_12696 = lb  in
+                     let uu___1799_12689 = lb  in
                      {
                        FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                        FStar_Syntax_Syntax.lbunivs =
-                         (uu___1799_12696.FStar_Syntax_Syntax.lbunivs);
+                         (uu___1799_12689.FStar_Syntax_Syntax.lbunivs);
                        FStar_Syntax_Syntax.lbtyp =
-                         (uu___1799_12696.FStar_Syntax_Syntax.lbtyp);
+                         (uu___1799_12689.FStar_Syntax_Syntax.lbtyp);
                        FStar_Syntax_Syntax.lbeff =
-                         (uu___1799_12696.FStar_Syntax_Syntax.lbeff);
+                         (uu___1799_12689.FStar_Syntax_Syntax.lbeff);
                        FStar_Syntax_Syntax.lbdef =
-                         (uu___1799_12696.FStar_Syntax_Syntax.lbdef);
+                         (uu___1799_12689.FStar_Syntax_Syntax.lbdef);
                        FStar_Syntax_Syntax.lbattrs =
-                         (uu___1799_12696.FStar_Syntax_Syntax.lbattrs);
+                         (uu___1799_12689.FStar_Syntax_Syntax.lbattrs);
                        FStar_Syntax_Syntax.lbpos =
-                         (uu___1799_12696.FStar_Syntax_Syntax.lbpos)
+                         (uu___1799_12689.FStar_Syntax_Syntax.lbpos)
                      }  in
                    let e'1 =
                      FStar_Syntax_Subst.subst
@@ -3670,57 +3664,57 @@ and (term_as_mlexpr' :
                       in
                    ([lb1], e'1)))
               in
-           (match uu____12663 with
+           (match uu____12656 with
             | (lbs1,e'1) ->
                 let lbs2 =
                   if top_level
                   then
                     let tcenv =
-                      let uu____12721 =
+                      let uu____12714 =
                         FStar_Extraction_ML_UEnv.tcenv_of_uenv g  in
-                      let uu____12722 =
-                        let uu____12723 =
-                          let uu____12724 =
-                            let uu____12728 =
+                      let uu____12715 =
+                        let uu____12716 =
+                          let uu____12717 =
+                            let uu____12721 =
                               FStar_Extraction_ML_UEnv.current_module_of_uenv
                                 g
                                in
-                            FStar_Pervasives_Native.fst uu____12728  in
-                          let uu____12741 =
-                            let uu____12745 =
-                              let uu____12747 =
+                            FStar_Pervasives_Native.fst uu____12721  in
+                          let uu____12734 =
+                            let uu____12738 =
+                              let uu____12740 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g
                                  in
-                              FStar_Pervasives_Native.snd uu____12747  in
-                            [uu____12745]  in
-                          FStar_List.append uu____12724 uu____12741  in
-                        FStar_Ident.lid_of_path uu____12723
+                              FStar_Pervasives_Native.snd uu____12740  in
+                            [uu____12738]  in
+                          FStar_List.append uu____12717 uu____12734  in
+                        FStar_Ident.lid_of_path uu____12716
                           FStar_Range.dummyRange
                          in
-                      FStar_TypeChecker_Env.set_current_module uu____12721
-                        uu____12722
+                      FStar_TypeChecker_Env.set_current_module uu____12714
+                        uu____12715
                        in
                     FStar_All.pipe_right lbs1
                       (FStar_List.map
                          (fun lb  ->
                             let lbdef =
-                              let uu____12774 = FStar_Options.ml_ish ()  in
-                              if uu____12774
+                              let uu____12767 = FStar_Options.ml_ish ()  in
+                              if uu____12767
                               then lb.FStar_Syntax_Syntax.lbdef
                               else
-                                (let norm_call uu____12786 =
-                                   let uu____12787 =
-                                     let uu____12788 =
+                                (let norm_call uu____12779 =
+                                   let uu____12780 =
+                                     let uu____12781 =
                                        extraction_norm_steps ()  in
                                      FStar_TypeChecker_Env.PureSubtermsWithinComputations
-                                       :: uu____12788
+                                       :: uu____12781
                                       in
                                    FStar_TypeChecker_Normalize.normalize
-                                     uu____12787 tcenv
+                                     uu____12780 tcenv
                                      lb.FStar_Syntax_Syntax.lbdef
                                     in
-                                 let uu____12791 =
+                                 let uu____12784 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug tcenv)
                                       (FStar_Options.Other "Extraction"))
@@ -3729,69 +3723,69 @@ and (term_as_mlexpr' :
                                         (FStar_TypeChecker_Env.debug tcenv)
                                         (FStar_Options.Other "ExtractNorm"))
                                     in
-                                 if uu____12791
+                                 if uu____12784
                                  then
-                                   ((let uu____12801 =
+                                   ((let uu____12794 =
                                        FStar_Syntax_Print.lbname_to_string
                                          lb.FStar_Syntax_Syntax.lbname
                                         in
                                      FStar_Util.print1
                                        "Starting to normalize top-level let %s\n"
-                                       uu____12801);
+                                       uu____12794);
                                     (let a =
-                                       let uu____12807 =
-                                         let uu____12809 =
+                                       let uu____12800 =
+                                         let uu____12802 =
                                            FStar_Syntax_Print.lbname_to_string
                                              lb.FStar_Syntax_Syntax.lbname
                                             in
                                          FStar_Util.format1
                                            "###(Time to normalize top-level let %s)"
-                                           uu____12809
+                                           uu____12802
                                           in
                                        FStar_Util.measure_execution_time
-                                         uu____12807 norm_call
+                                         uu____12800 norm_call
                                         in
                                      a))
                                  else norm_call ())
                                in
-                            let uu___1816_12816 = lb  in
+                            let uu___1816_12809 = lb  in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1816_12816.FStar_Syntax_Syntax.lbname);
+                                (uu___1816_12809.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1816_12816.FStar_Syntax_Syntax.lbunivs);
+                                (uu___1816_12809.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___1816_12816.FStar_Syntax_Syntax.lbtyp);
+                                (uu___1816_12809.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1816_12816.FStar_Syntax_Syntax.lbeff);
+                                (uu___1816_12809.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1816_12816.FStar_Syntax_Syntax.lbattrs);
+                                (uu___1816_12809.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1816_12816.FStar_Syntax_Syntax.lbpos)
+                                (uu___1816_12809.FStar_Syntax_Syntax.lbpos)
                             }))
                   else lbs1  in
-                let check_lb env uu____12869 =
-                  match uu____12869 with
+                let check_lb env uu____12862 =
+                  match uu____12862 with
                   | (nm,(_lbname,f,(_t,(targs,polytype)),add_unit,e)) ->
                       let env1 =
                         FStar_List.fold_left
                           (fun env1  ->
-                             fun uu____13025  ->
-                               match uu____13025 with
-                               | (a,uu____13033) ->
+                             fun uu____13018  ->
+                               match uu____13018 with
+                               | (a,uu____13026) ->
                                    FStar_Extraction_ML_UEnv.extend_ty env1 a
                                      false) env targs
                          in
                       let expected_t = FStar_Pervasives_Native.snd polytype
                          in
-                      let uu____13040 =
+                      let uu____13033 =
                         check_term_as_mlexpr env1 e f expected_t  in
-                      (match uu____13040 with
+                      (match uu____13033 with
                        | (e1,ty) ->
-                           let uu____13051 =
+                           let uu____13044 =
                              maybe_promote_effect e1 f expected_t  in
-                           (match uu____13051 with
+                           (match uu____13044 with
                             | (e2,f1) ->
                                 let meta =
                                   match (f1, ty) with
@@ -3801,7 +3795,7 @@ and (term_as_mlexpr' :
                                   | (FStar_Extraction_ML_Syntax.E_GHOST
                                      ,FStar_Extraction_ML_Syntax.MLTY_Erased
                                      ) -> [FStar_Extraction_ML_Syntax.Erased]
-                                  | uu____13063 -> []  in
+                                  | uu____13056 -> []  in
                                 (f1,
                                   {
                                     FStar_Extraction_ML_Syntax.mllb_name = nm;
@@ -3817,26 +3811,26 @@ and (term_as_mlexpr' :
                                   })))
                    in
                 let lbs3 = extract_lb_sig g (is_rec, lbs2)  in
-                let uu____13094 =
+                let uu____13087 =
                   FStar_List.fold_right
                     (fun lb  ->
-                       fun uu____13191  ->
-                         match uu____13191 with
+                       fun uu____13184  ->
+                         match uu____13184 with
                          | (env,lbs4) ->
-                             let uu____13325 = lb  in
-                             (match uu____13325 with
-                              | (lbname,uu____13376,(t1,(uu____13378,polytype)),add_unit,uu____13381)
+                             let uu____13318 = lb  in
+                             (match uu____13318 with
+                              | (lbname,uu____13369,(t1,(uu____13371,polytype)),add_unit,uu____13374)
                                   ->
-                                  let uu____13396 =
+                                  let uu____13389 =
                                     FStar_Extraction_ML_UEnv.extend_lb env
                                       lbname t1 polytype add_unit
                                      in
-                                  (match uu____13396 with
-                                   | (env1,nm,uu____13436) ->
+                                  (match uu____13389 with
+                                   | (env1,nm,uu____13429) ->
                                        (env1, ((nm, lb) :: lbs4))))) lbs3
                     (g, [])
                    in
-                (match uu____13094 with
+                (match uu____13087 with
                  | (env_body,lbs4) ->
                      let env_def = if is_rec then env_body else g  in
                      let lbs5 =
@@ -3844,46 +3838,46 @@ and (term_as_mlexpr' :
                          (FStar_List.map (check_lb env_def))
                         in
                      let e'_rng = e'1.FStar_Syntax_Syntax.pos  in
-                     let uu____13715 = term_as_mlexpr env_body e'1  in
-                     (match uu____13715 with
+                     let uu____13708 = term_as_mlexpr env_body e'1  in
+                     (match uu____13708 with
                       | (e'2,f',t') ->
                           let f =
-                            let uu____13732 =
-                              let uu____13735 =
+                            let uu____13725 =
+                              let uu____13728 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   lbs5
                                  in
-                              f' :: uu____13735  in
+                              f' :: uu____13728  in
                             FStar_Extraction_ML_Util.join_l e'_rng
-                              uu____13732
+                              uu____13725
                              in
                           let is_rec1 =
                             if is_rec = true
                             then FStar_Extraction_ML_Syntax.Rec
                             else FStar_Extraction_ML_Syntax.NonRec  in
-                          let uu____13748 =
-                            let uu____13749 =
-                              let uu____13750 =
-                                let uu____13751 =
+                          let uu____13741 =
+                            let uu____13742 =
+                              let uu____13743 =
+                                let uu____13744 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     lbs5
                                    in
-                                (is_rec1, uu____13751)  in
-                              mk_MLE_Let top_level uu____13750 e'2  in
-                            let uu____13760 =
+                                (is_rec1, uu____13744)  in
+                              mk_MLE_Let top_level uu____13743 e'2  in
+                            let uu____13753 =
                               FStar_Extraction_ML_Util.mlloc_of_range
                                 t.FStar_Syntax_Syntax.pos
                                in
                             FStar_Extraction_ML_Syntax.with_ty_loc t'
-                              uu____13749 uu____13760
+                              uu____13742 uu____13753
                              in
-                          (uu____13748, f, t'))))
+                          (uu____13741, f, t'))))
        | FStar_Syntax_Syntax.Tm_match (scrutinee,pats) ->
-           let uu____13799 = term_as_mlexpr g scrutinee  in
-           (match uu____13799 with
+           let uu____13792 = term_as_mlexpr g scrutinee  in
+           (match uu____13792 with
             | (e,f_e,t_e) ->
-                let uu____13815 = check_pats_for_ite pats  in
-                (match uu____13815 with
+                let uu____13808 = check_pats_for_ite pats  in
+                (match uu____13808 with
                  | (b,then_e,else_e) ->
                      let no_lift x t1 = x  in
                      if b
@@ -3891,80 +3885,80 @@ and (term_as_mlexpr' :
                        (match (then_e, else_e) with
                         | (FStar_Pervasives_Native.Some
                            then_e1,FStar_Pervasives_Native.Some else_e1) ->
-                            let uu____13880 = term_as_mlexpr g then_e1  in
-                            (match uu____13880 with
+                            let uu____13873 = term_as_mlexpr g then_e1  in
+                            (match uu____13873 with
                              | (then_mle,f_then,t_then) ->
-                                 let uu____13896 = term_as_mlexpr g else_e1
+                                 let uu____13889 = term_as_mlexpr g else_e1
                                     in
-                                 (match uu____13896 with
+                                 (match uu____13889 with
                                   | (else_mle,f_else,t_else) ->
-                                      let uu____13912 =
-                                        let uu____13923 =
+                                      let uu____13905 =
+                                        let uu____13916 =
                                           type_leq g t_then t_else  in
-                                        if uu____13923
+                                        if uu____13916
                                         then (t_else, no_lift)
                                         else
-                                          (let uu____13944 =
+                                          (let uu____13937 =
                                              type_leq g t_else t_then  in
-                                           if uu____13944
+                                           if uu____13937
                                            then (t_then, no_lift)
                                            else
                                              (FStar_Extraction_ML_Syntax.MLTY_Top,
                                                FStar_Extraction_ML_Syntax.apply_obj_repr))
                                          in
-                                      (match uu____13912 with
+                                      (match uu____13905 with
                                        | (t_branch,maybe_lift) ->
-                                           let uu____13991 =
-                                             let uu____13992 =
-                                               let uu____13993 =
-                                                 let uu____14002 =
+                                           let uu____13984 =
+                                             let uu____13985 =
+                                               let uu____13986 =
+                                                 let uu____13995 =
                                                    maybe_lift then_mle t_then
                                                     in
-                                                 let uu____14003 =
-                                                   let uu____14006 =
+                                                 let uu____13996 =
+                                                   let uu____13999 =
                                                      maybe_lift else_mle
                                                        t_else
                                                       in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____14006
+                                                     uu____13999
                                                     in
-                                                 (e, uu____14002,
-                                                   uu____14003)
+                                                 (e, uu____13995,
+                                                   uu____13996)
                                                   in
                                                FStar_Extraction_ML_Syntax.MLE_If
-                                                 uu____13993
+                                                 uu____13986
                                                 in
                                              FStar_All.pipe_left
                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu____13992
+                                                  t_branch) uu____13985
                                               in
-                                           let uu____14009 =
+                                           let uu____14002 =
                                              FStar_Extraction_ML_Util.join
                                                then_e1.FStar_Syntax_Syntax.pos
                                                f_then f_else
                                               in
-                                           (uu____13991, uu____14009,
+                                           (uu____13984, uu____14002,
                                              t_branch))))
-                        | uu____14010 ->
+                        | uu____14003 ->
                             failwith
                               "ITE pats matched but then and else expressions not found?")
                      else
-                       (let uu____14028 =
+                       (let uu____14021 =
                           FStar_All.pipe_right pats
                             (FStar_Util.fold_map
                                (fun compat  ->
                                   fun br  ->
-                                    let uu____14127 =
+                                    let uu____14120 =
                                       FStar_Syntax_Subst.open_branch br  in
-                                    match uu____14127 with
+                                    match uu____14120 with
                                     | (pat,when_opt,branch) ->
-                                        let uu____14172 =
+                                        let uu____14165 =
                                           extract_pat g pat t_e
                                             term_as_mlexpr
                                            in
-                                        (match uu____14172 with
+                                        (match uu____14165 with
                                          | (env,p,pat_t_compat) ->
-                                             let uu____14234 =
+                                             let uu____14227 =
                                                match when_opt with
                                                | FStar_Pervasives_Native.None
                                                     ->
@@ -3975,9 +3969,9 @@ and (term_as_mlexpr' :
                                                    let w_pos =
                                                      w.FStar_Syntax_Syntax.pos
                                                       in
-                                                   let uu____14257 =
+                                                   let uu____14250 =
                                                      term_as_mlexpr env w  in
-                                                   (match uu____14257 with
+                                                   (match uu____14250 with
                                                     | (w1,f_w,t_w) ->
                                                         let w2 =
                                                           maybe_coerce w_pos
@@ -3987,22 +3981,22 @@ and (term_as_mlexpr' :
                                                         ((FStar_Pervasives_Native.Some
                                                             w2), f_w))
                                                 in
-                                             (match uu____14234 with
+                                             (match uu____14227 with
                                               | (when_opt1,f_when) ->
-                                                  let uu____14307 =
+                                                  let uu____14300 =
                                                     term_as_mlexpr env branch
                                                      in
-                                                  (match uu____14307 with
+                                                  (match uu____14300 with
                                                    | (mlbranch,f_branch,t_branch)
                                                        ->
-                                                       let uu____14342 =
+                                                       let uu____14335 =
                                                          FStar_All.pipe_right
                                                            p
                                                            (FStar_List.map
                                                               (fun
-                                                                 uu____14419 
+                                                                 uu____14412 
                                                                  ->
-                                                                 match uu____14419
+                                                                 match uu____14412
                                                                  with
                                                                  | (p1,wopt)
                                                                     ->
@@ -4021,10 +4015,10 @@ and (term_as_mlexpr' :
                                                           in
                                                        ((compat &&
                                                            pat_t_compat),
-                                                         uu____14342)))))
+                                                         uu____14335)))))
                                true)
                            in
-                        match uu____14028 with
+                        match uu____14021 with
                         | (pat_t_compat,mlbranches) ->
                             let mlbranches1 = FStar_List.flatten mlbranches
                                in
@@ -4033,26 +4027,26 @@ and (term_as_mlexpr' :
                               then e
                               else
                                 (FStar_Extraction_ML_UEnv.debug g
-                                   (fun uu____14590  ->
-                                      let uu____14591 =
-                                        let uu____14593 =
+                                   (fun uu____14583  ->
+                                      let uu____14584 =
+                                        let uu____14586 =
                                           FStar_Extraction_ML_UEnv.current_module_of_uenv
                                             g
                                            in
                                         FStar_Extraction_ML_Code.string_of_mlexpr
-                                          uu____14593 e
+                                          uu____14586 e
                                          in
-                                      let uu____14594 =
-                                        let uu____14596 =
+                                      let uu____14587 =
+                                        let uu____14589 =
                                           FStar_Extraction_ML_UEnv.current_module_of_uenv
                                             g
                                            in
                                         FStar_Extraction_ML_Code.string_of_mlty
-                                          uu____14596 t_e
+                                          uu____14589 t_e
                                          in
                                       FStar_Util.print2
                                         "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
-                                        uu____14591 uu____14594);
+                                        uu____14584 uu____14587);
                                  FStar_All.pipe_left
                                    (FStar_Extraction_ML_Syntax.with_ty t_e)
                                    (FStar_Extraction_ML_Syntax.MLE_Coerce
@@ -4061,30 +4055,30 @@ and (term_as_mlexpr' :
                                in
                             (match mlbranches1 with
                              | [] ->
-                                 let uu____14622 =
-                                   let uu____14623 =
+                                 let uu____14615 =
+                                   let uu____14616 =
                                      FStar_Syntax_Syntax.lid_as_fv
                                        FStar_Parser_Const.failwith_lid
                                        FStar_Syntax_Syntax.delta_constant
                                        FStar_Pervasives_Native.None
                                       in
                                    FStar_Extraction_ML_UEnv.lookup_fv g
-                                     uu____14623
+                                     uu____14616
                                     in
-                                 (match uu____14622 with
+                                 (match uu____14615 with
                                   | {
                                       FStar_Extraction_ML_UEnv.exp_b_name =
-                                        uu____14630;
+                                        uu____14623;
                                       FStar_Extraction_ML_UEnv.exp_b_expr =
                                         fw;
                                       FStar_Extraction_ML_UEnv.exp_b_tscheme
-                                        = uu____14632;_}
+                                        = uu____14625;_}
                                       ->
-                                      let uu____14634 =
-                                        let uu____14635 =
-                                          let uu____14636 =
-                                            let uu____14643 =
-                                              let uu____14646 =
+                                      let uu____14627 =
+                                        let uu____14628 =
+                                          let uu____14629 =
+                                            let uu____14636 =
+                                              let uu____14639 =
                                                 FStar_All.pipe_left
                                                   (FStar_Extraction_ML_Syntax.with_ty
                                                      FStar_Extraction_ML_Syntax.ml_string_ty)
@@ -4092,29 +4086,29 @@ and (term_as_mlexpr' :
                                                      (FStar_Extraction_ML_Syntax.MLC_String
                                                         "unreachable"))
                                                  in
-                                              [uu____14646]  in
-                                            (fw, uu____14643)  in
+                                              [uu____14639]  in
+                                            (fw, uu____14636)  in
                                           FStar_Extraction_ML_Syntax.MLE_App
-                                            uu____14636
+                                            uu____14629
                                            in
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_int_ty)
-                                          uu____14635
+                                          uu____14628
                                          in
-                                      (uu____14634,
+                                      (uu____14627,
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         FStar_Extraction_ML_Syntax.ml_int_ty))
-                             | (uu____14650,uu____14651,(uu____14652,f_first,t_first))::rest
+                             | (uu____14643,uu____14644,(uu____14645,f_first,t_first))::rest
                                  ->
-                                 let uu____14712 =
+                                 let uu____14705 =
                                    FStar_List.fold_left
-                                     (fun uu____14754  ->
-                                        fun uu____14755  ->
-                                          match (uu____14754, uu____14755)
+                                     (fun uu____14747  ->
+                                        fun uu____14748  ->
+                                          match (uu____14747, uu____14748)
                                           with
-                                          | ((topt,f),(uu____14812,uu____14813,
-                                                       (uu____14814,f_branch,t_branch)))
+                                          | ((topt,f),(uu____14805,uu____14806,
+                                                       (uu____14807,f_branch,t_branch)))
                                               ->
                                               let f1 =
                                                 FStar_Extraction_ML_Util.join
@@ -4128,19 +4122,19 @@ and (term_as_mlexpr' :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     t1 ->
-                                                    let uu____14870 =
+                                                    let uu____14863 =
                                                       type_leq g t1 t_branch
                                                        in
-                                                    if uu____14870
+                                                    if uu____14863
                                                     then
                                                       FStar_Pervasives_Native.Some
                                                         t_branch
                                                     else
-                                                      (let uu____14877 =
+                                                      (let uu____14870 =
                                                          type_leq g t_branch
                                                            t1
                                                           in
-                                                       if uu____14877
+                                                       if uu____14870
                                                        then
                                                          FStar_Pervasives_Native.Some
                                                            t1
@@ -4151,15 +4145,15 @@ and (term_as_mlexpr' :
                                      ((FStar_Pervasives_Native.Some t_first),
                                        f_first) rest
                                     in
-                                 (match uu____14712 with
+                                 (match uu____14705 with
                                   | (topt,f_match) ->
                                       let mlbranches2 =
                                         FStar_All.pipe_right mlbranches1
                                           (FStar_List.map
-                                             (fun uu____14975  ->
-                                                match uu____14975 with
-                                                | (p,(wopt,uu____15004),
-                                                   (b1,uu____15006,t1)) ->
+                                             (fun uu____14968  ->
+                                                match uu____14968 with
+                                                | (p,(wopt,uu____14997),
+                                                   (b1,uu____14999,t1)) ->
                                                     let b2 =
                                                       match topt with
                                                       | FStar_Pervasives_Native.None
@@ -4167,7 +4161,7 @@ and (term_as_mlexpr' :
                                                           FStar_Extraction_ML_Syntax.apply_obj_repr
                                                             b1 t1
                                                       | FStar_Pervasives_Native.Some
-                                                          uu____15025 -> b1
+                                                          uu____15018 -> b1
                                                        in
                                                     (p, wopt, b2)))
                                          in
@@ -4178,14 +4172,14 @@ and (term_as_mlexpr' :
                                         | FStar_Pervasives_Native.Some t1 ->
                                             t1
                                          in
-                                      let uu____15030 =
+                                      let uu____15023 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              t_match)
                                           (FStar_Extraction_ML_Syntax.MLE_Match
                                              (e1, mlbranches2))
                                          in
-                                      (uu____15030, f_match, t_match)))))))
+                                      (uu____15023, f_match, t_match)))))))
 
 let (ind_discriminator_body :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -4195,79 +4189,79 @@ let (ind_discriminator_body :
   fun env  ->
     fun discName  ->
       fun constrName  ->
-        let uu____15057 =
-          let uu____15062 =
-            let uu____15071 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
-            FStar_TypeChecker_Env.lookup_lid uu____15071 discName  in
-          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____15062  in
-        match uu____15057 with
-        | (uu____15088,fstar_disc_type) ->
-            let uu____15090 =
-              let uu____15102 =
-                let uu____15103 = FStar_Syntax_Subst.compress fstar_disc_type
+        let uu____15050 =
+          let uu____15055 =
+            let uu____15064 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env  in
+            FStar_TypeChecker_Env.lookup_lid uu____15064 discName  in
+          FStar_All.pipe_left FStar_Pervasives_Native.fst uu____15055  in
+        match uu____15050 with
+        | (uu____15081,fstar_disc_type) ->
+            let uu____15083 =
+              let uu____15095 =
+                let uu____15096 = FStar_Syntax_Subst.compress fstar_disc_type
                    in
-                uu____15103.FStar_Syntax_Syntax.n  in
-              match uu____15102 with
-              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____15118) ->
+                uu____15096.FStar_Syntax_Syntax.n  in
+              match uu____15095 with
+              | FStar_Syntax_Syntax.Tm_arrow (binders,uu____15111) ->
                   let binders1 =
                     FStar_All.pipe_right binders
                       (FStar_List.filter
-                         (fun uu___2_15173  ->
-                            match uu___2_15173 with
-                            | (uu____15181,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____15182)) ->
+                         (fun uu___2_15166  ->
+                            match uu___2_15166 with
+                            | (uu____15174,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____15175)) ->
                                 true
-                            | uu____15187 -> false))
+                            | uu____15180 -> false))
                      in
                   FStar_List.fold_right
-                    (fun uu____15219  ->
-                       fun uu____15220  ->
-                         match uu____15220 with
+                    (fun uu____15212  ->
+                       fun uu____15213  ->
+                         match uu____15213 with
                          | (g,vs) ->
-                             let uu____15265 =
+                             let uu____15258 =
                                FStar_Extraction_ML_UEnv.new_mlident g  in
-                             (match uu____15265 with
+                             (match uu____15258 with
                               | (g1,v) ->
                                   (g1,
                                     ((v, FStar_Extraction_ML_Syntax.MLTY_Top)
                                     :: vs)))) binders1 (env, [])
-              | uu____15311 -> failwith "Discriminator must be a function"
+              | uu____15304 -> failwith "Discriminator must be a function"
                in
-            (match uu____15090 with
+            (match uu____15083 with
              | (g,wildcards) ->
-                 let uu____15340 = FStar_Extraction_ML_UEnv.new_mlident g  in
-                 (match uu____15340 with
+                 let uu____15333 = FStar_Extraction_ML_UEnv.new_mlident g  in
+                 (match uu____15333 with
                   | (g1,mlid) ->
                       let targ = FStar_Extraction_ML_Syntax.MLTY_Top  in
                       let disc_ty = FStar_Extraction_ML_Syntax.MLTY_Top  in
                       let discrBody =
-                        let uu____15353 =
-                          let uu____15354 =
-                            let uu____15366 =
-                              let uu____15367 =
-                                let uu____15368 =
-                                  let uu____15383 =
+                        let uu____15346 =
+                          let uu____15347 =
+                            let uu____15359 =
+                              let uu____15360 =
+                                let uu____15361 =
+                                  let uu____15376 =
                                     FStar_All.pipe_left
                                       (FStar_Extraction_ML_Syntax.with_ty
                                          targ)
                                       (FStar_Extraction_ML_Syntax.MLE_Name
                                          ([], mlid))
                                      in
-                                  let uu____15389 =
-                                    let uu____15400 =
-                                      let uu____15409 =
-                                        let uu____15410 =
-                                          let uu____15417 =
+                                  let uu____15382 =
+                                    let uu____15393 =
+                                      let uu____15402 =
+                                        let uu____15403 =
+                                          let uu____15410 =
                                             FStar_Extraction_ML_UEnv.mlpath_of_lident
                                               g1 constrName
                                              in
-                                          (uu____15417,
+                                          (uu____15410,
                                             [FStar_Extraction_ML_Syntax.MLP_Wild])
                                            in
                                         FStar_Extraction_ML_Syntax.MLP_CTor
-                                          uu____15410
+                                          uu____15403
                                          in
-                                      let uu____15420 =
+                                      let uu____15413 =
                                         FStar_All.pipe_left
                                           (FStar_Extraction_ML_Syntax.with_ty
                                              FStar_Extraction_ML_Syntax.ml_bool_ty)
@@ -4275,13 +4269,13 @@ let (ind_discriminator_body :
                                              (FStar_Extraction_ML_Syntax.MLC_Bool
                                                 true))
                                          in
-                                      (uu____15409,
+                                      (uu____15402,
                                         FStar_Pervasives_Native.None,
-                                        uu____15420)
+                                        uu____15413)
                                        in
-                                    let uu____15424 =
-                                      let uu____15435 =
-                                        let uu____15444 =
+                                    let uu____15417 =
+                                      let uu____15428 =
+                                        let uu____15437 =
                                           FStar_All.pipe_left
                                             (FStar_Extraction_ML_Syntax.with_ty
                                                FStar_Extraction_ML_Syntax.ml_bool_ty)
@@ -4291,33 +4285,33 @@ let (ind_discriminator_body :
                                            in
                                         (FStar_Extraction_ML_Syntax.MLP_Wild,
                                           FStar_Pervasives_Native.None,
-                                          uu____15444)
+                                          uu____15437)
                                          in
-                                      [uu____15435]  in
-                                    uu____15400 :: uu____15424  in
-                                  (uu____15383, uu____15389)  in
+                                      [uu____15428]  in
+                                    uu____15393 :: uu____15417  in
+                                  (uu____15376, uu____15382)  in
                                 FStar_Extraction_ML_Syntax.MLE_Match
-                                  uu____15368
+                                  uu____15361
                                  in
                               FStar_All.pipe_left
                                 (FStar_Extraction_ML_Syntax.with_ty
                                    FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                uu____15367
+                                uu____15360
                                in
                             ((FStar_List.append wildcards [(mlid, targ)]),
-                              uu____15366)
+                              uu____15359)
                              in
-                          FStar_Extraction_ML_Syntax.MLE_Fun uu____15354  in
+                          FStar_Extraction_ML_Syntax.MLE_Fun uu____15347  in
                         FStar_All.pipe_left
                           (FStar_Extraction_ML_Syntax.with_ty disc_ty)
-                          uu____15353
+                          uu____15346
                          in
-                      let uu____15505 =
+                      let uu____15498 =
                         FStar_Extraction_ML_UEnv.mlpath_of_lident env
                           discName
                          in
-                      (match uu____15505 with
-                       | (uu____15506,name) ->
+                      (match uu____15498 with
+                       | (uu____15499,name) ->
                            FStar_Extraction_ML_Syntax.MLM_Let
                              (FStar_Extraction_ML_Syntax.NonRec,
                                [{

--- a/src/ocaml-output/FStar_Extraction_ML_Util.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Util.ml
@@ -1171,258 +1171,256 @@ let (interpret_plugin_as_term_fun :
                   let tail =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_arrow ((more :: bs), c))
-                      FStar_Pervasives_Native.None t3.FStar_Syntax_Syntax.pos
+                      t3.FStar_Syntax_Syntax.pos
                      in
                   let t4 =
                     let uu____3777 =
-                      let uu____3784 =
-                        let uu____3785 =
-                          let uu____3800 = FStar_Syntax_Syntax.mk_Total tail
-                             in
-                          ([b], uu____3800)  in
-                        FStar_Syntax_Syntax.Tm_arrow uu____3785  in
-                      FStar_Syntax_Syntax.mk uu____3784  in
-                    uu____3777 FStar_Pervasives_Native.None
+                      let uu____3778 =
+                        let uu____3793 = FStar_Syntax_Syntax.mk_Total tail
+                           in
+                        ([b], uu____3793)  in
+                      FStar_Syntax_Syntax.Tm_arrow uu____3778  in
+                    FStar_Syntax_Syntax.mk uu____3777
                       t3.FStar_Syntax_Syntax.pos
                      in
                   mk_embedding l env1 t4
-              | FStar_Syntax_Syntax.Tm_fvar uu____3825 ->
-                  let uu____3826 = FStar_Syntax_Util.head_and_args t3  in
-                  (match uu____3826 with
+              | FStar_Syntax_Syntax.Tm_fvar uu____3818 ->
+                  let uu____3819 = FStar_Syntax_Util.head_and_args t3  in
+                  (match uu____3819 with
                    | (head,args) ->
                        let n_args = FStar_List.length args  in
-                       let uu____3878 =
-                         let uu____3879 = FStar_Syntax_Util.un_uinst head  in
-                         uu____3879.FStar_Syntax_Syntax.n  in
-                       (match uu____3878 with
+                       let uu____3871 =
+                         let uu____3872 = FStar_Syntax_Util.un_uinst head  in
+                         uu____3872.FStar_Syntax_Syntax.n  in
+                       (match uu____3871 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____3905  ->
-                                      match uu____3905 with
-                                      | (t4,uu____3913) ->
+                                   (fun uu____3898  ->
+                                      match uu____3898 with
+                                      | (t4,uu____3906) ->
                                           mk_embedding l env1 t4))
                                in
                             let nm =
-                              let uu____3920 =
+                              let uu____3913 =
                                 FStar_Ident.ident_of_lid
                                   (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                  in
-                              FStar_Ident.text_of_id uu____3920  in
-                            let uu____3921 =
-                              let uu____3934 =
+                              FStar_Ident.text_of_id uu____3913  in
+                            let uu____3914 =
+                              let uu____3927 =
                                 FStar_Util.find_opt
-                                  (fun uu____3966  ->
-                                     match uu____3966 with
-                                     | ((x,uu____3981,uu____3982),uu____3983)
+                                  (fun uu____3959  ->
+                                     match uu____3959 with
+                                     | ((x,uu____3974,uu____3975),uu____3976)
                                          ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l)
                                  in
-                              FStar_All.pipe_right uu____3934 FStar_Util.must
+                              FStar_All.pipe_right uu____3927 FStar_Util.must
                                in
-                            (match uu____3921 with
-                             | ((uu____4034,t_arity,_trepr_head),loc_embedding)
+                            (match uu____3914 with
+                             | ((uu____4027,t_arity,_trepr_head),loc_embedding)
                                  ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm  in
                                  (match t_arity with
-                                  | uu____4051 when
-                                      uu____4051 = Prims.int_zero -> head1
+                                  | uu____4044 when
+                                      uu____4044 = Prims.int_zero -> head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____4056 ->
-                            let uu____4057 =
-                              let uu____4058 =
-                                let uu____4060 =
+                        | uu____4049 ->
+                            let uu____4050 =
+                              let uu____4051 =
+                                let uu____4053 =
                                   FStar_Syntax_Print.term_to_string t3  in
                                 Prims.op_Hat
                                   "Embedding not defined for type "
-                                  uu____4060
+                                  uu____4053
                                  in
-                              NoTacticEmbedding uu____4058  in
-                            FStar_Exn.raise uu____4057))
-              | FStar_Syntax_Syntax.Tm_uinst uu____4063 ->
-                  let uu____4070 = FStar_Syntax_Util.head_and_args t3  in
-                  (match uu____4070 with
+                              NoTacticEmbedding uu____4051  in
+                            FStar_Exn.raise uu____4050))
+              | FStar_Syntax_Syntax.Tm_uinst uu____4056 ->
+                  let uu____4063 = FStar_Syntax_Util.head_and_args t3  in
+                  (match uu____4063 with
                    | (head,args) ->
                        let n_args = FStar_List.length args  in
-                       let uu____4122 =
-                         let uu____4123 = FStar_Syntax_Util.un_uinst head  in
-                         uu____4123.FStar_Syntax_Syntax.n  in
-                       (match uu____4122 with
+                       let uu____4115 =
+                         let uu____4116 = FStar_Syntax_Util.un_uinst head  in
+                         uu____4116.FStar_Syntax_Syntax.n  in
+                       (match uu____4115 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____4149  ->
-                                      match uu____4149 with
-                                      | (t4,uu____4157) ->
+                                   (fun uu____4142  ->
+                                      match uu____4142 with
+                                      | (t4,uu____4150) ->
                                           mk_embedding l env1 t4))
                                in
                             let nm =
-                              let uu____4164 =
+                              let uu____4157 =
                                 FStar_Ident.ident_of_lid
                                   (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                  in
-                              FStar_Ident.text_of_id uu____4164  in
-                            let uu____4165 =
-                              let uu____4178 =
+                              FStar_Ident.text_of_id uu____4157  in
+                            let uu____4158 =
+                              let uu____4171 =
                                 FStar_Util.find_opt
-                                  (fun uu____4210  ->
-                                     match uu____4210 with
-                                     | ((x,uu____4225,uu____4226),uu____4227)
+                                  (fun uu____4203  ->
+                                     match uu____4203 with
+                                     | ((x,uu____4218,uu____4219),uu____4220)
                                          ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l)
                                  in
-                              FStar_All.pipe_right uu____4178 FStar_Util.must
+                              FStar_All.pipe_right uu____4171 FStar_Util.must
                                in
-                            (match uu____4165 with
-                             | ((uu____4278,t_arity,_trepr_head),loc_embedding)
+                            (match uu____4158 with
+                             | ((uu____4271,t_arity,_trepr_head),loc_embedding)
                                  ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm  in
                                  (match t_arity with
-                                  | uu____4295 when
-                                      uu____4295 = Prims.int_zero -> head1
+                                  | uu____4288 when
+                                      uu____4288 = Prims.int_zero -> head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____4300 ->
-                            let uu____4301 =
-                              let uu____4302 =
-                                let uu____4304 =
+                        | uu____4293 ->
+                            let uu____4294 =
+                              let uu____4295 =
+                                let uu____4297 =
                                   FStar_Syntax_Print.term_to_string t3  in
                                 Prims.op_Hat
                                   "Embedding not defined for type "
-                                  uu____4304
+                                  uu____4297
                                  in
-                              NoTacticEmbedding uu____4302  in
-                            FStar_Exn.raise uu____4301))
-              | FStar_Syntax_Syntax.Tm_app uu____4307 ->
-                  let uu____4324 = FStar_Syntax_Util.head_and_args t3  in
-                  (match uu____4324 with
+                              NoTacticEmbedding uu____4295  in
+                            FStar_Exn.raise uu____4294))
+              | FStar_Syntax_Syntax.Tm_app uu____4300 ->
+                  let uu____4317 = FStar_Syntax_Util.head_and_args t3  in
+                  (match uu____4317 with
                    | (head,args) ->
                        let n_args = FStar_List.length args  in
-                       let uu____4376 =
-                         let uu____4377 = FStar_Syntax_Util.un_uinst head  in
-                         uu____4377.FStar_Syntax_Syntax.n  in
-                       (match uu____4376 with
+                       let uu____4369 =
+                         let uu____4370 = FStar_Syntax_Util.un_uinst head  in
+                         uu____4370.FStar_Syntax_Syntax.n  in
+                       (match uu____4369 with
                         | FStar_Syntax_Syntax.Tm_fvar fv1 when
                             is_known_type_constructor l fv1 n_args ->
                             let arg_embeddings =
                               FStar_All.pipe_right args
                                 (FStar_List.map
-                                   (fun uu____4403  ->
-                                      match uu____4403 with
-                                      | (t4,uu____4411) ->
+                                   (fun uu____4396  ->
+                                      match uu____4396 with
+                                      | (t4,uu____4404) ->
                                           mk_embedding l env1 t4))
                                in
                             let nm =
-                              let uu____4418 =
+                              let uu____4411 =
                                 FStar_Ident.ident_of_lid
                                   (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                  in
-                              FStar_Ident.text_of_id uu____4418  in
-                            let uu____4419 =
-                              let uu____4432 =
+                              FStar_Ident.text_of_id uu____4411  in
+                            let uu____4412 =
+                              let uu____4425 =
                                 FStar_Util.find_opt
-                                  (fun uu____4464  ->
-                                     match uu____4464 with
-                                     | ((x,uu____4479,uu____4480),uu____4481)
+                                  (fun uu____4457  ->
+                                     match uu____4457 with
+                                     | ((x,uu____4472,uu____4473),uu____4474)
                                          ->
                                          FStar_Syntax_Syntax.fv_eq_lid fv1 x)
                                   (known_type_constructors l)
                                  in
-                              FStar_All.pipe_right uu____4432 FStar_Util.must
+                              FStar_All.pipe_right uu____4425 FStar_Util.must
                                in
-                            (match uu____4419 with
-                             | ((uu____4532,t_arity,_trepr_head),loc_embedding)
+                            (match uu____4412 with
+                             | ((uu____4525,t_arity,_trepr_head),loc_embedding)
                                  ->
                                  let head1 =
                                    mk_basic_embedding loc_embedding nm  in
                                  (match t_arity with
-                                  | uu____4549 when
-                                      uu____4549 = Prims.int_zero -> head1
+                                  | uu____4542 when
+                                      uu____4542 = Prims.int_zero -> head1
                                   | n ->
                                       FStar_All.pipe_left w
                                         (FStar_Extraction_ML_Syntax.MLE_App
                                            (head1, arg_embeddings))))
-                        | uu____4554 ->
-                            let uu____4555 =
-                              let uu____4556 =
-                                let uu____4558 =
+                        | uu____4547 ->
+                            let uu____4548 =
+                              let uu____4549 =
+                                let uu____4551 =
                                   FStar_Syntax_Print.term_to_string t3  in
                                 Prims.op_Hat
                                   "Embedding not defined for type "
-                                  uu____4558
+                                  uu____4551
                                  in
-                              NoTacticEmbedding uu____4556  in
-                            FStar_Exn.raise uu____4555))
-              | uu____4561 ->
-                  let uu____4562 =
-                    let uu____4563 =
-                      let uu____4565 = FStar_Syntax_Print.term_to_string t3
+                              NoTacticEmbedding uu____4549  in
+                            FStar_Exn.raise uu____4548))
+              | uu____4554 ->
+                  let uu____4555 =
+                    let uu____4556 =
+                      let uu____4558 = FStar_Syntax_Print.term_to_string t3
                          in
                       Prims.op_Hat "Embedding not defined for type "
-                        uu____4565
+                        uu____4558
                        in
-                    NoTacticEmbedding uu____4563  in
-                  FStar_Exn.raise uu____4562
+                    NoTacticEmbedding uu____4556  in
+                  FStar_Exn.raise uu____4555
                in
             let abstract_tvars tvar_names body =
               match tvar_names with
               | [] ->
                   let body1 =
-                    let uu____4587 =
-                      let uu____4588 =
-                        let uu____4595 =
+                    let uu____4580 =
+                      let uu____4581 =
+                        let uu____4588 =
                           as_name (["FStar_Syntax_Embeddings"], "debug_wrap")
                            in
-                        let uu____4604 =
-                          let uu____4607 =
-                            let uu____4608 =
-                              let uu____4609 =
-                                let uu____4610 =
+                        let uu____4597 =
+                          let uu____4600 =
+                            let uu____4601 =
+                              let uu____4602 =
+                                let uu____4603 =
                                   FStar_Ident.string_of_lid fv_lid  in
                                 FStar_Extraction_ML_Syntax.MLC_String
-                                  uu____4610
+                                  uu____4603
                                  in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu____4609
+                              FStar_Extraction_ML_Syntax.MLE_Const uu____4602
                                in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.MLTY_Top)
-                              uu____4608
+                              uu____4601
                              in
-                          let uu____4612 =
-                            let uu____4615 =
-                              let uu____4616 =
-                                let uu____4617 =
-                                  let uu____4618 =
-                                    let uu____4625 =
-                                      let uu____4628 = str_to_name "args"  in
-                                      [uu____4628]  in
-                                    (body, uu____4625)  in
+                          let uu____4605 =
+                            let uu____4608 =
+                              let uu____4609 =
+                                let uu____4610 =
+                                  let uu____4611 =
+                                    let uu____4618 =
+                                      let uu____4621 = str_to_name "args"  in
+                                      [uu____4621]  in
+                                    (body, uu____4618)  in
                                   FStar_Extraction_ML_Syntax.MLE_App
-                                    uu____4618
+                                    uu____4611
                                    in
-                                FStar_All.pipe_left w uu____4617  in
-                              mk_lam "_" uu____4616  in
-                            [uu____4615]  in
-                          uu____4607 :: uu____4612  in
-                        (uu____4595, uu____4604)  in
-                      FStar_Extraction_ML_Syntax.MLE_App uu____4588  in
-                    FStar_All.pipe_left w uu____4587  in
+                                FStar_All.pipe_left w uu____4610  in
+                              mk_lam "_" uu____4609  in
+                            [uu____4608]  in
+                          uu____4600 :: uu____4605  in
+                        (uu____4588, uu____4597)  in
+                      FStar_Extraction_ML_Syntax.MLE_App uu____4581  in
+                    FStar_All.pipe_left w uu____4580  in
                   mk_lam "args" body1
-              | uu____4636 ->
+              | uu____4629 ->
                   let args_tail =
                     FStar_Extraction_ML_Syntax.MLP_Var "args_tail"  in
                   let mk_cons hd_pat tail_pat =
@@ -1440,79 +1438,79 @@ let (interpret_plugin_as_term_fun :
                       args_tail
                      in
                   let branch =
-                    let uu____4685 =
-                      let uu____4686 =
-                        let uu____4687 =
-                          let uu____4694 =
-                            let uu____4697 = as_name ([], "args")  in
-                            [uu____4697]  in
-                          (body, uu____4694)  in
-                        FStar_Extraction_ML_Syntax.MLE_App uu____4687  in
-                      FStar_All.pipe_left w uu____4686  in
-                    (pattern, FStar_Pervasives_Native.None, uu____4685)  in
+                    let uu____4678 =
+                      let uu____4679 =
+                        let uu____4680 =
+                          let uu____4687 =
+                            let uu____4690 = as_name ([], "args")  in
+                            [uu____4690]  in
+                          (body, uu____4687)  in
+                        FStar_Extraction_ML_Syntax.MLE_App uu____4680  in
+                      FStar_All.pipe_left w uu____4679  in
+                    (pattern, FStar_Pervasives_Native.None, uu____4678)  in
                   let default_branch =
-                    let uu____4717 =
-                      let uu____4718 =
-                        let uu____4719 =
-                          let uu____4726 = str_to_name "failwith"  in
-                          let uu____4728 =
-                            let uu____4731 =
-                              let uu____4732 =
+                    let uu____4710 =
+                      let uu____4711 =
+                        let uu____4712 =
+                          let uu____4719 = str_to_name "failwith"  in
+                          let uu____4721 =
+                            let uu____4724 =
+                              let uu____4725 =
                                 mlexpr_of_const FStar_Range.dummyRange
                                   (FStar_Const.Const_string
                                      ("arity mismatch",
                                        FStar_Range.dummyRange))
                                  in
-                              FStar_All.pipe_left w uu____4732  in
-                            [uu____4731]  in
-                          (uu____4726, uu____4728)  in
-                        FStar_Extraction_ML_Syntax.MLE_App uu____4719  in
-                      FStar_All.pipe_left w uu____4718  in
+                              FStar_All.pipe_left w uu____4725  in
+                            [uu____4724]  in
+                          (uu____4719, uu____4721)  in
+                        FStar_Extraction_ML_Syntax.MLE_App uu____4712  in
+                      FStar_All.pipe_left w uu____4711  in
                     (FStar_Extraction_ML_Syntax.MLP_Wild,
-                      FStar_Pervasives_Native.None, uu____4717)
+                      FStar_Pervasives_Native.None, uu____4710)
                      in
                   let body1 =
-                    let uu____4740 =
-                      let uu____4741 =
-                        let uu____4756 = as_name ([], "args")  in
-                        (uu____4756, [branch; default_branch])  in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu____4741  in
-                    FStar_All.pipe_left w uu____4740  in
+                    let uu____4733 =
+                      let uu____4734 =
+                        let uu____4749 = as_name ([], "args")  in
+                        (uu____4749, [branch; default_branch])  in
+                      FStar_Extraction_ML_Syntax.MLE_Match uu____4734  in
+                    FStar_All.pipe_left w uu____4733  in
                   let body2 =
-                    let uu____4798 =
-                      let uu____4799 =
-                        let uu____4806 =
+                    let uu____4791 =
+                      let uu____4792 =
+                        let uu____4799 =
                           as_name (["FStar_Syntax_Embeddings"], "debug_wrap")
                            in
-                        let uu____4815 =
-                          let uu____4818 =
-                            let uu____4819 =
-                              let uu____4820 =
-                                let uu____4821 =
+                        let uu____4808 =
+                          let uu____4811 =
+                            let uu____4812 =
+                              let uu____4813 =
+                                let uu____4814 =
                                   FStar_Ident.string_of_lid fv_lid  in
                                 FStar_Extraction_ML_Syntax.MLC_String
-                                  uu____4821
+                                  uu____4814
                                  in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu____4820
+                              FStar_Extraction_ML_Syntax.MLE_Const uu____4813
                                in
                             FStar_All.pipe_left
                               (FStar_Extraction_ML_Syntax.with_ty
                                  FStar_Extraction_ML_Syntax.MLTY_Top)
-                              uu____4819
+                              uu____4812
                              in
-                          let uu____4823 =
-                            let uu____4826 = mk_lam "_" body1  in
-                            [uu____4826]  in
-                          uu____4818 :: uu____4823  in
-                        (uu____4806, uu____4815)  in
-                      FStar_Extraction_ML_Syntax.MLE_App uu____4799  in
-                    FStar_All.pipe_left w uu____4798  in
+                          let uu____4816 =
+                            let uu____4819 = mk_lam "_" body1  in
+                            [uu____4819]  in
+                          uu____4811 :: uu____4816  in
+                        (uu____4799, uu____4808)  in
+                      FStar_Extraction_ML_Syntax.MLE_App uu____4792  in
+                    FStar_All.pipe_left w uu____4791  in
                   mk_lam "args" body2
                in
-            let uu____4831 = FStar_Syntax_Util.arrow_formals_comp t1  in
-            match uu____4831 with
+            let uu____4824 = FStar_Syntax_Util.arrow_formals_comp t1  in
+            match uu____4824 with
             | (bs,c) ->
-                let uu____4840 =
+                let uu____4833 =
                   match arity_opt with
                   | FStar_Pervasives_Native.None  -> (bs, c)
                   | FStar_Pervasives_Native.Some n ->
@@ -1522,56 +1520,56 @@ let (interpret_plugin_as_term_fun :
                       else
                         if n < n_bs
                         then
-                          (let uu____4933 = FStar_Util.first_N n bs  in
-                           match uu____4933 with
+                          (let uu____4926 = FStar_Util.first_N n bs  in
+                           match uu____4926 with
                            | (bs1,rest) ->
                                let c1 =
-                                 let uu____5011 =
+                                 let uu____5004 =
                                    FStar_Syntax_Util.arrow rest c  in
                                  FStar_All.pipe_left
-                                   FStar_Syntax_Syntax.mk_Total uu____5011
+                                   FStar_Syntax_Syntax.mk_Total uu____5004
                                   in
                                (bs1, c1))
                         else
                           (let msg =
-                             let uu____5028 =
+                             let uu____5021 =
                                FStar_Ident.string_of_lid fv_lid  in
-                             let uu____5030 = FStar_Util.string_of_int n  in
-                             let uu____5032 = FStar_Util.string_of_int n_bs
+                             let uu____5023 = FStar_Util.string_of_int n  in
+                             let uu____5025 = FStar_Util.string_of_int n_bs
                                 in
                              FStar_Util.format3
                                "Embedding not defined for %s; expected arity at least %s; got %s"
-                               uu____5028 uu____5030 uu____5032
+                               uu____5021 uu____5023 uu____5025
                               in
                            FStar_Exn.raise (NoTacticEmbedding msg))
                    in
-                (match uu____4840 with
+                (match uu____4833 with
                  | (bs1,c1) ->
                      let result_typ = FStar_Syntax_Util.comp_result c1  in
                      let arity = FStar_List.length bs1  in
-                     let uu____5083 =
-                       let uu____5104 =
+                     let uu____5076 =
+                       let uu____5097 =
                          FStar_Util.prefix_until
-                           (fun uu____5146  ->
-                              match uu____5146 with
-                              | (b,uu____5155) ->
-                                  let uu____5160 =
-                                    let uu____5161 =
+                           (fun uu____5139  ->
+                              match uu____5139 with
+                              | (b,uu____5148) ->
+                                  let uu____5153 =
+                                    let uu____5154 =
                                       FStar_Syntax_Subst.compress
                                         b.FStar_Syntax_Syntax.sort
                                        in
-                                    uu____5161.FStar_Syntax_Syntax.n  in
-                                  (match uu____5160 with
-                                   | FStar_Syntax_Syntax.Tm_type uu____5165
+                                    uu____5154.FStar_Syntax_Syntax.n  in
+                                  (match uu____5153 with
+                                   | FStar_Syntax_Syntax.Tm_type uu____5158
                                        -> false
-                                   | uu____5167 -> true)) bs1
+                                   | uu____5160 -> true)) bs1
                           in
-                       match uu____5104 with
+                       match uu____5097 with
                        | FStar_Pervasives_Native.None  -> (bs1, [])
                        | FStar_Pervasives_Native.Some (tvars,x,rest) ->
                            (tvars, (x :: rest))
                         in
-                     (match uu____5083 with
+                     (match uu____5076 with
                       | (type_vars,bs2) ->
                           let tvar_arity = FStar_List.length type_vars  in
                           let non_tvar_arity = FStar_List.length bs2  in
@@ -1579,9 +1577,9 @@ let (interpret_plugin_as_term_fun :
                             FStar_List.mapi
                               (fun i  ->
                                  fun tv  ->
-                                   let uu____5409 =
+                                   let uu____5402 =
                                      FStar_Util.string_of_int i  in
-                                   Prims.op_Hat "tv_" uu____5409) type_vars
+                                   Prims.op_Hat "tv_" uu____5402) type_vars
                              in
                           let tvar_context =
                             FStar_List.map2
@@ -1601,48 +1599,48 @@ let (interpret_plugin_as_term_fun :
                                 let fv_lid1 =
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                    in
-                                let uu____5509 =
+                                let uu____5502 =
                                   FStar_Syntax_Util.is_pure_comp c1  in
-                                if uu____5509
+                                if uu____5502
                                 then
                                   let cb = str_to_name "cb"  in
                                   let embed_fun_N =
                                     mk_arrow_as_prim_step loc non_tvar_arity
                                      in
                                   let args =
-                                    let uu____5526 =
-                                      let uu____5529 =
-                                        let uu____5532 = lid_to_name fv_lid1
+                                    let uu____5519 =
+                                      let uu____5522 =
+                                        let uu____5525 = lid_to_name fv_lid1
                                            in
-                                        let uu____5533 =
-                                          let uu____5536 =
-                                            let uu____5537 =
-                                              let uu____5538 =
-                                                let uu____5539 =
-                                                  let uu____5551 =
+                                        let uu____5526 =
+                                          let uu____5529 =
+                                            let uu____5530 =
+                                              let uu____5531 =
+                                                let uu____5532 =
+                                                  let uu____5544 =
                                                     FStar_Util.string_of_int
                                                       tvar_arity
                                                      in
-                                                  (uu____5551,
+                                                  (uu____5544,
                                                     FStar_Pervasives_Native.None)
                                                    in
                                                 FStar_Extraction_ML_Syntax.MLC_Int
-                                                  uu____5539
+                                                  uu____5532
                                                  in
                                               FStar_Extraction_ML_Syntax.MLE_Const
-                                                uu____5538
+                                                uu____5531
                                                in
                                             FStar_All.pipe_left
                                               (FStar_Extraction_ML_Syntax.with_ty
                                                  FStar_Extraction_ML_Syntax.MLTY_Top)
-                                              uu____5537
+                                              uu____5530
                                              in
-                                          [uu____5536; fv_lid_embedded; cb]
+                                          [uu____5529; fv_lid_embedded; cb]
                                            in
-                                        uu____5532 :: uu____5533  in
-                                      res_embedding :: uu____5529  in
+                                        uu____5525 :: uu____5526  in
+                                      res_embedding :: uu____5522  in
                                     FStar_List.append arg_unembeddings
-                                      uu____5526
+                                      uu____5519
                                      in
                                   let fun_embedding =
                                     FStar_All.pipe_left w
@@ -1653,44 +1651,44 @@ let (interpret_plugin_as_term_fun :
                                     abstract_tvars tvar_names fun_embedding
                                      in
                                   let cb_tabs = mk_lam "cb" tabs  in
-                                  let uu____5570 =
+                                  let uu____5563 =
                                     if loc = NBE_t
                                     then cb_tabs
                                     else mk_lam "_psc" cb_tabs  in
-                                  (uu____5570, arity, true)
+                                  (uu____5563, arity, true)
                                 else
-                                  (let uu____5580 =
-                                     let uu____5582 =
+                                  (let uu____5573 =
+                                     let uu____5575 =
                                        FStar_TypeChecker_Env.norm_eff_name
                                          tcenv
                                          (FStar_Syntax_Util.comp_effect_name
                                             c1)
                                         in
-                                     FStar_Ident.lid_equals uu____5582
+                                     FStar_Ident.lid_equals uu____5575
                                        FStar_Parser_Const.effect_TAC_lid
                                       in
-                                   if uu____5580
+                                   if uu____5573
                                    then
                                      let h =
                                        mk_tactic_interpretation loc
                                          non_tvar_arity
                                         in
                                      let tac_fun =
-                                       let uu____5594 =
-                                         let uu____5595 =
-                                           let uu____5602 =
+                                       let uu____5587 =
+                                         let uu____5588 =
+                                           let uu____5595 =
                                              mk_from_tactic loc
                                                non_tvar_arity
                                               in
-                                           let uu____5603 =
-                                             let uu____5606 =
+                                           let uu____5596 =
+                                             let uu____5599 =
                                                lid_to_name fv_lid1  in
-                                             [uu____5606]  in
-                                           (uu____5602, uu____5603)  in
+                                             [uu____5599]  in
+                                           (uu____5595, uu____5596)  in
                                          FStar_Extraction_ML_Syntax.MLE_App
-                                           uu____5595
+                                           uu____5588
                                           in
-                                       FStar_All.pipe_left w uu____5594  in
+                                       FStar_All.pipe_left w uu____5587  in
                                      let psc = str_to_name "psc"  in
                                      let ncb = str_to_name "ncb"  in
                                      let all_args = str_to_name "args"  in
@@ -1702,73 +1700,73 @@ let (interpret_plugin_as_term_fun :
                                      let tabs =
                                        match tvar_names with
                                        | [] ->
-                                           let uu____5620 =
+                                           let uu____5613 =
                                              FStar_All.pipe_left w
                                                (FStar_Extraction_ML_Syntax.MLE_App
                                                   (h,
                                                     (FStar_List.append args
                                                        [all_args])))
                                               in
-                                           mk_lam "args" uu____5620
-                                       | uu____5624 ->
-                                           let uu____5628 =
+                                           mk_lam "args" uu____5613
+                                       | uu____5617 ->
+                                           let uu____5621 =
                                              FStar_All.pipe_left w
                                                (FStar_Extraction_ML_Syntax.MLE_App
                                                   (h, args))
                                               in
                                            abstract_tvars tvar_names
-                                             uu____5628
+                                             uu____5621
                                         in
-                                     let uu____5631 =
-                                       let uu____5632 = mk_lam "ncb" tabs  in
-                                       mk_lam "psc" uu____5632  in
-                                     (uu____5631, (arity + Prims.int_one),
+                                     let uu____5624 =
+                                       let uu____5625 = mk_lam "ncb" tabs  in
+                                       mk_lam "psc" uu____5625  in
+                                     (uu____5624, (arity + Prims.int_one),
                                        false)
                                    else
-                                     (let uu____5641 =
-                                        let uu____5642 =
-                                          let uu____5644 =
+                                     (let uu____5634 =
+                                        let uu____5635 =
+                                          let uu____5637 =
                                             FStar_Syntax_Print.term_to_string
                                               t1
                                              in
                                           Prims.op_Hat
                                             "Plugins not defined for type "
-                                            uu____5644
+                                            uu____5637
                                            in
-                                        NoTacticEmbedding uu____5642  in
-                                      FStar_Exn.raise uu____5641))
-                            | (b,uu____5656)::bs4 ->
-                                let uu____5676 =
-                                  let uu____5679 =
+                                        NoTacticEmbedding uu____5635  in
+                                      FStar_Exn.raise uu____5634))
+                            | (b,uu____5649)::bs4 ->
+                                let uu____5669 =
+                                  let uu____5672 =
                                     mk_embedding loc tvar_context
                                       b.FStar_Syntax_Syntax.sort
                                      in
-                                  uu____5679 :: accum_embeddings  in
-                                aux loc uu____5676 bs4
+                                  uu____5672 :: accum_embeddings  in
+                                aux loc uu____5669 bs4
                              in
                           (try
-                             (fun uu___715_5701  ->
+                             (fun uu___715_5694  ->
                                 match () with
                                 | () ->
-                                    let uu____5714 = aux Syntax_term [] bs2
+                                    let uu____5707 = aux Syntax_term [] bs2
                                        in
-                                    (match uu____5714 with
+                                    (match uu____5707 with
                                      | (w1,a,b) ->
-                                         let uu____5742 = aux NBE_t [] bs2
+                                         let uu____5735 = aux NBE_t [] bs2
                                             in
-                                         (match uu____5742 with
-                                          | (w',uu____5764,uu____5765) ->
+                                         (match uu____5735 with
+                                          | (w',uu____5757,uu____5758) ->
                                               FStar_Pervasives_Native.Some
                                                 (w1, w', a, b)))) ()
                            with
                            | NoTacticEmbedding msg ->
-                               ((let uu____5801 =
+                               ((let uu____5794 =
                                    FStar_Ident.range_of_lid
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                     in
-                                 let uu____5802 =
+                                 let uu____5795 =
                                    FStar_Syntax_Print.fv_to_string fv  in
-                                 not_implemented_warning uu____5801
-                                   uu____5802 msg);
+                                 not_implemented_warning uu____5794
+                                   uu____5795 msg);
                                 FStar_Pervasives_Native.None))))
   

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -2469,7 +2469,7 @@ let (sc_typ :
             match uu____7056 with
             | FStar_Pervasives_Native.None  ->
                 FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-                  FStar_Pervasives_Native.None FStar_Range.dummyRange
+                  FStar_Range.dummyRange
             | FStar_Pervasives_Native.Some ((uu____7075,typ),uu____7077) ->
                 typ
              in

--- a/src/ocaml-output/FStar_Reflection_Basic.ml
+++ b/src/ocaml-output/FStar_Reflection_Basic.ml
@@ -132,15 +132,11 @@ let rec (inspect_ln :
              let q' = inspect_aqual q  in
              let uu____358 =
                let uu____363 =
-                 let uu____364 =
-                   let uu____369 = init args  in
-                   FStar_Syntax_Syntax.mk_Tm_app hd uu____369  in
-                 uu____364 FStar_Pervasives_Native.None
-                   t3.FStar_Syntax_Syntax.pos
-                  in
+                 let uu____364 = init args  in
+                 FStar_Syntax_Util.mk_app hd uu____364  in
                (uu____363, (a, q'))  in
              FStar_Reflection_Data.Tv_App uu____358)
-    | FStar_Syntax_Syntax.Tm_abs ([],uu____378,uu____379) ->
+    | FStar_Syntax_Syntax.Tm_abs ([],uu____383,uu____384) ->
         failwith "inspect_ln: empty arguments on Tm_abs"
     | FStar_Syntax_Syntax.Tm_abs (b::bs,t4,k) ->
         let body =
@@ -149,40 +145,40 @@ let rec (inspect_ln :
           | bs1 ->
               FStar_Syntax_Syntax.mk
                 (FStar_Syntax_Syntax.Tm_abs (bs1, t4, k))
-                FStar_Pervasives_Native.None t4.FStar_Syntax_Syntax.pos
+                t4.FStar_Syntax_Syntax.pos
            in
         FStar_Reflection_Data.Tv_Abs (b, body)
-    | FStar_Syntax_Syntax.Tm_type uu____471 ->
+    | FStar_Syntax_Syntax.Tm_type uu____476 ->
         FStar_Reflection_Data.Tv_Type ()
     | FStar_Syntax_Syntax.Tm_arrow ([],k) ->
         failwith "inspect_ln: empty binders on arrow"
-    | FStar_Syntax_Syntax.Tm_arrow uu____492 ->
-        let uu____507 = FStar_Syntax_Util.arrow_one_ln t3  in
-        (match uu____507 with
+    | FStar_Syntax_Syntax.Tm_arrow uu____497 ->
+        let uu____512 = FStar_Syntax_Util.arrow_one_ln t3  in
+        (match uu____512 with
          | FStar_Pervasives_Native.Some (b,c) ->
              FStar_Reflection_Data.Tv_Arrow (b, c)
          | FStar_Pervasives_Native.None  -> failwith "impossible")
     | FStar_Syntax_Syntax.Tm_refine (bv,t4) ->
         FStar_Reflection_Data.Tv_Refine (bv, t4)
     | FStar_Syntax_Syntax.Tm_constant c ->
-        let uu____532 = inspect_const c  in
-        FStar_Reflection_Data.Tv_Const uu____532
+        let uu____537 = inspect_const c  in
+        FStar_Reflection_Data.Tv_Const uu____537
     | FStar_Syntax_Syntax.Tm_uvar (ctx_u,s) ->
-        let uu____551 =
-          let uu____556 =
-            let uu____557 =
+        let uu____556 =
+          let uu____561 =
+            let uu____562 =
               FStar_Syntax_Unionfind.uvar_id
                 ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                in
-            FStar_BigInt.of_int_fs uu____557  in
-          (uu____556, (ctx_u, s))  in
-        FStar_Reflection_Data.Tv_Uvar uu____551
+            FStar_BigInt.of_int_fs uu____562  in
+          (uu____561, (ctx_u, s))  in
+        FStar_Reflection_Data.Tv_Uvar uu____556
     | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t21) ->
         if lb.FStar_Syntax_Syntax.lbunivs <> []
         then FStar_Reflection_Data.Tv_Unknown
         else
           (match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Util.Inr uu____589 -> FStar_Reflection_Data.Tv_Unknown
+           | FStar_Util.Inr uu____594 -> FStar_Reflection_Data.Tv_Unknown
            | FStar_Util.Inl bv ->
                FStar_Reflection_Data.Tv_Let
                  (false, (lb.FStar_Syntax_Syntax.lbattrs), bv,
@@ -192,7 +188,7 @@ let rec (inspect_ln :
         then FStar_Reflection_Data.Tv_Unknown
         else
           (match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Util.Inr uu____617 -> FStar_Reflection_Data.Tv_Unknown
+           | FStar_Util.Inr uu____622 -> FStar_Reflection_Data.Tv_Unknown
            | FStar_Util.Inl bv ->
                FStar_Reflection_Data.Tv_Let
                  (true, (lb.FStar_Syntax_Syntax.lbattrs), bv,
@@ -201,20 +197,20 @@ let rec (inspect_ln :
         let rec inspect_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_constant c ->
-              let uu____672 = inspect_const c  in
-              FStar_Reflection_Data.Pat_Constant uu____672
+              let uu____677 = inspect_const c  in
+              FStar_Reflection_Data.Pat_Constant uu____677
           | FStar_Syntax_Syntax.Pat_cons (fv,ps) ->
-              let uu____693 =
-                let uu____705 =
+              let uu____698 =
+                let uu____710 =
                   FStar_List.map
-                    (fun uu____729  ->
-                       match uu____729 with
+                    (fun uu____734  ->
+                       match uu____734 with
                        | (p1,b) ->
-                           let uu____750 = inspect_pat p1  in (uu____750, b))
+                           let uu____755 = inspect_pat p1  in (uu____755, b))
                     ps
                    in
-                (fv, uu____705)  in
-              FStar_Reflection_Data.Pat_Cons uu____693
+                (fv, uu____710)  in
+              FStar_Reflection_Data.Pat_Cons uu____698
           | FStar_Syntax_Syntax.Pat_var bv ->
               FStar_Reflection_Data.Pat_Var bv
           | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -224,98 +220,98 @@ let rec (inspect_ln :
            in
         let brs1 =
           FStar_List.map
-            (fun uu___0_801  ->
-               match uu___0_801 with
-               | (pat,uu____823,t5) ->
-                   let uu____841 = inspect_pat pat  in (uu____841, t5)) brs
+            (fun uu___0_806  ->
+               match uu___0_806 with
+               | (pat,uu____828,t5) ->
+                   let uu____846 = inspect_pat pat  in (uu____846, t5)) brs
            in
         FStar_Reflection_Data.Tv_Match (t4, brs1)
     | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Reflection_Data.Tv_Unknown
-    | uu____846 ->
-        ((let uu____848 =
-            let uu____854 =
-              let uu____856 = FStar_Syntax_Print.tag_of_term t3  in
-              let uu____858 = FStar_Syntax_Print.term_to_string t3  in
+    | uu____851 ->
+        ((let uu____853 =
+            let uu____859 =
+              let uu____861 = FStar_Syntax_Print.tag_of_term t3  in
+              let uu____863 = FStar_Syntax_Print.term_to_string t3  in
               FStar_Util.format2
-                "inspect_ln: outside of expected syntax (%s, %s)\n" uu____856
-                uu____858
+                "inspect_ln: outside of expected syntax (%s, %s)\n" uu____861
+                uu____863
                in
-            (FStar_Errors.Warning_CantInspect, uu____854)  in
-          FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____848);
+            (FStar_Errors.Warning_CantInspect, uu____859)  in
+          FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos uu____853);
          FStar_Reflection_Data.Tv_Unknown)
   
 let (inspect_comp :
   FStar_Syntax_Syntax.comp -> FStar_Reflection_Data.comp_view) =
   fun c  ->
     let get_dec flags =
-      let uu____882 =
+      let uu____887 =
         FStar_List.tryFind
-          (fun uu___1_887  ->
-             match uu___1_887 with
-             | FStar_Syntax_Syntax.DECREASES uu____889 -> true
-             | uu____893 -> false) flags
+          (fun uu___1_892  ->
+             match uu___1_892 with
+             | FStar_Syntax_Syntax.DECREASES uu____894 -> true
+             | uu____898 -> false) flags
          in
-      match uu____882 with
+      match uu____887 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES t) ->
           FStar_Pervasives_Native.Some t
-      | uu____900 -> failwith "impossible"  in
+      | uu____905 -> failwith "impossible"  in
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t,uu____907) ->
+    | FStar_Syntax_Syntax.Total (t,uu____912) ->
         FStar_Reflection_Data.C_Total (t, FStar_Pervasives_Native.None)
-    | FStar_Syntax_Syntax.GTotal (t,uu____919) ->
+    | FStar_Syntax_Syntax.GTotal (t,uu____924) ->
         FStar_Reflection_Data.C_GTotal (t, FStar_Pervasives_Native.None)
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____931 =
+        let uu____936 =
           FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
             FStar_Parser_Const.effect_Lemma_lid
            in
-        if uu____931
+        if uu____936
         then
           (match ct.FStar_Syntax_Syntax.effect_args with
-           | (pre,uu____935)::(post,uu____937)::(pats,uu____939)::uu____940
+           | (pre,uu____940)::(post,uu____942)::(pats,uu____944)::uu____945
                -> FStar_Reflection_Data.C_Lemma (pre, post, pats)
-           | uu____999 ->
+           | uu____1004 ->
                failwith "inspect_comp: Lemma does not have enough arguments?")
         else
-          (let uu____1013 =
+          (let uu____1018 =
              FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                FStar_Parser_Const.effect_Tot_lid
               in
-           if uu____1013
+           if uu____1018
            then
              let md = get_dec ct.FStar_Syntax_Syntax.flags  in
              FStar_Reflection_Data.C_Total
                ((ct.FStar_Syntax_Syntax.result_typ), md)
            else
-             (let uu____1023 =
+             (let uu____1028 =
                 FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                   FStar_Parser_Const.effect_GTot_lid
                  in
-              if uu____1023
+              if uu____1028
               then
                 let md = get_dec ct.FStar_Syntax_Syntax.flags  in
                 FStar_Reflection_Data.C_GTotal
                   ((ct.FStar_Syntax_Syntax.result_typ), md)
               else
-                (let inspect_arg uu____1050 =
-                   match uu____1050 with
+                (let inspect_arg uu____1055 =
+                   match uu____1055 with
                    | (a,q) ->
-                       let uu____1069 = inspect_aqual q  in (a, uu____1069)
+                       let uu____1074 = inspect_aqual q  in (a, uu____1074)
                     in
-                 let uu____1072 =
-                   let uu____1085 =
+                 let uu____1077 =
+                   let uu____1090 =
                      FStar_Ident.path_of_lid
                        ct.FStar_Syntax_Syntax.effect_name
                       in
-                   let uu____1086 =
+                   let uu____1091 =
                      FStar_List.map inspect_arg
                        ct.FStar_Syntax_Syntax.effect_args
                       in
-                   ([], uu____1085, (ct.FStar_Syntax_Syntax.result_typ),
-                     uu____1086)
+                   ([], uu____1090, (ct.FStar_Syntax_Syntax.result_typ),
+                     uu____1091)
                     in
-                 FStar_Reflection_Data.C_Eff uu____1072)))
+                 FStar_Reflection_Data.C_Eff uu____1077)))
   
 let (pack_comp : FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.comp)
   =
@@ -349,37 +345,37 @@ let (pack_comp : FStar_Reflection_Data.comp_view -> FStar_Syntax_Syntax.comp)
         FStar_Syntax_Syntax.mk_Comp ct
     | FStar_Reflection_Data.C_Lemma (pre,post,pats) ->
         let ct =
-          let uu____1143 =
-            let uu____1154 = FStar_Syntax_Syntax.as_arg pre  in
-            let uu____1163 =
-              let uu____1174 = FStar_Syntax_Syntax.as_arg post  in
-              let uu____1183 =
-                let uu____1194 = FStar_Syntax_Syntax.as_arg pats  in
-                [uu____1194]  in
-              uu____1174 :: uu____1183  in
-            uu____1154 :: uu____1163  in
+          let uu____1148 =
+            let uu____1159 = FStar_Syntax_Syntax.as_arg pre  in
+            let uu____1168 =
+              let uu____1179 = FStar_Syntax_Syntax.as_arg post  in
+              let uu____1188 =
+                let uu____1199 = FStar_Syntax_Syntax.as_arg pats  in
+                [uu____1199]  in
+              uu____1179 :: uu____1188  in
+            uu____1159 :: uu____1168  in
           {
             FStar_Syntax_Syntax.comp_univs = [];
             FStar_Syntax_Syntax.effect_name =
               FStar_Parser_Const.effect_Lemma_lid;
             FStar_Syntax_Syntax.result_typ = FStar_Syntax_Syntax.t_unit;
-            FStar_Syntax_Syntax.effect_args = uu____1143;
+            FStar_Syntax_Syntax.effect_args = uu____1148;
             FStar_Syntax_Syntax.flags = []
           }  in
         FStar_Syntax_Syntax.mk_Comp ct
     | FStar_Reflection_Data.C_Eff (us,ef,res,args) ->
-        let pack_arg uu____1264 =
-          match uu____1264 with
-          | (a,q) -> let uu____1283 = pack_aqual q  in (a, uu____1283)  in
+        let pack_arg uu____1269 =
+          match uu____1269 with
+          | (a,q) -> let uu____1288 = pack_aqual q  in (a, uu____1288)  in
         let ct =
-          let uu____1287 = FStar_Ident.lid_of_path ef FStar_Range.dummyRange
+          let uu____1292 = FStar_Ident.lid_of_path ef FStar_Range.dummyRange
              in
-          let uu____1288 = FStar_List.map pack_arg args  in
+          let uu____1293 = FStar_List.map pack_arg args  in
           {
             FStar_Syntax_Syntax.comp_univs = [];
-            FStar_Syntax_Syntax.effect_name = uu____1287;
+            FStar_Syntax_Syntax.effect_name = uu____1292;
             FStar_Syntax_Syntax.result_typ = res;
-            FStar_Syntax_Syntax.effect_args = uu____1288;
+            FStar_Syntax_Syntax.effect_args = uu____1293;
             FStar_Syntax_Syntax.flags = []
           }  in
         FStar_Syntax_Syntax.mk_Comp ct
@@ -390,10 +386,10 @@ let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
     match c with
     | FStar_Reflection_Data.C_Unit  -> FStar_Const.Const_unit
     | FStar_Reflection_Data.C_Int i ->
-        let uu____1314 =
-          let uu____1326 = FStar_BigInt.string_of_big_int i  in
-          (uu____1326, FStar_Pervasives_Native.None)  in
-        FStar_Const.Const_int uu____1314
+        let uu____1319 =
+          let uu____1331 = FStar_BigInt.string_of_big_int i  in
+          (uu____1331, FStar_Pervasives_Native.None)  in
+        FStar_Const.Const_int uu____1319
     | FStar_Reflection_Data.C_True  -> FStar_Const.Const_bool true
     | FStar_Reflection_Data.C_False  -> FStar_Const.Const_bool false
     | FStar_Reflection_Data.C_String s ->
@@ -401,9 +397,9 @@ let (pack_const : FStar_Reflection_Data.vconst -> FStar_Syntax_Syntax.sconst)
     | FStar_Reflection_Data.C_Range r -> FStar_Const.Const_range r
     | FStar_Reflection_Data.C_Reify  -> FStar_Const.Const_reify
     | FStar_Reflection_Data.C_Reflect ns ->
-        let uu____1346 = FStar_Ident.lid_of_path ns FStar_Range.dummyRange
+        let uu____1351 = FStar_Ident.lid_of_path ns FStar_Range.dummyRange
            in
-        FStar_Const.Const_reflect uu____1346
+        FStar_Const.Const_reflect uu____1351
   
 let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
   fun tv  ->
@@ -416,24 +412,22 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
     | FStar_Reflection_Data.Tv_Abs (b,t) ->
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_abs ([b], t, FStar_Pervasives_Native.None))
-          FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+          t.FStar_Syntax_Syntax.pos
     | FStar_Reflection_Data.Tv_Arrow (b,c) ->
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_arrow ([b], c))
-          FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
+          c.FStar_Syntax_Syntax.pos
     | FStar_Reflection_Data.Tv_Type () -> FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv,t) ->
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (bv, t))
-          FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+          t.FStar_Syntax_Syntax.pos
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____1435 =
-          let uu____1442 =
-            let uu____1443 = pack_const c  in
-            FStar_Syntax_Syntax.Tm_constant uu____1443  in
-          FStar_Syntax_Syntax.mk uu____1442  in
-        uu____1435 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____1440 =
+          let uu____1441 = pack_const c  in
+          FStar_Syntax_Syntax.Tm_constant uu____1441  in
+        FStar_Syntax_Syntax.mk uu____1440 FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Uvar (u,ctx_u_s) ->
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
-          FStar_Pervasives_Native.None FStar_Range.dummyRange
+          FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Let (false ,attrs,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
@@ -442,7 +436,7 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
            in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_let ((false, [lb]), t2))
-          FStar_Pervasives_Native.None FStar_Range.dummyRange
+          FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Let (true ,attrs,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
@@ -451,7 +445,7 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
            in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_let ((true, [lb]), t2))
-          FStar_Pervasives_Native.None FStar_Range.dummyRange
+          FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Match (t,brs) ->
         let wrap v =
           {
@@ -461,24 +455,24 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____1515 =
-                let uu____1516 = pack_const c  in
-                FStar_Syntax_Syntax.Pat_constant uu____1516  in
-              FStar_All.pipe_left wrap uu____1515
+              let uu____1513 =
+                let uu____1514 = pack_const c  in
+                FStar_Syntax_Syntax.Pat_constant uu____1514  in
+              FStar_All.pipe_left wrap uu____1513
           | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-              let uu____1533 =
-                let uu____1534 =
-                  let uu____1548 =
+              let uu____1531 =
+                let uu____1532 =
+                  let uu____1546 =
                     FStar_List.map
-                      (fun uu____1572  ->
-                         match uu____1572 with
+                      (fun uu____1570  ->
+                         match uu____1570 with
                          | (p1,b) ->
-                             let uu____1587 = pack_pat p1  in (uu____1587, b))
+                             let uu____1585 = pack_pat p1  in (uu____1585, b))
                       ps
                      in
-                  (fv, uu____1548)  in
-                FStar_Syntax_Syntax.Pat_cons uu____1534  in
-              FStar_All.pipe_left wrap uu____1533
+                  (fv, uu____1546)  in
+                FStar_Syntax_Syntax.Pat_cons uu____1532  in
+              FStar_All.pipe_left wrap uu____1531
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -489,27 +483,27 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
            in
         let brs1 =
           FStar_List.map
-            (fun uu___2_1635  ->
-               match uu___2_1635 with
+            (fun uu___2_1633  ->
+               match uu___2_1633 with
                | (pat,t1) ->
-                   let uu____1652 = pack_pat pat  in
-                   (uu____1652, FStar_Pervasives_Native.None, t1)) brs
+                   let uu____1650 = pack_pat pat  in
+                   (uu____1650, FStar_Pervasives_Native.None, t1)) brs
            in
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs1))
-          FStar_Pervasives_Native.None FStar_Range.dummyRange
+          FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_AscribedT (e,t,tacopt) ->
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_ascribed
              (e, ((FStar_Util.Inl t), tacopt), FStar_Pervasives_Native.None))
-          FStar_Pervasives_Native.None FStar_Range.dummyRange
+          FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_ascribed
              (e, ((FStar_Util.Inr c), tacopt), FStar_Pervasives_Native.None))
-          FStar_Pervasives_Native.None FStar_Range.dummyRange
+          FStar_Range.dummyRange
     | FStar_Reflection_Data.Tv_Unknown  ->
         FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-          FStar_Pervasives_Native.None FStar_Range.dummyRange
+          FStar_Range.dummyRange
   
 let (compare_bv :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.bv -> FStar_Order.order) =
@@ -529,39 +523,39 @@ let (lookup_attr :
   =
   fun attr  ->
     fun env  ->
-      let uu____1813 =
-        let uu____1814 = FStar_Syntax_Subst.compress attr  in
-        uu____1814.FStar_Syntax_Syntax.n  in
-      match uu____1813 with
+      let uu____1811 =
+        let uu____1812 = FStar_Syntax_Subst.compress attr  in
+        uu____1812.FStar_Syntax_Syntax.n  in
+      match uu____1811 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let ses =
-            let uu____1823 =
-              let uu____1825 = FStar_Syntax_Syntax.lid_of_fv fv  in
-              FStar_Ident.string_of_lid uu____1825  in
-            FStar_TypeChecker_Env.lookup_attr env uu____1823  in
+            let uu____1821 =
+              let uu____1823 = FStar_Syntax_Syntax.lid_of_fv fv  in
+              FStar_Ident.string_of_lid uu____1823  in
+            FStar_TypeChecker_Env.lookup_attr env uu____1821  in
           FStar_List.concatMap
             (fun se  ->
-               let uu____1829 = FStar_Syntax_Util.lid_of_sigelt se  in
-               match uu____1829 with
+               let uu____1827 = FStar_Syntax_Util.lid_of_sigelt se  in
+               match uu____1827 with
                | FStar_Pervasives_Native.None  -> []
                | FStar_Pervasives_Native.Some l ->
-                   let uu____1835 =
+                   let uu____1833 =
                      FStar_Syntax_Syntax.lid_as_fv l
                        (FStar_Syntax_Syntax.Delta_constant_at_level
                           (Prims.of_int (999))) FStar_Pervasives_Native.None
                       in
-                   [uu____1835]) ses
-      | uu____1837 -> []
+                   [uu____1833]) ses
+      | uu____1835 -> []
   
 let (all_defs_in_env :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.fv Prims.list) =
   fun env  ->
-    let uu____1848 = FStar_TypeChecker_Env.lidents env  in
+    let uu____1846 = FStar_TypeChecker_Env.lidents env  in
     FStar_List.map
       (fun l  ->
          FStar_Syntax_Syntax.lid_as_fv l
            (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (999)))
-           FStar_Pervasives_Native.None) uu____1848
+           FStar_Pervasives_Native.None) uu____1846
   
 let (defs_in_module :
   FStar_TypeChecker_Env.env ->
@@ -569,25 +563,25 @@ let (defs_in_module :
   =
   fun env  ->
     fun modul  ->
-      let uu____1869 = FStar_TypeChecker_Env.lidents env  in
+      let uu____1867 = FStar_TypeChecker_Env.lidents env  in
       FStar_List.concatMap
         (fun l  ->
            let ns =
-             let uu____1877 =
-               let uu____1880 = FStar_Ident.ids_of_lid l  in
-               FStar_All.pipe_right uu____1880 init  in
-             FStar_All.pipe_right uu____1877
+             let uu____1875 =
+               let uu____1878 = FStar_Ident.ids_of_lid l  in
+               FStar_All.pipe_right uu____1878 init  in
+             FStar_All.pipe_right uu____1875
                (FStar_List.map FStar_Ident.text_of_id)
               in
            if ns = modul
            then
-             let uu____1893 =
+             let uu____1891 =
                FStar_Syntax_Syntax.lid_as_fv l
                  (FStar_Syntax_Syntax.Delta_constant_at_level
                     (Prims.of_int (999))) FStar_Pervasives_Native.None
                 in
-             [uu____1893]
-           else []) uu____1869
+             [uu____1891]
+           else []) uu____1867
   
 let (lookup_typ :
   FStar_TypeChecker_Env.env ->
@@ -608,24 +602,24 @@ let (set_sigelt_attrs :
   =
   fun attrs  ->
     fun se  ->
-      let uu___416_1944 = se  in
+      let uu___416_1942 = se  in
       {
-        FStar_Syntax_Syntax.sigel = (uu___416_1944.FStar_Syntax_Syntax.sigel);
+        FStar_Syntax_Syntax.sigel = (uu___416_1942.FStar_Syntax_Syntax.sigel);
         FStar_Syntax_Syntax.sigrng =
-          (uu___416_1944.FStar_Syntax_Syntax.sigrng);
+          (uu___416_1942.FStar_Syntax_Syntax.sigrng);
         FStar_Syntax_Syntax.sigquals =
-          (uu___416_1944.FStar_Syntax_Syntax.sigquals);
+          (uu___416_1942.FStar_Syntax_Syntax.sigquals);
         FStar_Syntax_Syntax.sigmeta =
-          (uu___416_1944.FStar_Syntax_Syntax.sigmeta);
+          (uu___416_1942.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = attrs;
         FStar_Syntax_Syntax.sigopts =
-          (uu___416_1944.FStar_Syntax_Syntax.sigopts)
+          (uu___416_1942.FStar_Syntax_Syntax.sigopts)
       }
   
 let (rd_to_syntax_qual :
   FStar_Reflection_Data.qualifier -> FStar_Syntax_Syntax.qualifier) =
-  fun uu___3_1950  ->
-    match uu___3_1950 with
+  fun uu___3_1948  ->
+    match uu___3_1948 with
     | FStar_Reflection_Data.Assumption  -> FStar_Syntax_Syntax.Assumption
     | FStar_Reflection_Data.New  -> FStar_Syntax_Syntax.New
     | FStar_Reflection_Data.Private  -> FStar_Syntax_Syntax.Private
@@ -663,8 +657,8 @@ let (rd_to_syntax_qual :
   
 let (syntax_to_rd_qual :
   FStar_Syntax_Syntax.qualifier -> FStar_Reflection_Data.qualifier) =
-  fun uu___4_1989  ->
-    match uu___4_1989 with
+  fun uu___4_1987  ->
+    match uu___4_1987 with
     | FStar_Syntax_Syntax.Assumption  -> FStar_Reflection_Data.Assumption
     | FStar_Syntax_Syntax.New  -> FStar_Reflection_Data.New
     | FStar_Syntax_Syntax.Private  -> FStar_Reflection_Data.Private
@@ -712,19 +706,19 @@ let (set_sigelt_quals :
   =
   fun quals  ->
     fun se  ->
-      let uu___495_2052 = se  in
-      let uu____2053 = FStar_List.map rd_to_syntax_qual quals  in
+      let uu___495_2050 = se  in
+      let uu____2051 = FStar_List.map rd_to_syntax_qual quals  in
       {
-        FStar_Syntax_Syntax.sigel = (uu___495_2052.FStar_Syntax_Syntax.sigel);
+        FStar_Syntax_Syntax.sigel = (uu___495_2050.FStar_Syntax_Syntax.sigel);
         FStar_Syntax_Syntax.sigrng =
-          (uu___495_2052.FStar_Syntax_Syntax.sigrng);
-        FStar_Syntax_Syntax.sigquals = uu____2053;
+          (uu___495_2050.FStar_Syntax_Syntax.sigrng);
+        FStar_Syntax_Syntax.sigquals = uu____2051;
         FStar_Syntax_Syntax.sigmeta =
-          (uu___495_2052.FStar_Syntax_Syntax.sigmeta);
+          (uu___495_2050.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs =
-          (uu___495_2052.FStar_Syntax_Syntax.sigattrs);
+          (uu___495_2050.FStar_Syntax_Syntax.sigattrs);
         FStar_Syntax_Syntax.sigopts =
-          (uu___495_2052.FStar_Syntax_Syntax.sigopts)
+          (uu___495_2050.FStar_Syntax_Syntax.sigopts)
       }
   
 let (e_optionstate_hook :
@@ -739,32 +733,32 @@ let (sigelt_opts :
     match se.FStar_Syntax_Syntax.sigopts with
     | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
     | FStar_Pervasives_Native.Some o ->
-        let uu____2086 =
-          let uu____2087 =
-            let uu____2094 =
-              let uu____2097 = FStar_ST.op_Bang e_optionstate_hook  in
-              FStar_All.pipe_right uu____2097 FStar_Util.must  in
-            FStar_Syntax_Embeddings.embed uu____2094 o  in
-          uu____2087 FStar_Range.dummyRange FStar_Pervasives_Native.None
+        let uu____2084 =
+          let uu____2085 =
+            let uu____2092 =
+              let uu____2095 = FStar_ST.op_Bang e_optionstate_hook  in
+              FStar_All.pipe_right uu____2095 FStar_Util.must  in
+            FStar_Syntax_Embeddings.embed uu____2092 o  in
+          uu____2085 FStar_Range.dummyRange FStar_Pervasives_Native.None
             FStar_Syntax_Embeddings.id_norm_cb
            in
-        FStar_Pervasives_Native.Some uu____2086
+        FStar_Pervasives_Native.Some uu____2084
   
 let (inspect_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Reflection_Data.sigelt_view) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let ((r,lb::[]),uu____2147) ->
+    | FStar_Syntax_Syntax.Sig_let ((r,lb::[]),uu____2145) ->
         let fv =
           match lb.FStar_Syntax_Syntax.lbname with
           | FStar_Util.Inr fv -> fv
-          | FStar_Util.Inl uu____2158 ->
+          | FStar_Util.Inl uu____2156 ->
               failwith "impossible: global Sig_let has bv"
            in
-        let uu____2160 =
+        let uu____2158 =
           FStar_Syntax_Subst.univ_var_opening lb.FStar_Syntax_Syntax.lbunivs
            in
-        (match uu____2160 with
+        (match uu____2158 with
          | (s,us) ->
              let typ =
                FStar_Syntax_Subst.subst s lb.FStar_Syntax_Syntax.lbtyp  in
@@ -774,30 +768,30 @@ let (inspect_sigelt :
                (r, fv, (lb.FStar_Syntax_Syntax.lbunivs),
                  (lb.FStar_Syntax_Syntax.lbtyp),
                  (lb.FStar_Syntax_Syntax.lbdef)))
-    | FStar_Syntax_Syntax.Sig_inductive_typ (lid,us,bs,ty,uu____2188,c_lids)
+    | FStar_Syntax_Syntax.Sig_inductive_typ (lid,us,bs,ty,uu____2186,c_lids)
         ->
         let nm = FStar_Ident.path_of_lid lid  in
-        let uu____2199 = FStar_Syntax_Subst.univ_var_opening us  in
-        (match uu____2199 with
+        let uu____2197 = FStar_Syntax_Subst.univ_var_opening us  in
+        (match uu____2197 with
          | (s,us1) ->
              let bs1 = FStar_Syntax_Subst.subst_binders s bs  in
              let ty1 = FStar_Syntax_Subst.subst s ty  in
-             let uu____2220 =
-               let uu____2237 = FStar_List.map FStar_Ident.path_of_lid c_lids
+             let uu____2218 =
+               let uu____2235 = FStar_List.map FStar_Ident.path_of_lid c_lids
                   in
-               (nm, us1, bs1, ty1, uu____2237)  in
-             FStar_Reflection_Data.Sg_Inductive uu____2220)
-    | FStar_Syntax_Syntax.Sig_datacon (lid,us,ty,uu____2249,n,uu____2251) ->
-        let uu____2258 = FStar_Syntax_Subst.univ_var_opening us  in
-        (match uu____2258 with
+               (nm, us1, bs1, ty1, uu____2235)  in
+             FStar_Reflection_Data.Sg_Inductive uu____2218)
+    | FStar_Syntax_Syntax.Sig_datacon (lid,us,ty,uu____2247,n,uu____2249) ->
+        let uu____2256 = FStar_Syntax_Subst.univ_var_opening us  in
+        (match uu____2256 with
          | (s,us1) ->
              let ty1 = FStar_Syntax_Subst.subst s ty  in
              let ty2 = FStar_Syntax_Util.remove_inacc ty1  in
-             let uu____2279 =
-               let uu____2284 = FStar_Ident.path_of_lid lid  in
-               (uu____2284, ty2)  in
-             FStar_Reflection_Data.Sg_Constructor uu____2279)
-    | uu____2285 -> FStar_Reflection_Data.Unk
+             let uu____2277 =
+               let uu____2282 = FStar_Ident.path_of_lid lid  in
+               (uu____2282, ty2)  in
+             FStar_Reflection_Data.Sg_Constructor uu____2277)
+    | uu____2283 -> FStar_Reflection_Data.Unk
   
 let (pack_sigelt :
   FStar_Reflection_Data.sigelt_view -> FStar_Syntax_Syntax.sigelt) =
@@ -812,41 +806,41 @@ let (pack_sigelt :
             FStar_Parser_Const.effect_Tot_lid def1 []
             def1.FStar_Syntax_Syntax.pos
            in
-        let uu____2311 =
-          let uu____2312 =
-            let uu____2319 =
-              let uu____2322 = FStar_Syntax_Syntax.lid_of_fv fv  in
-              [uu____2322]  in
-            ((r, [lb]), uu____2319)  in
-          FStar_Syntax_Syntax.Sig_let uu____2312  in
-        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu____2311
-    | FStar_Reflection_Data.Sg_Constructor uu____2328 ->
+        let uu____2309 =
+          let uu____2310 =
+            let uu____2317 =
+              let uu____2320 = FStar_Syntax_Syntax.lid_of_fv fv  in
+              [uu____2320]  in
+            ((r, [lb]), uu____2317)  in
+          FStar_Syntax_Syntax.Sig_let uu____2310  in
+        FStar_All.pipe_left FStar_Syntax_Syntax.mk_sigelt uu____2309
+    | FStar_Reflection_Data.Sg_Constructor uu____2326 ->
         failwith "packing Sg_Constructor, sorry"
-    | FStar_Reflection_Data.Sg_Inductive uu____2334 ->
+    | FStar_Reflection_Data.Sg_Inductive uu____2332 ->
         failwith "packing Sg_Inductive, sorry"
     | FStar_Reflection_Data.Unk  -> failwith "packing Unk, sorry"
   
 let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_Data.bv_view) =
   fun bv  ->
-    let uu____2359 = FStar_Ident.text_of_id bv.FStar_Syntax_Syntax.ppname  in
-    let uu____2361 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index  in
+    let uu____2357 = FStar_Ident.text_of_id bv.FStar_Syntax_Syntax.ppname  in
+    let uu____2359 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index  in
     {
-      FStar_Reflection_Data.bv_ppname = uu____2359;
-      FStar_Reflection_Data.bv_index = uu____2361;
+      FStar_Reflection_Data.bv_ppname = uu____2357;
+      FStar_Reflection_Data.bv_index = uu____2359;
       FStar_Reflection_Data.bv_sort = (bv.FStar_Syntax_Syntax.sort)
     }
   
 let (pack_bv : FStar_Reflection_Data.bv_view -> FStar_Syntax_Syntax.bv) =
   fun bvv  ->
-    let uu____2368 =
+    let uu____2366 =
       FStar_Ident.mk_ident
         ((bvv.FStar_Reflection_Data.bv_ppname), FStar_Range.dummyRange)
        in
-    let uu____2370 =
+    let uu____2368 =
       FStar_BigInt.to_int_fs bvv.FStar_Reflection_Data.bv_index  in
     {
-      FStar_Syntax_Syntax.ppname = uu____2368;
-      FStar_Syntax_Syntax.index = uu____2370;
+      FStar_Syntax_Syntax.ppname = uu____2366;
+      FStar_Syntax_Syntax.index = uu____2368;
       FStar_Syntax_Syntax.sort = (bvv.FStar_Reflection_Data.bv_sort)
     }
   
@@ -855,28 +849,28 @@ let (inspect_binder :
     (FStar_Syntax_Syntax.bv * FStar_Reflection_Data.aqualv))
   =
   fun b  ->
-    let uu____2386 = b  in
-    match uu____2386 with
-    | (bv,aq) -> let uu____2397 = inspect_aqual aq  in (bv, uu____2397)
+    let uu____2384 = b  in
+    match uu____2384 with
+    | (bv,aq) -> let uu____2395 = inspect_aqual aq  in (bv, uu____2395)
   
 let (pack_binder :
   FStar_Syntax_Syntax.bv ->
     FStar_Reflection_Data.aqualv -> FStar_Syntax_Syntax.binder)
   =
-  fun bv  -> fun aqv  -> let uu____2409 = pack_aqual aqv  in (bv, uu____2409) 
+  fun bv  -> fun aqv  -> let uu____2407 = pack_aqual aqv  in (bv, uu____2407) 
 let (moduleof : FStar_TypeChecker_Env.env -> Prims.string Prims.list) =
   fun e  -> FStar_Ident.path_of_lid e.FStar_TypeChecker_Env.curmodule 
 let (env_open_modules :
   FStar_TypeChecker_Env.env -> FStar_Reflection_Data.name Prims.list) =
   fun e  ->
-    let uu____2436 =
+    let uu____2434 =
       FStar_Syntax_DsEnv.open_modules e.FStar_TypeChecker_Env.dsenv  in
     FStar_List.map
-      (fun uu____2454  ->
-         match uu____2454 with
+      (fun uu____2452  ->
+         match uu____2452 with
          | (l,m) ->
-             let uu____2464 = FStar_Ident.ids_of_lid l  in
-             FStar_List.map FStar_Ident.text_of_id uu____2464) uu____2436
+             let uu____2462 = FStar_Ident.ids_of_lid l  in
+             FStar_List.map FStar_Ident.text_of_id uu____2462) uu____2434
   
 let (binders_of_env :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.binders) =
@@ -885,9 +879,9 @@ let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1  ->
     fun t2  ->
-      let uu____2486 = FStar_Syntax_Util.un_uinst t1  in
-      let uu____2487 = FStar_Syntax_Util.un_uinst t2  in
-      FStar_Syntax_Util.term_eq uu____2486 uu____2487
+      let uu____2484 = FStar_Syntax_Util.un_uinst t1  in
+      let uu____2485 = FStar_Syntax_Util.un_uinst t2  in
+      FStar_Syntax_Util.term_eq uu____2484 uu____2485
   
 let (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
   fun t  -> FStar_Syntax_Print.term_to_string t 

--- a/src/ocaml-output/FStar_Reflection_Embeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_Embeddings.ml
@@ -171,9 +171,7 @@ let (e_term_aq :
           FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_static;
           FStar_Syntax_Syntax.antiquotes = aq
         }  in
-      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_quoted (t, qi))
-        FStar_Pervasives_Native.None rng
-       in
+      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_quoted (t, qi)) rng  in
     let rec unembed_term w t =
       let apply_antiquotes t1 aq1 =
         let uu____481 =
@@ -226,34 +224,31 @@ let (e_aqualv :
           FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Q_Meta t ->
           let uu____577 =
-            let uu____582 =
-              let uu____583 =
-                let uu____592 = embed e_term rng t  in
-                FStar_Syntax_Syntax.as_arg uu____592  in
-              [uu____583]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.t
-              uu____582
-             in
-          uu____577 FStar_Pervasives_Native.None FStar_Range.dummyRange
+            let uu____578 =
+              let uu____587 = embed e_term rng t  in
+              FStar_Syntax_Syntax.as_arg uu____587  in
+            [uu____578]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.t
+            uu____577 FStar_Range.dummyRange
        in
-    let uu___104_609 = r  in
+    let uu___104_604 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___104_609.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___104_604.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___104_609.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___104_604.FStar_Syntax_Syntax.vars)
     }  in
   let unembed_aqualv w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____630 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____630 with
+    let uu____625 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____625 with
     | (hd,args) ->
-        let uu____675 =
-          let uu____690 =
-            let uu____691 = FStar_Syntax_Util.un_uinst hd  in
-            uu____691.FStar_Syntax_Syntax.n  in
-          (uu____690, args)  in
-        (match uu____675 with
+        let uu____670 =
+          let uu____685 =
+            let uu____686 = FStar_Syntax_Util.un_uinst hd  in
+            uu____686.FStar_Syntax_Syntax.n  in
+          (uu____685, args)  in
+        (match uu____670 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Explicit.FStar_Reflection_Data.lid
@@ -262,26 +257,26 @@ let (e_aqualv :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Implicit.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Q_Implicit
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(t2,uu____746)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(t2,uu____741)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Q_Meta.FStar_Reflection_Data.lid
              ->
-             let uu____781 = unembed' w e_term t2  in
-             FStar_Util.bind_opt uu____781
+             let uu____776 = unembed' w e_term t2  in
+             FStar_Util.bind_opt uu____776
                (fun t3  ->
                   FStar_Pervasives_Native.Some
                     (FStar_Reflection_Data.Q_Meta t3))
-         | uu____786 ->
+         | uu____781 ->
              (if w
               then
-                (let uu____803 =
-                   let uu____809 =
-                     let uu____811 = FStar_Syntax_Print.term_to_string t1  in
+                (let uu____798 =
+                   let uu____804 =
+                     let uu____806 = FStar_Syntax_Print.term_to_string t1  in
                      FStar_Util.format1 "Not an embedded aqualv: %s"
-                       uu____811
+                       uu____806
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____809)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____803)
+                   (FStar_Errors.Warning_NotEmbedded, uu____804)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____798)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -295,27 +290,27 @@ let (e_fv : FStar_Syntax_Syntax.fv FStar_Syntax_Embeddings.embedding) =
       FStar_Syntax_Syntax.Lazy_fvar (FStar_Pervasives_Native.Some rng)
      in
   let unembed_fv w t =
-    let uu____851 =
-      let uu____852 = FStar_Syntax_Subst.compress t  in
-      uu____852.FStar_Syntax_Syntax.n  in
-    match uu____851 with
+    let uu____846 =
+      let uu____847 = FStar_Syntax_Subst.compress t  in
+      uu____847.FStar_Syntax_Syntax.n  in
+    match uu____846 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_fvar ;
-          FStar_Syntax_Syntax.ltyp = uu____858;
-          FStar_Syntax_Syntax.rng = uu____859;_}
+          FStar_Syntax_Syntax.ltyp = uu____853;
+          FStar_Syntax_Syntax.rng = uu____854;_}
         ->
-        let uu____862 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____862
-    | uu____863 ->
+        let uu____857 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____857
+    | uu____858 ->
         (if w
          then
-           (let uu____866 =
-              let uu____872 =
-                let uu____874 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded fvar: %s" uu____874  in
-              (FStar_Errors.Warning_NotEmbedded, uu____872)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____866)
+           (let uu____861 =
+              let uu____867 =
+                let uu____869 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded fvar: %s" uu____869  in
+              (FStar_Errors.Warning_NotEmbedded, uu____867)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____861)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -326,27 +321,27 @@ let (e_comp : FStar_Syntax_Syntax.comp FStar_Syntax_Embeddings.embedding) =
       FStar_Syntax_Syntax.Lazy_comp (FStar_Pervasives_Native.Some rng)
      in
   let unembed_comp w t =
-    let uu____911 =
-      let uu____912 = FStar_Syntax_Subst.compress t  in
-      uu____912.FStar_Syntax_Syntax.n  in
-    match uu____911 with
+    let uu____906 =
+      let uu____907 = FStar_Syntax_Subst.compress t  in
+      uu____907.FStar_Syntax_Syntax.n  in
+    match uu____906 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_comp ;
-          FStar_Syntax_Syntax.ltyp = uu____918;
-          FStar_Syntax_Syntax.rng = uu____919;_}
+          FStar_Syntax_Syntax.ltyp = uu____913;
+          FStar_Syntax_Syntax.rng = uu____914;_}
         ->
-        let uu____922 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____922
-    | uu____923 ->
+        let uu____917 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____917
+    | uu____918 ->
         (if w
          then
-           (let uu____926 =
-              let uu____932 =
-                let uu____934 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded comp: %s" uu____934  in
-              (FStar_Errors.Warning_NotEmbedded, uu____932)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____926)
+           (let uu____921 =
+              let uu____927 =
+                let uu____929 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded comp: %s" uu____929  in
+              (FStar_Errors.Warning_NotEmbedded, uu____927)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____921)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -357,27 +352,27 @@ let (e_env : FStar_TypeChecker_Env.env FStar_Syntax_Embeddings.embedding) =
       FStar_Syntax_Syntax.Lazy_env (FStar_Pervasives_Native.Some rng)
      in
   let unembed_env w t =
-    let uu____971 =
-      let uu____972 = FStar_Syntax_Subst.compress t  in
-      uu____972.FStar_Syntax_Syntax.n  in
-    match uu____971 with
+    let uu____966 =
+      let uu____967 = FStar_Syntax_Subst.compress t  in
+      uu____967.FStar_Syntax_Syntax.n  in
+    match uu____966 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_env ;
-          FStar_Syntax_Syntax.ltyp = uu____978;
-          FStar_Syntax_Syntax.rng = uu____979;_}
+          FStar_Syntax_Syntax.ltyp = uu____973;
+          FStar_Syntax_Syntax.rng = uu____974;_}
         ->
-        let uu____982 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____982
-    | uu____983 ->
+        let uu____977 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____977
+    | uu____978 ->
         (if w
          then
-           (let uu____986 =
-              let uu____992 =
-                let uu____994 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded env: %s" uu____994  in
-              (FStar_Errors.Warning_NotEmbedded, uu____992)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____986)
+           (let uu____981 =
+              let uu____987 =
+                let uu____989 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded env: %s" uu____989  in
+              (FStar_Errors.Warning_NotEmbedded, uu____987)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____981)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -394,78 +389,66 @@ let (e_const :
       | FStar_Reflection_Data.C_False  ->
           FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.t
       | FStar_Reflection_Data.C_Int i ->
-          let uu____1020 =
-            let uu____1025 =
-              let uu____1026 =
-                let uu____1035 =
-                  let uu____1036 = FStar_BigInt.string_of_big_int i  in
-                  FStar_Syntax_Util.exp_int uu____1036  in
-                FStar_Syntax_Syntax.as_arg uu____1035  in
-              [uu____1026]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.t
-              uu____1025
-             in
-          uu____1020 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____1015 =
+            let uu____1016 =
+              let uu____1025 =
+                let uu____1026 = FStar_BigInt.string_of_big_int i  in
+                FStar_Syntax_Util.exp_int uu____1026  in
+              FStar_Syntax_Syntax.as_arg uu____1025  in
+            [uu____1016]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.t
+            uu____1015 FStar_Range.dummyRange
       | FStar_Reflection_Data.C_String s ->
-          let uu____1056 =
-            let uu____1061 =
-              let uu____1062 =
-                let uu____1071 = embed FStar_Syntax_Embeddings.e_string rng s
-                   in
-                FStar_Syntax_Syntax.as_arg uu____1071  in
-              [uu____1062]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.t
-              uu____1061
-             in
-          uu____1056 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____1046 =
+            let uu____1047 =
+              let uu____1056 = embed FStar_Syntax_Embeddings.e_string rng s
+                 in
+              FStar_Syntax_Syntax.as_arg uu____1056  in
+            [uu____1047]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.t
+            uu____1046 FStar_Range.dummyRange
       | FStar_Reflection_Data.C_Range r ->
-          let uu____1090 =
-            let uu____1095 =
-              let uu____1096 =
-                let uu____1105 = embed FStar_Syntax_Embeddings.e_range rng r
-                   in
-                FStar_Syntax_Syntax.as_arg uu____1105  in
-              [uu____1096]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.t
-              uu____1095
-             in
-          uu____1090 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____1075 =
+            let uu____1076 =
+              let uu____1085 = embed FStar_Syntax_Embeddings.e_range rng r
+                 in
+              FStar_Syntax_Syntax.as_arg uu____1085  in
+            [uu____1076]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.t
+            uu____1075 FStar_Range.dummyRange
       | FStar_Reflection_Data.C_Reify  ->
           FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.t
       | FStar_Reflection_Data.C_Reflect ns ->
-          let uu____1123 =
-            let uu____1128 =
-              let uu____1129 =
-                let uu____1138 =
-                  embed FStar_Syntax_Embeddings.e_string_list rng ns  in
-                FStar_Syntax_Syntax.as_arg uu____1138  in
-              [uu____1129]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.t
-              uu____1128
-             in
-          uu____1123 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____1103 =
+            let uu____1104 =
+              let uu____1113 =
+                embed FStar_Syntax_Embeddings.e_string_list rng ns  in
+              FStar_Syntax_Syntax.as_arg uu____1113  in
+            [uu____1104]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.t
+            uu____1103 FStar_Range.dummyRange
        in
-    let uu___193_1158 = r  in
+    let uu___193_1133 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___193_1158.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___193_1133.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___193_1158.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___193_1133.FStar_Syntax_Syntax.vars)
     }  in
   let unembed_const w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____1179 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____1179 with
+    let uu____1154 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____1154 with
     | (hd,args) ->
-        let uu____1224 =
-          let uu____1239 =
-            let uu____1240 = FStar_Syntax_Util.un_uinst hd  in
-            uu____1240.FStar_Syntax_Syntax.n  in
-          (uu____1239, args)  in
-        (match uu____1224 with
+        let uu____1199 =
+          let uu____1214 =
+            let uu____1215 = FStar_Syntax_Util.un_uinst hd  in
+            uu____1215.FStar_Syntax_Syntax.n  in
+          (uu____1214, args)  in
+        (match uu____1199 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Unit.FStar_Reflection_Data.lid
@@ -478,255 +461,240 @@ let (e_const :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_False.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.C_False
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____1314)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____1289)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Int.FStar_Reflection_Data.lid
              ->
-             let uu____1349 = unembed' w FStar_Syntax_Embeddings.e_int i  in
-             FStar_Util.bind_opt uu____1349
+             let uu____1324 = unembed' w FStar_Syntax_Embeddings.e_int i  in
+             FStar_Util.bind_opt uu____1324
                (fun i1  ->
                   FStar_All.pipe_left
-                    (fun uu____1356  ->
-                       FStar_Pervasives_Native.Some uu____1356)
+                    (fun uu____1331  ->
+                       FStar_Pervasives_Native.Some uu____1331)
                     (FStar_Reflection_Data.C_Int i1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(s,uu____1359)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(s,uu____1334)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_String.FStar_Reflection_Data.lid
              ->
-             let uu____1394 = unembed' w FStar_Syntax_Embeddings.e_string s
+             let uu____1369 = unembed' w FStar_Syntax_Embeddings.e_string s
                 in
-             FStar_Util.bind_opt uu____1394
+             FStar_Util.bind_opt uu____1369
                (fun s1  ->
                   FStar_All.pipe_left
-                    (fun uu____1405  ->
-                       FStar_Pervasives_Native.Some uu____1405)
+                    (fun uu____1380  ->
+                       FStar_Pervasives_Native.Some uu____1380)
                     (FStar_Reflection_Data.C_String s1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(r,uu____1408)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(r,uu____1383)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Range.FStar_Reflection_Data.lid
              ->
-             let uu____1443 = unembed' w FStar_Syntax_Embeddings.e_range r
+             let uu____1418 = unembed' w FStar_Syntax_Embeddings.e_range r
                 in
-             FStar_Util.bind_opt uu____1443
+             FStar_Util.bind_opt uu____1418
                (fun r1  ->
                   FStar_All.pipe_left
-                    (fun uu____1450  ->
-                       FStar_Pervasives_Native.Some uu____1450)
+                    (fun uu____1425  ->
+                       FStar_Pervasives_Native.Some uu____1425)
                     (FStar_Reflection_Data.C_Range r1))
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Reify.FStar_Reflection_Data.lid
              ->
              FStar_All.pipe_left
-               (fun uu____1472  -> FStar_Pervasives_Native.Some uu____1472)
+               (fun uu____1447  -> FStar_Pervasives_Native.Some uu____1447)
                FStar_Reflection_Data.C_Reify
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(ns,uu____1475)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(ns,uu____1450)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Reflect.FStar_Reflection_Data.lid
              ->
-             let uu____1510 =
+             let uu____1485 =
                unembed' w FStar_Syntax_Embeddings.e_string_list ns  in
-             FStar_Util.bind_opt uu____1510
+             FStar_Util.bind_opt uu____1485
                (fun ns1  ->
                   FStar_All.pipe_left
-                    (fun uu____1529  ->
-                       FStar_Pervasives_Native.Some uu____1529)
+                    (fun uu____1504  ->
+                       FStar_Pervasives_Native.Some uu____1504)
                     (FStar_Reflection_Data.C_Reflect ns1))
-         | uu____1530 ->
+         | uu____1505 ->
              (if w
               then
-                (let uu____1547 =
-                   let uu____1553 =
-                     let uu____1555 = FStar_Syntax_Print.term_to_string t1
+                (let uu____1522 =
+                   let uu____1528 =
+                     let uu____1530 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded vconst: %s"
-                       uu____1555
+                       uu____1530
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____1553)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____1547)
+                   (FStar_Errors.Warning_NotEmbedded, uu____1528)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____1522)
               else ();
               FStar_Pervasives_Native.None))
      in
   mk_emb embed_const unembed_const FStar_Reflection_Data.fstar_refl_vconst 
 let rec (e_pattern' :
   unit -> FStar_Reflection_Data.pattern FStar_Syntax_Embeddings.embedding) =
-  fun uu____1568  ->
+  fun uu____1543  ->
     let rec embed_pattern rng p =
       match p with
       | FStar_Reflection_Data.Pat_Constant c ->
-          let uu____1581 =
-            let uu____1586 =
-              let uu____1587 =
-                let uu____1596 = embed e_const rng c  in
-                FStar_Syntax_Syntax.as_arg uu____1596  in
-              [uu____1587]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.t
-              uu____1586
-             in
-          uu____1581 FStar_Pervasives_Native.None rng
+          let uu____1556 =
+            let uu____1557 =
+              let uu____1566 = embed e_const rng c  in
+              FStar_Syntax_Syntax.as_arg uu____1566  in
+            [uu____1557]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.t
+            uu____1556 rng
       | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-          let uu____1629 =
-            let uu____1634 =
-              let uu____1635 =
-                let uu____1644 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____1644  in
-              let uu____1645 =
-                let uu____1656 =
-                  let uu____1665 =
-                    let uu____1666 =
-                      let uu____1676 =
-                        let uu____1684 = e_pattern' ()  in
-                        FStar_Syntax_Embeddings.e_tuple2 uu____1684
-                          FStar_Syntax_Embeddings.e_bool
-                         in
-                      FStar_Syntax_Embeddings.e_list uu____1676  in
-                    embed uu____1666 rng ps  in
-                  FStar_Syntax_Syntax.as_arg uu____1665  in
-                [uu____1656]  in
-              uu____1635 :: uu____1645  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.t
-              uu____1634
-             in
-          uu____1629 FStar_Pervasives_Native.None rng
+          let uu____1599 =
+            let uu____1600 =
+              let uu____1609 = embed e_fv rng fv  in
+              FStar_Syntax_Syntax.as_arg uu____1609  in
+            let uu____1610 =
+              let uu____1621 =
+                let uu____1630 =
+                  let uu____1631 =
+                    let uu____1641 =
+                      let uu____1649 = e_pattern' ()  in
+                      FStar_Syntax_Embeddings.e_tuple2 uu____1649
+                        FStar_Syntax_Embeddings.e_bool
+                       in
+                    FStar_Syntax_Embeddings.e_list uu____1641  in
+                  embed uu____1631 rng ps  in
+                FStar_Syntax_Syntax.as_arg uu____1630  in
+              [uu____1621]  in
+            uu____1600 :: uu____1610  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.t
+            uu____1599 rng
       | FStar_Reflection_Data.Pat_Var bv ->
-          let uu____1725 =
-            let uu____1730 =
-              let uu____1731 =
-                let uu____1740 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1740  in
-              [uu____1731]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.t
-              uu____1730
-             in
-          uu____1725 FStar_Pervasives_Native.None rng
+          let uu____1690 =
+            let uu____1691 =
+              let uu____1700 = embed e_bv rng bv  in
+              FStar_Syntax_Syntax.as_arg uu____1700  in
+            [uu____1691]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.t
+            uu____1690 rng
       | FStar_Reflection_Data.Pat_Wild bv ->
-          let uu____1758 =
-            let uu____1763 =
-              let uu____1764 =
-                let uu____1773 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1773  in
-              [uu____1764]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.t
-              uu____1763
-             in
-          uu____1758 FStar_Pervasives_Native.None rng
+          let uu____1718 =
+            let uu____1719 =
+              let uu____1728 = embed e_bv rng bv  in
+              FStar_Syntax_Syntax.as_arg uu____1728  in
+            [uu____1719]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.t
+            uu____1718 rng
       | FStar_Reflection_Data.Pat_Dot_Term (bv,t) ->
-          let uu____1792 =
-            let uu____1797 =
-              let uu____1798 =
-                let uu____1807 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____1807  in
-              let uu____1808 =
-                let uu____1819 =
-                  let uu____1828 = embed e_term rng t  in
-                  FStar_Syntax_Syntax.as_arg uu____1828  in
-                [uu____1819]  in
-              uu____1798 :: uu____1808  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.t
-              uu____1797
-             in
-          uu____1792 FStar_Pervasives_Native.None rng
+          let uu____1747 =
+            let uu____1748 =
+              let uu____1757 = embed e_bv rng bv  in
+              FStar_Syntax_Syntax.as_arg uu____1757  in
+            let uu____1758 =
+              let uu____1769 =
+                let uu____1778 = embed e_term rng t  in
+                FStar_Syntax_Syntax.as_arg uu____1778  in
+              [uu____1769]  in
+            uu____1748 :: uu____1758  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.t
+            uu____1747 rng
        in
     let rec unembed_pattern w t =
       let t1 = FStar_Syntax_Util.unascribe t  in
-      let uu____1871 = FStar_Syntax_Util.head_and_args t1  in
-      match uu____1871 with
+      let uu____1821 = FStar_Syntax_Util.head_and_args t1  in
+      match uu____1821 with
       | (hd,args) ->
-          let uu____1916 =
-            let uu____1929 =
-              let uu____1930 = FStar_Syntax_Util.un_uinst hd  in
-              uu____1930.FStar_Syntax_Syntax.n  in
-            (uu____1929, args)  in
-          (match uu____1916 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____1945)::[]) when
+          let uu____1866 =
+            let uu____1879 =
+              let uu____1880 = FStar_Syntax_Util.un_uinst hd  in
+              uu____1880.FStar_Syntax_Syntax.n  in
+            (uu____1879, args)  in
+          (match uu____1866 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____1895)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Constant.FStar_Reflection_Data.lid
                ->
-               let uu____1970 = unembed' w e_const c  in
-               FStar_Util.bind_opt uu____1970
+               let uu____1920 = unembed' w e_const c  in
+               FStar_Util.bind_opt uu____1920
                  (fun c1  ->
                     FStar_All.pipe_left
-                      (fun uu____1977  ->
-                         FStar_Pervasives_Native.Some uu____1977)
+                      (fun uu____1927  ->
+                         FStar_Pervasives_Native.Some uu____1927)
                       (FStar_Reflection_Data.Pat_Constant c1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(f,uu____1980)::(ps,uu____1982)::[]) when
+              fv,(f,uu____1930)::(ps,uu____1932)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Cons.FStar_Reflection_Data.lid
                ->
-               let uu____2017 = unembed' w e_fv f  in
-               FStar_Util.bind_opt uu____2017
+               let uu____1967 = unembed' w e_fv f  in
+               FStar_Util.bind_opt uu____1967
                  (fun f1  ->
-                    let uu____2023 =
-                      let uu____2033 =
-                        let uu____2043 =
-                          let uu____2051 = e_pattern' ()  in
-                          FStar_Syntax_Embeddings.e_tuple2 uu____2051
+                    let uu____1973 =
+                      let uu____1983 =
+                        let uu____1993 =
+                          let uu____2001 = e_pattern' ()  in
+                          FStar_Syntax_Embeddings.e_tuple2 uu____2001
                             FStar_Syntax_Embeddings.e_bool
                            in
-                        FStar_Syntax_Embeddings.e_list uu____2043  in
-                      unembed' w uu____2033 ps  in
-                    FStar_Util.bind_opt uu____2023
+                        FStar_Syntax_Embeddings.e_list uu____1993  in
+                      unembed' w uu____1983 ps  in
+                    FStar_Util.bind_opt uu____1973
                       (fun ps1  ->
                          FStar_All.pipe_left
-                           (fun uu____2085  ->
-                              FStar_Pervasives_Native.Some uu____2085)
+                           (fun uu____2035  ->
+                              FStar_Pervasives_Native.Some uu____2035)
                            (FStar_Reflection_Data.Pat_Cons (f1, ps1))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2095)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2045)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Var.FStar_Reflection_Data.lid
                ->
-               let uu____2120 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____2120
+               let uu____2070 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2070
                  (fun bv1  ->
                     FStar_All.pipe_left
-                      (fun uu____2127  ->
-                         FStar_Pervasives_Native.Some uu____2127)
+                      (fun uu____2077  ->
+                         FStar_Pervasives_Native.Some uu____2077)
                       (FStar_Reflection_Data.Pat_Var bv1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2130)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(bv,uu____2080)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Wild.FStar_Reflection_Data.lid
                ->
-               let uu____2155 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____2155
+               let uu____2105 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2105
                  (fun bv1  ->
                     FStar_All.pipe_left
-                      (fun uu____2162  ->
-                         FStar_Pervasives_Native.Some uu____2162)
+                      (fun uu____2112  ->
+                         FStar_Pervasives_Native.Some uu____2112)
                       (FStar_Reflection_Data.Pat_Wild bv1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(bv,uu____2165)::(t2,uu____2167)::[]) when
+              fv,(bv,uu____2115)::(t2,uu____2117)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Pat_Dot_Term.FStar_Reflection_Data.lid
                ->
-               let uu____2202 = unembed' w e_bv bv  in
-               FStar_Util.bind_opt uu____2202
+               let uu____2152 = unembed' w e_bv bv  in
+               FStar_Util.bind_opt uu____2152
                  (fun bv1  ->
-                    let uu____2208 = unembed' w e_term t2  in
-                    FStar_Util.bind_opt uu____2208
+                    let uu____2158 = unembed' w e_term t2  in
+                    FStar_Util.bind_opt uu____2158
                       (fun t3  ->
                          FStar_All.pipe_left
-                           (fun uu____2215  ->
-                              FStar_Pervasives_Native.Some uu____2215)
+                           (fun uu____2165  ->
+                              FStar_Pervasives_Native.Some uu____2165)
                            (FStar_Reflection_Data.Pat_Dot_Term (bv1, t3))))
-           | uu____2216 ->
+           | uu____2166 ->
                (if w
                 then
-                  (let uu____2231 =
-                     let uu____2237 =
-                       let uu____2239 = FStar_Syntax_Print.term_to_string t1
+                  (let uu____2181 =
+                     let uu____2187 =
+                       let uu____2189 = FStar_Syntax_Print.term_to_string t1
                           in
                        FStar_Util.format1 "Not an embedded pattern: %s"
-                         uu____2239
+                         uu____2189
                         in
-                     (FStar_Errors.Warning_NotEmbedded, uu____2237)  in
+                     (FStar_Errors.Warning_NotEmbedded, uu____2187)  in
                    FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos
-                     uu____2231)
+                     uu____2181)
                 else ();
                 FStar_Pervasives_Native.None))
        in
@@ -750,8 +718,8 @@ let (e_branch_aq :
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq  ->
-    let uu____2271 = e_term_aq aq  in
-    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu____2271
+    let uu____2221 = e_term_aq aq  in
+    FStar_Syntax_Embeddings.e_tuple2 e_pattern uu____2221
   
 let (e_argv_aq :
   FStar_Syntax_Syntax.antiquotations ->
@@ -759,8 +727,8 @@ let (e_argv_aq :
       FStar_Syntax_Embeddings.embedding)
   =
   fun aq  ->
-    let uu____2286 = e_term_aq aq  in
-    FStar_Syntax_Embeddings.e_tuple2 uu____2286 e_aqualv
+    let uu____2236 = e_term_aq aq  in
+    FStar_Syntax_Embeddings.e_tuple2 uu____2236 e_aqualv
   
 let (e_term_view_aq :
   FStar_Syntax_Syntax.antiquotations ->
@@ -770,532 +738,483 @@ let (e_term_view_aq :
     let embed_term_view rng t =
       match t with
       | FStar_Reflection_Data.Tv_FVar fv ->
-          let uu____2309 =
-            let uu____2314 =
-              let uu____2315 =
-                let uu____2324 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____2324  in
-              [uu____2315]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.t
-              uu____2314
-             in
-          uu____2309 FStar_Pervasives_Native.None rng
+          let uu____2259 =
+            let uu____2260 =
+              let uu____2269 = embed e_fv rng fv  in
+              FStar_Syntax_Syntax.as_arg uu____2269  in
+            [uu____2260]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.t
+            uu____2259 rng
       | FStar_Reflection_Data.Tv_BVar fv ->
-          let uu____2342 =
-            let uu____2347 =
-              let uu____2348 =
-                let uu____2357 = embed e_bv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____2357  in
-              [uu____2348]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.t
-              uu____2347
-             in
-          uu____2342 FStar_Pervasives_Native.None rng
+          let uu____2287 =
+            let uu____2288 =
+              let uu____2297 = embed e_bv rng fv  in
+              FStar_Syntax_Syntax.as_arg uu____2297  in
+            [uu____2288]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.t
+            uu____2287 rng
       | FStar_Reflection_Data.Tv_Var bv ->
-          let uu____2375 =
-            let uu____2380 =
-              let uu____2381 =
-                let uu____2390 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____2390  in
-              [uu____2381]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.t
-              uu____2380
-             in
-          uu____2375 FStar_Pervasives_Native.None rng
+          let uu____2315 =
+            let uu____2316 =
+              let uu____2325 = embed e_bv rng bv  in
+              FStar_Syntax_Syntax.as_arg uu____2325  in
+            [uu____2316]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.t
+            uu____2315 rng
       | FStar_Reflection_Data.Tv_App (hd,a) ->
-          let uu____2409 =
-            let uu____2414 =
-              let uu____2415 =
-                let uu____2424 =
-                  let uu____2425 = e_term_aq aq  in embed uu____2425 rng hd
+          let uu____2344 =
+            let uu____2345 =
+              let uu____2354 =
+                let uu____2355 = e_term_aq aq  in embed uu____2355 rng hd  in
+              FStar_Syntax_Syntax.as_arg uu____2354  in
+            let uu____2358 =
+              let uu____2369 =
+                let uu____2378 =
+                  let uu____2379 = e_argv_aq aq  in embed uu____2379 rng a
                    in
-                FStar_Syntax_Syntax.as_arg uu____2424  in
-              let uu____2428 =
-                let uu____2439 =
-                  let uu____2448 =
-                    let uu____2449 = e_argv_aq aq  in embed uu____2449 rng a
-                     in
-                  FStar_Syntax_Syntax.as_arg uu____2448  in
-                [uu____2439]  in
-              uu____2415 :: uu____2428  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.t
-              uu____2414
-             in
-          uu____2409 FStar_Pervasives_Native.None rng
+                FStar_Syntax_Syntax.as_arg uu____2378  in
+              [uu____2369]  in
+            uu____2345 :: uu____2358  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.t
+            uu____2344 rng
       | FStar_Reflection_Data.Tv_Abs (b,t1) ->
-          let uu____2486 =
-            let uu____2491 =
-              let uu____2492 =
-                let uu____2501 = embed e_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____2501  in
-              let uu____2502 =
-                let uu____2513 =
-                  let uu____2522 =
-                    let uu____2523 = e_term_aq aq  in embed uu____2523 rng t1
-                     in
-                  FStar_Syntax_Syntax.as_arg uu____2522  in
-                [uu____2513]  in
-              uu____2492 :: uu____2502  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.t
-              uu____2491
-             in
-          uu____2486 FStar_Pervasives_Native.None rng
+          let uu____2416 =
+            let uu____2417 =
+              let uu____2426 = embed e_binder rng b  in
+              FStar_Syntax_Syntax.as_arg uu____2426  in
+            let uu____2427 =
+              let uu____2438 =
+                let uu____2447 =
+                  let uu____2448 = e_term_aq aq  in embed uu____2448 rng t1
+                   in
+                FStar_Syntax_Syntax.as_arg uu____2447  in
+              [uu____2438]  in
+            uu____2417 :: uu____2427  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.t
+            uu____2416 rng
       | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-          let uu____2552 =
-            let uu____2557 =
-              let uu____2558 =
-                let uu____2567 = embed e_binder rng b  in
-                FStar_Syntax_Syntax.as_arg uu____2567  in
-              let uu____2568 =
-                let uu____2579 =
-                  let uu____2588 = embed e_comp rng c  in
-                  FStar_Syntax_Syntax.as_arg uu____2588  in
-                [uu____2579]  in
-              uu____2558 :: uu____2568  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.t
-              uu____2557
-             in
-          uu____2552 FStar_Pervasives_Native.None rng
+          let uu____2477 =
+            let uu____2478 =
+              let uu____2487 = embed e_binder rng b  in
+              FStar_Syntax_Syntax.as_arg uu____2487  in
+            let uu____2488 =
+              let uu____2499 =
+                let uu____2508 = embed e_comp rng c  in
+                FStar_Syntax_Syntax.as_arg uu____2508  in
+              [uu____2499]  in
+            uu____2478 :: uu____2488  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.t
+            uu____2477 rng
       | FStar_Reflection_Data.Tv_Type u ->
-          let uu____2614 =
-            let uu____2619 =
-              let uu____2620 =
-                let uu____2629 = embed FStar_Syntax_Embeddings.e_unit rng ()
-                   in
-                FStar_Syntax_Syntax.as_arg uu____2629  in
-              [uu____2620]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.t
-              uu____2619
-             in
-          uu____2614 FStar_Pervasives_Native.None rng
+          let uu____2534 =
+            let uu____2535 =
+              let uu____2544 = embed FStar_Syntax_Embeddings.e_unit rng ()
+                 in
+              FStar_Syntax_Syntax.as_arg uu____2544  in
+            [uu____2535]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.t
+            uu____2534 rng
       | FStar_Reflection_Data.Tv_Refine (bv,t1) ->
-          let uu____2648 =
-            let uu____2653 =
-              let uu____2654 =
-                let uu____2663 = embed e_bv rng bv  in
-                FStar_Syntax_Syntax.as_arg uu____2663  in
-              let uu____2664 =
-                let uu____2675 =
-                  let uu____2684 =
-                    let uu____2685 = e_term_aq aq  in embed uu____2685 rng t1
-                     in
-                  FStar_Syntax_Syntax.as_arg uu____2684  in
-                [uu____2675]  in
-              uu____2654 :: uu____2664  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.t
-              uu____2653
-             in
-          uu____2648 FStar_Pervasives_Native.None rng
-      | FStar_Reflection_Data.Tv_Const c ->
-          let uu____2713 =
-            let uu____2718 =
-              let uu____2719 =
-                let uu____2728 = embed e_const rng c  in
-                FStar_Syntax_Syntax.as_arg uu____2728  in
-              [uu____2719]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.t
-              uu____2718
-             in
-          uu____2713 FStar_Pervasives_Native.None rng
-      | FStar_Reflection_Data.Tv_Uvar (u,d) ->
-          let uu____2747 =
-            let uu____2752 =
-              let uu____2753 =
-                let uu____2762 = embed FStar_Syntax_Embeddings.e_int rng u
+          let uu____2563 =
+            let uu____2564 =
+              let uu____2573 = embed e_bv rng bv  in
+              FStar_Syntax_Syntax.as_arg uu____2573  in
+            let uu____2574 =
+              let uu____2585 =
+                let uu____2594 =
+                  let uu____2595 = e_term_aq aq  in embed uu____2595 rng t1
                    in
-                FStar_Syntax_Syntax.as_arg uu____2762  in
+                FStar_Syntax_Syntax.as_arg uu____2594  in
+              [uu____2585]  in
+            uu____2564 :: uu____2574  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.t
+            uu____2563 rng
+      | FStar_Reflection_Data.Tv_Const c ->
+          let uu____2623 =
+            let uu____2624 =
+              let uu____2633 = embed e_const rng c  in
+              FStar_Syntax_Syntax.as_arg uu____2633  in
+            [uu____2624]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.t
+            uu____2623 rng
+      | FStar_Reflection_Data.Tv_Uvar (u,d) ->
+          let uu____2652 =
+            let uu____2653 =
+              let uu____2662 = embed FStar_Syntax_Embeddings.e_int rng u  in
+              FStar_Syntax_Syntax.as_arg uu____2662  in
+            let uu____2663 =
+              let uu____2674 =
+                let uu____2683 =
+                  FStar_Syntax_Util.mk_lazy (u, d)
+                    FStar_Syntax_Util.t_ctx_uvar_and_sust
+                    FStar_Syntax_Syntax.Lazy_uvar
+                    FStar_Pervasives_Native.None
+                   in
+                FStar_Syntax_Syntax.as_arg uu____2683  in
+              [uu____2674]  in
+            uu____2653 :: uu____2663  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.t
+            uu____2652 rng
+      | FStar_Reflection_Data.Tv_Let (r,attrs,b,t1,t2) ->
+          let uu____2723 =
+            let uu____2724 =
+              let uu____2733 = embed FStar_Syntax_Embeddings.e_bool rng r  in
+              FStar_Syntax_Syntax.as_arg uu____2733  in
+            let uu____2735 =
+              let uu____2746 =
+                let uu____2755 =
+                  let uu____2756 = FStar_Syntax_Embeddings.e_list e_term  in
+                  embed uu____2756 rng attrs  in
+                FStar_Syntax_Syntax.as_arg uu____2755  in
               let uu____2763 =
                 let uu____2774 =
-                  let uu____2783 =
-                    FStar_Syntax_Util.mk_lazy (u, d)
-                      FStar_Syntax_Util.t_ctx_uvar_and_sust
-                      FStar_Syntax_Syntax.Lazy_uvar
-                      FStar_Pervasives_Native.None
-                     in
+                  let uu____2783 = embed e_bv rng b  in
                   FStar_Syntax_Syntax.as_arg uu____2783  in
-                [uu____2774]  in
-              uu____2753 :: uu____2763  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.t
-              uu____2752
-             in
-          uu____2747 FStar_Pervasives_Native.None rng
-      | FStar_Reflection_Data.Tv_Let (r,attrs,b,t1,t2) ->
-          let uu____2823 =
-            let uu____2828 =
-              let uu____2829 =
-                let uu____2838 = embed FStar_Syntax_Embeddings.e_bool rng r
-                   in
-                FStar_Syntax_Syntax.as_arg uu____2838  in
-              let uu____2840 =
-                let uu____2851 =
-                  let uu____2860 =
-                    let uu____2861 = FStar_Syntax_Embeddings.e_list e_term
-                       in
-                    embed uu____2861 rng attrs  in
-                  FStar_Syntax_Syntax.as_arg uu____2860  in
-                let uu____2868 =
-                  let uu____2879 =
-                    let uu____2888 = embed e_bv rng b  in
-                    FStar_Syntax_Syntax.as_arg uu____2888  in
-                  let uu____2889 =
-                    let uu____2900 =
-                      let uu____2909 =
-                        let uu____2910 = e_term_aq aq  in
-                        embed uu____2910 rng t1  in
-                      FStar_Syntax_Syntax.as_arg uu____2909  in
-                    let uu____2913 =
-                      let uu____2924 =
-                        let uu____2933 =
-                          let uu____2934 = e_term_aq aq  in
-                          embed uu____2934 rng t2  in
-                        FStar_Syntax_Syntax.as_arg uu____2933  in
-                      [uu____2924]  in
-                    uu____2900 :: uu____2913  in
-                  uu____2879 :: uu____2889  in
-                uu____2851 :: uu____2868  in
-              uu____2829 :: uu____2840  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.t
-              uu____2828
-             in
-          uu____2823 FStar_Pervasives_Native.None rng
+                let uu____2784 =
+                  let uu____2795 =
+                    let uu____2804 =
+                      let uu____2805 = e_term_aq aq  in
+                      embed uu____2805 rng t1  in
+                    FStar_Syntax_Syntax.as_arg uu____2804  in
+                  let uu____2808 =
+                    let uu____2819 =
+                      let uu____2828 =
+                        let uu____2829 = e_term_aq aq  in
+                        embed uu____2829 rng t2  in
+                      FStar_Syntax_Syntax.as_arg uu____2828  in
+                    [uu____2819]  in
+                  uu____2795 :: uu____2808  in
+                uu____2774 :: uu____2784  in
+              uu____2746 :: uu____2763  in
+            uu____2724 :: uu____2735  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.t
+            uu____2723 rng
       | FStar_Reflection_Data.Tv_Match (t1,brs) ->
-          let uu____2991 =
-            let uu____2996 =
-              let uu____2997 =
-                let uu____3006 =
-                  let uu____3007 = e_term_aq aq  in embed uu____3007 rng t1
-                   in
-                FStar_Syntax_Syntax.as_arg uu____3006  in
-              let uu____3010 =
-                let uu____3021 =
-                  let uu____3030 =
-                    let uu____3031 =
-                      let uu____3040 = e_branch_aq aq  in
-                      FStar_Syntax_Embeddings.e_list uu____3040  in
-                    embed uu____3031 rng brs  in
-                  FStar_Syntax_Syntax.as_arg uu____3030  in
-                [uu____3021]  in
-              uu____2997 :: uu____3010  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.t
-              uu____2996
-             in
-          uu____2991 FStar_Pervasives_Native.None rng
+          let uu____2886 =
+            let uu____2887 =
+              let uu____2896 =
+                let uu____2897 = e_term_aq aq  in embed uu____2897 rng t1  in
+              FStar_Syntax_Syntax.as_arg uu____2896  in
+            let uu____2900 =
+              let uu____2911 =
+                let uu____2920 =
+                  let uu____2921 =
+                    let uu____2930 = e_branch_aq aq  in
+                    FStar_Syntax_Embeddings.e_list uu____2930  in
+                  embed uu____2921 rng brs  in
+                FStar_Syntax_Syntax.as_arg uu____2920  in
+              [uu____2911]  in
+            uu____2887 :: uu____2900  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.t
+            uu____2886 rng
       | FStar_Reflection_Data.Tv_AscribedT (e,t1,tacopt) ->
-          let uu____3088 =
-            let uu____3093 =
-              let uu____3094 =
-                let uu____3103 =
-                  let uu____3104 = e_term_aq aq  in embed uu____3104 rng e
+          let uu____2978 =
+            let uu____2979 =
+              let uu____2988 =
+                let uu____2989 = e_term_aq aq  in embed uu____2989 rng e  in
+              FStar_Syntax_Syntax.as_arg uu____2988  in
+            let uu____2992 =
+              let uu____3003 =
+                let uu____3012 =
+                  let uu____3013 = e_term_aq aq  in embed uu____3013 rng t1
                    in
-                FStar_Syntax_Syntax.as_arg uu____3103  in
-              let uu____3107 =
-                let uu____3118 =
-                  let uu____3127 =
-                    let uu____3128 = e_term_aq aq  in embed uu____3128 rng t1
-                     in
-                  FStar_Syntax_Syntax.as_arg uu____3127  in
-                let uu____3131 =
-                  let uu____3142 =
-                    let uu____3151 =
-                      let uu____3152 =
-                        let uu____3157 = e_term_aq aq  in
-                        FStar_Syntax_Embeddings.e_option uu____3157  in
-                      embed uu____3152 rng tacopt  in
-                    FStar_Syntax_Syntax.as_arg uu____3151  in
-                  [uu____3142]  in
-                uu____3118 :: uu____3131  in
-              uu____3094 :: uu____3107  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.t
-              uu____3093
-             in
-          uu____3088 FStar_Pervasives_Native.None rng
+                FStar_Syntax_Syntax.as_arg uu____3012  in
+              let uu____3016 =
+                let uu____3027 =
+                  let uu____3036 =
+                    let uu____3037 =
+                      let uu____3042 = e_term_aq aq  in
+                      FStar_Syntax_Embeddings.e_option uu____3042  in
+                    embed uu____3037 rng tacopt  in
+                  FStar_Syntax_Syntax.as_arg uu____3036  in
+                [uu____3027]  in
+              uu____3003 :: uu____3016  in
+            uu____2979 :: uu____2992  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.t
+            uu____2978 rng
       | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-          let uu____3201 =
-            let uu____3206 =
-              let uu____3207 =
-                let uu____3216 =
-                  let uu____3217 = e_term_aq aq  in embed uu____3217 rng e
-                   in
-                FStar_Syntax_Syntax.as_arg uu____3216  in
-              let uu____3220 =
-                let uu____3231 =
-                  let uu____3240 = embed e_comp rng c  in
-                  FStar_Syntax_Syntax.as_arg uu____3240  in
-                let uu____3241 =
-                  let uu____3252 =
-                    let uu____3261 =
-                      let uu____3262 =
-                        let uu____3267 = e_term_aq aq  in
-                        FStar_Syntax_Embeddings.e_option uu____3267  in
-                      embed uu____3262 rng tacopt  in
-                    FStar_Syntax_Syntax.as_arg uu____3261  in
-                  [uu____3252]  in
-                uu____3231 :: uu____3241  in
-              uu____3207 :: uu____3220  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.t
-              uu____3206
-             in
-          uu____3201 FStar_Pervasives_Native.None rng
+          let uu____3086 =
+            let uu____3087 =
+              let uu____3096 =
+                let uu____3097 = e_term_aq aq  in embed uu____3097 rng e  in
+              FStar_Syntax_Syntax.as_arg uu____3096  in
+            let uu____3100 =
+              let uu____3111 =
+                let uu____3120 = embed e_comp rng c  in
+                FStar_Syntax_Syntax.as_arg uu____3120  in
+              let uu____3121 =
+                let uu____3132 =
+                  let uu____3141 =
+                    let uu____3142 =
+                      let uu____3147 = e_term_aq aq  in
+                      FStar_Syntax_Embeddings.e_option uu____3147  in
+                    embed uu____3142 rng tacopt  in
+                  FStar_Syntax_Syntax.as_arg uu____3141  in
+                [uu____3132]  in
+              uu____3111 :: uu____3121  in
+            uu____3087 :: uu____3100  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.t
+            uu____3086 rng
       | FStar_Reflection_Data.Tv_Unknown  ->
-          let uu___387_3304 =
+          let uu___387_3184 =
             FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.t  in
           {
-            FStar_Syntax_Syntax.n = (uu___387_3304.FStar_Syntax_Syntax.n);
+            FStar_Syntax_Syntax.n = (uu___387_3184.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
             FStar_Syntax_Syntax.vars =
-              (uu___387_3304.FStar_Syntax_Syntax.vars)
+              (uu___387_3184.FStar_Syntax_Syntax.vars)
           }
        in
     let unembed_term_view w t =
-      let uu____3322 = FStar_Syntax_Util.head_and_args t  in
-      match uu____3322 with
+      let uu____3202 = FStar_Syntax_Util.head_and_args t  in
+      match uu____3202 with
       | (hd,args) ->
-          let uu____3367 =
-            let uu____3380 =
-              let uu____3381 = FStar_Syntax_Util.un_uinst hd  in
-              uu____3381.FStar_Syntax_Syntax.n  in
-            (uu____3380, args)  in
-          (match uu____3367 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3396)::[]) when
+          let uu____3247 =
+            let uu____3260 =
+              let uu____3261 = FStar_Syntax_Util.un_uinst hd  in
+              uu____3261.FStar_Syntax_Syntax.n  in
+            (uu____3260, args)  in
+          (match uu____3247 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3276)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Var.FStar_Reflection_Data.lid
                ->
-               let uu____3421 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3421
+               let uu____3301 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3301
                  (fun b1  ->
                     FStar_All.pipe_left
-                      (fun uu____3428  ->
-                         FStar_Pervasives_Native.Some uu____3428)
+                      (fun uu____3308  ->
+                         FStar_Pervasives_Native.Some uu____3308)
                       (FStar_Reflection_Data.Tv_Var b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3431)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(b,uu____3311)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_BVar.FStar_Reflection_Data.lid
                ->
-               let uu____3456 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3456
+               let uu____3336 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3336
                  (fun b1  ->
                     FStar_All.pipe_left
-                      (fun uu____3463  ->
-                         FStar_Pervasives_Native.Some uu____3463)
+                      (fun uu____3343  ->
+                         FStar_Pervasives_Native.Some uu____3343)
                       (FStar_Reflection_Data.Tv_BVar b1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(f,uu____3466)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(f,uu____3346)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_FVar.FStar_Reflection_Data.lid
                ->
-               let uu____3491 = unembed' w e_fv f  in
-               FStar_Util.bind_opt uu____3491
+               let uu____3371 = unembed' w e_fv f  in
+               FStar_Util.bind_opt uu____3371
                  (fun f1  ->
                     FStar_All.pipe_left
-                      (fun uu____3498  ->
-                         FStar_Pervasives_Native.Some uu____3498)
+                      (fun uu____3378  ->
+                         FStar_Pervasives_Native.Some uu____3378)
                       (FStar_Reflection_Data.Tv_FVar f1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(l,uu____3501)::(r,uu____3503)::[]) when
+              fv,(l,uu____3381)::(r,uu____3383)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_App.FStar_Reflection_Data.lid
                ->
-               let uu____3538 = unembed' w e_term l  in
-               FStar_Util.bind_opt uu____3538
+               let uu____3418 = unembed' w e_term l  in
+               FStar_Util.bind_opt uu____3418
                  (fun l1  ->
-                    let uu____3544 = unembed' w e_argv r  in
-                    FStar_Util.bind_opt uu____3544
+                    let uu____3424 = unembed' w e_argv r  in
+                    FStar_Util.bind_opt uu____3424
                       (fun r1  ->
                          FStar_All.pipe_left
-                           (fun uu____3551  ->
-                              FStar_Pervasives_Native.Some uu____3551)
+                           (fun uu____3431  ->
+                              FStar_Pervasives_Native.Some uu____3431)
                            (FStar_Reflection_Data.Tv_App (l1, r1))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3554)::(t1,uu____3556)::[]) when
+              fv,(b,uu____3434)::(t1,uu____3436)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Abs.FStar_Reflection_Data.lid
                ->
-               let uu____3591 = unembed' w e_binder b  in
-               FStar_Util.bind_opt uu____3591
+               let uu____3471 = unembed' w e_binder b  in
+               FStar_Util.bind_opt uu____3471
                  (fun b1  ->
-                    let uu____3597 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3597
+                    let uu____3477 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3477
                       (fun t2  ->
                          FStar_All.pipe_left
-                           (fun uu____3604  ->
-                              FStar_Pervasives_Native.Some uu____3604)
+                           (fun uu____3484  ->
+                              FStar_Pervasives_Native.Some uu____3484)
                            (FStar_Reflection_Data.Tv_Abs (b1, t2))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3607)::(t1,uu____3609)::[]) when
+              fv,(b,uu____3487)::(t1,uu____3489)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Arrow.FStar_Reflection_Data.lid
                ->
-               let uu____3644 = unembed' w e_binder b  in
-               FStar_Util.bind_opt uu____3644
+               let uu____3524 = unembed' w e_binder b  in
+               FStar_Util.bind_opt uu____3524
                  (fun b1  ->
-                    let uu____3650 = unembed' w e_comp t1  in
-                    FStar_Util.bind_opt uu____3650
+                    let uu____3530 = unembed' w e_comp t1  in
+                    FStar_Util.bind_opt uu____3530
                       (fun c  ->
                          FStar_All.pipe_left
-                           (fun uu____3657  ->
-                              FStar_Pervasives_Native.Some uu____3657)
+                           (fun uu____3537  ->
+                              FStar_Pervasives_Native.Some uu____3537)
                            (FStar_Reflection_Data.Tv_Arrow (b1, c))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(u,uu____3660)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(u,uu____3540)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Type.FStar_Reflection_Data.lid
                ->
-               let uu____3685 = unembed' w FStar_Syntax_Embeddings.e_unit u
+               let uu____3565 = unembed' w FStar_Syntax_Embeddings.e_unit u
                   in
-               FStar_Util.bind_opt uu____3685
+               FStar_Util.bind_opt uu____3565
                  (fun u1  ->
                     FStar_All.pipe_left
-                      (fun uu____3692  ->
-                         FStar_Pervasives_Native.Some uu____3692)
+                      (fun uu____3572  ->
+                         FStar_Pervasives_Native.Some uu____3572)
                       (FStar_Reflection_Data.Tv_Type ()))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(b,uu____3695)::(t1,uu____3697)::[]) when
+              fv,(b,uu____3575)::(t1,uu____3577)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Refine.FStar_Reflection_Data.lid
                ->
-               let uu____3732 = unembed' w e_bv b  in
-               FStar_Util.bind_opt uu____3732
+               let uu____3612 = unembed' w e_bv b  in
+               FStar_Util.bind_opt uu____3612
                  (fun b1  ->
-                    let uu____3738 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____3738
+                    let uu____3618 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3618
                       (fun t2  ->
                          FStar_All.pipe_left
-                           (fun uu____3745  ->
-                              FStar_Pervasives_Native.Some uu____3745)
+                           (fun uu____3625  ->
+                              FStar_Pervasives_Native.Some uu____3625)
                            (FStar_Reflection_Data.Tv_Refine (b1, t2))))
-           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____3748)::[]) when
+           | (FStar_Syntax_Syntax.Tm_fvar fv,(c,uu____3628)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Const.FStar_Reflection_Data.lid
                ->
-               let uu____3773 = unembed' w e_const c  in
-               FStar_Util.bind_opt uu____3773
+               let uu____3653 = unembed' w e_const c  in
+               FStar_Util.bind_opt uu____3653
                  (fun c1  ->
                     FStar_All.pipe_left
-                      (fun uu____3780  ->
-                         FStar_Pervasives_Native.Some uu____3780)
+                      (fun uu____3660  ->
+                         FStar_Pervasives_Native.Some uu____3660)
                       (FStar_Reflection_Data.Tv_Const c1))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(u,uu____3783)::(l,uu____3785)::[]) when
+              fv,(u,uu____3663)::(l,uu____3665)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Uvar.FStar_Reflection_Data.lid
                ->
-               let uu____3820 = unembed' w FStar_Syntax_Embeddings.e_int u
+               let uu____3700 = unembed' w FStar_Syntax_Embeddings.e_int u
                   in
-               FStar_Util.bind_opt uu____3820
+               FStar_Util.bind_opt uu____3700
                  (fun u1  ->
                     let ctx_u_s =
                       FStar_Syntax_Util.unlazy_as_t
                         FStar_Syntax_Syntax.Lazy_uvar l
                        in
                     FStar_All.pipe_left
-                      (fun uu____3829  ->
-                         FStar_Pervasives_Native.Some uu____3829)
+                      (fun uu____3709  ->
+                         FStar_Pervasives_Native.Some uu____3709)
                       (FStar_Reflection_Data.Tv_Uvar (u1, ctx_u_s)))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(r,uu____3832)::(attrs,uu____3834)::(b,uu____3836)::
-              (t1,uu____3838)::(t2,uu____3840)::[]) when
+              fv,(r,uu____3712)::(attrs,uu____3714)::(b,uu____3716)::
+              (t1,uu____3718)::(t2,uu____3720)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Let.FStar_Reflection_Data.lid
                ->
-               let uu____3905 = unembed' w FStar_Syntax_Embeddings.e_bool r
+               let uu____3785 = unembed' w FStar_Syntax_Embeddings.e_bool r
                   in
-               FStar_Util.bind_opt uu____3905
+               FStar_Util.bind_opt uu____3785
                  (fun r1  ->
-                    let uu____3915 =
-                      let uu____3920 = FStar_Syntax_Embeddings.e_list e_term
+                    let uu____3795 =
+                      let uu____3800 = FStar_Syntax_Embeddings.e_list e_term
                          in
-                      unembed' w uu____3920 attrs  in
-                    FStar_Util.bind_opt uu____3915
+                      unembed' w uu____3800 attrs  in
+                    FStar_Util.bind_opt uu____3795
                       (fun attrs1  ->
-                         let uu____3934 = unembed' w e_bv b  in
-                         FStar_Util.bind_opt uu____3934
+                         let uu____3814 = unembed' w e_bv b  in
+                         FStar_Util.bind_opt uu____3814
                            (fun b1  ->
-                              let uu____3940 = unembed' w e_term t1  in
-                              FStar_Util.bind_opt uu____3940
+                              let uu____3820 = unembed' w e_term t1  in
+                              FStar_Util.bind_opt uu____3820
                                 (fun t11  ->
-                                   let uu____3946 = unembed' w e_term t2  in
-                                   FStar_Util.bind_opt uu____3946
+                                   let uu____3826 = unembed' w e_term t2  in
+                                   FStar_Util.bind_opt uu____3826
                                      (fun t21  ->
                                         FStar_All.pipe_left
-                                          (fun uu____3953  ->
+                                          (fun uu____3833  ->
                                              FStar_Pervasives_Native.Some
-                                               uu____3953)
+                                               uu____3833)
                                           (FStar_Reflection_Data.Tv_Let
                                              (r1, attrs1, b1, t11, t21)))))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(t1,uu____3959)::(brs,uu____3961)::[]) when
+              fv,(t1,uu____3839)::(brs,uu____3841)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_Match.FStar_Reflection_Data.lid
                ->
-               let uu____3996 = unembed' w e_term t1  in
-               FStar_Util.bind_opt uu____3996
+               let uu____3876 = unembed' w e_term t1  in
+               FStar_Util.bind_opt uu____3876
                  (fun t2  ->
-                    let uu____4002 =
-                      let uu____4007 =
+                    let uu____3882 =
+                      let uu____3887 =
                         FStar_Syntax_Embeddings.e_list e_branch  in
-                      unembed' w uu____4007 brs  in
-                    FStar_Util.bind_opt uu____4002
+                      unembed' w uu____3887 brs  in
+                    FStar_Util.bind_opt uu____3882
                       (fun brs1  ->
                          FStar_All.pipe_left
-                           (fun uu____4022  ->
-                              FStar_Pervasives_Native.Some uu____4022)
+                           (fun uu____3902  ->
+                              FStar_Pervasives_Native.Some uu____3902)
                            (FStar_Reflection_Data.Tv_Match (t2, brs1))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(e,uu____4027)::(t1,uu____4029)::(tacopt,uu____4031)::[])
+              fv,(e,uu____3907)::(t1,uu____3909)::(tacopt,uu____3911)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscT.FStar_Reflection_Data.lid
                ->
-               let uu____4076 = unembed' w e_term e  in
-               FStar_Util.bind_opt uu____4076
+               let uu____3956 = unembed' w e_term e  in
+               FStar_Util.bind_opt uu____3956
                  (fun e1  ->
-                    let uu____4082 = unembed' w e_term t1  in
-                    FStar_Util.bind_opt uu____4082
+                    let uu____3962 = unembed' w e_term t1  in
+                    FStar_Util.bind_opt uu____3962
                       (fun t2  ->
-                         let uu____4088 =
-                           let uu____4093 =
+                         let uu____3968 =
+                           let uu____3973 =
                              FStar_Syntax_Embeddings.e_option e_term  in
-                           unembed' w uu____4093 tacopt  in
-                         FStar_Util.bind_opt uu____4088
+                           unembed' w uu____3973 tacopt  in
+                         FStar_Util.bind_opt uu____3968
                            (fun tacopt1  ->
                               FStar_All.pipe_left
-                                (fun uu____4108  ->
-                                   FStar_Pervasives_Native.Some uu____4108)
+                                (fun uu____3988  ->
+                                   FStar_Pervasives_Native.Some uu____3988)
                                 (FStar_Reflection_Data.Tv_AscribedT
                                    (e1, t2, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar
-              fv,(e,uu____4113)::(c,uu____4115)::(tacopt,uu____4117)::[])
+              fv,(e,uu____3993)::(c,uu____3995)::(tacopt,uu____3997)::[])
                when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Data.ref_Tv_AscC.FStar_Reflection_Data.lid
                ->
-               let uu____4162 = unembed' w e_term e  in
-               FStar_Util.bind_opt uu____4162
+               let uu____4042 = unembed' w e_term e  in
+               FStar_Util.bind_opt uu____4042
                  (fun e1  ->
-                    let uu____4168 = unembed' w e_comp c  in
-                    FStar_Util.bind_opt uu____4168
+                    let uu____4048 = unembed' w e_comp c  in
+                    FStar_Util.bind_opt uu____4048
                       (fun c1  ->
-                         let uu____4174 =
-                           let uu____4179 =
+                         let uu____4054 =
+                           let uu____4059 =
                              FStar_Syntax_Embeddings.e_option e_term  in
-                           unembed' w uu____4179 tacopt  in
-                         FStar_Util.bind_opt uu____4174
+                           unembed' w uu____4059 tacopt  in
+                         FStar_Util.bind_opt uu____4054
                            (fun tacopt1  ->
                               FStar_All.pipe_left
-                                (fun uu____4194  ->
-                                   FStar_Pervasives_Native.Some uu____4194)
+                                (fun uu____4074  ->
+                                   FStar_Pervasives_Native.Some uu____4074)
                                 (FStar_Reflection_Data.Tv_AscribedC
                                    (e1, c1, tacopt1)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
@@ -1303,21 +1222,21 @@ let (e_term_view_aq :
                  FStar_Reflection_Data.ref_Tv_Unknown.FStar_Reflection_Data.lid
                ->
                FStar_All.pipe_left
-                 (fun uu____4214  -> FStar_Pervasives_Native.Some uu____4214)
+                 (fun uu____4094  -> FStar_Pervasives_Native.Some uu____4094)
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____4215 ->
+           | uu____4095 ->
                (if w
                 then
-                  (let uu____4230 =
-                     let uu____4236 =
-                       let uu____4238 = FStar_Syntax_Print.term_to_string t
+                  (let uu____4110 =
+                     let uu____4116 =
+                       let uu____4118 = FStar_Syntax_Print.term_to_string t
                           in
                        FStar_Util.format1 "Not an embedded term_view: %s"
-                         uu____4238
+                         uu____4118
                         in
-                     (FStar_Errors.Warning_NotEmbedded, uu____4236)  in
+                     (FStar_Errors.Warning_NotEmbedded, uu____4116)  in
                    FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
-                     uu____4230)
+                     uu____4110)
                 else ();
                 FStar_Pervasives_Native.None))
        in
@@ -1329,97 +1248,95 @@ let (e_term_view :
   e_term_view_aq [] 
 let (e_lid : FStar_Ident.lid FStar_Syntax_Embeddings.embedding) =
   let embed1 rng lid =
-    let uu____4267 = FStar_Ident.path_of_lid lid  in
-    embed FStar_Syntax_Embeddings.e_string_list rng uu____4267  in
+    let uu____4147 = FStar_Ident.path_of_lid lid  in
+    embed FStar_Syntax_Embeddings.e_string_list rng uu____4147  in
   let unembed w t =
-    let uu____4295 = unembed' w FStar_Syntax_Embeddings.e_string_list t  in
-    FStar_Util.map_opt uu____4295
+    let uu____4175 = unembed' w FStar_Syntax_Embeddings.e_string_list t  in
+    FStar_Util.map_opt uu____4175
       (fun p  -> FStar_Ident.lid_of_path p t.FStar_Syntax_Syntax.pos)
      in
-  let uu____4312 = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string
+  let uu____4192 = FStar_Syntax_Syntax.t_list_of FStar_Syntax_Syntax.t_string
      in
   FStar_Syntax_Embeddings.mk_emb_full
-    (fun x  -> fun r  -> fun uu____4319  -> fun uu____4320  -> embed1 r x)
-    (fun x  -> fun w  -> fun uu____4327  -> unembed w x) uu____4312
+    (fun x  -> fun r  -> fun uu____4199  -> fun uu____4200  -> embed1 r x)
+    (fun x  -> fun w  -> fun uu____4207  -> unembed w x) uu____4192
     FStar_Ident.string_of_lid FStar_Syntax_Syntax.ET_abstract
   
 let (e_bv_view :
   FStar_Reflection_Data.bv_view FStar_Syntax_Embeddings.embedding) =
   let embed_bv_view rng bvv =
-    let uu____4344 =
-      let uu____4349 =
-        let uu____4350 =
-          let uu____4359 =
-            embed FStar_Syntax_Embeddings.e_string rng
-              bvv.FStar_Reflection_Data.bv_ppname
+    let uu____4224 =
+      let uu____4225 =
+        let uu____4234 =
+          embed FStar_Syntax_Embeddings.e_string rng
+            bvv.FStar_Reflection_Data.bv_ppname
+           in
+        FStar_Syntax_Syntax.as_arg uu____4234  in
+      let uu____4236 =
+        let uu____4247 =
+          let uu____4256 =
+            embed FStar_Syntax_Embeddings.e_int rng
+              bvv.FStar_Reflection_Data.bv_index
              in
-          FStar_Syntax_Syntax.as_arg uu____4359  in
-        let uu____4361 =
-          let uu____4372 =
-            let uu____4381 =
-              embed FStar_Syntax_Embeddings.e_int rng
-                bvv.FStar_Reflection_Data.bv_index
-               in
-            FStar_Syntax_Syntax.as_arg uu____4381  in
-          let uu____4382 =
-            let uu____4393 =
-              let uu____4402 =
-                embed e_term rng bvv.FStar_Reflection_Data.bv_sort  in
-              FStar_Syntax_Syntax.as_arg uu____4402  in
-            [uu____4393]  in
-          uu____4372 :: uu____4382  in
-        uu____4350 :: uu____4361  in
-      FStar_Syntax_Syntax.mk_Tm_app
-        FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu____4349
-       in
-    uu____4344 FStar_Pervasives_Native.None rng  in
+          FStar_Syntax_Syntax.as_arg uu____4256  in
+        let uu____4257 =
+          let uu____4268 =
+            let uu____4277 =
+              embed e_term rng bvv.FStar_Reflection_Data.bv_sort  in
+            FStar_Syntax_Syntax.as_arg uu____4277  in
+          [uu____4268]  in
+        uu____4247 :: uu____4257  in
+      uu____4225 :: uu____4236  in
+    FStar_Syntax_Syntax.mk_Tm_app
+      FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.t uu____4224 rng
+     in
   let unembed_bv_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____4453 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____4453 with
+    let uu____4328 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4328 with
     | (hd,args) ->
-        let uu____4498 =
-          let uu____4511 =
-            let uu____4512 = FStar_Syntax_Util.un_uinst hd  in
-            uu____4512.FStar_Syntax_Syntax.n  in
-          (uu____4511, args)  in
-        (match uu____4498 with
+        let uu____4373 =
+          let uu____4386 =
+            let uu____4387 = FStar_Syntax_Util.un_uinst hd  in
+            uu____4387.FStar_Syntax_Syntax.n  in
+          (uu____4386, args)  in
+        (match uu____4373 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(nm,uu____4527)::(idx,uu____4529)::(s,uu____4531)::[]) when
+            fv,(nm,uu____4402)::(idx,uu____4404)::(s,uu____4406)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Mk_bv.FStar_Reflection_Data.lid
              ->
-             let uu____4576 = unembed' w FStar_Syntax_Embeddings.e_string nm
+             let uu____4451 = unembed' w FStar_Syntax_Embeddings.e_string nm
                 in
-             FStar_Util.bind_opt uu____4576
+             FStar_Util.bind_opt uu____4451
                (fun nm1  ->
-                  let uu____4586 =
+                  let uu____4461 =
                     unembed' w FStar_Syntax_Embeddings.e_int idx  in
-                  FStar_Util.bind_opt uu____4586
+                  FStar_Util.bind_opt uu____4461
                     (fun idx1  ->
-                       let uu____4592 = unembed' w e_term s  in
-                       FStar_Util.bind_opt uu____4592
+                       let uu____4467 = unembed' w e_term s  in
+                       FStar_Util.bind_opt uu____4467
                          (fun s1  ->
                             FStar_All.pipe_left
-                              (fun uu____4599  ->
-                                 FStar_Pervasives_Native.Some uu____4599)
+                              (fun uu____4474  ->
+                                 FStar_Pervasives_Native.Some uu____4474)
                               {
                                 FStar_Reflection_Data.bv_ppname = nm1;
                                 FStar_Reflection_Data.bv_index = idx1;
                                 FStar_Reflection_Data.bv_sort = s1
                               })))
-         | uu____4600 ->
+         | uu____4475 ->
              (if w
               then
-                (let uu____4615 =
-                   let uu____4621 =
-                     let uu____4623 = FStar_Syntax_Print.term_to_string t1
+                (let uu____4490 =
+                   let uu____4496 =
+                     let uu____4498 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded bv_view: %s"
-                       uu____4623
+                       uu____4498
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____4621)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4615)
+                   (FStar_Errors.Warning_NotEmbedded, uu____4496)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____4490)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1431,207 +1348,192 @@ let (e_comp_view :
   let embed_comp_view rng cv =
     match cv with
     | FStar_Reflection_Data.C_Total (t,md) ->
-        let uu____4649 =
-          let uu____4654 =
-            let uu____4655 =
-              let uu____4664 = embed e_term rng t  in
-              FStar_Syntax_Syntax.as_arg uu____4664  in
-            let uu____4665 =
-              let uu____4676 =
-                let uu____4685 =
-                  let uu____4686 = FStar_Syntax_Embeddings.e_option e_term
-                     in
-                  embed uu____4686 rng md  in
-                FStar_Syntax_Syntax.as_arg uu____4685  in
-              [uu____4676]  in
-            uu____4655 :: uu____4665  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.t
-            uu____4654
-           in
-        uu____4649 FStar_Pervasives_Native.None rng
+        let uu____4524 =
+          let uu____4525 =
+            let uu____4534 = embed e_term rng t  in
+            FStar_Syntax_Syntax.as_arg uu____4534  in
+          let uu____4535 =
+            let uu____4546 =
+              let uu____4555 =
+                let uu____4556 = FStar_Syntax_Embeddings.e_option e_term  in
+                embed uu____4556 rng md  in
+              FStar_Syntax_Syntax.as_arg uu____4555  in
+            [uu____4546]  in
+          uu____4525 :: uu____4535  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.t
+          uu____4524 rng
     | FStar_Reflection_Data.C_GTotal (t,md) ->
-        let uu____4723 =
-          let uu____4728 =
-            let uu____4729 =
-              let uu____4738 = embed e_term rng t  in
-              FStar_Syntax_Syntax.as_arg uu____4738  in
-            let uu____4739 =
-              let uu____4750 =
-                let uu____4759 =
-                  let uu____4760 = FStar_Syntax_Embeddings.e_option e_term
-                     in
-                  embed uu____4760 rng md  in
-                FStar_Syntax_Syntax.as_arg uu____4759  in
-              [uu____4750]  in
-            uu____4729 :: uu____4739  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.t
-            uu____4728
-           in
-        uu____4723 FStar_Pervasives_Native.None rng
+        let uu____4593 =
+          let uu____4594 =
+            let uu____4603 = embed e_term rng t  in
+            FStar_Syntax_Syntax.as_arg uu____4603  in
+          let uu____4604 =
+            let uu____4615 =
+              let uu____4624 =
+                let uu____4625 = FStar_Syntax_Embeddings.e_option e_term  in
+                embed uu____4625 rng md  in
+              FStar_Syntax_Syntax.as_arg uu____4624  in
+            [uu____4615]  in
+          uu____4594 :: uu____4604  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.t
+          uu____4593 rng
     | FStar_Reflection_Data.C_Lemma (pre,post,pats) ->
-        let uu____4794 =
-          let uu____4799 =
-            let uu____4800 =
-              let uu____4809 = embed e_term rng pre  in
-              FStar_Syntax_Syntax.as_arg uu____4809  in
-            let uu____4810 =
-              let uu____4821 =
-                let uu____4830 = embed e_term rng post  in
-                FStar_Syntax_Syntax.as_arg uu____4830  in
-              let uu____4831 =
-                let uu____4842 =
-                  let uu____4851 = embed e_term rng pats  in
-                  FStar_Syntax_Syntax.as_arg uu____4851  in
-                [uu____4842]  in
-              uu____4821 :: uu____4831  in
-            uu____4800 :: uu____4810  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.t
-            uu____4799
-           in
-        uu____4794 FStar_Pervasives_Native.None rng
+        let uu____4659 =
+          let uu____4660 =
+            let uu____4669 = embed e_term rng pre  in
+            FStar_Syntax_Syntax.as_arg uu____4669  in
+          let uu____4670 =
+            let uu____4681 =
+              let uu____4690 = embed e_term rng post  in
+              FStar_Syntax_Syntax.as_arg uu____4690  in
+            let uu____4691 =
+              let uu____4702 =
+                let uu____4711 = embed e_term rng pats  in
+                FStar_Syntax_Syntax.as_arg uu____4711  in
+              [uu____4702]  in
+            uu____4681 :: uu____4691  in
+          uu____4660 :: uu____4670  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.t
+          uu____4659 rng
     | FStar_Reflection_Data.C_Eff (us,eff,res,args) ->
-        let uu____4896 =
-          let uu____4901 =
-            let uu____4902 =
-              let uu____4911 = embed FStar_Syntax_Embeddings.e_unit rng ()
-                 in
-              FStar_Syntax_Syntax.as_arg uu____4911  in
-            let uu____4912 =
-              let uu____4923 =
-                let uu____4932 =
-                  embed FStar_Syntax_Embeddings.e_string_list rng eff  in
-                FStar_Syntax_Syntax.as_arg uu____4932  in
-              let uu____4936 =
-                let uu____4947 =
-                  let uu____4956 = embed e_term rng res  in
-                  FStar_Syntax_Syntax.as_arg uu____4956  in
-                let uu____4957 =
-                  let uu____4968 =
-                    let uu____4977 =
-                      let uu____4978 = FStar_Syntax_Embeddings.e_list e_argv
-                         in
-                      embed uu____4978 rng args  in
-                    FStar_Syntax_Syntax.as_arg uu____4977  in
-                  [uu____4968]  in
-                uu____4947 :: uu____4957  in
-              uu____4923 :: uu____4936  in
-            uu____4902 :: uu____4912  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.t
-            uu____4901
-           in
-        uu____4896 FStar_Pervasives_Native.None rng
+        let uu____4756 =
+          let uu____4757 =
+            let uu____4766 = embed FStar_Syntax_Embeddings.e_unit rng ()  in
+            FStar_Syntax_Syntax.as_arg uu____4766  in
+          let uu____4767 =
+            let uu____4778 =
+              let uu____4787 =
+                embed FStar_Syntax_Embeddings.e_string_list rng eff  in
+              FStar_Syntax_Syntax.as_arg uu____4787  in
+            let uu____4791 =
+              let uu____4802 =
+                let uu____4811 = embed e_term rng res  in
+                FStar_Syntax_Syntax.as_arg uu____4811  in
+              let uu____4812 =
+                let uu____4823 =
+                  let uu____4832 =
+                    let uu____4833 = FStar_Syntax_Embeddings.e_list e_argv
+                       in
+                    embed uu____4833 rng args  in
+                  FStar_Syntax_Syntax.as_arg uu____4832  in
+                [uu____4823]  in
+              uu____4802 :: uu____4812  in
+            uu____4778 :: uu____4791  in
+          uu____4757 :: uu____4767  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.t uu____4756
+          rng
      in
   let unembed_comp_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____5043 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____5043 with
+    let uu____4898 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____4898 with
     | (hd,args) ->
-        let uu____5088 =
-          let uu____5101 =
-            let uu____5102 = FStar_Syntax_Util.un_uinst hd  in
-            uu____5102.FStar_Syntax_Syntax.n  in
-          (uu____5101, args)  in
-        (match uu____5088 with
+        let uu____4943 =
+          let uu____4956 =
+            let uu____4957 = FStar_Syntax_Util.un_uinst hd  in
+            uu____4957.FStar_Syntax_Syntax.n  in
+          (uu____4956, args)  in
+        (match uu____4943 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(t2,uu____5117)::(md,uu____5119)::[]) when
+            fv,(t2,uu____4972)::(md,uu____4974)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Total.FStar_Reflection_Data.lid
              ->
-             let uu____5154 = unembed' w e_term t2  in
-             FStar_Util.bind_opt uu____5154
+             let uu____5009 = unembed' w e_term t2  in
+             FStar_Util.bind_opt uu____5009
                (fun t3  ->
-                  let uu____5160 =
-                    let uu____5165 = FStar_Syntax_Embeddings.e_option e_term
+                  let uu____5015 =
+                    let uu____5020 = FStar_Syntax_Embeddings.e_option e_term
                        in
-                    unembed' w uu____5165 md  in
-                  FStar_Util.bind_opt uu____5160
+                    unembed' w uu____5020 md  in
+                  FStar_Util.bind_opt uu____5015
                     (fun md1  ->
                        FStar_All.pipe_left
-                         (fun uu____5180  ->
-                            FStar_Pervasives_Native.Some uu____5180)
+                         (fun uu____5035  ->
+                            FStar_Pervasives_Native.Some uu____5035)
                          (FStar_Reflection_Data.C_Total (t3, md1))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(t2,uu____5185)::(md,uu____5187)::[]) when
+            fv,(t2,uu____5040)::(md,uu____5042)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_GTotal.FStar_Reflection_Data.lid
              ->
-             let uu____5222 = unembed' w e_term t2  in
-             FStar_Util.bind_opt uu____5222
+             let uu____5077 = unembed' w e_term t2  in
+             FStar_Util.bind_opt uu____5077
                (fun t3  ->
-                  let uu____5228 =
-                    let uu____5233 = FStar_Syntax_Embeddings.e_option e_term
+                  let uu____5083 =
+                    let uu____5088 = FStar_Syntax_Embeddings.e_option e_term
                        in
-                    unembed' w uu____5233 md  in
-                  FStar_Util.bind_opt uu____5228
+                    unembed' w uu____5088 md  in
+                  FStar_Util.bind_opt uu____5083
                     (fun md1  ->
                        FStar_All.pipe_left
-                         (fun uu____5248  ->
-                            FStar_Pervasives_Native.Some uu____5248)
+                         (fun uu____5103  ->
+                            FStar_Pervasives_Native.Some uu____5103)
                          (FStar_Reflection_Data.C_GTotal (t3, md1))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(pre,uu____5253)::(post,uu____5255)::(pats,uu____5257)::[])
+            fv,(pre,uu____5108)::(post,uu____5110)::(pats,uu____5112)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Lemma.FStar_Reflection_Data.lid
              ->
-             let uu____5302 = unembed' w e_term pre  in
-             FStar_Util.bind_opt uu____5302
+             let uu____5157 = unembed' w e_term pre  in
+             FStar_Util.bind_opt uu____5157
                (fun pre1  ->
-                  let uu____5308 = unembed' w e_term post  in
-                  FStar_Util.bind_opt uu____5308
+                  let uu____5163 = unembed' w e_term post  in
+                  FStar_Util.bind_opt uu____5163
                     (fun post1  ->
-                       let uu____5314 = unembed' w e_term pats  in
-                       FStar_Util.bind_opt uu____5314
+                       let uu____5169 = unembed' w e_term pats  in
+                       FStar_Util.bind_opt uu____5169
                          (fun pats1  ->
                             FStar_All.pipe_left
-                              (fun uu____5321  ->
-                                 FStar_Pervasives_Native.Some uu____5321)
+                              (fun uu____5176  ->
+                                 FStar_Pervasives_Native.Some uu____5176)
                               (FStar_Reflection_Data.C_Lemma
                                  (pre1, post1, pats1)))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(us,uu____5324)::(eff,uu____5326)::(res,uu____5328)::(args1,uu____5330)::[])
+            fv,(us,uu____5179)::(eff,uu____5181)::(res,uu____5183)::(args1,uu____5185)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_C_Eff.FStar_Reflection_Data.lid
              ->
-             let uu____5385 = unembed' w FStar_Syntax_Embeddings.e_unit us
+             let uu____5240 = unembed' w FStar_Syntax_Embeddings.e_unit us
                 in
-             FStar_Util.bind_opt uu____5385
+             FStar_Util.bind_opt uu____5240
                (fun us1  ->
-                  let uu____5391 =
+                  let uu____5246 =
                     unembed' w FStar_Syntax_Embeddings.e_string_list eff  in
-                  FStar_Util.bind_opt uu____5391
+                  FStar_Util.bind_opt uu____5246
                     (fun eff1  ->
-                       let uu____5409 = unembed' w e_term res  in
-                       FStar_Util.bind_opt uu____5409
+                       let uu____5264 = unembed' w e_term res  in
+                       FStar_Util.bind_opt uu____5264
                          (fun res1  ->
-                            let uu____5415 =
-                              let uu____5420 =
+                            let uu____5270 =
+                              let uu____5275 =
                                 FStar_Syntax_Embeddings.e_list e_argv  in
-                              unembed' w uu____5420 args1  in
-                            FStar_Util.bind_opt uu____5415
+                              unembed' w uu____5275 args1  in
+                            FStar_Util.bind_opt uu____5270
                               (fun args2  ->
                                  FStar_All.pipe_left
-                                   (fun uu____5435  ->
-                                      FStar_Pervasives_Native.Some uu____5435)
+                                   (fun uu____5290  ->
+                                      FStar_Pervasives_Native.Some uu____5290)
                                    (FStar_Reflection_Data.C_Eff
                                       ([], eff1, res1, args2))))))
-         | uu____5440 ->
+         | uu____5295 ->
              (if w
               then
-                (let uu____5455 =
-                   let uu____5461 =
-                     let uu____5463 = FStar_Syntax_Print.term_to_string t1
+                (let uu____5310 =
+                   let uu____5316 =
+                     let uu____5318 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded comp_view: %s"
-                       uu____5463
+                       uu____5318
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____5461)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5455)
+                   (FStar_Errors.Warning_NotEmbedded, uu____5316)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5310)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1645,23 +1547,23 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
       | FStar_Order.Lt  -> FStar_Reflection_Data.ord_Lt
       | FStar_Order.Eq  -> FStar_Reflection_Data.ord_Eq
       | FStar_Order.Gt  -> FStar_Reflection_Data.ord_Gt  in
-    let uu___712_5488 = r  in
+    let uu___712_5343 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___712_5488.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___712_5343.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___712_5488.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___712_5343.FStar_Syntax_Syntax.vars)
     }  in
   let unembed_order w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____5509 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____5509 with
+    let uu____5364 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____5364 with
     | (hd,args) ->
-        let uu____5554 =
-          let uu____5569 =
-            let uu____5570 = FStar_Syntax_Util.un_uinst hd  in
-            uu____5570.FStar_Syntax_Syntax.n  in
-          (uu____5569, args)  in
-        (match uu____5554 with
+        let uu____5409 =
+          let uu____5424 =
+            let uu____5425 = FStar_Syntax_Util.un_uinst hd  in
+            uu____5425.FStar_Syntax_Syntax.n  in
+          (uu____5424, args)  in
+        (match uu____5409 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Lt_lid
@@ -1674,18 +1576,18 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ord_Gt_lid
              -> FStar_Pervasives_Native.Some FStar_Order.Gt
-         | uu____5642 ->
+         | uu____5497 ->
              (if w
               then
-                (let uu____5659 =
-                   let uu____5665 =
-                     let uu____5667 = FStar_Syntax_Print.term_to_string t1
+                (let uu____5514 =
+                   let uu____5520 =
+                     let uu____5522 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded order: %s"
-                       uu____5667
+                       uu____5522
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____5665)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5659)
+                   (FStar_Errors.Warning_NotEmbedded, uu____5520)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____5514)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1697,28 +1599,28 @@ let (e_sigelt : FStar_Syntax_Syntax.sigelt FStar_Syntax_Embeddings.embedding)
       FStar_Syntax_Syntax.Lazy_sigelt (FStar_Pervasives_Native.Some rng)
      in
   let unembed_sigelt w t =
-    let uu____5704 =
-      let uu____5705 = FStar_Syntax_Subst.compress t  in
-      uu____5705.FStar_Syntax_Syntax.n  in
-    match uu____5704 with
+    let uu____5559 =
+      let uu____5560 = FStar_Syntax_Subst.compress t  in
+      uu____5560.FStar_Syntax_Syntax.n  in
+    match uu____5559 with
     | FStar_Syntax_Syntax.Tm_lazy
         { FStar_Syntax_Syntax.blob = b;
           FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_sigelt ;
-          FStar_Syntax_Syntax.ltyp = uu____5711;
-          FStar_Syntax_Syntax.rng = uu____5712;_}
+          FStar_Syntax_Syntax.ltyp = uu____5566;
+          FStar_Syntax_Syntax.rng = uu____5567;_}
         ->
-        let uu____5715 = FStar_Dyn.undyn b  in
-        FStar_Pervasives_Native.Some uu____5715
-    | uu____5716 ->
+        let uu____5570 = FStar_Dyn.undyn b  in
+        FStar_Pervasives_Native.Some uu____5570
+    | uu____5571 ->
         (if w
          then
-           (let uu____5719 =
-              let uu____5725 =
-                let uu____5727 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded sigelt: %s" uu____5727
+           (let uu____5574 =
+              let uu____5580 =
+                let uu____5582 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded sigelt: %s" uu____5582
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____5725)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____5719)
+              (FStar_Errors.Warning_NotEmbedded, uu____5580)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____5574)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -1730,9 +1632,9 @@ let (e_ident : FStar_Ident.ident FStar_Syntax_Embeddings.embedding) =
      in
   FStar_Syntax_Embeddings.embed_as repr FStar_Ident.mk_ident
     (fun i  ->
-       let uu____5756 = FStar_Ident.text_of_id i  in
-       let uu____5758 = FStar_Ident.range_of_id i  in
-       (uu____5756, uu____5758))
+       let uu____5611 = FStar_Ident.text_of_id i  in
+       let uu____5613 = FStar_Ident.range_of_id i  in
+       (uu____5611, uu____5613))
     (FStar_Pervasives_Native.Some FStar_Reflection_Data.fstar_refl_ident)
   
 let (e_univ_name :
@@ -1748,189 +1650,180 @@ let (e_sigelt_view :
   let embed_sigelt_view rng sev =
     match sev with
     | FStar_Reflection_Data.Sg_Let (r,fv,univs,ty,t) ->
-        let uu____5793 =
-          let uu____5798 =
-            let uu____5799 =
-              let uu____5808 = embed FStar_Syntax_Embeddings.e_bool rng r  in
-              FStar_Syntax_Syntax.as_arg uu____5808  in
-            let uu____5810 =
-              let uu____5821 =
-                let uu____5830 = embed e_fv rng fv  in
-                FStar_Syntax_Syntax.as_arg uu____5830  in
-              let uu____5831 =
-                let uu____5842 =
-                  let uu____5851 = embed e_univ_names rng univs  in
-                  FStar_Syntax_Syntax.as_arg uu____5851  in
-                let uu____5854 =
-                  let uu____5865 =
-                    let uu____5874 = embed e_term rng ty  in
-                    FStar_Syntax_Syntax.as_arg uu____5874  in
-                  let uu____5875 =
-                    let uu____5886 =
-                      let uu____5895 = embed e_term rng t  in
-                      FStar_Syntax_Syntax.as_arg uu____5895  in
-                    [uu____5886]  in
-                  uu____5865 :: uu____5875  in
-                uu____5842 :: uu____5854  in
-              uu____5821 :: uu____5831  in
-            uu____5799 :: uu____5810  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.t
-            uu____5798
-           in
-        uu____5793 FStar_Pervasives_Native.None rng
+        let uu____5648 =
+          let uu____5649 =
+            let uu____5658 = embed FStar_Syntax_Embeddings.e_bool rng r  in
+            FStar_Syntax_Syntax.as_arg uu____5658  in
+          let uu____5660 =
+            let uu____5671 =
+              let uu____5680 = embed e_fv rng fv  in
+              FStar_Syntax_Syntax.as_arg uu____5680  in
+            let uu____5681 =
+              let uu____5692 =
+                let uu____5701 = embed e_univ_names rng univs  in
+                FStar_Syntax_Syntax.as_arg uu____5701  in
+              let uu____5704 =
+                let uu____5715 =
+                  let uu____5724 = embed e_term rng ty  in
+                  FStar_Syntax_Syntax.as_arg uu____5724  in
+                let uu____5725 =
+                  let uu____5736 =
+                    let uu____5745 = embed e_term rng t  in
+                    FStar_Syntax_Syntax.as_arg uu____5745  in
+                  [uu____5736]  in
+                uu____5715 :: uu____5725  in
+              uu____5692 :: uu____5704  in
+            uu____5671 :: uu____5681  in
+          uu____5649 :: uu____5660  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.t uu____5648
+          rng
     | FStar_Reflection_Data.Sg_Constructor (nm,ty) ->
-        let uu____5946 =
-          let uu____5951 =
-            let uu____5952 =
-              let uu____5961 =
-                embed FStar_Syntax_Embeddings.e_string_list rng nm  in
-              FStar_Syntax_Syntax.as_arg uu____5961  in
-            let uu____5965 =
-              let uu____5976 =
-                let uu____5985 = embed e_term rng ty  in
-                FStar_Syntax_Syntax.as_arg uu____5985  in
-              [uu____5976]  in
-            uu____5952 :: uu____5965  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Sg_Constructor.FStar_Reflection_Data.t
-            uu____5951
-           in
-        uu____5946 FStar_Pervasives_Native.None rng
+        let uu____5796 =
+          let uu____5797 =
+            let uu____5806 =
+              embed FStar_Syntax_Embeddings.e_string_list rng nm  in
+            FStar_Syntax_Syntax.as_arg uu____5806  in
+          let uu____5810 =
+            let uu____5821 =
+              let uu____5830 = embed e_term rng ty  in
+              FStar_Syntax_Syntax.as_arg uu____5830  in
+            [uu____5821]  in
+          uu____5797 :: uu____5810  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.ref_Sg_Constructor.FStar_Reflection_Data.t
+          uu____5796 rng
     | FStar_Reflection_Data.Sg_Inductive (nm,univs,bs,t,dcs) ->
-        let uu____6027 =
-          let uu____6032 =
-            let uu____6033 =
-              let uu____6042 =
-                embed FStar_Syntax_Embeddings.e_string_list rng nm  in
-              FStar_Syntax_Syntax.as_arg uu____6042  in
-            let uu____6046 =
-              let uu____6057 =
-                let uu____6066 = embed e_univ_names rng univs  in
-                FStar_Syntax_Syntax.as_arg uu____6066  in
-              let uu____6069 =
-                let uu____6080 =
-                  let uu____6089 = embed e_binders rng bs  in
-                  FStar_Syntax_Syntax.as_arg uu____6089  in
-                let uu____6090 =
-                  let uu____6101 =
-                    let uu____6110 = embed e_term rng t  in
-                    FStar_Syntax_Syntax.as_arg uu____6110  in
-                  let uu____6111 =
-                    let uu____6122 =
-                      let uu____6131 =
-                        let uu____6132 =
-                          FStar_Syntax_Embeddings.e_list
-                            FStar_Syntax_Embeddings.e_string_list
-                           in
-                        embed uu____6132 rng dcs  in
-                      FStar_Syntax_Syntax.as_arg uu____6131  in
-                    [uu____6122]  in
-                  uu____6101 :: uu____6111  in
-                uu____6080 :: uu____6090  in
-              uu____6057 :: uu____6069  in
-            uu____6033 :: uu____6046  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.t
-            uu____6032
-           in
-        uu____6027 FStar_Pervasives_Native.None rng
+        let uu____5872 =
+          let uu____5873 =
+            let uu____5882 =
+              embed FStar_Syntax_Embeddings.e_string_list rng nm  in
+            FStar_Syntax_Syntax.as_arg uu____5882  in
+          let uu____5886 =
+            let uu____5897 =
+              let uu____5906 = embed e_univ_names rng univs  in
+              FStar_Syntax_Syntax.as_arg uu____5906  in
+            let uu____5909 =
+              let uu____5920 =
+                let uu____5929 = embed e_binders rng bs  in
+                FStar_Syntax_Syntax.as_arg uu____5929  in
+              let uu____5930 =
+                let uu____5941 =
+                  let uu____5950 = embed e_term rng t  in
+                  FStar_Syntax_Syntax.as_arg uu____5950  in
+                let uu____5951 =
+                  let uu____5962 =
+                    let uu____5971 =
+                      let uu____5972 =
+                        FStar_Syntax_Embeddings.e_list
+                          FStar_Syntax_Embeddings.e_string_list
+                         in
+                      embed uu____5972 rng dcs  in
+                    FStar_Syntax_Syntax.as_arg uu____5971  in
+                  [uu____5962]  in
+                uu____5941 :: uu____5951  in
+              uu____5920 :: uu____5930  in
+            uu____5897 :: uu____5909  in
+          uu____5873 :: uu____5886  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.t
+          uu____5872 rng
     | FStar_Reflection_Data.Unk  ->
-        let uu___775_6196 =
+        let uu___775_6036 =
           FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.t  in
         {
-          FStar_Syntax_Syntax.n = (uu___775_6196.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___775_6036.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___775_6196.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___775_6036.FStar_Syntax_Syntax.vars)
         }
      in
   let unembed_sigelt_view w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____6215 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____6215 with
+    let uu____6055 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____6055 with
     | (hd,args) ->
-        let uu____6260 =
-          let uu____6273 =
-            let uu____6274 = FStar_Syntax_Util.un_uinst hd  in
-            uu____6274.FStar_Syntax_Syntax.n  in
-          (uu____6273, args)  in
-        (match uu____6260 with
+        let uu____6100 =
+          let uu____6113 =
+            let uu____6114 = FStar_Syntax_Util.un_uinst hd  in
+            uu____6114.FStar_Syntax_Syntax.n  in
+          (uu____6113, args)  in
+        (match uu____6100 with
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(nm,uu____6289)::(us,uu____6291)::(bs,uu____6293)::(t2,uu____6295)::
-            (dcs,uu____6297)::[]) when
+            fv,(nm,uu____6129)::(us,uu____6131)::(bs,uu____6133)::(t2,uu____6135)::
+            (dcs,uu____6137)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Inductive.FStar_Reflection_Data.lid
              ->
-             let uu____6362 =
+             let uu____6202 =
                unembed' w FStar_Syntax_Embeddings.e_string_list nm  in
-             FStar_Util.bind_opt uu____6362
+             FStar_Util.bind_opt uu____6202
                (fun nm1  ->
-                  let uu____6380 = unembed' w e_univ_names us  in
-                  FStar_Util.bind_opt uu____6380
+                  let uu____6220 = unembed' w e_univ_names us  in
+                  FStar_Util.bind_opt uu____6220
                     (fun us1  ->
-                       let uu____6394 = unembed' w e_binders bs  in
-                       FStar_Util.bind_opt uu____6394
+                       let uu____6234 = unembed' w e_binders bs  in
+                       FStar_Util.bind_opt uu____6234
                          (fun bs1  ->
-                            let uu____6400 = unembed' w e_term t2  in
-                            FStar_Util.bind_opt uu____6400
+                            let uu____6240 = unembed' w e_term t2  in
+                            FStar_Util.bind_opt uu____6240
                               (fun t3  ->
-                                 let uu____6406 =
-                                   let uu____6414 =
+                                 let uu____6246 =
+                                   let uu____6254 =
                                      FStar_Syntax_Embeddings.e_list
                                        FStar_Syntax_Embeddings.e_string_list
                                       in
-                                   unembed' w uu____6414 dcs  in
-                                 FStar_Util.bind_opt uu____6406
+                                   unembed' w uu____6254 dcs  in
+                                 FStar_Util.bind_opt uu____6246
                                    (fun dcs1  ->
                                       FStar_All.pipe_left
-                                        (fun uu____6444  ->
+                                        (fun uu____6284  ->
                                            FStar_Pervasives_Native.Some
-                                             uu____6444)
+                                             uu____6284)
                                         (FStar_Reflection_Data.Sg_Inductive
                                            (nm1, us1, bs1, t3, dcs1)))))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(r,uu____6453)::(fvar,uu____6455)::(univs,uu____6457)::
-            (ty,uu____6459)::(t2,uu____6461)::[]) when
+            fv,(r,uu____6293)::(fvar,uu____6295)::(univs,uu____6297)::
+            (ty,uu____6299)::(t2,uu____6301)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Sg_Let.FStar_Reflection_Data.lid
              ->
-             let uu____6526 = unembed' w FStar_Syntax_Embeddings.e_bool r  in
-             FStar_Util.bind_opt uu____6526
+             let uu____6366 = unembed' w FStar_Syntax_Embeddings.e_bool r  in
+             FStar_Util.bind_opt uu____6366
                (fun r1  ->
-                  let uu____6536 = unembed' w e_fv fvar  in
-                  FStar_Util.bind_opt uu____6536
+                  let uu____6376 = unembed' w e_fv fvar  in
+                  FStar_Util.bind_opt uu____6376
                     (fun fvar1  ->
-                       let uu____6542 = unembed' w e_univ_names univs  in
-                       FStar_Util.bind_opt uu____6542
+                       let uu____6382 = unembed' w e_univ_names univs  in
+                       FStar_Util.bind_opt uu____6382
                          (fun univs1  ->
-                            let uu____6556 = unembed' w e_term ty  in
-                            FStar_Util.bind_opt uu____6556
+                            let uu____6396 = unembed' w e_term ty  in
+                            FStar_Util.bind_opt uu____6396
                               (fun ty1  ->
-                                 let uu____6562 = unembed' w e_term t2  in
-                                 FStar_Util.bind_opt uu____6562
+                                 let uu____6402 = unembed' w e_term t2  in
+                                 FStar_Util.bind_opt uu____6402
                                    (fun t3  ->
                                       FStar_All.pipe_left
-                                        (fun uu____6569  ->
+                                        (fun uu____6409  ->
                                            FStar_Pervasives_Native.Some
-                                             uu____6569)
+                                             uu____6409)
                                         (FStar_Reflection_Data.Sg_Let
                                            (r1, fvar1, univs1, ty1, t3)))))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_Unk.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unk
-         | uu____6588 ->
+         | uu____6428 ->
              (if w
               then
-                (let uu____6603 =
-                   let uu____6609 =
-                     let uu____6611 = FStar_Syntax_Print.term_to_string t1
+                (let uu____6443 =
+                   let uu____6449 =
+                     let uu____6451 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded sigelt_view: %s"
-                       uu____6611
+                       uu____6451
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____6609)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6603)
+                   (FStar_Errors.Warning_NotEmbedded, uu____6449)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6443)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -1944,95 +1837,89 @@ let (e_exp : FStar_Reflection_Data.exp FStar_Syntax_Embeddings.embedding) =
       | FStar_Reflection_Data.Unit  ->
           FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Var i ->
-          let uu____6637 =
-            let uu____6642 =
-              let uu____6643 =
-                let uu____6652 =
-                  let uu____6653 = FStar_BigInt.string_of_big_int i  in
-                  FStar_Syntax_Util.exp_int uu____6653  in
-                FStar_Syntax_Syntax.as_arg uu____6652  in
-              [uu____6643]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.t
-              uu____6642
-             in
-          uu____6637 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____6477 =
+            let uu____6478 =
+              let uu____6487 =
+                let uu____6488 = FStar_BigInt.string_of_big_int i  in
+                FStar_Syntax_Util.exp_int uu____6488  in
+              FStar_Syntax_Syntax.as_arg uu____6487  in
+            [uu____6478]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.t
+            uu____6477 FStar_Range.dummyRange
       | FStar_Reflection_Data.Mult (e1,e2) ->
-          let uu____6673 =
-            let uu____6678 =
-              let uu____6679 =
-                let uu____6688 = embed_exp rng e1  in
-                FStar_Syntax_Syntax.as_arg uu____6688  in
-              let uu____6689 =
-                let uu____6700 =
-                  let uu____6709 = embed_exp rng e2  in
-                  FStar_Syntax_Syntax.as_arg uu____6709  in
-                [uu____6700]  in
-              uu____6679 :: uu____6689  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.t
-              uu____6678
-             in
-          uu____6673 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____6508 =
+            let uu____6509 =
+              let uu____6518 = embed_exp rng e1  in
+              FStar_Syntax_Syntax.as_arg uu____6518  in
+            let uu____6519 =
+              let uu____6530 =
+                let uu____6539 = embed_exp rng e2  in
+                FStar_Syntax_Syntax.as_arg uu____6539  in
+              [uu____6530]  in
+            uu____6509 :: uu____6519  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.t
+            uu____6508 FStar_Range.dummyRange
        in
-    let uu___850_6734 = r  in
+    let uu___850_6564 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___850_6734.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___850_6564.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___850_6734.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___850_6564.FStar_Syntax_Syntax.vars)
     }  in
   let rec unembed_exp w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____6755 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____6755 with
+    let uu____6585 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____6585 with
     | (hd,args) ->
-        let uu____6800 =
-          let uu____6813 =
-            let uu____6814 = FStar_Syntax_Util.un_uinst hd  in
-            uu____6814.FStar_Syntax_Syntax.n  in
-          (uu____6813, args)  in
-        (match uu____6800 with
+        let uu____6630 =
+          let uu____6643 =
+            let uu____6644 = FStar_Syntax_Util.un_uinst hd  in
+            uu____6644.FStar_Syntax_Syntax.n  in
+          (uu____6643, args)  in
+        (match uu____6630 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Unit.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.Unit
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____6844)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(i,uu____6674)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Var.FStar_Reflection_Data.lid
              ->
-             let uu____6869 = unembed' w FStar_Syntax_Embeddings.e_int i  in
-             FStar_Util.bind_opt uu____6869
+             let uu____6699 = unembed' w FStar_Syntax_Embeddings.e_int i  in
+             FStar_Util.bind_opt uu____6699
                (fun i1  ->
                   FStar_All.pipe_left
-                    (fun uu____6876  ->
-                       FStar_Pervasives_Native.Some uu____6876)
+                    (fun uu____6706  ->
+                       FStar_Pervasives_Native.Some uu____6706)
                     (FStar_Reflection_Data.Var i1))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(e1,uu____6879)::(e2,uu____6881)::[]) when
+            fv,(e1,uu____6709)::(e2,uu____6711)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_E_Mult.FStar_Reflection_Data.lid
              ->
-             let uu____6916 = unembed_exp w e1  in
-             FStar_Util.bind_opt uu____6916
+             let uu____6746 = unembed_exp w e1  in
+             FStar_Util.bind_opt uu____6746
                (fun e11  ->
-                  let uu____6922 = unembed_exp w e2  in
-                  FStar_Util.bind_opt uu____6922
+                  let uu____6752 = unembed_exp w e2  in
+                  FStar_Util.bind_opt uu____6752
                     (fun e21  ->
                        FStar_All.pipe_left
-                         (fun uu____6929  ->
-                            FStar_Pervasives_Native.Some uu____6929)
+                         (fun uu____6759  ->
+                            FStar_Pervasives_Native.Some uu____6759)
                          (FStar_Reflection_Data.Mult (e11, e21))))
-         | uu____6930 ->
+         | uu____6760 ->
              (if w
               then
-                (let uu____6945 =
-                   let uu____6951 =
-                     let uu____6953 = FStar_Syntax_Print.term_to_string t1
+                (let uu____6775 =
+                   let uu____6781 =
+                     let uu____6783 = FStar_Syntax_Print.term_to_string t1
                         in
-                     FStar_Util.format1 "Not an embedded exp: %s" uu____6953
+                     FStar_Util.format1 "Not an embedded exp: %s" uu____6783
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____6951)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6945)
+                   (FStar_Errors.Warning_NotEmbedded, uu____6781)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____6775)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -2087,120 +1974,100 @@ let (e_qualifier :
       | FStar_Reflection_Data.OnlyName  ->
           FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.t
       | FStar_Reflection_Data.Reflectable l ->
-          let uu____6990 =
-            let uu____6995 =
-              let uu____6996 =
-                let uu____7005 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____7005  in
-              [uu____6996]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.t
-              uu____6995
-             in
-          uu____6990 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____6820 =
+            let uu____6821 =
+              let uu____6830 = embed e_lid rng l  in
+              FStar_Syntax_Syntax.as_arg uu____6830  in
+            [uu____6821]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.t
+            uu____6820 FStar_Range.dummyRange
       | FStar_Reflection_Data.Discriminator l ->
-          let uu____7023 =
-            let uu____7028 =
-              let uu____7029 =
-                let uu____7038 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____7038  in
-              [uu____7029]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.t
-              uu____7028
-             in
-          uu____7023 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____6848 =
+            let uu____6849 =
+              let uu____6858 = embed e_lid rng l  in
+              FStar_Syntax_Syntax.as_arg uu____6858  in
+            [uu____6849]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.t
+            uu____6848 FStar_Range.dummyRange
       | FStar_Reflection_Data.Action l ->
-          let uu____7056 =
-            let uu____7061 =
-              let uu____7062 =
-                let uu____7071 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____7071  in
-              [uu____7062]  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.t
-              uu____7061
-             in
-          uu____7056 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____6876 =
+            let uu____6877 =
+              let uu____6886 = embed e_lid rng l  in
+              FStar_Syntax_Syntax.as_arg uu____6886  in
+            [uu____6877]  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.t
+            uu____6876 FStar_Range.dummyRange
       | FStar_Reflection_Data.Projector (l,i) ->
-          let uu____7090 =
-            let uu____7095 =
-              let uu____7096 =
-                let uu____7105 = embed e_lid rng l  in
-                FStar_Syntax_Syntax.as_arg uu____7105  in
-              let uu____7106 =
-                let uu____7117 =
-                  let uu____7126 = embed e_ident rng i  in
-                  FStar_Syntax_Syntax.as_arg uu____7126  in
-                [uu____7117]  in
-              uu____7096 :: uu____7106  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.t
-              uu____7095
-             in
-          uu____7090 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____6905 =
+            let uu____6906 =
+              let uu____6915 = embed e_lid rng l  in
+              FStar_Syntax_Syntax.as_arg uu____6915  in
+            let uu____6916 =
+              let uu____6927 =
+                let uu____6936 = embed e_ident rng i  in
+                FStar_Syntax_Syntax.as_arg uu____6936  in
+              [uu____6927]  in
+            uu____6906 :: uu____6916  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.t
+            uu____6905 FStar_Range.dummyRange
       | FStar_Reflection_Data.RecordType (ids1,ids2) ->
-          let uu____7161 =
-            let uu____7166 =
-              let uu____7167 =
-                let uu____7176 =
-                  let uu____7177 = FStar_Syntax_Embeddings.e_list e_ident  in
-                  embed uu____7177 rng ids1  in
-                FStar_Syntax_Syntax.as_arg uu____7176  in
-              let uu____7184 =
-                let uu____7195 =
-                  let uu____7204 =
-                    let uu____7205 = FStar_Syntax_Embeddings.e_list e_ident
-                       in
-                    embed uu____7205 rng ids2  in
-                  FStar_Syntax_Syntax.as_arg uu____7204  in
-                [uu____7195]  in
-              uu____7167 :: uu____7184  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.t
-              uu____7166
-             in
-          uu____7161 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____6971 =
+            let uu____6972 =
+              let uu____6981 =
+                let uu____6982 = FStar_Syntax_Embeddings.e_list e_ident  in
+                embed uu____6982 rng ids1  in
+              FStar_Syntax_Syntax.as_arg uu____6981  in
+            let uu____6989 =
+              let uu____7000 =
+                let uu____7009 =
+                  let uu____7010 = FStar_Syntax_Embeddings.e_list e_ident  in
+                  embed uu____7010 rng ids2  in
+                FStar_Syntax_Syntax.as_arg uu____7009  in
+              [uu____7000]  in
+            uu____6972 :: uu____6989  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.t
+            uu____6971 FStar_Range.dummyRange
       | FStar_Reflection_Data.RecordConstructor (ids1,ids2) ->
-          let uu____7246 =
-            let uu____7251 =
-              let uu____7252 =
-                let uu____7261 =
-                  let uu____7262 = FStar_Syntax_Embeddings.e_list e_ident  in
-                  embed uu____7262 rng ids1  in
-                FStar_Syntax_Syntax.as_arg uu____7261  in
-              let uu____7269 =
-                let uu____7280 =
-                  let uu____7289 =
-                    let uu____7290 = FStar_Syntax_Embeddings.e_list e_ident
-                       in
-                    embed uu____7290 rng ids2  in
-                  FStar_Syntax_Syntax.as_arg uu____7289  in
-                [uu____7280]  in
-              uu____7252 :: uu____7269  in
-            FStar_Syntax_Syntax.mk_Tm_app
-              FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.t
-              uu____7251
-             in
-          uu____7246 FStar_Pervasives_Native.None FStar_Range.dummyRange
+          let uu____7051 =
+            let uu____7052 =
+              let uu____7061 =
+                let uu____7062 = FStar_Syntax_Embeddings.e_list e_ident  in
+                embed uu____7062 rng ids1  in
+              FStar_Syntax_Syntax.as_arg uu____7061  in
+            let uu____7069 =
+              let uu____7080 =
+                let uu____7089 =
+                  let uu____7090 = FStar_Syntax_Embeddings.e_list e_ident  in
+                  embed uu____7090 rng ids2  in
+                FStar_Syntax_Syntax.as_arg uu____7089  in
+              [uu____7080]  in
+            uu____7052 :: uu____7069  in
+          FStar_Syntax_Syntax.mk_Tm_app
+            FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.t
+            uu____7051 FStar_Range.dummyRange
        in
-    let uu___926_7321 = r  in
+    let uu___926_7121 = r  in
     {
-      FStar_Syntax_Syntax.n = (uu___926_7321.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___926_7121.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___926_7321.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___926_7121.FStar_Syntax_Syntax.vars)
     }  in
   let unembed w t =
     let t1 = FStar_Syntax_Util.unascribe t  in
-    let uu____7342 = FStar_Syntax_Util.head_and_args t1  in
-    match uu____7342 with
+    let uu____7142 = FStar_Syntax_Util.head_and_args t1  in
+    match uu____7142 with
     | (hd,args) ->
-        let uu____7387 =
-          let uu____7400 =
-            let uu____7401 = FStar_Syntax_Util.un_uinst hd  in
-            uu____7401.FStar_Syntax_Syntax.n  in
-          (uu____7400, args)  in
-        (match uu____7387 with
+        let uu____7187 =
+          let uu____7200 =
+            let uu____7201 = FStar_Syntax_Util.un_uinst hd  in
+            uu____7201.FStar_Syntax_Syntax.n  in
+          (uu____7200, args)  in
+        (match uu____7187 with
          | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Assumption.FStar_Reflection_Data.lid
@@ -2285,107 +2152,107 @@ let (e_qualifier :
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_OnlyName.FStar_Reflection_Data.lid
              -> FStar_Pervasives_Native.Some FStar_Reflection_Data.OnlyName
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7686)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7486)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Reflectable.FStar_Reflection_Data.lid
              ->
-             let uu____7711 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7711
+             let uu____7511 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7511
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun uu____7718  ->
-                       FStar_Pervasives_Native.Some uu____7718)
+                    (fun uu____7518  ->
+                       FStar_Pervasives_Native.Some uu____7518)
                     (FStar_Reflection_Data.Reflectable l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7721)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7521)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Discriminator.FStar_Reflection_Data.lid
              ->
-             let uu____7746 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7746
+             let uu____7546 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7546
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun uu____7753  ->
-                       FStar_Pervasives_Native.Some uu____7753)
+                    (fun uu____7553  ->
+                       FStar_Pervasives_Native.Some uu____7553)
                     (FStar_Reflection_Data.Discriminator l1))
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7756)::[]) when
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____7556)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Action.FStar_Reflection_Data.lid
              ->
-             let uu____7781 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7781
+             let uu____7581 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7581
                (fun l1  ->
                   FStar_All.pipe_left
-                    (fun uu____7788  ->
-                       FStar_Pervasives_Native.Some uu____7788)
+                    (fun uu____7588  ->
+                       FStar_Pervasives_Native.Some uu____7588)
                     (FStar_Reflection_Data.Action l1))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(l,uu____7791)::(i,uu____7793)::[]) when
+            fv,(l,uu____7591)::(i,uu____7593)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_Projector.FStar_Reflection_Data.lid
              ->
-             let uu____7828 = unembed' w e_lid l  in
-             FStar_Util.bind_opt uu____7828
+             let uu____7628 = unembed' w e_lid l  in
+             FStar_Util.bind_opt uu____7628
                (fun l1  ->
-                  let uu____7834 = unembed' w e_ident i  in
-                  FStar_Util.bind_opt uu____7834
+                  let uu____7634 = unembed' w e_ident i  in
+                  FStar_Util.bind_opt uu____7634
                     (fun i1  ->
                        FStar_All.pipe_left
-                         (fun uu____7841  ->
-                            FStar_Pervasives_Native.Some uu____7841)
+                         (fun uu____7641  ->
+                            FStar_Pervasives_Native.Some uu____7641)
                          (FStar_Reflection_Data.Projector (l1, i1))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(ids1,uu____7844)::(ids2,uu____7846)::[]) when
+            fv,(ids1,uu____7644)::(ids2,uu____7646)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordType.FStar_Reflection_Data.lid
              ->
-             let uu____7881 =
-               let uu____7886 = FStar_Syntax_Embeddings.e_list e_ident  in
-               unembed' w uu____7886 ids1  in
-             FStar_Util.bind_opt uu____7881
+             let uu____7681 =
+               let uu____7686 = FStar_Syntax_Embeddings.e_list e_ident  in
+               unembed' w uu____7686 ids1  in
+             FStar_Util.bind_opt uu____7681
                (fun ids11  ->
-                  let uu____7900 =
-                    let uu____7905 = FStar_Syntax_Embeddings.e_list e_ident
+                  let uu____7700 =
+                    let uu____7705 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    unembed' w uu____7905 ids2  in
-                  FStar_Util.bind_opt uu____7900
+                    unembed' w uu____7705 ids2  in
+                  FStar_Util.bind_opt uu____7700
                     (fun ids21  ->
                        FStar_All.pipe_left
-                         (fun uu____7920  ->
-                            FStar_Pervasives_Native.Some uu____7920)
+                         (fun uu____7720  ->
+                            FStar_Pervasives_Native.Some uu____7720)
                          (FStar_Reflection_Data.RecordType (ids11, ids21))))
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,(ids1,uu____7927)::(ids2,uu____7929)::[]) when
+            fv,(ids1,uu____7727)::(ids2,uu____7729)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_Data.ref_qual_RecordConstructor.FStar_Reflection_Data.lid
              ->
-             let uu____7964 =
-               let uu____7969 = FStar_Syntax_Embeddings.e_list e_ident  in
-               unembed' w uu____7969 ids1  in
-             FStar_Util.bind_opt uu____7964
+             let uu____7764 =
+               let uu____7769 = FStar_Syntax_Embeddings.e_list e_ident  in
+               unembed' w uu____7769 ids1  in
+             FStar_Util.bind_opt uu____7764
                (fun ids11  ->
-                  let uu____7983 =
-                    let uu____7988 = FStar_Syntax_Embeddings.e_list e_ident
+                  let uu____7783 =
+                    let uu____7788 = FStar_Syntax_Embeddings.e_list e_ident
                        in
-                    unembed' w uu____7988 ids2  in
-                  FStar_Util.bind_opt uu____7983
+                    unembed' w uu____7788 ids2  in
+                  FStar_Util.bind_opt uu____7783
                     (fun ids21  ->
                        FStar_All.pipe_left
-                         (fun uu____8003  ->
-                            FStar_Pervasives_Native.Some uu____8003)
+                         (fun uu____7803  ->
+                            FStar_Pervasives_Native.Some uu____7803)
                          (FStar_Reflection_Data.RecordConstructor
                             (ids11, ids21))))
-         | uu____8008 ->
+         | uu____7808 ->
              (if w
               then
-                (let uu____8023 =
-                   let uu____8029 =
-                     let uu____8031 = FStar_Syntax_Print.term_to_string t1
+                (let uu____7823 =
+                   let uu____7829 =
+                     let uu____7831 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not an embedded qualifier: %s"
-                       uu____8031
+                       uu____7831
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____8029)  in
-                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____8023)
+                   (FStar_Errors.Warning_NotEmbedded, uu____7829)  in
+                 FStar_Errors.log_issue t1.FStar_Syntax_Syntax.pos uu____7823)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -2398,83 +2265,71 @@ let (unfold_lazy_bv :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let bv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____8049 =
-      let uu____8054 =
-        let uu____8055 =
-          let uu____8064 =
-            let uu____8065 = FStar_Reflection_Basic.inspect_bv bv  in
-            embed e_bv_view i.FStar_Syntax_Syntax.rng uu____8065  in
-          FStar_Syntax_Syntax.as_arg uu____8064  in
-        [uu____8055]  in
-      FStar_Syntax_Syntax.mk_Tm_app
-        FStar_Reflection_Data.fstar_refl_pack_bv.FStar_Reflection_Data.t
-        uu____8054
-       in
-    uu____8049 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    let uu____7849 =
+      let uu____7850 =
+        let uu____7859 =
+          let uu____7860 = FStar_Reflection_Basic.inspect_bv bv  in
+          embed e_bv_view i.FStar_Syntax_Syntax.rng uu____7860  in
+        FStar_Syntax_Syntax.as_arg uu____7859  in
+      [uu____7850]  in
+    FStar_Syntax_Syntax.mk_Tm_app
+      FStar_Reflection_Data.fstar_refl_pack_bv.FStar_Reflection_Data.t
+      uu____7849 i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_binder :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let binder = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____8089 = FStar_Reflection_Basic.inspect_binder binder  in
-    match uu____8089 with
+    let uu____7884 = FStar_Reflection_Basic.inspect_binder binder  in
+    match uu____7884 with
     | (bv,aq) ->
-        let uu____8096 =
-          let uu____8101 =
-            let uu____8102 =
-              let uu____8111 = embed e_bv i.FStar_Syntax_Syntax.rng bv  in
-              FStar_Syntax_Syntax.as_arg uu____8111  in
-            let uu____8112 =
-              let uu____8123 =
-                let uu____8132 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq
-                   in
-                FStar_Syntax_Syntax.as_arg uu____8132  in
-              [uu____8123]  in
-            uu____8102 :: uu____8112  in
-          FStar_Syntax_Syntax.mk_Tm_app
-            FStar_Reflection_Data.fstar_refl_pack_binder.FStar_Reflection_Data.t
-            uu____8101
-           in
-        uu____8096 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+        let uu____7891 =
+          let uu____7892 =
+            let uu____7901 = embed e_bv i.FStar_Syntax_Syntax.rng bv  in
+            FStar_Syntax_Syntax.as_arg uu____7901  in
+          let uu____7902 =
+            let uu____7913 =
+              let uu____7922 = embed e_aqualv i.FStar_Syntax_Syntax.rng aq
+                 in
+              FStar_Syntax_Syntax.as_arg uu____7922  in
+            [uu____7913]  in
+          uu____7892 :: uu____7902  in
+        FStar_Syntax_Syntax.mk_Tm_app
+          FStar_Reflection_Data.fstar_refl_pack_binder.FStar_Reflection_Data.t
+          uu____7891 i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_fvar :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let fv = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____8164 =
-      let uu____8169 =
-        let uu____8170 =
-          let uu____8179 =
-            let uu____8180 =
-              FStar_Syntax_Embeddings.e_list FStar_Syntax_Embeddings.e_string
-               in
-            let uu____8187 = FStar_Reflection_Basic.inspect_fv fv  in
-            embed uu____8180 i.FStar_Syntax_Syntax.rng uu____8187  in
-          FStar_Syntax_Syntax.as_arg uu____8179  in
-        [uu____8170]  in
-      FStar_Syntax_Syntax.mk_Tm_app
-        FStar_Reflection_Data.fstar_refl_pack_fv.FStar_Reflection_Data.t
-        uu____8169
-       in
-    uu____8164 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    let uu____7954 =
+      let uu____7955 =
+        let uu____7964 =
+          let uu____7965 =
+            FStar_Syntax_Embeddings.e_list FStar_Syntax_Embeddings.e_string
+             in
+          let uu____7972 = FStar_Reflection_Basic.inspect_fv fv  in
+          embed uu____7965 i.FStar_Syntax_Syntax.rng uu____7972  in
+        FStar_Syntax_Syntax.as_arg uu____7964  in
+      [uu____7955]  in
+    FStar_Syntax_Syntax.mk_Tm_app
+      FStar_Reflection_Data.fstar_refl_pack_fv.FStar_Reflection_Data.t
+      uu____7954 i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_comp :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let comp = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____8217 =
-      let uu____8222 =
-        let uu____8223 =
-          let uu____8232 =
-            let uu____8233 = FStar_Reflection_Basic.inspect_comp comp  in
-            embed e_comp_view i.FStar_Syntax_Syntax.rng uu____8233  in
-          FStar_Syntax_Syntax.as_arg uu____8232  in
-        [uu____8223]  in
-      FStar_Syntax_Syntax.mk_Tm_app
-        FStar_Reflection_Data.fstar_refl_pack_comp.FStar_Reflection_Data.t
-        uu____8222
-       in
-    uu____8217 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    let uu____8002 =
+      let uu____8003 =
+        let uu____8012 =
+          let uu____8013 = FStar_Reflection_Basic.inspect_comp comp  in
+          embed e_comp_view i.FStar_Syntax_Syntax.rng uu____8013  in
+        FStar_Syntax_Syntax.as_arg uu____8012  in
+      [uu____8003]  in
+    FStar_Syntax_Syntax.mk_Tm_app
+      FStar_Reflection_Data.fstar_refl_pack_comp.FStar_Reflection_Data.t
+      uu____8002 i.FStar_Syntax_Syntax.rng
   
 let (unfold_lazy_env :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
@@ -2486,17 +2341,14 @@ let (unfold_lazy_sigelt :
   FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term) =
   fun i  ->
     let sigelt = FStar_Dyn.undyn i.FStar_Syntax_Syntax.blob  in
-    let uu____8269 =
-      let uu____8274 =
-        let uu____8275 =
-          let uu____8284 =
-            let uu____8285 = FStar_Reflection_Basic.inspect_sigelt sigelt  in
-            embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu____8285  in
-          FStar_Syntax_Syntax.as_arg uu____8284  in
-        [uu____8275]  in
-      FStar_Syntax_Syntax.mk_Tm_app
-        FStar_Reflection_Data.fstar_refl_pack_sigelt.FStar_Reflection_Data.t
-        uu____8274
-       in
-    uu____8269 FStar_Pervasives_Native.None i.FStar_Syntax_Syntax.rng
+    let uu____8049 =
+      let uu____8050 =
+        let uu____8059 =
+          let uu____8060 = FStar_Reflection_Basic.inspect_sigelt sigelt  in
+          embed e_sigelt_view i.FStar_Syntax_Syntax.rng uu____8060  in
+        FStar_Syntax_Syntax.as_arg uu____8059  in
+      [uu____8050]  in
+    FStar_Syntax_Syntax.mk_Tm_app
+      FStar_Reflection_Data.fstar_refl_pack_sigelt.FStar_Reflection_Data.t
+      uu____8049 i.FStar_Syntax_Syntax.rng
   

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -2849,187 +2849,183 @@ let (encode_top_level_let :
         | (is_rec,bindings) ->
             let eta_expand binders formals body t =
               let nbinders = FStar_List.length binders  in
-              let uu____9212 = FStar_Util.first_N nbinders formals  in
-              match uu____9212 with
+              let uu____9210 = FStar_Util.first_N nbinders formals  in
+              match uu____9210 with
               | (formals1,extra_formals) ->
                   let subst =
                     FStar_List.map2
-                      (fun uu____9309  ->
-                         fun uu____9310  ->
-                           match (uu____9309, uu____9310) with
-                           | ((formal,uu____9336),(binder,uu____9338)) ->
-                               let uu____9359 =
-                                 let uu____9366 =
+                      (fun uu____9305  ->
+                         fun uu____9306  ->
+                           match (uu____9305, uu____9306) with
+                           | ((formal,uu____9332),(binder,uu____9334)) ->
+                               let uu____9355 =
+                                 let uu____9362 =
                                    FStar_Syntax_Syntax.bv_to_name binder  in
-                                 (formal, uu____9366)  in
-                               FStar_Syntax_Syntax.NT uu____9359) formals1
+                                 (formal, uu____9362)  in
+                               FStar_Syntax_Syntax.NT uu____9355) formals1
                       binders
                      in
                   let extra_formals1 =
-                    let uu____9380 =
+                    let uu____9376 =
                       FStar_All.pipe_right extra_formals
                         (FStar_List.map
-                           (fun uu____9421  ->
-                              match uu____9421 with
+                           (fun uu____9417  ->
+                              match uu____9417 with
                               | (x,i) ->
-                                  let uu____9440 =
-                                    let uu___521_9441 = x  in
-                                    let uu____9442 =
+                                  let uu____9436 =
+                                    let uu___521_9437 = x  in
+                                    let uu____9438 =
                                       FStar_Syntax_Subst.subst subst
                                         x.FStar_Syntax_Syntax.sort
                                        in
                                     {
                                       FStar_Syntax_Syntax.ppname =
-                                        (uu___521_9441.FStar_Syntax_Syntax.ppname);
+                                        (uu___521_9437.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
-                                        (uu___521_9441.FStar_Syntax_Syntax.index);
-                                      FStar_Syntax_Syntax.sort = uu____9442
+                                        (uu___521_9437.FStar_Syntax_Syntax.index);
+                                      FStar_Syntax_Syntax.sort = uu____9438
                                     }  in
-                                  (uu____9440, i)))
+                                  (uu____9436, i)))
                        in
-                    FStar_All.pipe_right uu____9380
+                    FStar_All.pipe_right uu____9376
                       FStar_Syntax_Util.name_binders
                      in
                   let body1 =
-                    let uu____9466 =
-                      let uu____9471 = FStar_Syntax_Subst.compress body  in
-                      let uu____9472 =
-                        let uu____9473 =
-                          FStar_Syntax_Util.args_of_binders extra_formals1
-                           in
-                        FStar_All.pipe_left FStar_Pervasives_Native.snd
-                          uu____9473
-                         in
-                      FStar_Syntax_Syntax.extend_app_n uu____9471 uu____9472
+                    let uu____9460 = FStar_Syntax_Subst.compress body  in
+                    let uu____9461 =
+                      let uu____9462 =
+                        FStar_Syntax_Util.args_of_binders extra_formals1  in
+                      FStar_All.pipe_left FStar_Pervasives_Native.snd
+                        uu____9462
                        in
-                    uu____9466 FStar_Pervasives_Native.None
+                    FStar_Syntax_Syntax.extend_app_n uu____9460 uu____9461
                       body.FStar_Syntax_Syntax.pos
                      in
                   ((FStar_List.append binders extra_formals1), body1)
                in
             let destruct_bound_function t e =
               let tcenv =
-                let uu___528_9522 = env.FStar_SMTEncoding_Env.tcenv  in
+                let uu___528_9509 = env.FStar_SMTEncoding_Env.tcenv  in
                 {
                   FStar_TypeChecker_Env.solver =
-                    (uu___528_9522.FStar_TypeChecker_Env.solver);
+                    (uu___528_9509.FStar_TypeChecker_Env.solver);
                   FStar_TypeChecker_Env.range =
-                    (uu___528_9522.FStar_TypeChecker_Env.range);
+                    (uu___528_9509.FStar_TypeChecker_Env.range);
                   FStar_TypeChecker_Env.curmodule =
-                    (uu___528_9522.FStar_TypeChecker_Env.curmodule);
+                    (uu___528_9509.FStar_TypeChecker_Env.curmodule);
                   FStar_TypeChecker_Env.gamma =
-                    (uu___528_9522.FStar_TypeChecker_Env.gamma);
+                    (uu___528_9509.FStar_TypeChecker_Env.gamma);
                   FStar_TypeChecker_Env.gamma_sig =
-                    (uu___528_9522.FStar_TypeChecker_Env.gamma_sig);
+                    (uu___528_9509.FStar_TypeChecker_Env.gamma_sig);
                   FStar_TypeChecker_Env.gamma_cache =
-                    (uu___528_9522.FStar_TypeChecker_Env.gamma_cache);
+                    (uu___528_9509.FStar_TypeChecker_Env.gamma_cache);
                   FStar_TypeChecker_Env.modules =
-                    (uu___528_9522.FStar_TypeChecker_Env.modules);
+                    (uu___528_9509.FStar_TypeChecker_Env.modules);
                   FStar_TypeChecker_Env.expected_typ =
-                    (uu___528_9522.FStar_TypeChecker_Env.expected_typ);
+                    (uu___528_9509.FStar_TypeChecker_Env.expected_typ);
                   FStar_TypeChecker_Env.sigtab =
-                    (uu___528_9522.FStar_TypeChecker_Env.sigtab);
+                    (uu___528_9509.FStar_TypeChecker_Env.sigtab);
                   FStar_TypeChecker_Env.attrtab =
-                    (uu___528_9522.FStar_TypeChecker_Env.attrtab);
+                    (uu___528_9509.FStar_TypeChecker_Env.attrtab);
                   FStar_TypeChecker_Env.instantiate_imp =
-                    (uu___528_9522.FStar_TypeChecker_Env.instantiate_imp);
+                    (uu___528_9509.FStar_TypeChecker_Env.instantiate_imp);
                   FStar_TypeChecker_Env.effects =
-                    (uu___528_9522.FStar_TypeChecker_Env.effects);
+                    (uu___528_9509.FStar_TypeChecker_Env.effects);
                   FStar_TypeChecker_Env.generalize =
-                    (uu___528_9522.FStar_TypeChecker_Env.generalize);
+                    (uu___528_9509.FStar_TypeChecker_Env.generalize);
                   FStar_TypeChecker_Env.letrecs =
-                    (uu___528_9522.FStar_TypeChecker_Env.letrecs);
+                    (uu___528_9509.FStar_TypeChecker_Env.letrecs);
                   FStar_TypeChecker_Env.top_level =
-                    (uu___528_9522.FStar_TypeChecker_Env.top_level);
+                    (uu___528_9509.FStar_TypeChecker_Env.top_level);
                   FStar_TypeChecker_Env.check_uvars =
-                    (uu___528_9522.FStar_TypeChecker_Env.check_uvars);
+                    (uu___528_9509.FStar_TypeChecker_Env.check_uvars);
                   FStar_TypeChecker_Env.use_eq =
-                    (uu___528_9522.FStar_TypeChecker_Env.use_eq);
+                    (uu___528_9509.FStar_TypeChecker_Env.use_eq);
                   FStar_TypeChecker_Env.use_eq_strict =
-                    (uu___528_9522.FStar_TypeChecker_Env.use_eq_strict);
+                    (uu___528_9509.FStar_TypeChecker_Env.use_eq_strict);
                   FStar_TypeChecker_Env.is_iface =
-                    (uu___528_9522.FStar_TypeChecker_Env.is_iface);
+                    (uu___528_9509.FStar_TypeChecker_Env.is_iface);
                   FStar_TypeChecker_Env.admit =
-                    (uu___528_9522.FStar_TypeChecker_Env.admit);
+                    (uu___528_9509.FStar_TypeChecker_Env.admit);
                   FStar_TypeChecker_Env.lax = true;
                   FStar_TypeChecker_Env.lax_universes =
-                    (uu___528_9522.FStar_TypeChecker_Env.lax_universes);
+                    (uu___528_9509.FStar_TypeChecker_Env.lax_universes);
                   FStar_TypeChecker_Env.phase1 =
-                    (uu___528_9522.FStar_TypeChecker_Env.phase1);
+                    (uu___528_9509.FStar_TypeChecker_Env.phase1);
                   FStar_TypeChecker_Env.failhard =
-                    (uu___528_9522.FStar_TypeChecker_Env.failhard);
+                    (uu___528_9509.FStar_TypeChecker_Env.failhard);
                   FStar_TypeChecker_Env.nosynth =
-                    (uu___528_9522.FStar_TypeChecker_Env.nosynth);
+                    (uu___528_9509.FStar_TypeChecker_Env.nosynth);
                   FStar_TypeChecker_Env.uvar_subtyping =
-                    (uu___528_9522.FStar_TypeChecker_Env.uvar_subtyping);
+                    (uu___528_9509.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.tc_term =
-                    (uu___528_9522.FStar_TypeChecker_Env.tc_term);
+                    (uu___528_9509.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.type_of =
-                    (uu___528_9522.FStar_TypeChecker_Env.type_of);
+                    (uu___528_9509.FStar_TypeChecker_Env.type_of);
                   FStar_TypeChecker_Env.universe_of =
-                    (uu___528_9522.FStar_TypeChecker_Env.universe_of);
+                    (uu___528_9509.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.check_type_of =
-                    (uu___528_9522.FStar_TypeChecker_Env.check_type_of);
+                    (uu___528_9509.FStar_TypeChecker_Env.check_type_of);
                   FStar_TypeChecker_Env.use_bv_sorts =
-                    (uu___528_9522.FStar_TypeChecker_Env.use_bv_sorts);
+                    (uu___528_9509.FStar_TypeChecker_Env.use_bv_sorts);
                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                    (uu___528_9522.FStar_TypeChecker_Env.qtbl_name_and_index);
+                    (uu___528_9509.FStar_TypeChecker_Env.qtbl_name_and_index);
                   FStar_TypeChecker_Env.normalized_eff_names =
-                    (uu___528_9522.FStar_TypeChecker_Env.normalized_eff_names);
+                    (uu___528_9509.FStar_TypeChecker_Env.normalized_eff_names);
                   FStar_TypeChecker_Env.fv_delta_depths =
-                    (uu___528_9522.FStar_TypeChecker_Env.fv_delta_depths);
+                    (uu___528_9509.FStar_TypeChecker_Env.fv_delta_depths);
                   FStar_TypeChecker_Env.proof_ns =
-                    (uu___528_9522.FStar_TypeChecker_Env.proof_ns);
+                    (uu___528_9509.FStar_TypeChecker_Env.proof_ns);
                   FStar_TypeChecker_Env.synth_hook =
-                    (uu___528_9522.FStar_TypeChecker_Env.synth_hook);
+                    (uu___528_9509.FStar_TypeChecker_Env.synth_hook);
                   FStar_TypeChecker_Env.try_solve_implicits_hook =
-                    (uu___528_9522.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                    (uu___528_9509.FStar_TypeChecker_Env.try_solve_implicits_hook);
                   FStar_TypeChecker_Env.splice =
-                    (uu___528_9522.FStar_TypeChecker_Env.splice);
+                    (uu___528_9509.FStar_TypeChecker_Env.splice);
                   FStar_TypeChecker_Env.mpreprocess =
-                    (uu___528_9522.FStar_TypeChecker_Env.mpreprocess);
+                    (uu___528_9509.FStar_TypeChecker_Env.mpreprocess);
                   FStar_TypeChecker_Env.postprocess =
-                    (uu___528_9522.FStar_TypeChecker_Env.postprocess);
+                    (uu___528_9509.FStar_TypeChecker_Env.postprocess);
                   FStar_TypeChecker_Env.identifier_info =
-                    (uu___528_9522.FStar_TypeChecker_Env.identifier_info);
+                    (uu___528_9509.FStar_TypeChecker_Env.identifier_info);
                   FStar_TypeChecker_Env.tc_hooks =
-                    (uu___528_9522.FStar_TypeChecker_Env.tc_hooks);
+                    (uu___528_9509.FStar_TypeChecker_Env.tc_hooks);
                   FStar_TypeChecker_Env.dsenv =
-                    (uu___528_9522.FStar_TypeChecker_Env.dsenv);
+                    (uu___528_9509.FStar_TypeChecker_Env.dsenv);
                   FStar_TypeChecker_Env.nbe =
-                    (uu___528_9522.FStar_TypeChecker_Env.nbe);
+                    (uu___528_9509.FStar_TypeChecker_Env.nbe);
                   FStar_TypeChecker_Env.strict_args_tab =
-                    (uu___528_9522.FStar_TypeChecker_Env.strict_args_tab);
+                    (uu___528_9509.FStar_TypeChecker_Env.strict_args_tab);
                   FStar_TypeChecker_Env.erasable_types_tab =
-                    (uu___528_9522.FStar_TypeChecker_Env.erasable_types_tab)
+                    (uu___528_9509.FStar_TypeChecker_Env.erasable_types_tab)
                 }  in
               let subst_comp formals actuals comp =
                 let subst =
                   FStar_List.map2
-                    (fun uu____9594  ->
-                       fun uu____9595  ->
-                         match (uu____9594, uu____9595) with
-                         | ((x,uu____9621),(b,uu____9623)) ->
-                             let uu____9644 =
-                               let uu____9651 =
+                    (fun uu____9581  ->
+                       fun uu____9582  ->
+                         match (uu____9581, uu____9582) with
+                         | ((x,uu____9608),(b,uu____9610)) ->
+                             let uu____9631 =
+                               let uu____9638 =
                                  FStar_Syntax_Syntax.bv_to_name b  in
-                               (x, uu____9651)  in
-                             FStar_Syntax_Syntax.NT uu____9644) formals
+                               (x, uu____9638)  in
+                             FStar_Syntax_Syntax.NT uu____9631) formals
                     actuals
                    in
                 FStar_Syntax_Subst.subst_comp subst comp  in
               let rec arrow_formals_comp_norm norm t1 =
                 let t2 =
-                  let uu____9676 = FStar_Syntax_Subst.compress t1  in
-                  FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____9676
+                  let uu____9663 = FStar_Syntax_Subst.compress t1  in
+                  FStar_All.pipe_left FStar_Syntax_Util.unascribe uu____9663
                    in
                 match t2.FStar_Syntax_Syntax.n with
                 | FStar_Syntax_Syntax.Tm_arrow (formals,comp) ->
                     FStar_Syntax_Subst.open_comp formals comp
-                | FStar_Syntax_Syntax.Tm_refine uu____9705 ->
-                    let uu____9712 = FStar_Syntax_Util.unrefine t2  in
-                    arrow_formals_comp_norm norm uu____9712
-                | uu____9713 when Prims.op_Negation norm ->
+                | FStar_Syntax_Syntax.Tm_refine uu____9692 ->
+                    let uu____9699 = FStar_Syntax_Util.unrefine t2  in
+                    arrow_formals_comp_norm norm uu____9699
+                | uu____9700 when Prims.op_Negation norm ->
                     let t_norm =
                       norm_with_steps
                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -3043,63 +3039,63 @@ let (encode_top_level_let :
                         FStar_TypeChecker_Env.EraseUniverses] tcenv t2
                        in
                     arrow_formals_comp_norm true t_norm
-                | uu____9716 ->
-                    let uu____9717 = FStar_Syntax_Syntax.mk_Total t2  in
-                    ([], uu____9717)
+                | uu____9703 ->
+                    let uu____9704 = FStar_Syntax_Syntax.mk_Total t2  in
+                    ([], uu____9704)
                  in
               let aux t1 e1 =
-                let uu____9759 = FStar_Syntax_Util.abs_formals e1  in
-                match uu____9759 with
+                let uu____9746 = FStar_Syntax_Util.abs_formals e1  in
+                match uu____9746 with
                 | (binders,body,lopt) ->
-                    let uu____9791 =
+                    let uu____9778 =
                       match binders with
                       | [] -> arrow_formals_comp_norm true t1
-                      | uu____9807 -> arrow_formals_comp_norm false t1  in
-                    (match uu____9791 with
+                      | uu____9794 -> arrow_formals_comp_norm false t1  in
+                    (match uu____9778 with
                      | (formals,comp) ->
                          let nformals = FStar_List.length formals  in
                          let nbinders = FStar_List.length binders  in
-                         let uu____9841 =
+                         let uu____9828 =
                            if nformals < nbinders
                            then
-                             let uu____9875 =
+                             let uu____9862 =
                                FStar_Util.first_N nformals binders  in
-                             match uu____9875 with
+                             match uu____9862 with
                              | (bs0,rest) ->
                                  let body1 =
                                    FStar_Syntax_Util.abs rest body lopt  in
-                                 let uu____9955 = subst_comp formals bs0 comp
+                                 let uu____9942 = subst_comp formals bs0 comp
                                     in
-                                 (bs0, body1, uu____9955)
+                                 (bs0, body1, uu____9942)
                            else
                              if nformals > nbinders
                              then
-                               (let uu____9985 =
+                               (let uu____9972 =
                                   eta_expand binders formals body
                                     (FStar_Syntax_Util.comp_result comp)
                                    in
-                                match uu____9985 with
+                                match uu____9972 with
                                 | (binders1,body1) ->
-                                    let uu____10038 =
+                                    let uu____10019 =
                                       subst_comp formals binders1 comp  in
-                                    (binders1, body1, uu____10038))
+                                    (binders1, body1, uu____10019))
                              else
-                               (let uu____10051 =
+                               (let uu____10032 =
                                   subst_comp formals binders comp  in
-                                (binders, body, uu____10051))
+                                (binders, body, uu____10032))
                             in
-                         (match uu____9841 with
+                         (match uu____9828 with
                           | (binders1,body1,comp1) ->
                               (binders1, body1, comp1)))
                  in
-              let uu____10111 = aux t e  in
-              match uu____10111 with
+              let uu____10092 = aux t e  in
+              match uu____10092 with
               | (binders,body,comp) ->
-                  let uu____10157 =
-                    let uu____10168 =
+                  let uu____10138 =
+                    let uu____10149 =
                       FStar_SMTEncoding_Util.is_smt_reifiable_comp tcenv comp
                        in
-                    if uu____10168
+                    if uu____10149
                     then
                       let comp1 =
                         FStar_TypeChecker_Env.reify_comp tcenv comp
@@ -3107,27 +3103,27 @@ let (encode_top_level_let :
                          in
                       let body1 =
                         FStar_TypeChecker_Util.reify_body tcenv [] body  in
-                      let uu____10183 = aux comp1 body1  in
-                      match uu____10183 with
+                      let uu____10164 = aux comp1 body1  in
+                      match uu____10164 with
                       | (more_binders,body2,comp2) ->
                           ((FStar_List.append binders more_binders), body2,
                             comp2)
                     else (binders, body, comp)  in
-                  (match uu____10157 with
+                  (match uu____10138 with
                    | (binders1,body1,comp1) ->
-                       let uu____10266 =
+                       let uu____10247 =
                          FStar_Syntax_Util.ascribe body1
                            ((FStar_Util.Inl
                                (FStar_Syntax_Util.comp_result comp1)),
                              FStar_Pervasives_Native.None)
                           in
-                       (binders1, uu____10266, comp1))
+                       (binders1, uu____10247, comp1))
                in
             (try
-               (fun uu___598_10293  ->
+               (fun uu___598_10274  ->
                   match () with
                   | () ->
-                      let uu____10300 =
+                      let uu____10281 =
                         FStar_All.pipe_right bindings
                           (FStar_Util.for_all
                              (fun lb  ->
@@ -3135,21 +3131,21 @@ let (encode_top_level_let :
                                    lb.FStar_Syntax_Syntax.lbtyp)
                                   || (is_tactic lb.FStar_Syntax_Syntax.lbtyp)))
                          in
-                      if uu____10300
+                      if uu____10281
                       then encode_top_level_vals env bindings quals
                       else
-                        (let uu____10316 =
+                        (let uu____10297 =
                            FStar_All.pipe_right bindings
                              (FStar_List.fold_left
-                                (fun uu____10379  ->
+                                (fun uu____10360  ->
                                    fun lb  ->
-                                     match uu____10379 with
+                                     match uu____10360 with
                                      | (toks,typs,decls,env1) ->
-                                         ((let uu____10434 =
+                                         ((let uu____10415 =
                                              FStar_Syntax_Util.is_lemma
                                                lb.FStar_Syntax_Syntax.lbtyp
                                               in
-                                           if uu____10434
+                                           if uu____10415
                                            then
                                              FStar_Exn.raise
                                                Let_rec_unencodeable
@@ -3158,23 +3154,23 @@ let (encode_top_level_let :
                                              norm_before_encoding env1
                                                lb.FStar_Syntax_Syntax.lbtyp
                                               in
-                                           let uu____10440 =
-                                             let uu____10449 =
+                                           let uu____10421 =
+                                             let uu____10430 =
                                                FStar_Util.right
                                                  lb.FStar_Syntax_Syntax.lbname
                                                 in
                                              declare_top_level_let env1
-                                               uu____10449
+                                               uu____10430
                                                lb.FStar_Syntax_Syntax.lbtyp
                                                t_norm
                                               in
-                                           match uu____10440 with
+                                           match uu____10421 with
                                            | (tok,decl,env2) ->
                                                ((tok :: toks), (t_norm ::
                                                  typs), (decl :: decls),
                                                  env2)))) ([], [], [], env))
                             in
-                         match uu____10316 with
+                         match uu____10297 with
                          | (toks,typs,decls,env1) ->
                              let toks_fvbs = FStar_List.rev toks  in
                              let decls1 =
@@ -3188,107 +3184,107 @@ let (encode_top_level_let :
                                match (bindings1, typs2, toks1) with
                                | ({ FStar_Syntax_Syntax.lbname = lbn;
                                     FStar_Syntax_Syntax.lbunivs = uvs;
-                                    FStar_Syntax_Syntax.lbtyp = uu____10590;
-                                    FStar_Syntax_Syntax.lbeff = uu____10591;
+                                    FStar_Syntax_Syntax.lbtyp = uu____10571;
+                                    FStar_Syntax_Syntax.lbeff = uu____10572;
                                     FStar_Syntax_Syntax.lbdef = e;
-                                    FStar_Syntax_Syntax.lbattrs = uu____10593;
-                                    FStar_Syntax_Syntax.lbpos = uu____10594;_}::[],t_norm::[],fvb::[])
+                                    FStar_Syntax_Syntax.lbattrs = uu____10574;
+                                    FStar_Syntax_Syntax.lbpos = uu____10575;_}::[],t_norm::[],fvb::[])
                                    ->
                                    let flid =
                                      fvb.FStar_SMTEncoding_Env.fvar_lid  in
-                                   let uu____10618 =
-                                     let uu____10625 =
+                                   let uu____10599 =
+                                     let uu____10606 =
                                        FStar_TypeChecker_Env.open_universes_in
                                          env2.FStar_SMTEncoding_Env.tcenv uvs
                                          [e; t_norm]
                                         in
-                                     match uu____10625 with
-                                     | (tcenv',uu____10641,e_t) ->
-                                         let uu____10647 =
+                                     match uu____10606 with
+                                     | (tcenv',uu____10622,e_t) ->
+                                         let uu____10628 =
                                            match e_t with
                                            | e1::t_norm1::[] -> (e1, t_norm1)
-                                           | uu____10658 ->
+                                           | uu____10639 ->
                                                failwith "Impossible"
                                             in
-                                         (match uu____10647 with
+                                         (match uu____10628 with
                                           | (e1,t_norm1) ->
-                                              ((let uu___661_10675 = env2  in
+                                              ((let uu___661_10656 = env2  in
                                                 {
                                                   FStar_SMTEncoding_Env.bvar_bindings
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.bvar_bindings);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.bvar_bindings);
                                                   FStar_SMTEncoding_Env.fvar_bindings
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.fvar_bindings);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.fvar_bindings);
                                                   FStar_SMTEncoding_Env.depth
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.depth);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.depth);
                                                   FStar_SMTEncoding_Env.tcenv
                                                     = tcenv';
                                                   FStar_SMTEncoding_Env.warn
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.warn);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.warn);
                                                   FStar_SMTEncoding_Env.nolabels
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.nolabels);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.nolabels);
                                                   FStar_SMTEncoding_Env.use_zfuel_name
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.use_zfuel_name);
                                                   FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                                                   FStar_SMTEncoding_Env.current_module_name
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.current_module_name);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.current_module_name);
                                                   FStar_SMTEncoding_Env.encoding_quantifier
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.encoding_quantifier);
                                                   FStar_SMTEncoding_Env.global_cache
                                                     =
-                                                    (uu___661_10675.FStar_SMTEncoding_Env.global_cache)
+                                                    (uu___661_10656.FStar_SMTEncoding_Env.global_cache)
                                                 }), e1, t_norm1))
                                       in
-                                   (match uu____10618 with
+                                   (match uu____10599 with
                                     | (env',e1,t_norm1) ->
-                                        let uu____10685 =
+                                        let uu____10666 =
                                           destruct_bound_function t_norm1 e1
                                            in
-                                        (match uu____10685 with
+                                        (match uu____10666 with
                                          | (binders,body,t_body_comp) ->
                                              let t_body =
                                                FStar_Syntax_Util.comp_result
                                                  t_body_comp
                                                 in
-                                             ((let uu____10705 =
+                                             ((let uu____10686 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env2.FStar_SMTEncoding_Env.tcenv)
                                                    (FStar_Options.Other
                                                       "SMTEncoding")
                                                   in
-                                               if uu____10705
+                                               if uu____10686
                                                then
-                                                 let uu____10710 =
+                                                 let uu____10691 =
                                                    FStar_Syntax_Print.binders_to_string
                                                      ", " binders
                                                     in
-                                                 let uu____10713 =
+                                                 let uu____10694 =
                                                    FStar_Syntax_Print.term_to_string
                                                      body
                                                     in
                                                  FStar_Util.print2
                                                    "Encoding let : binders=[%s], body=%s\n"
-                                                   uu____10710 uu____10713
+                                                   uu____10691 uu____10694
                                                else ());
-                                              (let uu____10718 =
+                                              (let uu____10699 =
                                                  FStar_SMTEncoding_EncodeTerm.encode_binders
                                                    FStar_Pervasives_Native.None
                                                    binders env'
                                                   in
-                                               match uu____10718 with
-                                               | (vars,_guards,env'1,binder_decls,uu____10745)
+                                               match uu____10699 with
+                                               | (vars,_guards,env'1,binder_decls,uu____10726)
                                                    ->
-                                                   let uu____10758 =
+                                                   let uu____10739 =
                                                      if
                                                        fvb.FStar_SMTEncoding_Env.fvb_thunked
                                                          && (vars = [])
@@ -3304,46 +3300,46 @@ let (encode_top_level_let :
                                                            FStar_Range.dummyRange
                                                           in
                                                        let app =
-                                                         let uu____10775 =
+                                                         let uu____10756 =
                                                            FStar_Syntax_Util.range_of_lbname
                                                              lbn
                                                             in
                                                          FStar_SMTEncoding_Term.mkApp
                                                            ((fvb.FStar_SMTEncoding_Env.smt_id),
                                                              [dummy_tm])
-                                                           uu____10775
+                                                           uu____10756
                                                           in
                                                        ([dummy_var], app)
                                                      else
-                                                       (let uu____10797 =
-                                                          let uu____10798 =
+                                                       (let uu____10778 =
+                                                          let uu____10779 =
                                                             FStar_Syntax_Util.range_of_lbname
                                                               lbn
                                                              in
-                                                          let uu____10799 =
+                                                          let uu____10780 =
                                                             FStar_List.map
                                                               FStar_SMTEncoding_Util.mkFreeV
                                                               vars
                                                              in
                                                           FStar_SMTEncoding_EncodeTerm.maybe_curry_fvb
-                                                            uu____10798 fvb
-                                                            uu____10799
+                                                            uu____10779 fvb
+                                                            uu____10780
                                                            in
-                                                        (vars, uu____10797))
+                                                        (vars, uu____10778))
                                                       in
-                                                   (match uu____10758 with
+                                                   (match uu____10739 with
                                                     | (vars1,app) ->
-                                                        let uu____10810 =
+                                                        let uu____10791 =
                                                           let is_logical =
-                                                            let uu____10823 =
-                                                              let uu____10824
+                                                            let uu____10804 =
+                                                              let uu____10805
                                                                 =
                                                                 FStar_Syntax_Subst.compress
                                                                   t_body
                                                                  in
-                                                              uu____10824.FStar_Syntax_Syntax.n
+                                                              uu____10805.FStar_Syntax_Syntax.n
                                                                in
-                                                            match uu____10823
+                                                            match uu____10804
                                                             with
                                                             | FStar_Syntax_Syntax.Tm_fvar
                                                                 fv when
@@ -3351,38 +3347,38 @@ let (encode_top_level_let :
                                                                   fv
                                                                   FStar_Parser_Const.logical_lid
                                                                 -> true
-                                                            | uu____10830 ->
+                                                            | uu____10811 ->
                                                                 false
                                                              in
                                                           let is_prims =
-                                                            let uu____10834 =
-                                                              let uu____10835
+                                                            let uu____10815 =
+                                                              let uu____10816
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   lbn
                                                                   FStar_Util.right
                                                                  in
                                                               FStar_All.pipe_right
-                                                                uu____10835
+                                                                uu____10816
                                                                 FStar_Syntax_Syntax.lid_of_fv
                                                                in
                                                             FStar_All.pipe_right
-                                                              uu____10834
+                                                              uu____10815
                                                               (fun lid  ->
-                                                                 let uu____10844
+                                                                 let uu____10825
                                                                    =
-                                                                   let uu____10845
+                                                                   let uu____10826
                                                                     =
                                                                     FStar_Ident.ns_of_lid
                                                                     lid  in
                                                                    FStar_Ident.lid_of_ids
-                                                                    uu____10845
+                                                                    uu____10826
                                                                     in
                                                                  FStar_Ident.lid_equals
-                                                                   uu____10844
+                                                                   uu____10825
                                                                    FStar_Parser_Const.prims_lid)
                                                              in
-                                                          let uu____10846 =
+                                                          let uu____10827 =
                                                             (Prims.op_Negation
                                                                is_prims)
                                                               &&
@@ -3393,45 +3389,45 @@ let (encode_top_level_let :
                                                                  ||
                                                                  is_logical)
                                                              in
-                                                          if uu____10846
+                                                          if uu____10827
                                                           then
-                                                            let uu____10862 =
+                                                            let uu____10843 =
                                                               FStar_SMTEncoding_Term.mk_Valid
                                                                 app
                                                                in
-                                                            let uu____10863 =
+                                                            let uu____10844 =
                                                               FStar_SMTEncoding_EncodeTerm.encode_formula
                                                                 body env'1
                                                                in
                                                             (app,
-                                                              uu____10862,
-                                                              uu____10863)
+                                                              uu____10843,
+                                                              uu____10844)
                                                           else
-                                                            (let uu____10874
+                                                            (let uu____10855
                                                                =
                                                                FStar_SMTEncoding_EncodeTerm.encode_term
                                                                  body env'1
                                                                 in
                                                              (app, app,
-                                                               uu____10874))
+                                                               uu____10855))
                                                            in
-                                                        (match uu____10810
+                                                        (match uu____10791
                                                          with
                                                          | (pat,app1,
                                                             (body1,decls2))
                                                              ->
                                                              let eqn =
-                                                               let uu____10898
+                                                               let uu____10879
                                                                  =
-                                                                 let uu____10906
+                                                                 let uu____10887
                                                                    =
-                                                                   let uu____10907
+                                                                   let uu____10888
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                   let uu____10908
+                                                                   let uu____10889
                                                                     =
-                                                                    let uu____10919
+                                                                    let uu____10900
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app1,
@@ -3439,47 +3435,47 @@ let (encode_top_level_let :
                                                                      in
                                                                     ([[pat]],
                                                                     vars1,
-                                                                    uu____10919)
+                                                                    uu____10900)
                                                                      in
                                                                    FStar_SMTEncoding_Term.mkForall
-                                                                    uu____10907
-                                                                    uu____10908
+                                                                    uu____10888
+                                                                    uu____10889
                                                                     in
-                                                                 let uu____10928
+                                                                 let uu____10909
                                                                    =
-                                                                   let uu____10929
+                                                                   let uu____10910
                                                                     =
-                                                                    let uu____10931
+                                                                    let uu____10912
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     flid  in
                                                                     FStar_Util.format1
                                                                     "Equation for %s"
-                                                                    uu____10931
+                                                                    uu____10912
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____10929
+                                                                    uu____10910
                                                                     in
-                                                                 (uu____10906,
-                                                                   uu____10928,
+                                                                 (uu____10887,
+                                                                   uu____10909,
                                                                    (Prims.op_Hat
                                                                     "equation_"
                                                                     fvb.FStar_SMTEncoding_Env.smt_id))
                                                                   in
                                                                FStar_SMTEncoding_Util.mkAssume
-                                                                 uu____10898
+                                                                 uu____10879
                                                                 in
-                                                             let uu____10937
+                                                             let uu____10918
                                                                =
-                                                               let uu____10940
+                                                               let uu____10921
                                                                  =
-                                                                 let uu____10943
+                                                                 let uu____10924
                                                                    =
-                                                                   let uu____10946
+                                                                   let uu____10927
                                                                     =
-                                                                    let uu____10949
+                                                                    let uu____10930
                                                                     =
-                                                                    let uu____10952
+                                                                    let uu____10933
                                                                     =
                                                                     primitive_type_axioms
                                                                     env2.FStar_SMTEncoding_Env.tcenv
@@ -3487,199 +3483,199 @@ let (encode_top_level_let :
                                                                     fvb.FStar_SMTEncoding_Env.smt_id
                                                                     app1  in
                                                                     eqn ::
-                                                                    uu____10952
+                                                                    uu____10933
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____10949
+                                                                    uu____10930
                                                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                                                      in
                                                                    FStar_List.append
                                                                     decls2
-                                                                    uu____10946
+                                                                    uu____10927
                                                                     in
                                                                  FStar_List.append
                                                                    binder_decls
-                                                                   uu____10943
+                                                                   uu____10924
                                                                   in
                                                                FStar_List.append
                                                                  decls1
-                                                                 uu____10940
+                                                                 uu____10921
                                                                 in
-                                                             (uu____10937,
+                                                             (uu____10918,
                                                                env2)))))))
-                               | uu____10961 -> failwith "Impossible"  in
+                               | uu____10942 -> failwith "Impossible"  in
                              let encode_rec_lbdefs bindings1 typs2 toks1 env2
                                =
                                let fuel =
-                                 let uu____11021 =
-                                   let uu____11027 =
+                                 let uu____11002 =
+                                   let uu____11008 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
                                        env2.FStar_SMTEncoding_Env.current_module_name
                                        "fuel"
                                       in
-                                   (uu____11027,
+                                   (uu____11008,
                                      FStar_SMTEncoding_Term.Fuel_sort)
                                     in
-                                 FStar_SMTEncoding_Term.mk_fv uu____11021  in
+                                 FStar_SMTEncoding_Term.mk_fv uu____11002  in
                                let fuel_tm =
                                  FStar_SMTEncoding_Util.mkFreeV fuel  in
                                let env0 = env2  in
-                               let uu____11033 =
+                               let uu____11014 =
                                  FStar_All.pipe_right toks1
                                    (FStar_List.fold_left
-                                      (fun uu____11086  ->
+                                      (fun uu____11067  ->
                                          fun fvb  ->
-                                           match uu____11086 with
+                                           match uu____11067 with
                                            | (gtoks,env3) ->
                                                let flid =
                                                  fvb.FStar_SMTEncoding_Env.fvar_lid
                                                   in
                                                let g =
-                                                 let uu____11141 =
+                                                 let uu____11122 =
                                                    FStar_Ident.lid_add_suffix
                                                      flid "fuel_instrumented"
                                                     in
                                                  FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu____11141
+                                                   uu____11122
                                                   in
                                                let gtok =
-                                                 let uu____11145 =
+                                                 let uu____11126 =
                                                    FStar_Ident.lid_add_suffix
                                                      flid
                                                      "fuel_instrumented_token"
                                                     in
                                                  FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu____11145
+                                                   uu____11126
                                                   in
                                                let env4 =
-                                                 let uu____11148 =
-                                                   let uu____11151 =
+                                                 let uu____11129 =
+                                                   let uu____11132 =
                                                      FStar_SMTEncoding_Util.mkApp
                                                        (g, [fuel_tm])
                                                       in
                                                    FStar_All.pipe_left
-                                                     (fun uu____11157  ->
+                                                     (fun uu____11138  ->
                                                         FStar_Pervasives_Native.Some
-                                                          uu____11157)
-                                                     uu____11151
+                                                          uu____11138)
+                                                     uu____11132
                                                     in
                                                  FStar_SMTEncoding_Env.push_free_var
                                                    env3 flid
                                                    fvb.FStar_SMTEncoding_Env.smt_arity
-                                                   gtok uu____11148
+                                                   gtok uu____11129
                                                   in
                                                (((fvb, g, gtok) :: gtoks),
                                                  env4)) ([], env2))
                                   in
-                               match uu____11033 with
+                               match uu____11014 with
                                | (gtoks,env3) ->
                                    let gtoks1 = FStar_List.rev gtoks  in
-                                   let encode_one_binding env01 uu____11277
-                                     t_norm uu____11279 =
-                                     match (uu____11277, uu____11279) with
+                                   let encode_one_binding env01 uu____11258
+                                     t_norm uu____11260 =
+                                     match (uu____11258, uu____11260) with
                                      | ((fvb,g,gtok),{
                                                        FStar_Syntax_Syntax.lbname
                                                          = lbn;
                                                        FStar_Syntax_Syntax.lbunivs
                                                          = uvs;
                                                        FStar_Syntax_Syntax.lbtyp
-                                                         = uu____11309;
+                                                         = uu____11290;
                                                        FStar_Syntax_Syntax.lbeff
-                                                         = uu____11310;
+                                                         = uu____11291;
                                                        FStar_Syntax_Syntax.lbdef
                                                          = e;
                                                        FStar_Syntax_Syntax.lbattrs
-                                                         = uu____11312;
+                                                         = uu____11293;
                                                        FStar_Syntax_Syntax.lbpos
-                                                         = uu____11313;_})
+                                                         = uu____11294;_})
                                          ->
-                                         let uu____11340 =
-                                           let uu____11347 =
+                                         let uu____11321 =
+                                           let uu____11328 =
                                              FStar_TypeChecker_Env.open_universes_in
                                                env3.FStar_SMTEncoding_Env.tcenv
                                                uvs [e; t_norm]
                                               in
-                                           match uu____11347 with
-                                           | (tcenv',uu____11363,e_t) ->
-                                               let uu____11369 =
+                                           match uu____11328 with
+                                           | (tcenv',uu____11344,e_t) ->
+                                               let uu____11350 =
                                                  match e_t with
                                                  | e1::t_norm1::[] ->
                                                      (e1, t_norm1)
-                                                 | uu____11380 ->
+                                                 | uu____11361 ->
                                                      failwith "Impossible"
                                                   in
-                                               (match uu____11369 with
+                                               (match uu____11350 with
                                                 | (e1,t_norm1) ->
-                                                    ((let uu___748_11397 =
+                                                    ((let uu___748_11378 =
                                                         env3  in
                                                       {
                                                         FStar_SMTEncoding_Env.bvar_bindings
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.bvar_bindings);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.bvar_bindings);
                                                         FStar_SMTEncoding_Env.fvar_bindings
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.fvar_bindings);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.fvar_bindings);
                                                         FStar_SMTEncoding_Env.depth
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.depth);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.depth);
                                                         FStar_SMTEncoding_Env.tcenv
                                                           = tcenv';
                                                         FStar_SMTEncoding_Env.warn
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.warn);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.warn);
                                                         FStar_SMTEncoding_Env.nolabels
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.nolabels);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.nolabels);
                                                         FStar_SMTEncoding_Env.use_zfuel_name
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.use_zfuel_name);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.use_zfuel_name);
                                                         FStar_SMTEncoding_Env.encode_non_total_function_typ
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                                                         FStar_SMTEncoding_Env.current_module_name
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.current_module_name);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.current_module_name);
                                                         FStar_SMTEncoding_Env.encoding_quantifier
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.encoding_quantifier);
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.encoding_quantifier);
                                                         FStar_SMTEncoding_Env.global_cache
                                                           =
-                                                          (uu___748_11397.FStar_SMTEncoding_Env.global_cache)
+                                                          (uu___748_11378.FStar_SMTEncoding_Env.global_cache)
                                                       }), e1, t_norm1))
                                             in
-                                         (match uu____11340 with
+                                         (match uu____11321 with
                                           | (env',e1,t_norm1) ->
-                                              ((let uu____11410 =
+                                              ((let uu____11391 =
                                                   FStar_All.pipe_left
                                                     (FStar_TypeChecker_Env.debug
                                                        env01.FStar_SMTEncoding_Env.tcenv)
                                                     (FStar_Options.Other
                                                        "SMTEncoding")
                                                    in
-                                                if uu____11410
+                                                if uu____11391
                                                 then
-                                                  let uu____11415 =
+                                                  let uu____11396 =
                                                     FStar_Syntax_Print.lbname_to_string
                                                       lbn
                                                      in
-                                                  let uu____11417 =
+                                                  let uu____11398 =
                                                     FStar_Syntax_Print.term_to_string
                                                       t_norm1
                                                      in
-                                                  let uu____11419 =
+                                                  let uu____11400 =
                                                     FStar_Syntax_Print.term_to_string
                                                       e1
                                                      in
                                                   FStar_Util.print3
                                                     "Encoding let rec %s : %s = %s\n"
-                                                    uu____11415 uu____11417
-                                                    uu____11419
+                                                    uu____11396 uu____11398
+                                                    uu____11400
                                                 else ());
-                                               (let uu____11424 =
+                                               (let uu____11405 =
                                                   destruct_bound_function
                                                     t_norm1 e1
                                                    in
-                                                match uu____11424 with
+                                                match uu____11405 with
                                                 | (binders,body,tres_comp) ->
                                                     let curry =
                                                       fvb.FStar_SMTEncoding_Env.smt_arity
@@ -3687,94 +3683,94 @@ let (encode_top_level_let :
                                                         (FStar_List.length
                                                            binders)
                                                        in
-                                                    let uu____11451 =
+                                                    let uu____11432 =
                                                       FStar_TypeChecker_Util.pure_or_ghost_pre_and_post
                                                         env3.FStar_SMTEncoding_Env.tcenv
                                                         tres_comp
                                                        in
-                                                    (match uu____11451 with
+                                                    (match uu____11432 with
                                                      | (pre_opt,tres) ->
-                                                         ((let uu____11473 =
+                                                         ((let uu____11454 =
                                                              FStar_All.pipe_left
                                                                (FStar_TypeChecker_Env.debug
                                                                   env01.FStar_SMTEncoding_Env.tcenv)
                                                                (FStar_Options.Other
                                                                   "SMTEncodingReify")
                                                               in
-                                                           if uu____11473
+                                                           if uu____11454
                                                            then
-                                                             let uu____11478
+                                                             let uu____11459
                                                                =
                                                                FStar_Syntax_Print.lbname_to_string
                                                                  lbn
                                                                 in
-                                                             let uu____11480
+                                                             let uu____11461
                                                                =
                                                                FStar_Syntax_Print.binders_to_string
                                                                  ", " binders
                                                                 in
-                                                             let uu____11483
+                                                             let uu____11464
                                                                =
                                                                FStar_Syntax_Print.term_to_string
                                                                  body
                                                                 in
-                                                             let uu____11485
+                                                             let uu____11466
                                                                =
                                                                FStar_Syntax_Print.comp_to_string
                                                                  tres_comp
                                                                 in
                                                              FStar_Util.print4
                                                                "Encoding let rec %s: \n\tbinders=[%s], \n\tbody=%s, \n\ttres=%s\n"
-                                                               uu____11478
-                                                               uu____11480
-                                                               uu____11483
-                                                               uu____11485
+                                                               uu____11459
+                                                               uu____11461
+                                                               uu____11464
+                                                               uu____11466
                                                            else ());
-                                                          (let uu____11490 =
+                                                          (let uu____11471 =
                                                              FStar_SMTEncoding_EncodeTerm.encode_binders
                                                                FStar_Pervasives_Native.None
                                                                binders env'
                                                               in
-                                                           match uu____11490
+                                                           match uu____11471
                                                            with
-                                                           | (vars,guards,env'1,binder_decls,uu____11519)
+                                                           | (vars,guards,env'1,binder_decls,uu____11500)
                                                                ->
-                                                               let uu____11532
+                                                               let uu____11513
                                                                  =
                                                                  match pre_opt
                                                                  with
                                                                  | FStar_Pervasives_Native.None
                                                                      ->
-                                                                    let uu____11545
+                                                                    let uu____11526
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     guards
                                                                      in
-                                                                    (uu____11545,
+                                                                    (uu____11526,
                                                                     [])
                                                                  | FStar_Pervasives_Native.Some
                                                                     pre ->
-                                                                    let uu____11549
+                                                                    let uu____11530
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_formula
                                                                     pre env'1
                                                                      in
-                                                                    (match uu____11549
+                                                                    (match uu____11530
                                                                     with
                                                                     | 
                                                                     (guard,decls0)
                                                                     ->
-                                                                    let uu____11562
+                                                                    let uu____11543
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     guards
                                                                     [guard])
                                                                      in
-                                                                    (uu____11562,
+                                                                    (uu____11543,
                                                                     decls0))
                                                                   in
-                                                               (match uu____11532
+                                                               (match uu____11513
                                                                 with
                                                                 | (guard,guard_decls)
                                                                     ->
@@ -3786,38 +3782,38 @@ let (encode_top_level_let :
                                                                      in
                                                                     let decl_g
                                                                     =
-                                                                    let uu____11583
+                                                                    let uu____11564
                                                                     =
-                                                                    let uu____11595
+                                                                    let uu____11576
                                                                     =
-                                                                    let uu____11598
+                                                                    let uu____11579
                                                                     =
-                                                                    let uu____11601
+                                                                    let uu____11582
                                                                     =
-                                                                    let uu____11604
+                                                                    let uu____11585
                                                                     =
                                                                     FStar_Util.first_N
                                                                     fvb.FStar_SMTEncoding_Env.smt_arity
                                                                     vars  in
                                                                     FStar_Pervasives_Native.fst
-                                                                    uu____11604
+                                                                    uu____11585
                                                                      in
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Term.fv_sort
-                                                                    uu____11601
+                                                                    uu____11582
                                                                      in
                                                                     FStar_SMTEncoding_Term.Fuel_sort
                                                                     ::
-                                                                    uu____11598
+                                                                    uu____11579
                                                                      in
                                                                     (g,
-                                                                    uu____11595,
+                                                                    uu____11576,
                                                                     FStar_SMTEncoding_Term.Term_sort,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel-instrumented function name"))
                                                                      in
                                                                     FStar_SMTEncoding_Term.DeclFun
-                                                                    uu____11583
+                                                                    uu____11564
                                                                      in
                                                                     let env02
                                                                     =
@@ -3843,14 +3839,14 @@ let (encode_top_level_let :
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
                                                                     let app =
-                                                                    let uu____11634
+                                                                    let uu____11615
                                                                     =
                                                                     FStar_List.map
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     vars  in
                                                                     FStar_SMTEncoding_EncodeTerm.maybe_curry_fvb
                                                                     rng fvb
-                                                                    uu____11634
+                                                                    uu____11615
                                                                      in
                                                                     let mk_g_app
                                                                     args =
@@ -3865,74 +3861,74 @@ let (encode_top_level_let :
                                                                     args  in
                                                                     let gsapp
                                                                     =
-                                                                    let uu____11649
+                                                                    let uu____11630
                                                                     =
-                                                                    let uu____11652
+                                                                    let uu____11633
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     ("SFuel",
                                                                     [fuel_tm])
                                                                      in
-                                                                    uu____11652
+                                                                    uu____11633
                                                                     ::
                                                                     vars_tm
                                                                      in
                                                                     mk_g_app
-                                                                    uu____11649
+                                                                    uu____11630
                                                                      in
                                                                     let gmax
                                                                     =
-                                                                    let uu____11658
+                                                                    let uu____11639
                                                                     =
-                                                                    let uu____11661
+                                                                    let uu____11642
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkApp
                                                                     ("MaxFuel",
                                                                     [])  in
-                                                                    uu____11661
+                                                                    uu____11642
                                                                     ::
                                                                     vars_tm
                                                                      in
                                                                     mk_g_app
-                                                                    uu____11658
+                                                                    uu____11639
                                                                      in
-                                                                    let uu____11666
+                                                                    let uu____11647
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_term
                                                                     body
                                                                     env'1  in
-                                                                    (match uu____11666
+                                                                    (match uu____11647
                                                                     with
                                                                     | 
                                                                     (body_tm,decls2)
                                                                     ->
                                                                     let eqn_g
                                                                     =
-                                                                    let uu____11682
+                                                                    let uu____11663
                                                                     =
-                                                                    let uu____11690
+                                                                    let uu____11671
                                                                     =
-                                                                    let uu____11691
+                                                                    let uu____11672
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11692
+                                                                    let uu____11673
                                                                     =
-                                                                    let uu____11708
+                                                                    let uu____11689
                                                                     =
-                                                                    let uu____11709
+                                                                    let uu____11690
                                                                     =
-                                                                    let uu____11714
+                                                                    let uu____11695
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (gsapp,
                                                                     body_tm)
                                                                      in
                                                                     (guard,
-                                                                    uu____11714)
+                                                                    uu____11695)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____11709
+                                                                    uu____11690
                                                                      in
                                                                     ([
                                                                     [gsapp]],
@@ -3940,128 +3936,128 @@ let (encode_top_level_let :
                                                                     Prims.int_zero),
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11708)
+                                                                    uu____11689)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall'
-                                                                    uu____11691
-                                                                    uu____11692
+                                                                    uu____11672
+                                                                    uu____11673
                                                                      in
-                                                                    let uu____11728
+                                                                    let uu____11709
                                                                     =
-                                                                    let uu____11729
+                                                                    let uu____11710
                                                                     =
-                                                                    let uu____11731
+                                                                    let uu____11712
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     fvb.FStar_SMTEncoding_Env.fvar_lid
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Equation for fuel-instrumented recursive function: %s"
-                                                                    uu____11731
+                                                                    uu____11712
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____11729
+                                                                    uu____11710
                                                                      in
-                                                                    (uu____11690,
-                                                                    uu____11728,
+                                                                    (uu____11671,
+                                                                    uu____11709,
                                                                     (Prims.op_Hat
                                                                     "equation_with_fuel_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11682
+                                                                    uu____11663
                                                                      in
                                                                     let eqn_f
                                                                     =
-                                                                    let uu____11738
+                                                                    let uu____11719
                                                                     =
-                                                                    let uu____11746
+                                                                    let uu____11727
                                                                     =
-                                                                    let uu____11747
+                                                                    let uu____11728
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11748
+                                                                    let uu____11729
                                                                     =
-                                                                    let uu____11759
+                                                                    let uu____11740
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
                                                                     gmax)  in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu____11759)
+                                                                    uu____11740)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11747
-                                                                    uu____11748
+                                                                    uu____11728
+                                                                    uu____11729
                                                                      in
-                                                                    (uu____11746,
+                                                                    (uu____11727,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Correspondence of recursive function to instrumented version"),
                                                                     (Prims.op_Hat
                                                                     "@fuel_correspondence_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11738
+                                                                    uu____11719
                                                                      in
                                                                     let eqn_g'
                                                                     =
-                                                                    let uu____11773
+                                                                    let uu____11754
+                                                                    =
+                                                                    let uu____11762
+                                                                    =
+                                                                    let uu____11763
+                                                                    =
+                                                                    FStar_Syntax_Util.range_of_lbname
+                                                                    lbn  in
+                                                                    let uu____11764
+                                                                    =
+                                                                    let uu____11775
+                                                                    =
+                                                                    let uu____11776
                                                                     =
                                                                     let uu____11781
                                                                     =
                                                                     let uu____11782
                                                                     =
-                                                                    FStar_Syntax_Util.range_of_lbname
-                                                                    lbn  in
-                                                                    let uu____11783
-                                                                    =
-                                                                    let uu____11794
-                                                                    =
-                                                                    let uu____11795
-                                                                    =
-                                                                    let uu____11800
-                                                                    =
-                                                                    let uu____11801
-                                                                    =
-                                                                    let uu____11804
+                                                                    let uu____11785
                                                                     =
                                                                     FStar_SMTEncoding_Term.n_fuel
                                                                     Prims.int_zero
                                                                      in
-                                                                    uu____11804
+                                                                    uu____11785
                                                                     ::
                                                                     vars_tm
                                                                      in
                                                                     mk_g_app
-                                                                    uu____11801
+                                                                    uu____11782
                                                                      in
                                                                     (gsapp,
-                                                                    uu____11800)
+                                                                    uu____11781)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkEq
-                                                                    uu____11795
+                                                                    uu____11776
                                                                      in
                                                                     ([
                                                                     [gsapp]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11794)
+                                                                    uu____11775)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11782
-                                                                    uu____11783
+                                                                    uu____11763
+                                                                    uu____11764
                                                                      in
-                                                                    (uu____11781,
+                                                                    (uu____11762,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel irrelevance"),
                                                                     (Prims.op_Hat
                                                                     "@fuel_irrelevance_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11773
+                                                                    uu____11754
                                                                      in
-                                                                    let uu____11818
+                                                                    let uu____11799
                                                                     =
                                                                     let gapp
                                                                     =
@@ -4074,9 +4070,9 @@ let (encode_top_level_let :
                                                                     =
                                                                     let tok_app
                                                                     =
-                                                                    let uu____11830
+                                                                    let uu____11811
                                                                     =
-                                                                    let uu____11831
+                                                                    let uu____11812
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
@@ -4084,17 +4080,17 @@ let (encode_top_level_let :
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____11831
+                                                                    uu____11812
                                                                      in
                                                                     FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                                    uu____11830
+                                                                    uu____11811
                                                                     (fuel ::
                                                                     vars)  in
                                                                     let tot_fun_axioms
                                                                     =
                                                                     let head
                                                                     =
-                                                                    let uu____11835
+                                                                    let uu____11816
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
@@ -4102,7 +4098,7 @@ let (encode_top_level_let :
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____11835
+                                                                    uu____11816
                                                                      in
                                                                     let vars1
                                                                     = fuel ::
@@ -4111,11 +4107,11 @@ let (encode_top_level_let :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____11844
+                                                                    uu____11825
                                                                      ->
                                                                     FStar_SMTEncoding_Util.mkTrue)
                                                                     vars1  in
-                                                                    let uu____11845
+                                                                    let uu____11826
                                                                     =
                                                                     FStar_Syntax_Util.is_pure_comp
                                                                     tres_comp
@@ -4124,23 +4120,23 @@ let (encode_top_level_let :
                                                                     rng head
                                                                     vars1
                                                                     guards1
-                                                                    uu____11845
+                                                                    uu____11826
                                                                      in
-                                                                    let uu____11847
+                                                                    let uu____11828
                                                                     =
-                                                                    let uu____11855
+                                                                    let uu____11836
                                                                     =
-                                                                    let uu____11856
+                                                                    let uu____11837
                                                                     =
-                                                                    let uu____11861
+                                                                    let uu____11842
                                                                     =
-                                                                    let uu____11862
+                                                                    let uu____11843
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11863
+                                                                    let uu____11844
                                                                     =
-                                                                    let uu____11874
+                                                                    let uu____11855
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (tok_app,
@@ -4149,19 +4145,19 @@ let (encode_top_level_let :
                                                                     [tok_app]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11874)
+                                                                    uu____11855)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11862
-                                                                    uu____11863
+                                                                    uu____11843
+                                                                    uu____11844
                                                                      in
-                                                                    (uu____11861,
+                                                                    (uu____11842,
                                                                     tot_fun_axioms)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAnd
-                                                                    uu____11856
+                                                                    uu____11837
                                                                      in
-                                                                    (uu____11855,
+                                                                    (uu____11836,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Fuel token correspondence"),
                                                                     (Prims.op_Hat
@@ -4169,37 +4165,37 @@ let (encode_top_level_let :
                                                                     gtok))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11847
+                                                                    uu____11828
                                                                      in
-                                                                    let uu____11887
+                                                                    let uu____11868
                                                                     =
-                                                                    let uu____11896
+                                                                    let uu____11877
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                                                     FStar_Pervasives_Native.None
                                                                     tres
                                                                     env'1
                                                                     gapp  in
-                                                                    match uu____11896
+                                                                    match uu____11877
                                                                     with
                                                                     | 
                                                                     (g_typing,d3)
                                                                     ->
-                                                                    let uu____11911
+                                                                    let uu____11892
                                                                     =
-                                                                    let uu____11914
+                                                                    let uu____11895
                                                                     =
-                                                                    let uu____11915
+                                                                    let uu____11896
                                                                     =
-                                                                    let uu____11923
+                                                                    let uu____11904
                                                                     =
-                                                                    let uu____11924
+                                                                    let uu____11905
                                                                     =
                                                                     FStar_Syntax_Util.range_of_lbname
                                                                     lbn  in
-                                                                    let uu____11925
+                                                                    let uu____11906
                                                                     =
-                                                                    let uu____11936
+                                                                    let uu____11917
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard,
@@ -4208,27 +4204,27 @@ let (encode_top_level_let :
                                                                     ([[gapp]],
                                                                     (fuel ::
                                                                     vars),
-                                                                    uu____11936)
+                                                                    uu____11917)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____11924
-                                                                    uu____11925
+                                                                    uu____11905
+                                                                    uu____11906
                                                                      in
-                                                                    (uu____11923,
+                                                                    (uu____11904,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "Typing correspondence of token to term"),
                                                                     (Prims.op_Hat
                                                                     "token_correspondence_"
                                                                     g))  in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____11915
+                                                                    uu____11896
                                                                      in
-                                                                    [uu____11914]
+                                                                    [uu____11895]
                                                                      in
                                                                     (d3,
-                                                                    uu____11911)
+                                                                    uu____11892)
                                                                      in
-                                                                    match uu____11887
+                                                                    match uu____11868
                                                                     with
                                                                     | 
                                                                     (aux_decls,typing_corr)
@@ -4238,18 +4234,18 @@ let (encode_top_level_let :
                                                                     typing_corr
                                                                     [tok_corr]))
                                                                      in
-                                                                    (match uu____11818
+                                                                    (match uu____11799
                                                                     with
                                                                     | 
                                                                     (aux_decls,g_typing)
                                                                     ->
-                                                                    let uu____11993
+                                                                    let uu____11974
                                                                     =
-                                                                    let uu____11996
+                                                                    let uu____11977
                                                                     =
-                                                                    let uu____11999
+                                                                    let uu____11980
                                                                     =
-                                                                    let uu____12002
+                                                                    let uu____11983
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     [decl_g;
@@ -4258,17 +4254,17 @@ let (encode_top_level_let :
                                                                      in
                                                                     FStar_List.append
                                                                     aux_decls
-                                                                    uu____12002
+                                                                    uu____11983
                                                                      in
                                                                     FStar_List.append
                                                                     decls2
-                                                                    uu____11999
+                                                                    uu____11980
                                                                      in
                                                                     FStar_List.append
                                                                     binder_decls1
-                                                                    uu____11996
+                                                                    uu____11977
                                                                      in
-                                                                    let uu____12009
+                                                                    let uu____11990
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     (FStar_List.append
@@ -4278,55 +4274,55 @@ let (encode_top_level_let :
                                                                     g_typing)
                                                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                                                      in
-                                                                    (uu____11993,
-                                                                    uu____12009,
+                                                                    (uu____11974,
+                                                                    uu____11990,
                                                                     env02))))))))))
                                       in
-                                   let uu____12014 =
-                                     let uu____12027 =
+                                   let uu____11995 =
+                                     let uu____12008 =
                                        FStar_List.zip3 gtoks1 typs2 bindings1
                                         in
                                      FStar_List.fold_left
-                                       (fun uu____12090  ->
-                                          fun uu____12091  ->
-                                            match (uu____12090, uu____12091)
+                                       (fun uu____12071  ->
+                                          fun uu____12072  ->
+                                            match (uu____12071, uu____12072)
                                             with
                                             | ((decls2,eqns,env01),(gtok,ty,lb))
                                                 ->
-                                                let uu____12216 =
+                                                let uu____12197 =
                                                   encode_one_binding env01
                                                     gtok ty lb
                                                    in
-                                                (match uu____12216 with
+                                                (match uu____12197 with
                                                  | (decls',eqns',env02) ->
                                                      ((decls' :: decls2),
                                                        (FStar_List.append
                                                           eqns' eqns), env02)))
-                                       ([decls1], [], env0) uu____12027
+                                       ([decls1], [], env0) uu____12008
                                       in
-                                   (match uu____12014 with
+                                   (match uu____11995 with
                                     | (decls2,eqns,env01) ->
-                                        let uu____12283 =
-                                          let isDeclFun uu___1_12300 =
-                                            match uu___1_12300 with
+                                        let uu____12264 =
+                                          let isDeclFun uu___1_12281 =
+                                            match uu___1_12281 with
                                             | FStar_SMTEncoding_Term.DeclFun
-                                                uu____12302 -> true
-                                            | uu____12315 -> false  in
-                                          let uu____12317 =
+                                                uu____12283 -> true
+                                            | uu____12296 -> false  in
+                                          let uu____12298 =
                                             FStar_All.pipe_right decls2
                                               FStar_List.flatten
                                              in
-                                          FStar_All.pipe_right uu____12317
+                                          FStar_All.pipe_right uu____12298
                                             (fun decls3  ->
-                                               let uu____12347 =
+                                               let uu____12328 =
                                                  FStar_List.fold_left
-                                                   (fun uu____12378  ->
+                                                   (fun uu____12359  ->
                                                       fun elt  ->
-                                                        match uu____12378
+                                                        match uu____12359
                                                         with
                                                         | (prefix_decls,elts,rest)
                                                             ->
-                                                            let uu____12419 =
+                                                            let uu____12400 =
                                                               (FStar_All.pipe_right
                                                                  elt.FStar_SMTEncoding_Term.key
                                                                  FStar_Util.is_some)
@@ -4335,7 +4331,7 @@ let (encode_top_level_let :
                                                                    isDeclFun
                                                                    elt.FStar_SMTEncoding_Term.decls)
                                                                in
-                                                            if uu____12419
+                                                            if uu____12400
                                                             then
                                                               (prefix_decls,
                                                                 (FStar_List.append
@@ -4343,13 +4339,13 @@ let (encode_top_level_let :
                                                                    [elt]),
                                                                 rest)
                                                             else
-                                                              (let uu____12447
+                                                              (let uu____12428
                                                                  =
                                                                  FStar_List.partition
                                                                    isDeclFun
                                                                    elt.FStar_SMTEncoding_Term.decls
                                                                   in
-                                                               match uu____12447
+                                                               match uu____12428
                                                                with
                                                                | (elt_decl_funs,elt_rest)
                                                                    ->
@@ -4360,34 +4356,34 @@ let (encode_top_level_let :
                                                                     (FStar_List.append
                                                                     rest
                                                                     [(
-                                                                    let uu___846_12485
+                                                                    let uu___846_12466
                                                                     = elt  in
                                                                     {
                                                                     FStar_SMTEncoding_Term.sym_name
                                                                     =
-                                                                    (uu___846_12485.FStar_SMTEncoding_Term.sym_name);
+                                                                    (uu___846_12466.FStar_SMTEncoding_Term.sym_name);
                                                                     FStar_SMTEncoding_Term.key
                                                                     =
-                                                                    (uu___846_12485.FStar_SMTEncoding_Term.key);
+                                                                    (uu___846_12466.FStar_SMTEncoding_Term.key);
                                                                     FStar_SMTEncoding_Term.decls
                                                                     =
                                                                     elt_rest;
                                                                     FStar_SMTEncoding_Term.a_names
                                                                     =
-                                                                    (uu___846_12485.FStar_SMTEncoding_Term.a_names)
+                                                                    (uu___846_12466.FStar_SMTEncoding_Term.a_names)
                                                                     })]))))
                                                    ([], [], []) decls3
                                                   in
-                                               match uu____12347 with
+                                               match uu____12328 with
                                                | (prefix_decls,elts,rest) ->
-                                                   let uu____12517 =
+                                                   let uu____12498 =
                                                      FStar_All.pipe_right
                                                        prefix_decls
                                                        FStar_SMTEncoding_Term.mk_decls_trivial
                                                       in
-                                                   (uu____12517, elts, rest))
+                                                   (uu____12498, elts, rest))
                                            in
-                                        (match uu____12283 with
+                                        (match uu____12264 with
                                          | (prefix_decls,elts,rest) ->
                                              let eqns1 = FStar_List.rev eqns
                                                 in
@@ -4396,19 +4392,19 @@ let (encode_top_level_let :
                                                     (FStar_List.append rest
                                                        eqns1))), env01)))
                                 in
-                             let uu____12546 =
+                             let uu____12527 =
                                (FStar_All.pipe_right quals
                                   (FStar_Util.for_some
-                                     (fun uu___2_12552  ->
-                                        match uu___2_12552 with
+                                     (fun uu___2_12533  ->
+                                        match uu___2_12533 with
                                         | FStar_Syntax_Syntax.HasMaskedEffect
                                              -> true
-                                        | uu____12555 -> false)))
+                                        | uu____12536 -> false)))
                                  ||
                                  (FStar_All.pipe_right typs1
                                     (FStar_Util.for_some
                                        (fun t  ->
-                                          let uu____12563 =
+                                          let uu____12544 =
                                             (FStar_Syntax_Util.is_pure_or_ghost_function
                                                t)
                                               ||
@@ -4417,13 +4413,13 @@ let (encode_top_level_let :
                                                  t)
                                              in
                                           FStar_All.pipe_left
-                                            Prims.op_Negation uu____12563)))
+                                            Prims.op_Negation uu____12544)))
                                 in
-                             if uu____12546
+                             if uu____12527
                              then (decls1, env_decls)
                              else
                                (try
-                                  (fun uu___863_12585  ->
+                                  (fun uu___863_12566  ->
                                      match () with
                                      | () ->
                                          if Prims.op_Negation is_rec
@@ -4441,62 +4437,62 @@ let (encode_top_level_let :
                                         Prims.int_one
                                        in
                                     let r =
-                                      let uu____12630 = FStar_List.hd names
+                                      let uu____12611 = FStar_List.hd names
                                          in
-                                      FStar_All.pipe_right uu____12630
+                                      FStar_All.pipe_right uu____12611
                                         FStar_Pervasives_Native.snd
                                        in
-                                    ((let uu____12648 =
-                                        let uu____12658 =
-                                          let uu____12666 =
-                                            let uu____12668 =
-                                              let uu____12670 =
+                                    ((let uu____12629 =
+                                        let uu____12639 =
+                                          let uu____12647 =
+                                            let uu____12649 =
+                                              let uu____12651 =
                                                 FStar_List.map
                                                   FStar_Pervasives_Native.fst
                                                   names
                                                  in
                                               FStar_All.pipe_right
-                                                uu____12670
+                                                uu____12651
                                                 (FStar_String.concat ",")
                                                in
                                             FStar_Util.format3
                                               "Definitions of inner let-rec%s %s and %s enclosing top-level letbinding are not encoded to the solver, you will only be able to reason with their types"
                                               (if plural then "s" else "")
-                                              uu____12668
+                                              uu____12649
                                               (if plural
                                                then "their"
                                                else "its")
                                              in
                                           (FStar_Errors.Warning_DefinitionNotTranslated,
-                                            uu____12666, r)
+                                            uu____12647, r)
                                            in
-                                        [uu____12658]  in
+                                        [uu____12639]  in
                                       FStar_TypeChecker_Err.add_errors
                                         env1.FStar_SMTEncoding_Env.tcenv
-                                        uu____12648);
+                                        uu____12629);
                                      (decls1, env_decls))))) ()
              with
              | Let_rec_unencodeable  ->
                  let msg =
-                   let uu____12729 =
+                   let uu____12710 =
                      FStar_All.pipe_right bindings
                        (FStar_List.map
                           (fun lb  ->
                              FStar_Syntax_Print.lbname_to_string
                                lb.FStar_Syntax_Syntax.lbname))
                       in
-                   FStar_All.pipe_right uu____12729
+                   FStar_All.pipe_right uu____12710
                      (FStar_String.concat " and ")
                     in
                  let decl =
                    FStar_SMTEncoding_Term.Caption
                      (Prims.op_Hat "let rec unencodeable: Skipping: " msg)
                     in
-                 let uu____12748 =
+                 let uu____12729 =
                    FStar_All.pipe_right [decl]
                      FStar_SMTEncoding_Term.mk_decls_trivial
                     in
-                 (uu____12748, env))
+                 (uu____12729, env))
   
 let rec (encode_sigelt :
   FStar_SMTEncoding_Env.env_t ->
@@ -4506,48 +4502,48 @@ let rec (encode_sigelt :
   fun env  ->
     fun se  ->
       let nm =
-        let uu____12804 = FStar_Syntax_Util.lid_of_sigelt se  in
-        match uu____12804 with
+        let uu____12785 = FStar_Syntax_Util.lid_of_sigelt se  in
+        match uu____12785 with
         | FStar_Pervasives_Native.None  -> ""
         | FStar_Pervasives_Native.Some l -> FStar_Ident.string_of_lid l  in
-      let uu____12810 = encode_sigelt' env se  in
-      match uu____12810 with
+      let uu____12791 = encode_sigelt' env se  in
+      match uu____12791 with
       | (g,env1) ->
           let g1 =
             match g with
             | [] ->
-                let uu____12822 =
-                  let uu____12825 =
-                    let uu____12826 = FStar_Util.format1 "<Skipped %s/>" nm
+                let uu____12803 =
+                  let uu____12806 =
+                    let uu____12807 = FStar_Util.format1 "<Skipped %s/>" nm
                        in
-                    FStar_SMTEncoding_Term.Caption uu____12826  in
-                  [uu____12825]  in
-                FStar_All.pipe_right uu____12822
+                    FStar_SMTEncoding_Term.Caption uu____12807  in
+                  [uu____12806]  in
+                FStar_All.pipe_right uu____12803
                   FStar_SMTEncoding_Term.mk_decls_trivial
-            | uu____12831 ->
-                let uu____12832 =
-                  let uu____12835 =
-                    let uu____12838 =
-                      let uu____12839 =
+            | uu____12812 ->
+                let uu____12813 =
+                  let uu____12816 =
+                    let uu____12819 =
+                      let uu____12820 =
                         FStar_Util.format1 "<Start encoding %s>" nm  in
-                      FStar_SMTEncoding_Term.Caption uu____12839  in
-                    [uu____12838]  in
-                  FStar_All.pipe_right uu____12835
+                      FStar_SMTEncoding_Term.Caption uu____12820  in
+                    [uu____12819]  in
+                  FStar_All.pipe_right uu____12816
                     FStar_SMTEncoding_Term.mk_decls_trivial
                    in
-                let uu____12846 =
-                  let uu____12849 =
-                    let uu____12852 =
-                      let uu____12855 =
-                        let uu____12856 =
+                let uu____12827 =
+                  let uu____12830 =
+                    let uu____12833 =
+                      let uu____12836 =
+                        let uu____12837 =
                           FStar_Util.format1 "</end encoding %s>" nm  in
-                        FStar_SMTEncoding_Term.Caption uu____12856  in
-                      [uu____12855]  in
-                    FStar_All.pipe_right uu____12852
+                        FStar_SMTEncoding_Term.Caption uu____12837  in
+                      [uu____12836]  in
+                    FStar_All.pipe_right uu____12833
                       FStar_SMTEncoding_Term.mk_decls_trivial
                      in
-                  FStar_List.append g uu____12849  in
-                FStar_List.append uu____12832 uu____12846
+                  FStar_List.append g uu____12830  in
+                FStar_List.append uu____12813 uu____12827
              in
           (g1, env1)
 
@@ -4558,56 +4554,56 @@ and (encode_sigelt' :
   =
   fun env  ->
     fun se  ->
-      (let uu____12870 =
+      (let uu____12851 =
          FStar_All.pipe_left
            (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
            (FStar_Options.Other "SMTEncoding")
           in
-       if uu____12870
+       if uu____12851
        then
-         let uu____12875 = FStar_Syntax_Print.sigelt_to_string se  in
-         FStar_Util.print1 "@@@Encoding sigelt %s\n" uu____12875
+         let uu____12856 = FStar_Syntax_Print.sigelt_to_string se  in
+         FStar_Util.print1 "@@@Encoding sigelt %s\n" uu____12856
        else ());
       (let is_opaque_to_smt t =
-         let uu____12887 =
-           let uu____12888 = FStar_Syntax_Subst.compress t  in
-           uu____12888.FStar_Syntax_Syntax.n  in
-         match uu____12887 with
+         let uu____12868 =
+           let uu____12869 = FStar_Syntax_Subst.compress t  in
+           uu____12869.FStar_Syntax_Syntax.n  in
+         match uu____12868 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-             (s,uu____12893)) -> s = "opaque_to_smt"
-         | uu____12898 -> false  in
+             (s,uu____12874)) -> s = "opaque_to_smt"
+         | uu____12879 -> false  in
        let is_uninterpreted_by_smt t =
-         let uu____12907 =
-           let uu____12908 = FStar_Syntax_Subst.compress t  in
-           uu____12908.FStar_Syntax_Syntax.n  in
-         match uu____12907 with
+         let uu____12888 =
+           let uu____12889 = FStar_Syntax_Subst.compress t  in
+           uu____12889.FStar_Syntax_Syntax.n  in
+         match uu____12888 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-             (s,uu____12913)) -> s = "uninterpreted_by_smt"
-         | uu____12918 -> false  in
+             (s,uu____12894)) -> s = "uninterpreted_by_smt"
+         | uu____12899 -> false  in
        match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_splice uu____12924 ->
+       | FStar_Syntax_Syntax.Sig_splice uu____12905 ->
            failwith "impossible -- splice should have been removed by Tc.fs"
-       | FStar_Syntax_Syntax.Sig_fail uu____12936 ->
+       | FStar_Syntax_Syntax.Sig_fail uu____12917 ->
            failwith
              "impossible -- Sig_fail should have been removed by Tc.fs"
-       | FStar_Syntax_Syntax.Sig_pragma uu____12954 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____12955 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____12968 -> ([], env)
-       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____12969 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_pragma uu____12935 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____12936 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____12949 -> ([], env)
+       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____12950 -> ([], env)
        | FStar_Syntax_Syntax.Sig_new_effect ed ->
-           let uu____12981 =
-             let uu____12983 =
+           let uu____12962 =
+             let uu____12964 =
                FStar_SMTEncoding_Util.is_smt_reifiable_effect
                  env.FStar_SMTEncoding_Env.tcenv ed.FStar_Syntax_Syntax.mname
                 in
-             Prims.op_Negation uu____12983  in
-           if uu____12981
+             Prims.op_Negation uu____12964  in
+           if uu____12962
            then ([], env)
            else
              (let close_effect_params tm =
                 match ed.FStar_Syntax_Syntax.binders with
                 | [] -> tm
-                | uu____13012 ->
+                | uu____12993 ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_abs
                          ((ed.FStar_Syntax_Syntax.binders), tm,
@@ -4616,193 +4612,193 @@ and (encode_sigelt' :
                                  FStar_Parser_Const.effect_Tot_lid
                                  FStar_Pervasives_Native.None
                                  [FStar_Syntax_Syntax.TOTAL]))))
-                      FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
+                      tm.FStar_Syntax_Syntax.pos
                  in
               let encode_action env1 a =
                 let action_defn =
-                  let uu____13045 =
+                  let uu____13026 =
                     close_effect_params a.FStar_Syntax_Syntax.action_defn  in
-                  norm_before_encoding env1 uu____13045  in
-                let uu____13046 =
+                  norm_before_encoding env1 uu____13026  in
+                let uu____13027 =
                   FStar_Syntax_Util.arrow_formals_comp
                     a.FStar_Syntax_Syntax.action_typ
                    in
-                match uu____13046 with
-                | (formals,uu____13058) ->
+                match uu____13027 with
+                | (formals,uu____13039) ->
                     let arity = FStar_List.length formals  in
-                    let uu____13066 =
+                    let uu____13047 =
                       FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                         env1 a.FStar_Syntax_Syntax.action_name arity
                        in
-                    (match uu____13066 with
+                    (match uu____13047 with
                      | (aname,atok,env2) ->
-                         let uu____13088 =
+                         let uu____13069 =
                            FStar_SMTEncoding_EncodeTerm.encode_term
                              action_defn env2
                             in
-                         (match uu____13088 with
+                         (match uu____13069 with
                           | (tm,decls) ->
                               let a_decls =
-                                let uu____13104 =
-                                  let uu____13105 =
-                                    let uu____13117 =
+                                let uu____13085 =
+                                  let uu____13086 =
+                                    let uu____13098 =
                                       FStar_All.pipe_right formals
                                         (FStar_List.map
-                                           (fun uu____13137  ->
+                                           (fun uu____13118  ->
                                               FStar_SMTEncoding_Term.Term_sort))
                                        in
-                                    (aname, uu____13117,
+                                    (aname, uu____13098,
                                       FStar_SMTEncoding_Term.Term_sort,
                                       (FStar_Pervasives_Native.Some "Action"))
                                      in
-                                  FStar_SMTEncoding_Term.DeclFun uu____13105
+                                  FStar_SMTEncoding_Term.DeclFun uu____13086
                                    in
-                                [uu____13104;
+                                [uu____13085;
                                 FStar_SMTEncoding_Term.DeclFun
                                   (atok, [],
                                     FStar_SMTEncoding_Term.Term_sort,
                                     (FStar_Pervasives_Native.Some
                                        "Action token"))]
                                  in
-                              let uu____13154 =
-                                let aux uu____13200 uu____13201 =
-                                  match (uu____13200, uu____13201) with
-                                  | ((bv,uu____13245),(env3,acc_sorts,acc))
+                              let uu____13135 =
+                                let aux uu____13181 uu____13182 =
+                                  match (uu____13181, uu____13182) with
+                                  | ((bv,uu____13226),(env3,acc_sorts,acc))
                                       ->
-                                      let uu____13277 =
+                                      let uu____13258 =
                                         FStar_SMTEncoding_Env.gen_term_var
                                           env3 bv
                                          in
-                                      (match uu____13277 with
+                                      (match uu____13258 with
                                        | (xxsym,xx,env4) ->
-                                           let uu____13300 =
-                                             let uu____13303 =
+                                           let uu____13281 =
+                                             let uu____13284 =
                                                FStar_SMTEncoding_Term.mk_fv
                                                  (xxsym,
                                                    FStar_SMTEncoding_Term.Term_sort)
                                                 in
-                                             uu____13303 :: acc_sorts  in
-                                           (env4, uu____13300, (xx :: acc)))
+                                             uu____13284 :: acc_sorts  in
+                                           (env4, uu____13281, (xx :: acc)))
                                    in
                                 FStar_List.fold_right aux formals
                                   (env2, [], [])
                                  in
-                              (match uu____13154 with
-                               | (uu____13335,xs_sorts,xs) ->
+                              (match uu____13135 with
+                               | (uu____13316,xs_sorts,xs) ->
                                    let app =
                                      FStar_SMTEncoding_Util.mkApp (aname, xs)
                                       in
                                    let a_eq =
-                                     let uu____13351 =
-                                       let uu____13359 =
-                                         let uu____13360 =
+                                     let uu____13332 =
+                                       let uu____13340 =
+                                         let uu____13341 =
                                            FStar_Ident.range_of_lid
                                              a.FStar_Syntax_Syntax.action_name
                                             in
-                                         let uu____13361 =
-                                           let uu____13372 =
-                                             let uu____13373 =
-                                               let uu____13378 =
+                                         let uu____13342 =
+                                           let uu____13353 =
+                                             let uu____13354 =
+                                               let uu____13359 =
                                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
                                                    tm xs_sorts
                                                   in
-                                               (app, uu____13378)  in
+                                               (app, uu____13359)  in
                                              FStar_SMTEncoding_Util.mkEq
-                                               uu____13373
+                                               uu____13354
                                               in
-                                           ([[app]], xs_sorts, uu____13372)
+                                           ([[app]], xs_sorts, uu____13353)
                                             in
                                          FStar_SMTEncoding_Term.mkForall
-                                           uu____13360 uu____13361
+                                           uu____13341 uu____13342
                                           in
-                                       (uu____13359,
+                                       (uu____13340,
                                          (FStar_Pervasives_Native.Some
                                             "Action equality"),
                                          (Prims.op_Hat aname "_equality"))
                                         in
                                      FStar_SMTEncoding_Util.mkAssume
-                                       uu____13351
+                                       uu____13332
                                       in
                                    let tok_correspondence =
                                      let tok_term =
-                                       let uu____13393 =
+                                       let uu____13374 =
                                          FStar_SMTEncoding_Term.mk_fv
                                            (atok,
                                              FStar_SMTEncoding_Term.Term_sort)
                                           in
                                        FStar_All.pipe_left
                                          FStar_SMTEncoding_Util.mkFreeV
-                                         uu____13393
+                                         uu____13374
                                         in
                                      let tok_app =
                                        FStar_SMTEncoding_EncodeTerm.mk_Apply
                                          tok_term xs_sorts
                                         in
-                                     let uu____13396 =
-                                       let uu____13404 =
-                                         let uu____13405 =
+                                     let uu____13377 =
+                                       let uu____13385 =
+                                         let uu____13386 =
                                            FStar_Ident.range_of_lid
                                              a.FStar_Syntax_Syntax.action_name
                                             in
-                                         let uu____13406 =
-                                           let uu____13417 =
+                                         let uu____13387 =
+                                           let uu____13398 =
                                              FStar_SMTEncoding_Util.mkEq
                                                (tok_app, app)
                                               in
                                            ([[tok_app]], xs_sorts,
-                                             uu____13417)
+                                             uu____13398)
                                             in
                                          FStar_SMTEncoding_Term.mkForall
-                                           uu____13405 uu____13406
+                                           uu____13386 uu____13387
                                           in
-                                       (uu____13404,
+                                       (uu____13385,
                                          (FStar_Pervasives_Native.Some
                                             "Action token correspondence"),
                                          (Prims.op_Hat aname
                                             "_token_correspondence"))
                                         in
                                      FStar_SMTEncoding_Util.mkAssume
-                                       uu____13396
+                                       uu____13377
                                       in
-                                   let uu____13430 =
-                                     let uu____13433 =
+                                   let uu____13411 =
+                                     let uu____13414 =
                                        FStar_All.pipe_right
                                          (FStar_List.append a_decls
                                             [a_eq; tok_correspondence])
                                          FStar_SMTEncoding_Term.mk_decls_trivial
                                         in
-                                     FStar_List.append decls uu____13433  in
-                                   (env2, uu____13430))))
+                                     FStar_List.append decls uu____13414  in
+                                   (env2, uu____13411))))
                  in
-              let uu____13442 =
+              let uu____13423 =
                 FStar_Util.fold_map encode_action env
                   ed.FStar_Syntax_Syntax.actions
                  in
-              match uu____13442 with
+              match uu____13423 with
               | (env1,decls2) -> ((FStar_List.flatten decls2), env1))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13468,uu____13469)
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13449,uu____13450)
            when FStar_Ident.lid_equals lid FStar_Parser_Const.precedes_lid ->
-           let uu____13470 =
+           let uu____13451 =
              FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid env lid
                (Prims.of_int (4))
               in
-           (match uu____13470 with | (tname,ttok,env1) -> ([], env1))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13492,t) ->
+           (match uu____13451 with | (tname,ttok,env1) -> ([], env1))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____13473,t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
            let will_encode_definition =
-             let uu____13499 =
+             let uu____13480 =
                FStar_All.pipe_right quals
                  (FStar_Util.for_some
-                    (fun uu___3_13505  ->
-                       match uu___3_13505 with
+                    (fun uu___3_13486  ->
+                       match uu___3_13486 with
                        | FStar_Syntax_Syntax.Assumption  -> true
-                       | FStar_Syntax_Syntax.Projector uu____13508 -> true
-                       | FStar_Syntax_Syntax.Discriminator uu____13514 ->
+                       | FStar_Syntax_Syntax.Projector uu____13489 -> true
+                       | FStar_Syntax_Syntax.Discriminator uu____13495 ->
                            true
                        | FStar_Syntax_Syntax.Irreducible  -> true
-                       | uu____13517 -> false))
+                       | uu____13498 -> false))
                 in
-             Prims.op_Negation uu____13499  in
+             Prims.op_Negation uu____13480  in
            if will_encode_definition
            then ([], env)
            else
@@ -4811,96 +4807,96 @@ and (encode_sigelt' :
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None
                  in
-              let uu____13527 =
-                let uu____13532 =
+              let uu____13508 =
+                let uu____13513 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigattrs
                     (FStar_Util.for_some is_uninterpreted_by_smt)
                    in
-                encode_top_level_val uu____13532 env fv t quals  in
-              match uu____13527 with
+                encode_top_level_val uu____13513 env fv t quals  in
+              match uu____13508 with
               | (decls,env1) ->
                   let tname = FStar_Ident.string_of_lid lid  in
                   let tsym =
-                    let uu____13546 =
+                    let uu____13527 =
                       FStar_SMTEncoding_Env.try_lookup_free_var env1 lid  in
-                    FStar_Option.get uu____13546  in
-                  let uu____13549 =
-                    let uu____13550 =
-                      let uu____13553 =
+                    FStar_Option.get uu____13527  in
+                  let uu____13530 =
+                    let uu____13531 =
+                      let uu____13534 =
                         primitive_type_axioms
                           env1.FStar_SMTEncoding_Env.tcenv lid tname tsym
                          in
-                      FStar_All.pipe_right uu____13553
+                      FStar_All.pipe_right uu____13534
                         FStar_SMTEncoding_Term.mk_decls_trivial
                        in
-                    FStar_List.append decls uu____13550  in
-                  (uu____13549, env1))
+                    FStar_List.append decls uu____13531  in
+                  (uu____13530, env1))
        | FStar_Syntax_Syntax.Sig_assume (l,us,f) ->
-           let uu____13563 = FStar_Syntax_Subst.open_univ_vars us f  in
-           (match uu____13563 with
+           let uu____13544 = FStar_Syntax_Subst.open_univ_vars us f  in
+           (match uu____13544 with
             | (uvs,f1) ->
                 let env1 =
-                  let uu___1006_13575 = env  in
-                  let uu____13576 =
+                  let uu___1006_13556 = env  in
+                  let uu____13557 =
                     FStar_TypeChecker_Env.push_univ_vars
                       env.FStar_SMTEncoding_Env.tcenv uvs
                      in
                   {
                     FStar_SMTEncoding_Env.bvar_bindings =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.bvar_bindings);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.bvar_bindings);
                     FStar_SMTEncoding_Env.fvar_bindings =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.fvar_bindings);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.fvar_bindings);
                     FStar_SMTEncoding_Env.depth =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.depth);
-                    FStar_SMTEncoding_Env.tcenv = uu____13576;
+                      (uu___1006_13556.FStar_SMTEncoding_Env.depth);
+                    FStar_SMTEncoding_Env.tcenv = uu____13557;
                     FStar_SMTEncoding_Env.warn =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.warn);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.warn);
                     FStar_SMTEncoding_Env.nolabels =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.nolabels);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.nolabels);
                     FStar_SMTEncoding_Env.use_zfuel_name =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.use_zfuel_name);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.use_zfuel_name);
                     FStar_SMTEncoding_Env.encode_non_total_function_typ =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                     FStar_SMTEncoding_Env.current_module_name =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.current_module_name);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.current_module_name);
                     FStar_SMTEncoding_Env.encoding_quantifier =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.encoding_quantifier);
+                      (uu___1006_13556.FStar_SMTEncoding_Env.encoding_quantifier);
                     FStar_SMTEncoding_Env.global_cache =
-                      (uu___1006_13575.FStar_SMTEncoding_Env.global_cache)
+                      (uu___1006_13556.FStar_SMTEncoding_Env.global_cache)
                   }  in
                 let f2 = norm_before_encoding env1 f1  in
-                let uu____13578 =
+                let uu____13559 =
                   FStar_SMTEncoding_EncodeTerm.encode_formula f2 env1  in
-                (match uu____13578 with
+                (match uu____13559 with
                  | (f3,decls) ->
                      let g =
-                       let uu____13592 =
-                         let uu____13595 =
-                           let uu____13596 =
-                             let uu____13604 =
-                               let uu____13605 =
-                                 let uu____13607 =
+                       let uu____13573 =
+                         let uu____13576 =
+                           let uu____13577 =
+                             let uu____13585 =
+                               let uu____13586 =
+                                 let uu____13588 =
                                    FStar_Syntax_Print.lid_to_string l  in
                                  FStar_Util.format1 "Assumption: %s"
-                                   uu____13607
+                                   uu____13588
                                   in
-                               FStar_Pervasives_Native.Some uu____13605  in
-                             let uu____13611 =
-                               let uu____13613 =
-                                 let uu____13615 =
+                               FStar_Pervasives_Native.Some uu____13586  in
+                             let uu____13592 =
+                               let uu____13594 =
+                                 let uu____13596 =
                                    FStar_Ident.string_of_lid l  in
-                                 Prims.op_Hat "assumption_" uu____13615  in
+                                 Prims.op_Hat "assumption_" uu____13596  in
                                FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                                 uu____13613
+                                 uu____13594
                                 in
-                             (f3, uu____13604, uu____13611)  in
-                           FStar_SMTEncoding_Util.mkAssume uu____13596  in
-                         [uu____13595]  in
-                       FStar_All.pipe_right uu____13592
+                             (f3, uu____13585, uu____13592)  in
+                           FStar_SMTEncoding_Util.mkAssume uu____13577  in
+                         [uu____13576]  in
+                       FStar_All.pipe_right uu____13573
                          FStar_SMTEncoding_Term.mk_decls_trivial
                         in
                      ((FStar_List.append decls g), env1)))
-       | FStar_Syntax_Syntax.Sig_let (lbs,uu____13624) when
+       | FStar_Syntax_Syntax.Sig_let (lbs,uu____13605) when
            (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_List.contains FStar_Syntax_Syntax.Irreducible))
              ||
@@ -4908,65 +4904,65 @@ and (encode_sigelt' :
                 (FStar_Util.for_some is_opaque_to_smt))
            ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs  in
-           let uu____13638 =
+           let uu____13619 =
              FStar_Util.fold_map
                (fun env1  ->
                   fun lb  ->
                     let lid =
-                      let uu____13660 =
-                        let uu____13663 =
+                      let uu____13641 =
+                        let uu____13644 =
                           FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
-                        uu____13663.FStar_Syntax_Syntax.fv_name  in
-                      uu____13660.FStar_Syntax_Syntax.v  in
-                    let uu____13664 =
-                      let uu____13666 =
+                        uu____13644.FStar_Syntax_Syntax.fv_name  in
+                      uu____13641.FStar_Syntax_Syntax.v  in
+                    let uu____13645 =
+                      let uu____13647 =
                         FStar_TypeChecker_Env.try_lookup_val_decl
                           env1.FStar_SMTEncoding_Env.tcenv lid
                          in
-                      FStar_All.pipe_left FStar_Option.isNone uu____13666  in
-                    if uu____13664
+                      FStar_All.pipe_left FStar_Option.isNone uu____13647  in
+                    if uu____13645
                     then
                       let val_decl =
-                        let uu___1023_13698 = se  in
+                        let uu___1023_13679 = se  in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_declare_typ
                                (lid, (lb.FStar_Syntax_Syntax.lbunivs),
                                  (lb.FStar_Syntax_Syntax.lbtyp)));
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___1023_13698.FStar_Syntax_Syntax.sigrng);
+                            (uu___1023_13679.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
                             (FStar_Syntax_Syntax.Irreducible ::
                             (se.FStar_Syntax_Syntax.sigquals));
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___1023_13698.FStar_Syntax_Syntax.sigmeta);
+                            (uu___1023_13679.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___1023_13698.FStar_Syntax_Syntax.sigattrs);
+                            (uu___1023_13679.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___1023_13698.FStar_Syntax_Syntax.sigopts)
+                            (uu___1023_13679.FStar_Syntax_Syntax.sigopts)
                         }  in
-                      let uu____13699 = encode_sigelt' env1 val_decl  in
-                      match uu____13699 with | (decls,env2) -> (env2, decls)
+                      let uu____13680 = encode_sigelt' env1 val_decl  in
+                      match uu____13680 with | (decls,env2) -> (env2, decls)
                     else (env1, [])) env (FStar_Pervasives_Native.snd lbs)
               in
-           (match uu____13638 with
+           (match uu____13619 with
             | (env1,decls) -> ((FStar_List.flatten decls), env1))
        | FStar_Syntax_Syntax.Sig_let
-           ((uu____13735,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr b2t;
-                           FStar_Syntax_Syntax.lbunivs = uu____13737;
-                           FStar_Syntax_Syntax.lbtyp = uu____13738;
-                           FStar_Syntax_Syntax.lbeff = uu____13739;
-                           FStar_Syntax_Syntax.lbdef = uu____13740;
-                           FStar_Syntax_Syntax.lbattrs = uu____13741;
-                           FStar_Syntax_Syntax.lbpos = uu____13742;_}::[]),uu____13743)
+           ((uu____13716,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr b2t;
+                           FStar_Syntax_Syntax.lbunivs = uu____13718;
+                           FStar_Syntax_Syntax.lbtyp = uu____13719;
+                           FStar_Syntax_Syntax.lbeff = uu____13720;
+                           FStar_Syntax_Syntax.lbdef = uu____13721;
+                           FStar_Syntax_Syntax.lbattrs = uu____13722;
+                           FStar_Syntax_Syntax.lbpos = uu____13723;_}::[]),uu____13724)
            when FStar_Syntax_Syntax.fv_eq_lid b2t FStar_Parser_Const.b2t_lid
            ->
-           let uu____13762 =
+           let uu____13743 =
              FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid env
                (b2t.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                Prims.int_one
               in
-           (match uu____13762 with
+           (match uu____13743 with
             | (tname,ttok,env1) ->
                 let xx =
                   FStar_SMTEncoding_Term.mk_fv
@@ -4978,106 +4974,106 @@ and (encode_sigelt' :
                 let valid_b2t_x =
                   FStar_SMTEncoding_Util.mkApp ("Valid", [b2t_x])  in
                 let decls =
-                  let uu____13800 =
-                    let uu____13803 =
-                      let uu____13804 =
-                        let uu____13812 =
-                          let uu____13813 =
+                  let uu____13781 =
+                    let uu____13784 =
+                      let uu____13785 =
+                        let uu____13793 =
+                          let uu____13794 =
                             FStar_Syntax_Syntax.range_of_fv b2t  in
-                          let uu____13814 =
-                            let uu____13825 =
-                              let uu____13826 =
-                                let uu____13831 =
+                          let uu____13795 =
+                            let uu____13806 =
+                              let uu____13807 =
+                                let uu____13812 =
                                   FStar_SMTEncoding_Util.mkApp
                                     ((FStar_Pervasives_Native.snd
                                         FStar_SMTEncoding_Term.boxBoolFun),
                                       [x])
                                    in
-                                (valid_b2t_x, uu____13831)  in
-                              FStar_SMTEncoding_Util.mkEq uu____13826  in
-                            ([[b2t_x]], [xx], uu____13825)  in
-                          FStar_SMTEncoding_Term.mkForall uu____13813
-                            uu____13814
+                                (valid_b2t_x, uu____13812)  in
+                              FStar_SMTEncoding_Util.mkEq uu____13807  in
+                            ([[b2t_x]], [xx], uu____13806)  in
+                          FStar_SMTEncoding_Term.mkForall uu____13794
+                            uu____13795
                            in
-                        (uu____13812,
+                        (uu____13793,
                           (FStar_Pervasives_Native.Some "b2t def"),
                           "b2t_def")
                          in
-                      FStar_SMTEncoding_Util.mkAssume uu____13804  in
-                    [uu____13803]  in
+                      FStar_SMTEncoding_Util.mkAssume uu____13785  in
+                    [uu____13784]  in
                   (FStar_SMTEncoding_Term.DeclFun
                      (tname, [FStar_SMTEncoding_Term.Term_sort],
                        FStar_SMTEncoding_Term.Term_sort,
                        FStar_Pervasives_Native.None))
-                    :: uu____13800
+                    :: uu____13781
                    in
-                let uu____13869 =
+                let uu____13850 =
                   FStar_All.pipe_right decls
                     FStar_SMTEncoding_Term.mk_decls_trivial
                    in
-                (uu____13869, env1))
-       | FStar_Syntax_Syntax.Sig_let (uu____13872,uu____13873) when
+                (uu____13850, env1))
+       | FStar_Syntax_Syntax.Sig_let (uu____13853,uu____13854) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___4_13883  ->
-                   match uu___4_13883 with
-                   | FStar_Syntax_Syntax.Discriminator uu____13885 -> true
-                   | uu____13887 -> false))
+                (fun uu___4_13864  ->
+                   match uu___4_13864 with
+                   | FStar_Syntax_Syntax.Discriminator uu____13866 -> true
+                   | uu____13868 -> false))
            -> ([], env)
-       | FStar_Syntax_Syntax.Sig_let (uu____13889,lids) when
+       | FStar_Syntax_Syntax.Sig_let (uu____13870,lids) when
            (FStar_All.pipe_right lids
               (FStar_Util.for_some
                  (fun l  ->
-                    let uu____13901 =
-                      let uu____13903 =
-                        let uu____13904 = FStar_Ident.ns_of_lid l  in
-                        FStar_List.hd uu____13904  in
-                      FStar_Ident.text_of_id uu____13903  in
-                    uu____13901 = "Prims")))
+                    let uu____13882 =
+                      let uu____13884 =
+                        let uu____13885 = FStar_Ident.ns_of_lid l  in
+                        FStar_List.hd uu____13885  in
+                      FStar_Ident.text_of_id uu____13884  in
+                    uu____13882 = "Prims")))
              &&
              (FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                 (FStar_Util.for_some
-                   (fun uu___5_13913  ->
-                      match uu___5_13913 with
+                   (fun uu___5_13894  ->
+                      match uu___5_13894 with
                       | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen 
                           -> true
-                      | uu____13916 -> false)))
+                      | uu____13897 -> false)))
            -> ([], env)
-       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13919) when
+       | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____13900) when
            FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
              (FStar_Util.for_some
-                (fun uu___6_13933  ->
-                   match uu___6_13933 with
-                   | FStar_Syntax_Syntax.Projector uu____13935 -> true
-                   | uu____13941 -> false))
+                (fun uu___6_13914  ->
+                   match uu___6_13914 with
+                   | FStar_Syntax_Syntax.Projector uu____13916 -> true
+                   | uu____13922 -> false))
            ->
            let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
            let l = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v  in
-           let uu____13945 = FStar_SMTEncoding_Env.try_lookup_free_var env l
+           let uu____13926 = FStar_SMTEncoding_Env.try_lookup_free_var env l
               in
-           (match uu____13945 with
-            | FStar_Pervasives_Native.Some uu____13952 -> ([], env)
+           (match uu____13926 with
+            | FStar_Pervasives_Native.Some uu____13933 -> ([], env)
             | FStar_Pervasives_Native.None  ->
                 let se1 =
-                  let uu___1088_13954 = se  in
-                  let uu____13955 = FStar_Ident.range_of_lid l  in
+                  let uu___1088_13935 = se  in
+                  let uu____13936 = FStar_Ident.range_of_lid l  in
                   {
                     FStar_Syntax_Syntax.sigel =
                       (FStar_Syntax_Syntax.Sig_declare_typ
                          (l, (lb.FStar_Syntax_Syntax.lbunivs),
                            (lb.FStar_Syntax_Syntax.lbtyp)));
-                    FStar_Syntax_Syntax.sigrng = uu____13955;
+                    FStar_Syntax_Syntax.sigrng = uu____13936;
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___1088_13954.FStar_Syntax_Syntax.sigquals);
+                      (uu___1088_13935.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___1088_13954.FStar_Syntax_Syntax.sigmeta);
+                      (uu___1088_13935.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___1088_13954.FStar_Syntax_Syntax.sigattrs);
+                      (uu___1088_13935.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___1088_13954.FStar_Syntax_Syntax.sigopts)
+                      (uu___1088_13935.FStar_Syntax_Syntax.sigopts)
                   }  in
                 encode_sigelt env se1)
-       | FStar_Syntax_Syntax.Sig_let ((is_rec,bindings),uu____13958) ->
+       | FStar_Syntax_Syntax.Sig_let ((is_rec,bindings),uu____13939) ->
            let bindings1 =
              FStar_List.map
                (fun lb  ->
@@ -5085,213 +5081,209 @@ and (encode_sigelt' :
                     norm_before_encoding env lb.FStar_Syntax_Syntax.lbdef  in
                   let typ =
                     norm_before_encoding env lb.FStar_Syntax_Syntax.lbtyp  in
-                  let uu___1100_13979 = lb  in
+                  let uu___1100_13960 = lb  in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___1100_13979.FStar_Syntax_Syntax.lbname);
+                      (uu___1100_13960.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___1100_13979.FStar_Syntax_Syntax.lbunivs);
+                      (uu___1100_13960.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp = typ;
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___1100_13979.FStar_Syntax_Syntax.lbeff);
+                      (uu___1100_13960.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = def;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___1100_13979.FStar_Syntax_Syntax.lbattrs);
+                      (uu___1100_13960.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___1100_13979.FStar_Syntax_Syntax.lbpos)
+                      (uu___1100_13960.FStar_Syntax_Syntax.lbpos)
                   }) bindings
               in
            encode_top_level_let env (is_rec, bindings1)
              se.FStar_Syntax_Syntax.sigquals
-       | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13984) ->
-           let uu____13993 = encode_sigelts env ses  in
-           (match uu____13993 with
+       | FStar_Syntax_Syntax.Sig_bundle (ses,uu____13965) ->
+           let uu____13974 = encode_sigelts env ses  in
+           (match uu____13974 with
             | (g,env1) ->
-                let uu____14004 =
+                let uu____13985 =
                   FStar_List.fold_left
-                    (fun uu____14028  ->
+                    (fun uu____14009  ->
                        fun elt  ->
-                         match uu____14028 with
+                         match uu____14009 with
                          | (g',inversions) ->
-                             let uu____14056 =
+                             let uu____14037 =
                                FStar_All.pipe_right
                                  elt.FStar_SMTEncoding_Term.decls
                                  (FStar_List.partition
-                                    (fun uu___7_14079  ->
-                                       match uu___7_14079 with
+                                    (fun uu___7_14060  ->
+                                       match uu___7_14060 with
                                        | FStar_SMTEncoding_Term.Assume
                                            {
                                              FStar_SMTEncoding_Term.assumption_term
-                                               = uu____14081;
+                                               = uu____14062;
                                              FStar_SMTEncoding_Term.assumption_caption
                                                = FStar_Pervasives_Native.Some
                                                "inversion axiom";
                                              FStar_SMTEncoding_Term.assumption_name
-                                               = uu____14082;
+                                               = uu____14063;
                                              FStar_SMTEncoding_Term.assumption_fact_ids
-                                               = uu____14083;_}
+                                               = uu____14064;_}
                                            -> false
-                                       | uu____14090 -> true))
+                                       | uu____14071 -> true))
                                 in
-                             (match uu____14056 with
+                             (match uu____14037 with
                               | (elt_g',elt_inversions) ->
                                   ((FStar_List.append g'
-                                      [(let uu___1126_14115 = elt  in
+                                      [(let uu___1126_14096 = elt  in
                                         {
                                           FStar_SMTEncoding_Term.sym_name =
-                                            (uu___1126_14115.FStar_SMTEncoding_Term.sym_name);
+                                            (uu___1126_14096.FStar_SMTEncoding_Term.sym_name);
                                           FStar_SMTEncoding_Term.key =
-                                            (uu___1126_14115.FStar_SMTEncoding_Term.key);
+                                            (uu___1126_14096.FStar_SMTEncoding_Term.key);
                                           FStar_SMTEncoding_Term.decls =
                                             elt_g';
                                           FStar_SMTEncoding_Term.a_names =
-                                            (uu___1126_14115.FStar_SMTEncoding_Term.a_names)
+                                            (uu___1126_14096.FStar_SMTEncoding_Term.a_names)
                                         })]),
                                     (FStar_List.append inversions
                                        elt_inversions)))) ([], []) g
                    in
-                (match uu____14004 with
+                (match uu____13985 with
                  | (g',inversions) ->
-                     let uu____14134 =
+                     let uu____14115 =
                        FStar_List.fold_left
-                         (fun uu____14165  ->
+                         (fun uu____14146  ->
                             fun elt  ->
-                              match uu____14165 with
+                              match uu____14146 with
                               | (decls,elts,rest) ->
-                                  let uu____14206 =
+                                  let uu____14187 =
                                     (FStar_All.pipe_right
                                        elt.FStar_SMTEncoding_Term.key
                                        FStar_Util.is_some)
                                       &&
                                       (FStar_List.existsb
-                                         (fun uu___8_14215  ->
-                                            match uu___8_14215 with
+                                         (fun uu___8_14196  ->
+                                            match uu___8_14196 with
                                             | FStar_SMTEncoding_Term.DeclFun
-                                                uu____14217 -> true
-                                            | uu____14230 -> false)
+                                                uu____14198 -> true
+                                            | uu____14211 -> false)
                                          elt.FStar_SMTEncoding_Term.decls)
                                      in
-                                  if uu____14206
+                                  if uu____14187
                                   then
                                     (decls, (FStar_List.append elts [elt]),
                                       rest)
                                   else
-                                    (let uu____14253 =
+                                    (let uu____14234 =
                                        FStar_All.pipe_right
                                          elt.FStar_SMTEncoding_Term.decls
                                          (FStar_List.partition
-                                            (fun uu___9_14274  ->
-                                               match uu___9_14274 with
+                                            (fun uu___9_14255  ->
+                                               match uu___9_14255 with
                                                | FStar_SMTEncoding_Term.DeclFun
-                                                   uu____14276 -> true
-                                               | uu____14289 -> false))
+                                                   uu____14257 -> true
+                                               | uu____14270 -> false))
                                         in
-                                     match uu____14253 with
+                                     match uu____14234 with
                                      | (elt_decls,elt_rest) ->
                                          ((FStar_List.append decls elt_decls),
                                            elts,
                                            (FStar_List.append rest
-                                              [(let uu___1148_14320 = elt  in
+                                              [(let uu___1148_14301 = elt  in
                                                 {
                                                   FStar_SMTEncoding_Term.sym_name
                                                     =
-                                                    (uu___1148_14320.FStar_SMTEncoding_Term.sym_name);
+                                                    (uu___1148_14301.FStar_SMTEncoding_Term.sym_name);
                                                   FStar_SMTEncoding_Term.key
                                                     =
-                                                    (uu___1148_14320.FStar_SMTEncoding_Term.key);
+                                                    (uu___1148_14301.FStar_SMTEncoding_Term.key);
                                                   FStar_SMTEncoding_Term.decls
                                                     = elt_rest;
                                                   FStar_SMTEncoding_Term.a_names
                                                     =
-                                                    (uu___1148_14320.FStar_SMTEncoding_Term.a_names)
+                                                    (uu___1148_14301.FStar_SMTEncoding_Term.a_names)
                                                 })])))) ([], [], []) g'
                         in
-                     (match uu____14134 with
+                     (match uu____14115 with
                       | (decls,elts,rest) ->
-                          let uu____14346 =
-                            let uu____14347 =
+                          let uu____14327 =
+                            let uu____14328 =
                               FStar_All.pipe_right decls
                                 FStar_SMTEncoding_Term.mk_decls_trivial
                                in
-                            let uu____14354 =
-                              let uu____14357 =
-                                let uu____14360 =
+                            let uu____14335 =
+                              let uu____14338 =
+                                let uu____14341 =
                                   FStar_All.pipe_right inversions
                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                    in
-                                FStar_List.append rest uu____14360  in
-                              FStar_List.append elts uu____14357  in
-                            FStar_List.append uu____14347 uu____14354  in
-                          (uu____14346, env1))))
+                                FStar_List.append rest uu____14341  in
+                              FStar_List.append elts uu____14338  in
+                            FStar_List.append uu____14328 uu____14335  in
+                          (uu____14327, env1))))
        | FStar_Syntax_Syntax.Sig_inductive_typ
-           (t,universe_names,tps,k,uu____14371,datas) ->
+           (t,universe_names,tps,k,uu____14352,datas) ->
            let tcenv = env.FStar_SMTEncoding_Env.tcenv  in
            let is_injective =
-             let uu____14384 =
+             let uu____14365 =
                FStar_Syntax_Subst.univ_var_opening universe_names  in
-             match uu____14384 with
+             match uu____14365 with
              | (usubst,uvs) ->
-                 let uu____14404 =
-                   let uu____14411 =
+                 let uu____14385 =
+                   let uu____14392 =
                      FStar_TypeChecker_Env.push_univ_vars tcenv uvs  in
-                   let uu____14412 =
+                   let uu____14393 =
                      FStar_Syntax_Subst.subst_binders usubst tps  in
-                   let uu____14413 =
-                     let uu____14414 =
+                   let uu____14394 =
+                     let uu____14395 =
                        FStar_Syntax_Subst.shift_subst (FStar_List.length tps)
                          usubst
                         in
-                     FStar_Syntax_Subst.subst uu____14414 k  in
-                   (uu____14411, uu____14412, uu____14413)  in
-                 (match uu____14404 with
+                     FStar_Syntax_Subst.subst uu____14395 k  in
+                   (uu____14392, uu____14393, uu____14394)  in
+                 (match uu____14385 with
                   | (env1,tps1,k1) ->
-                      let uu____14427 = FStar_Syntax_Subst.open_term tps1 k1
+                      let uu____14408 = FStar_Syntax_Subst.open_term tps1 k1
                          in
-                      (match uu____14427 with
+                      (match uu____14408 with
                        | (tps2,k2) ->
-                           let uu____14435 =
+                           let uu____14416 =
                              FStar_Syntax_Util.arrow_formals k2  in
-                           (match uu____14435 with
-                            | (uu____14443,k3) ->
-                                let uu____14449 =
+                           (match uu____14416 with
+                            | (uu____14424,k3) ->
+                                let uu____14430 =
                                   FStar_TypeChecker_TcTerm.tc_binders env1
                                     tps2
                                    in
-                                (match uu____14449 with
-                                 | (tps3,env_tps,uu____14461,us) ->
+                                (match uu____14430 with
+                                 | (tps3,env_tps,uu____14442,us) ->
                                      let u_k =
-                                       let uu____14464 =
-                                         let uu____14465 =
-                                           FStar_Ident.range_of_lid t  in
-                                         let uu____14466 =
-                                           let uu____14471 =
-                                             FStar_Syntax_Syntax.fvar t
-                                               (FStar_Syntax_Syntax.Delta_constant_at_level
-                                                  Prims.int_zero)
-                                               FStar_Pervasives_Native.None
-                                              in
-                                           let uu____14473 =
-                                             let uu____14474 =
-                                               FStar_Syntax_Util.args_of_binders
-                                                 tps3
-                                                in
-                                             FStar_Pervasives_Native.snd
-                                               uu____14474
-                                              in
-                                           FStar_Syntax_Syntax.mk_Tm_app
-                                             uu____14471 uu____14473
+                                       let uu____14445 =
+                                         let uu____14446 =
+                                           FStar_Syntax_Syntax.fvar t
+                                             (FStar_Syntax_Syntax.Delta_constant_at_level
+                                                Prims.int_zero)
+                                             FStar_Pervasives_Native.None
                                             in
-                                         uu____14466
-                                           FStar_Pervasives_Native.None
-                                           uu____14465
+                                         let uu____14448 =
+                                           let uu____14449 =
+                                             FStar_Syntax_Util.args_of_binders
+                                               tps3
+                                              in
+                                           FStar_Pervasives_Native.snd
+                                             uu____14449
+                                            in
+                                         let uu____14454 =
+                                           FStar_Ident.range_of_lid t  in
+                                         FStar_Syntax_Syntax.mk_Tm_app
+                                           uu____14446 uu____14448
+                                           uu____14454
                                           in
                                        FStar_TypeChecker_TcTerm.level_of_type
-                                         env_tps uu____14464 k3
+                                         env_tps uu____14445 k3
                                         in
                                      let rec universe_leq u v =
                                        match (u, v) with
                                        | (FStar_Syntax_Syntax.U_zero
-                                          ,uu____14492) -> true
+                                          ,uu____14468) -> true
                                        | (FStar_Syntax_Syntax.U_succ
                                           u0,FStar_Syntax_Syntax.U_succ v0)
                                            -> universe_leq u0 v0
@@ -5299,89 +5291,89 @@ and (encode_sigelt' :
                                           u0,FStar_Syntax_Syntax.U_name v0)
                                            -> FStar_Ident.ident_equals u0 v0
                                        | (FStar_Syntax_Syntax.U_name
-                                          uu____14498,FStar_Syntax_Syntax.U_succ
+                                          uu____14474,FStar_Syntax_Syntax.U_succ
                                           v0) -> universe_leq u v0
                                        | (FStar_Syntax_Syntax.U_max
-                                          us1,uu____14501) ->
+                                          us1,uu____14477) ->
                                            FStar_All.pipe_right us1
                                              (FStar_Util.for_all
                                                 (fun u1  -> universe_leq u1 v))
-                                       | (uu____14509,FStar_Syntax_Syntax.U_max
+                                       | (uu____14485,FStar_Syntax_Syntax.U_max
                                           vs) ->
                                            FStar_All.pipe_right vs
                                              (FStar_Util.for_some
                                                 (universe_leq u))
                                        | (FStar_Syntax_Syntax.U_unknown
-                                          ,uu____14516) ->
-                                           let uu____14517 =
-                                             let uu____14519 =
+                                          ,uu____14492) ->
+                                           let uu____14493 =
+                                             let uu____14495 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14519
+                                               uu____14495
                                               in
-                                           failwith uu____14517
-                                       | (uu____14523,FStar_Syntax_Syntax.U_unknown
+                                           failwith uu____14493
+                                       | (uu____14499,FStar_Syntax_Syntax.U_unknown
                                           ) ->
-                                           let uu____14524 =
-                                             let uu____14526 =
+                                           let uu____14500 =
+                                             let uu____14502 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14526
+                                               uu____14502
                                               in
-                                           failwith uu____14524
+                                           failwith uu____14500
                                        | (FStar_Syntax_Syntax.U_unif
-                                          uu____14530,uu____14531) ->
-                                           let uu____14542 =
-                                             let uu____14544 =
+                                          uu____14506,uu____14507) ->
+                                           let uu____14518 =
+                                             let uu____14520 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14544
+                                               uu____14520
                                               in
-                                           failwith uu____14542
-                                       | (uu____14548,FStar_Syntax_Syntax.U_unif
-                                          uu____14549) ->
-                                           let uu____14560 =
-                                             let uu____14562 =
+                                           failwith uu____14518
+                                       | (uu____14524,FStar_Syntax_Syntax.U_unif
+                                          uu____14525) ->
+                                           let uu____14536 =
+                                             let uu____14538 =
                                                FStar_Ident.string_of_lid t
                                                 in
                                              FStar_Util.format1
                                                "Impossible: Unresolved or unknown universe in inductive type %s"
-                                               uu____14562
+                                               uu____14538
                                               in
-                                           failwith uu____14560
-                                       | uu____14566 -> false  in
+                                           failwith uu____14536
+                                       | uu____14542 -> false  in
                                      let u_leq_u_k u =
-                                       let uu____14579 =
+                                       let uu____14555 =
                                          FStar_TypeChecker_Normalize.normalize_universe
                                            env_tps u
                                           in
-                                       universe_leq uu____14579 u_k  in
+                                       universe_leq uu____14555 u_k  in
                                      let tp_ok tp u_tp =
                                        let t_tp =
                                          (FStar_Pervasives_Native.fst tp).FStar_Syntax_Syntax.sort
                                           in
-                                       let uu____14597 = u_leq_u_k u_tp  in
-                                       if uu____14597
+                                       let uu____14573 = u_leq_u_k u_tp  in
+                                       if uu____14573
                                        then true
                                        else
-                                         (let uu____14604 =
+                                         (let uu____14580 =
                                             FStar_Syntax_Util.arrow_formals
                                               t_tp
                                              in
-                                          match uu____14604 with
-                                          | (formals,uu____14613) ->
-                                              let uu____14618 =
+                                          match uu____14580 with
+                                          | (formals,uu____14589) ->
+                                              let uu____14594 =
                                                 FStar_TypeChecker_TcTerm.tc_binders
                                                   env_tps formals
                                                  in
-                                              (match uu____14618 with
-                                               | (uu____14628,uu____14629,uu____14630,u_formals)
+                                              (match uu____14594 with
+                                               | (uu____14604,uu____14605,uu____14606,u_formals)
                                                    ->
                                                    FStar_Util.for_all
                                                      (fun u_formal  ->
@@ -5390,137 +5382,137 @@ and (encode_sigelt' :
                                         in
                                      FStar_List.forall2 tp_ok tps3 us))))
               in
-           ((let uu____14641 =
+           ((let uu____14617 =
                FStar_All.pipe_left
                  (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
                  (FStar_Options.Other "SMTEncoding")
                 in
-             if uu____14641
+             if uu____14617
              then
-               let uu____14646 = FStar_Ident.string_of_lid t  in
+               let uu____14622 = FStar_Ident.string_of_lid t  in
                FStar_Util.print2 "%s injectivity for %s\n"
-                 (if is_injective then "YES" else "NO") uu____14646
+                 (if is_injective then "YES" else "NO") uu____14622
              else ());
             (let quals = se.FStar_Syntax_Syntax.sigquals  in
              let is_logical =
                FStar_All.pipe_right quals
                  (FStar_Util.for_some
-                    (fun uu___10_14666  ->
-                       match uu___10_14666 with
+                    (fun uu___10_14642  ->
+                       match uu___10_14642 with
                        | FStar_Syntax_Syntax.Logic  -> true
                        | FStar_Syntax_Syntax.Assumption  -> true
-                       | uu____14670 -> false))
+                       | uu____14646 -> false))
                 in
              let constructor_or_logic_type_decl c =
                if is_logical
                then
-                 let uu____14683 = c  in
-                 match uu____14683 with
-                 | (name,args,uu____14688,uu____14689,uu____14690) ->
-                     let uu____14701 =
-                       let uu____14702 =
-                         let uu____14714 =
+                 let uu____14659 = c  in
+                 match uu____14659 with
+                 | (name,args,uu____14664,uu____14665,uu____14666) ->
+                     let uu____14677 =
+                       let uu____14678 =
+                         let uu____14690 =
                            FStar_All.pipe_right args
                              (FStar_List.map
-                                (fun uu____14741  ->
-                                   match uu____14741 with
-                                   | (uu____14750,sort,uu____14752) -> sort))
+                                (fun uu____14717  ->
+                                   match uu____14717 with
+                                   | (uu____14726,sort,uu____14728) -> sort))
                             in
-                         (name, uu____14714,
+                         (name, uu____14690,
                            FStar_SMTEncoding_Term.Term_sort,
                            FStar_Pervasives_Native.None)
                           in
-                       FStar_SMTEncoding_Term.DeclFun uu____14702  in
-                     [uu____14701]
+                       FStar_SMTEncoding_Term.DeclFun uu____14678  in
+                     [uu____14677]
                else
-                 (let uu____14763 = FStar_Ident.range_of_lid t  in
-                  FStar_SMTEncoding_Term.constructor_to_decl uu____14763 c)
+                 (let uu____14739 = FStar_Ident.range_of_lid t  in
+                  FStar_SMTEncoding_Term.constructor_to_decl uu____14739 c)
                 in
              let inversion_axioms tapp vars =
-               let uu____14781 =
+               let uu____14757 =
                  FStar_All.pipe_right datas
                    (FStar_Util.for_some
                       (fun l  ->
-                         let uu____14789 =
+                         let uu____14765 =
                            FStar_TypeChecker_Env.try_lookup_lid
                              env.FStar_SMTEncoding_Env.tcenv l
                             in
-                         FStar_All.pipe_right uu____14789 FStar_Option.isNone))
+                         FStar_All.pipe_right uu____14765 FStar_Option.isNone))
                   in
-               if uu____14781
+               if uu____14757
                then []
                else
-                 (let uu____14824 =
+                 (let uu____14800 =
                     FStar_SMTEncoding_Env.fresh_fvar
                       env.FStar_SMTEncoding_Env.current_module_name "x"
                       FStar_SMTEncoding_Term.Term_sort
                      in
-                  match uu____14824 with
+                  match uu____14800 with
                   | (xxsym,xx) ->
-                      let uu____14837 =
+                      let uu____14813 =
                         FStar_All.pipe_right datas
                           (FStar_List.fold_left
-                             (fun uu____14876  ->
+                             (fun uu____14852  ->
                                 fun l  ->
-                                  match uu____14876 with
+                                  match uu____14852 with
                                   | (out,decls) ->
-                                      let uu____14896 =
+                                      let uu____14872 =
                                         FStar_TypeChecker_Env.lookup_datacon
                                           env.FStar_SMTEncoding_Env.tcenv l
                                          in
-                                      (match uu____14896 with
-                                       | (uu____14907,data_t) ->
-                                           let uu____14909 =
+                                      (match uu____14872 with
+                                       | (uu____14883,data_t) ->
+                                           let uu____14885 =
                                              FStar_Syntax_Util.arrow_formals
                                                data_t
                                               in
-                                           (match uu____14909 with
+                                           (match uu____14885 with
                                             | (args,res) ->
                                                 let indices =
-                                                  let uu____14929 =
-                                                    let uu____14930 =
+                                                  let uu____14905 =
+                                                    let uu____14906 =
                                                       FStar_Syntax_Subst.compress
                                                         res
                                                        in
-                                                    uu____14930.FStar_Syntax_Syntax.n
+                                                    uu____14906.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____14929 with
+                                                  match uu____14905 with
                                                   | FStar_Syntax_Syntax.Tm_app
-                                                      (uu____14933,indices)
+                                                      (uu____14909,indices)
                                                       -> indices
-                                                  | uu____14959 -> []  in
+                                                  | uu____14935 -> []  in
                                                 let env1 =
                                                   FStar_All.pipe_right args
                                                     (FStar_List.fold_left
                                                        (fun env1  ->
-                                                          fun uu____14989  ->
-                                                            match uu____14989
+                                                          fun uu____14965  ->
+                                                            match uu____14965
                                                             with
-                                                            | (x,uu____14997)
+                                                            | (x,uu____14973)
                                                                 ->
-                                                                let uu____15002
+                                                                let uu____14978
                                                                   =
-                                                                  let uu____15003
+                                                                  let uu____14979
                                                                     =
-                                                                    let uu____15011
+                                                                    let uu____14987
                                                                     =
                                                                     FStar_SMTEncoding_Env.mk_term_projector_name
                                                                     l x  in
-                                                                    (uu____15011,
+                                                                    (uu____14987,
                                                                     [xx])  in
                                                                   FStar_SMTEncoding_Util.mkApp
-                                                                    uu____15003
+                                                                    uu____14979
                                                                    in
                                                                 FStar_SMTEncoding_Env.push_term_var
                                                                   env1 x
-                                                                  uu____15002)
+                                                                  uu____14978)
                                                        env)
                                                    in
-                                                let uu____15016 =
+                                                let uu____14992 =
                                                   FStar_SMTEncoding_EncodeTerm.encode_args
                                                     indices env1
                                                    in
-                                                (match uu____15016 with
+                                                (match uu____14992 with
                                                  | (indices1,decls') ->
                                                      (if
                                                         (FStar_List.length
@@ -5537,58 +5529,58 @@ and (encode_sigelt' :
                                                            FStar_List.map2
                                                              (fun v  ->
                                                                 fun a  ->
-                                                                  let uu____15051
+                                                                  let uu____15027
                                                                     =
-                                                                    let uu____15056
+                                                                    let uu____15032
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v  in
-                                                                    (uu____15056,
+                                                                    (uu____15032,
                                                                     a)  in
                                                                   FStar_SMTEncoding_Util.mkEq
-                                                                    uu____15051)
+                                                                    uu____15027)
                                                              vars indices1
                                                          else []  in
-                                                       let uu____15059 =
-                                                         let uu____15060 =
-                                                           let uu____15065 =
-                                                             let uu____15066
+                                                       let uu____15035 =
+                                                         let uu____15036 =
+                                                           let uu____15041 =
+                                                             let uu____15042
                                                                =
-                                                               let uu____15071
+                                                               let uu____15047
                                                                  =
                                                                  FStar_SMTEncoding_Env.mk_data_tester
                                                                    env1 l xx
                                                                   in
-                                                               let uu____15072
+                                                               let uu____15048
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    eqs
                                                                    FStar_SMTEncoding_Util.mk_and_l
                                                                   in
-                                                               (uu____15071,
-                                                                 uu____15072)
+                                                               (uu____15047,
+                                                                 uu____15048)
                                                                 in
                                                              FStar_SMTEncoding_Util.mkAnd
-                                                               uu____15066
+                                                               uu____15042
                                                               in
-                                                           (out, uu____15065)
+                                                           (out, uu____15041)
                                                             in
                                                          FStar_SMTEncoding_Util.mkOr
-                                                           uu____15060
+                                                           uu____15036
                                                           in
-                                                       (uu____15059,
+                                                       (uu____15035,
                                                          (FStar_List.append
                                                             decls decls'))))))))
                              (FStar_SMTEncoding_Util.mkFalse, []))
                          in
-                      (match uu____14837 with
+                      (match uu____14813 with
                        | (data_ax,decls) ->
-                           let uu____15087 =
+                           let uu____15063 =
                              FStar_SMTEncoding_Env.fresh_fvar
                                env.FStar_SMTEncoding_Env.current_module_name
                                "f" FStar_SMTEncoding_Term.Fuel_sort
                               in
-                           (match uu____15087 with
+                           (match uu____15063 with
                             | (ffsym,ff) ->
                                 let fuel_guarded_inversion =
                                   let xx_has_type_sfuel =
@@ -5596,164 +5588,161 @@ and (encode_sigelt' :
                                       (FStar_List.length datas) >
                                         Prims.int_one
                                     then
-                                      let uu____15104 =
+                                      let uu____15080 =
                                         FStar_SMTEncoding_Util.mkApp
                                           ("SFuel", [ff])
                                          in
                                       FStar_SMTEncoding_Term.mk_HasTypeFuel
-                                        uu____15104 xx tapp
+                                        uu____15080 xx tapp
                                     else
                                       FStar_SMTEncoding_Term.mk_HasTypeFuel
                                         ff xx tapp
                                      in
-                                  let uu____15111 =
-                                    let uu____15119 =
-                                      let uu____15120 =
+                                  let uu____15087 =
+                                    let uu____15095 =
+                                      let uu____15096 =
                                         FStar_Ident.range_of_lid t  in
-                                      let uu____15121 =
-                                        let uu____15132 =
-                                          let uu____15133 =
+                                      let uu____15097 =
+                                        let uu____15108 =
+                                          let uu____15109 =
                                             FStar_SMTEncoding_Term.mk_fv
                                               (ffsym,
                                                 FStar_SMTEncoding_Term.Fuel_sort)
                                              in
-                                          let uu____15135 =
-                                            let uu____15138 =
+                                          let uu____15111 =
+                                            let uu____15114 =
                                               FStar_SMTEncoding_Term.mk_fv
                                                 (xxsym,
                                                   FStar_SMTEncoding_Term.Term_sort)
                                                in
-                                            uu____15138 :: vars  in
+                                            uu____15114 :: vars  in
                                           FStar_SMTEncoding_Env.add_fuel
-                                            uu____15133 uu____15135
+                                            uu____15109 uu____15111
                                            in
-                                        let uu____15140 =
+                                        let uu____15116 =
                                           FStar_SMTEncoding_Util.mkImp
                                             (xx_has_type_sfuel, data_ax)
                                            in
-                                        ([[xx_has_type_sfuel]], uu____15132,
-                                          uu____15140)
+                                        ([[xx_has_type_sfuel]], uu____15108,
+                                          uu____15116)
                                          in
                                       FStar_SMTEncoding_Term.mkForall
-                                        uu____15120 uu____15121
+                                        uu____15096 uu____15097
                                        in
-                                    let uu____15149 =
-                                      let uu____15151 =
-                                        let uu____15153 =
+                                    let uu____15125 =
+                                      let uu____15127 =
+                                        let uu____15129 =
                                           FStar_Ident.string_of_lid t  in
                                         Prims.op_Hat
                                           "fuel_guarded_inversion_"
-                                          uu____15153
+                                          uu____15129
                                          in
                                       FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
-                                        uu____15151
+                                        uu____15127
                                        in
-                                    (uu____15119,
+                                    (uu____15095,
                                       (FStar_Pervasives_Native.Some
-                                         "inversion axiom"), uu____15149)
+                                         "inversion axiom"), uu____15125)
                                      in
-                                  FStar_SMTEncoding_Util.mkAssume uu____15111
+                                  FStar_SMTEncoding_Util.mkAssume uu____15087
                                    in
-                                let uu____15159 =
+                                let uu____15135 =
                                   FStar_All.pipe_right
                                     [fuel_guarded_inversion]
                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                    in
-                                FStar_List.append decls uu____15159)))
+                                FStar_List.append decls uu____15135)))
                 in
-             let uu____15166 =
+             let uu____15142 =
                let k1 =
                  match tps with
                  | [] -> k
-                 | uu____15180 ->
-                     let uu____15181 =
-                       let uu____15188 =
-                         let uu____15189 =
-                           let uu____15204 = FStar_Syntax_Syntax.mk_Total k
-                              in
-                           (tps, uu____15204)  in
-                         FStar_Syntax_Syntax.Tm_arrow uu____15189  in
-                       FStar_Syntax_Syntax.mk uu____15188  in
-                     uu____15181 FStar_Pervasives_Native.None
+                 | uu____15156 ->
+                     let uu____15157 =
+                       let uu____15158 =
+                         let uu____15173 = FStar_Syntax_Syntax.mk_Total k  in
+                         (tps, uu____15173)  in
+                       FStar_Syntax_Syntax.Tm_arrow uu____15158  in
+                     FStar_Syntax_Syntax.mk uu____15157
                        k.FStar_Syntax_Syntax.pos
                   in
                let k2 = norm_before_encoding env k1  in
                FStar_Syntax_Util.arrow_formals k2  in
-             match uu____15166 with
+             match uu____15142 with
              | (formals,res) ->
-                 let uu____15228 =
+                 let uu____15197 =
                    FStar_SMTEncoding_EncodeTerm.encode_binders
                      FStar_Pervasives_Native.None formals env
                     in
-                 (match uu____15228 with
-                  | (vars,guards,env',binder_decls,uu____15253) ->
+                 (match uu____15197 with
+                  | (vars,guards,env',binder_decls,uu____15222) ->
                       let arity = FStar_List.length vars  in
-                      let uu____15267 =
+                      let uu____15236 =
                         FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                           env t arity
                          in
-                      (match uu____15267 with
+                      (match uu____15236 with
                        | (tname,ttok,env1) ->
                            let ttok_tm =
                              FStar_SMTEncoding_Util.mkApp (ttok, [])  in
                            let guard = FStar_SMTEncoding_Util.mk_and_l guards
                               in
                            let tapp =
-                             let uu____15293 =
-                               let uu____15301 =
+                             let uu____15262 =
+                               let uu____15270 =
                                  FStar_List.map
                                    FStar_SMTEncoding_Util.mkFreeV vars
                                   in
-                               (tname, uu____15301)  in
-                             FStar_SMTEncoding_Util.mkApp uu____15293  in
-                           let uu____15307 =
+                               (tname, uu____15270)  in
+                             FStar_SMTEncoding_Util.mkApp uu____15262  in
+                           let uu____15276 =
                              let tname_decl =
-                               let uu____15317 =
-                                 let uu____15318 =
+                               let uu____15286 =
+                                 let uu____15287 =
                                    FStar_All.pipe_right vars
                                      (FStar_List.map
                                         (fun fv  ->
-                                           let uu____15337 =
-                                             let uu____15339 =
+                                           let uu____15306 =
+                                             let uu____15308 =
                                                FStar_SMTEncoding_Term.fv_name
                                                  fv
                                                 in
-                                             Prims.op_Hat tname uu____15339
+                                             Prims.op_Hat tname uu____15308
                                               in
-                                           let uu____15341 =
+                                           let uu____15310 =
                                              FStar_SMTEncoding_Term.fv_sort
                                                fv
                                               in
-                                           (uu____15337, uu____15341, false)))
+                                           (uu____15306, uu____15310, false)))
                                     in
-                                 let uu____15345 =
+                                 let uu____15314 =
                                    FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                      ()
                                     in
-                                 (tname, uu____15318,
+                                 (tname, uu____15287,
                                    FStar_SMTEncoding_Term.Term_sort,
-                                   uu____15345, false)
+                                   uu____15314, false)
                                   in
-                               constructor_or_logic_type_decl uu____15317  in
-                             let uu____15353 =
+                               constructor_or_logic_type_decl uu____15286  in
+                             let uu____15322 =
                                match vars with
                                | [] ->
-                                   let uu____15366 =
-                                     let uu____15367 =
-                                       let uu____15370 =
+                                   let uu____15335 =
+                                     let uu____15336 =
+                                       let uu____15339 =
                                          FStar_SMTEncoding_Util.mkApp
                                            (tname, [])
                                           in
                                        FStar_All.pipe_left
-                                         (fun uu____15376  ->
+                                         (fun uu____15345  ->
                                             FStar_Pervasives_Native.Some
-                                              uu____15376) uu____15370
+                                              uu____15345) uu____15339
                                         in
                                      FStar_SMTEncoding_Env.push_free_var env1
-                                       t arity tname uu____15367
+                                       t arity tname uu____15336
                                       in
-                                   ([], uu____15366)
-                               | uu____15379 ->
+                                   ([], uu____15335)
+                               | uu____15348 ->
                                    let ttok_decl =
                                      FStar_SMTEncoding_Term.DeclFun
                                        (ttok, [],
@@ -5762,14 +5751,14 @@ and (encode_sigelt' :
                                             "token"))
                                       in
                                    let ttok_fresh =
-                                     let uu____15389 =
+                                     let uu____15358 =
                                        FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                          ()
                                         in
                                      FStar_SMTEncoding_Term.fresh_token
                                        (ttok,
                                          FStar_SMTEncoding_Term.Term_sort)
-                                       uu____15389
+                                       uu____15358
                                       in
                                    let ttok_app =
                                      FStar_SMTEncoding_EncodeTerm.mk_Apply
@@ -5777,199 +5766,199 @@ and (encode_sigelt' :
                                       in
                                    let pats = [[ttok_app]; [tapp]]  in
                                    let name_tok_corr =
-                                     let uu____15405 =
-                                       let uu____15413 =
-                                         let uu____15414 =
+                                     let uu____15374 =
+                                       let uu____15382 =
+                                         let uu____15383 =
                                            FStar_Ident.range_of_lid t  in
-                                         let uu____15415 =
-                                           let uu____15431 =
+                                         let uu____15384 =
+                                           let uu____15400 =
                                              FStar_SMTEncoding_Util.mkEq
                                                (ttok_app, tapp)
                                               in
                                            (pats,
                                              FStar_Pervasives_Native.None,
-                                             vars, uu____15431)
+                                             vars, uu____15400)
                                             in
                                          FStar_SMTEncoding_Term.mkForall'
-                                           uu____15414 uu____15415
+                                           uu____15383 uu____15384
                                           in
-                                       (uu____15413,
+                                       (uu____15382,
                                          (FStar_Pervasives_Native.Some
                                             "name-token correspondence"),
                                          (Prims.op_Hat
                                             "token_correspondence_" ttok))
                                         in
                                      FStar_SMTEncoding_Util.mkAssume
-                                       uu____15405
+                                       uu____15374
                                       in
                                    ([ttok_decl; ttok_fresh; name_tok_corr],
                                      env1)
                                 in
-                             match uu____15353 with
+                             match uu____15322 with
                              | (tok_decls,env2) ->
-                                 let uu____15458 =
+                                 let uu____15427 =
                                    FStar_Ident.lid_equals t
                                      FStar_Parser_Const.lex_t_lid
                                     in
-                                 if uu____15458
+                                 if uu____15427
                                  then (tok_decls, env2)
                                  else
                                    ((FStar_List.append tname_decl tok_decls),
                                      env2)
                               in
-                           (match uu____15307 with
+                           (match uu____15276 with
                             | (decls,env2) ->
                                 let kindingAx =
-                                  let uu____15486 =
+                                  let uu____15455 =
                                     FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                       FStar_Pervasives_Native.None res env'
                                       tapp
                                      in
-                                  match uu____15486 with
+                                  match uu____15455 with
                                   | (k1,decls1) ->
                                       let karr =
                                         if
                                           (FStar_List.length formals) >
                                             Prims.int_zero
                                         then
-                                          let uu____15508 =
-                                            let uu____15509 =
-                                              let uu____15517 =
-                                                let uu____15518 =
+                                          let uu____15477 =
+                                            let uu____15478 =
+                                              let uu____15486 =
+                                                let uu____15487 =
                                                   FStar_SMTEncoding_Term.mk_PreType
                                                     ttok_tm
                                                    in
                                                 FStar_SMTEncoding_Term.mk_tester
-                                                  "Tm_arrow" uu____15518
+                                                  "Tm_arrow" uu____15487
                                                  in
-                                              (uu____15517,
+                                              (uu____15486,
                                                 (FStar_Pervasives_Native.Some
                                                    "kinding"),
                                                 (Prims.op_Hat "pre_kinding_"
                                                    ttok))
                                                in
                                             FStar_SMTEncoding_Util.mkAssume
-                                              uu____15509
+                                              uu____15478
                                              in
-                                          [uu____15508]
+                                          [uu____15477]
                                         else []  in
                                       let rng = FStar_Ident.range_of_lid t
                                          in
                                       let tot_fun_axioms =
-                                        let uu____15528 =
+                                        let uu____15497 =
                                           FStar_List.map
-                                            (fun uu____15532  ->
+                                            (fun uu____15501  ->
                                                FStar_SMTEncoding_Util.mkTrue)
                                             vars
                                            in
                                         FStar_SMTEncoding_EncodeTerm.isTotFun_axioms
-                                          rng ttok_tm vars uu____15528 true
+                                          rng ttok_tm vars uu____15497 true
                                          in
-                                      let uu____15534 =
-                                        let uu____15537 =
-                                          let uu____15540 =
-                                            let uu____15543 =
-                                              let uu____15544 =
-                                                let uu____15552 =
-                                                  let uu____15553 =
-                                                    let uu____15558 =
-                                                      let uu____15559 =
-                                                        let uu____15570 =
+                                      let uu____15503 =
+                                        let uu____15506 =
+                                          let uu____15509 =
+                                            let uu____15512 =
+                                              let uu____15513 =
+                                                let uu____15521 =
+                                                  let uu____15522 =
+                                                    let uu____15527 =
+                                                      let uu____15528 =
+                                                        let uu____15539 =
                                                           FStar_SMTEncoding_Util.mkImp
                                                             (guard, k1)
                                                            in
                                                         ([[tapp]], vars,
-                                                          uu____15570)
+                                                          uu____15539)
                                                          in
                                                       FStar_SMTEncoding_Term.mkForall
-                                                        rng uu____15559
+                                                        rng uu____15528
                                                        in
                                                     (tot_fun_axioms,
-                                                      uu____15558)
+                                                      uu____15527)
                                                      in
                                                   FStar_SMTEncoding_Util.mkAnd
-                                                    uu____15553
+                                                    uu____15522
                                                    in
-                                                (uu____15552,
+                                                (uu____15521,
                                                   FStar_Pervasives_Native.None,
                                                   (Prims.op_Hat "kinding_"
                                                      ttok))
                                                  in
                                               FStar_SMTEncoding_Util.mkAssume
-                                                uu____15544
+                                                uu____15513
                                                in
-                                            [uu____15543]  in
-                                          FStar_List.append karr uu____15540
+                                            [uu____15512]  in
+                                          FStar_List.append karr uu____15509
                                            in
-                                        FStar_All.pipe_right uu____15537
+                                        FStar_All.pipe_right uu____15506
                                           FStar_SMTEncoding_Term.mk_decls_trivial
                                          in
-                                      FStar_List.append decls1 uu____15534
+                                      FStar_List.append decls1 uu____15503
                                    in
                                 let aux =
-                                  let uu____15589 =
-                                    let uu____15592 =
+                                  let uu____15558 =
+                                    let uu____15561 =
                                       inversion_axioms tapp vars  in
-                                    let uu____15595 =
-                                      let uu____15598 =
-                                        let uu____15601 =
-                                          let uu____15602 =
+                                    let uu____15564 =
+                                      let uu____15567 =
+                                        let uu____15570 =
+                                          let uu____15571 =
                                             FStar_Ident.range_of_lid t  in
-                                          pretype_axiom uu____15602 env2 tapp
+                                          pretype_axiom uu____15571 env2 tapp
                                             vars
                                            in
-                                        [uu____15601]  in
-                                      FStar_All.pipe_right uu____15598
+                                        [uu____15570]  in
+                                      FStar_All.pipe_right uu____15567
                                         FStar_SMTEncoding_Term.mk_decls_trivial
                                        in
-                                    FStar_List.append uu____15592 uu____15595
+                                    FStar_List.append uu____15561 uu____15564
                                      in
-                                  FStar_List.append kindingAx uu____15589  in
+                                  FStar_List.append kindingAx uu____15558  in
                                 let g =
-                                  let uu____15610 =
+                                  let uu____15579 =
                                     FStar_All.pipe_right decls
                                       FStar_SMTEncoding_Term.mk_decls_trivial
                                      in
-                                  FStar_List.append uu____15610
+                                  FStar_List.append uu____15579
                                     (FStar_List.append binder_decls aux)
                                    in
                                 (g, env2))))))
        | FStar_Syntax_Syntax.Sig_datacon
-           (d,uu____15618,uu____15619,uu____15620,uu____15621,uu____15622)
+           (d,uu____15587,uu____15588,uu____15589,uu____15590,uu____15591)
            when FStar_Ident.lid_equals d FStar_Parser_Const.lexcons_lid ->
            ([], env)
        | FStar_Syntax_Syntax.Sig_datacon
-           (d,uu____15630,t,uu____15632,n_tps,uu____15634) ->
+           (d,uu____15599,t,uu____15601,n_tps,uu____15603) ->
            let quals = se.FStar_Syntax_Syntax.sigquals  in
            let t1 = norm_before_encoding env t  in
-           let uu____15645 = FStar_Syntax_Util.arrow_formals t1  in
-           (match uu____15645 with
+           let uu____15614 = FStar_Syntax_Util.arrow_formals t1  in
+           (match uu____15614 with
             | (formals,t_res) ->
                 let arity = FStar_List.length formals  in
-                let uu____15669 =
+                let uu____15638 =
                   FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                     env d arity
                    in
-                (match uu____15669 with
+                (match uu____15638 with
                  | (ddconstrsym,ddtok,env1) ->
                      let ddtok_tm = FStar_SMTEncoding_Util.mkApp (ddtok, [])
                         in
-                     let uu____15693 =
+                     let uu____15662 =
                        FStar_SMTEncoding_Env.fresh_fvar
                          env1.FStar_SMTEncoding_Env.current_module_name "f"
                          FStar_SMTEncoding_Term.Fuel_sort
                         in
-                     (match uu____15693 with
+                     (match uu____15662 with
                       | (fuel_var,fuel_tm) ->
                           let s_fuel_tm =
                             FStar_SMTEncoding_Util.mkApp ("SFuel", [fuel_tm])
                              in
-                          let uu____15713 =
+                          let uu____15682 =
                             FStar_SMTEncoding_EncodeTerm.encode_binders
                               (FStar_Pervasives_Native.Some fuel_tm) formals
                               env1
                              in
-                          (match uu____15713 with
+                          (match uu____15682 with
                            | (vars,guards,env',binder_decls,names) ->
                                let fields =
                                  FStar_All.pipe_right names
@@ -5977,31 +5966,31 @@ and (encode_sigelt' :
                                       (fun n  ->
                                          fun x  ->
                                            let projectible = true  in
-                                           let uu____15792 =
+                                           let uu____15761 =
                                              FStar_SMTEncoding_Env.mk_term_projector_name
                                                d x
                                               in
-                                           (uu____15792,
+                                           (uu____15761,
                                              FStar_SMTEncoding_Term.Term_sort,
                                              projectible)))
                                   in
                                let datacons =
-                                 let uu____15799 =
-                                   let uu____15800 =
+                                 let uu____15768 =
+                                   let uu____15769 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                        ()
                                       in
                                    (ddconstrsym, fields,
                                      FStar_SMTEncoding_Term.Term_sort,
-                                     uu____15800, true)
+                                     uu____15769, true)
                                     in
-                                 let uu____15808 =
-                                   let uu____15815 =
+                                 let uu____15777 =
+                                   let uu____15784 =
                                      FStar_Ident.range_of_lid d  in
                                    FStar_SMTEncoding_Term.constructor_to_decl
-                                     uu____15815
+                                     uu____15784
                                     in
-                                 FStar_All.pipe_right uu____15799 uu____15808
+                                 FStar_All.pipe_right uu____15768 uu____15777
                                   in
                                let app =
                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
@@ -6017,16 +6006,16 @@ and (encode_sigelt' :
                                  FStar_SMTEncoding_Util.mkApp
                                    (ddconstrsym, xvars)
                                   in
-                               let uu____15827 =
+                               let uu____15796 =
                                  FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                    FStar_Pervasives_Native.None t1 env1
                                    ddtok_tm
                                   in
-                               (match uu____15827 with
+                               (match uu____15796 with
                                 | (tok_typing,decls3) ->
                                     let tok_typing1 =
                                       match fields with
-                                      | uu____15839::uu____15840 ->
+                                      | uu____15808::uu____15809 ->
                                           let ff =
                                             FStar_SMTEncoding_Term.mk_fv
                                               ("ty",
@@ -6040,38 +6029,38 @@ and (encode_sigelt' :
                                               ddtok_tm [ff]
                                              in
                                           let vtok_app_r =
-                                            let uu____15889 =
-                                              let uu____15890 =
+                                            let uu____15858 =
+                                              let uu____15859 =
                                                 FStar_SMTEncoding_Term.mk_fv
                                                   (ddtok,
                                                     FStar_SMTEncoding_Term.Term_sort)
                                                  in
-                                              [uu____15890]  in
+                                              [uu____15859]  in
                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                              f uu____15889
+                                              f uu____15858
                                              in
-                                          let uu____15916 =
+                                          let uu____15885 =
                                             FStar_Ident.range_of_lid d  in
-                                          let uu____15917 =
-                                            let uu____15928 =
+                                          let uu____15886 =
+                                            let uu____15897 =
                                               FStar_SMTEncoding_Term.mk_NoHoist
                                                 f tok_typing
                                                in
                                             ([[vtok_app_l]; [vtok_app_r]],
-                                              [ff], uu____15928)
+                                              [ff], uu____15897)
                                              in
                                           FStar_SMTEncoding_Term.mkForall
-                                            uu____15916 uu____15917
-                                      | uu____15955 -> tok_typing  in
-                                    let uu____15966 =
+                                            uu____15885 uu____15886
+                                      | uu____15924 -> tok_typing  in
+                                    let uu____15935 =
                                       FStar_SMTEncoding_EncodeTerm.encode_binders
                                         (FStar_Pervasives_Native.Some fuel_tm)
                                         formals env1
                                        in
-                                    (match uu____15966 with
-                                     | (vars',guards',env'',decls_formals,uu____15991)
+                                    (match uu____15935 with
+                                     | (vars',guards',env'',decls_formals,uu____15960)
                                          ->
-                                         let uu____16004 =
+                                         let uu____15973 =
                                            let xvars1 =
                                              FStar_List.map
                                                FStar_SMTEncoding_Util.mkFreeV
@@ -6085,7 +6074,7 @@ and (encode_sigelt' :
                                              (FStar_Pervasives_Native.Some
                                                 fuel_tm) t_res env'' dapp1
                                             in
-                                         (match uu____16004 with
+                                         (match uu____15973 with
                                           | (ty_pred',decls_pred) ->
                                               let guard' =
                                                 FStar_SMTEncoding_Util.mk_and_l
@@ -6094,34 +6083,34 @@ and (encode_sigelt' :
                                               let proxy_fresh =
                                                 match formals with
                                                 | [] -> []
-                                                | uu____16034 ->
-                                                    let uu____16035 =
-                                                      let uu____16036 =
+                                                | uu____16003 ->
+                                                    let uu____16004 =
+                                                      let uu____16005 =
                                                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                                           ()
                                                          in
                                                       FStar_SMTEncoding_Term.fresh_token
                                                         (ddtok,
                                                           FStar_SMTEncoding_Term.Term_sort)
-                                                        uu____16036
+                                                        uu____16005
                                                        in
-                                                    [uu____16035]
+                                                    [uu____16004]
                                                  in
-                                              let encode_elim uu____16052 =
-                                                let uu____16053 =
+                                              let encode_elim uu____16021 =
+                                                let uu____16022 =
                                                   FStar_Syntax_Util.head_and_args
                                                     t_res
                                                    in
-                                                match uu____16053 with
+                                                match uu____16022 with
                                                 | (head,args) ->
-                                                    let uu____16104 =
-                                                      let uu____16105 =
+                                                    let uu____16073 =
+                                                      let uu____16074 =
                                                         FStar_Syntax_Subst.compress
                                                           head
                                                          in
-                                                      uu____16105.FStar_Syntax_Syntax.n
+                                                      uu____16074.FStar_Syntax_Syntax.n
                                                        in
-                                                    (match uu____16104 with
+                                                    (match uu____16073 with
                                                      | FStar_Syntax_Syntax.Tm_uinst
                                                          ({
                                                             FStar_Syntax_Syntax.n
@@ -6129,9 +6118,9 @@ and (encode_sigelt' :
                                                               FStar_Syntax_Syntax.Tm_fvar
                                                               fv;
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu____16117;
+                                                              = uu____16086;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu____16118;_},uu____16119)
+                                                              = uu____16087;_},uu____16088)
                                                          ->
                                                          let encoded_head_fvb
                                                            =
@@ -6139,11 +6128,11 @@ and (encode_sigelt' :
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name
                                                             in
-                                                         let uu____16125 =
+                                                         let uu____16094 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env'
                                                             in
-                                                         (match uu____16125
+                                                         (match uu____16094
                                                           with
                                                           | (encoded_args,arg_decls)
                                                               ->
@@ -6157,26 +6146,26 @@ and (encode_sigelt' :
                                                                   | FStar_SMTEncoding_Term.FreeV
                                                                     fv1 ->
                                                                     fv1
-                                                                  | uu____16188
+                                                                  | uu____16157
                                                                     ->
-                                                                    let uu____16189
+                                                                    let uu____16158
                                                                     =
-                                                                    let uu____16195
+                                                                    let uu____16164
                                                                     =
-                                                                    let uu____16197
+                                                                    let uu____16166
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____16197
+                                                                    uu____16166
                                                                      in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____16195)
+                                                                    uu____16164)
                                                                      in
                                                                     FStar_Errors.raise_error
-                                                                    uu____16189
+                                                                    uu____16158
                                                                     orig_arg.FStar_Syntax_Syntax.pos
                                                                    in
                                                                 let guards1 =
@@ -6186,33 +6175,33 @@ and (encode_sigelt' :
                                                                     FStar_List.collect
                                                                     (fun g 
                                                                     ->
-                                                                    let uu____16220
+                                                                    let uu____16189
                                                                     =
-                                                                    let uu____16222
+                                                                    let uu____16191
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g  in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____16222
+                                                                    uu____16191
                                                                      in
                                                                     if
-                                                                    uu____16220
+                                                                    uu____16189
                                                                     then
-                                                                    let uu____16244
+                                                                    let uu____16213
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv
                                                                      in
-                                                                    [uu____16244]
+                                                                    [uu____16213]
                                                                     else []))
                                                                    in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1
                                                                  in
-                                                              let uu____16247
+                                                              let uu____16216
                                                                 =
-                                                                let uu____16261
+                                                                let uu____16230
                                                                   =
                                                                   FStar_List.zip
                                                                     args
@@ -6220,22 +6209,22 @@ and (encode_sigelt' :
                                                                    in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu____16318
+                                                                    uu____16287
                                                                      ->
                                                                     fun
-                                                                    uu____16319
+                                                                    uu____16288
                                                                      ->
                                                                     match 
-                                                                    (uu____16318,
-                                                                    uu____16319)
+                                                                    (uu____16287,
+                                                                    uu____16288)
                                                                     with
                                                                     | 
                                                                     ((env2,arg_vars,eqns_or_guards,i),
                                                                     (orig_arg,arg))
                                                                     ->
-                                                                    let uu____16430
+                                                                    let uu____16399
                                                                     =
-                                                                    let uu____16438
+                                                                    let uu____16407
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
@@ -6243,35 +6232,35 @@ and (encode_sigelt' :
                                                                      in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu____16438
+                                                                    uu____16407
                                                                      in
-                                                                    (match uu____16430
+                                                                    (match uu____16399
                                                                     with
                                                                     | 
-                                                                    (uu____16452,xv,env3)
+                                                                    (uu____16421,xv,env3)
                                                                     ->
                                                                     let eqns
                                                                     =
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu____16463
+                                                                    let uu____16432
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv
                                                                      in
-                                                                    uu____16463
+                                                                    uu____16432
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu____16468
+                                                                    (let uu____16437
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv)
                                                                      in
-                                                                    uu____16468
+                                                                    uu____16437
                                                                     ::
                                                                     eqns_or_guards)
                                                                      in
@@ -6284,11 +6273,11 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu____16261
+                                                                  uu____16230
                                                                  in
-                                                              (match uu____16247
+                                                              (match uu____16216
                                                                with
-                                                               | (uu____16489,arg_vars,elim_eqns_or_guards,uu____16492)
+                                                               | (uu____16458,arg_vars,elim_eqns_or_guards,uu____16461)
                                                                    ->
                                                                    let arg_vars1
                                                                     =
@@ -6327,35 +6316,35 @@ and (encode_sigelt' :
                                                                      in
                                                                    let typing_inversion
                                                                     =
-                                                                    let uu____16519
+                                                                    let uu____16488
                                                                     =
-                                                                    let uu____16527
+                                                                    let uu____16496
                                                                     =
-                                                                    let uu____16528
+                                                                    let uu____16497
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____16529
+                                                                    let uu____16498
                                                                     =
-                                                                    let uu____16540
+                                                                    let uu____16509
                                                                     =
-                                                                    let uu____16541
+                                                                    let uu____16510
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____16541
+                                                                    uu____16510
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____16543
+                                                                    let uu____16512
                                                                     =
-                                                                    let uu____16544
+                                                                    let uu____16513
                                                                     =
-                                                                    let uu____16549
+                                                                    let uu____16518
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
@@ -6363,21 +6352,21 @@ and (encode_sigelt' :
                                                                     guards)
                                                                      in
                                                                     (ty_pred,
-                                                                    uu____16549)
+                                                                    uu____16518)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____16544
+                                                                    uu____16513
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____16540,
-                                                                    uu____16543)
+                                                                    uu____16509,
+                                                                    uu____16512)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____16528
-                                                                    uu____16529
+                                                                    uu____16497
+                                                                    uu____16498
                                                                      in
-                                                                    (uu____16527,
+                                                                    (uu____16496,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
@@ -6385,34 +6374,34 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____16519
+                                                                    uu____16488
                                                                      in
                                                                    let subterm_ordering
                                                                     =
                                                                     let lex_t
                                                                     =
-                                                                    let uu____16564
+                                                                    let uu____16533
                                                                     =
-                                                                    let uu____16565
+                                                                    let uu____16534
                                                                     =
-                                                                    let uu____16571
+                                                                    let uu____16540
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid
                                                                      in
-                                                                    (uu____16571,
+                                                                    (uu____16540,
                                                                     FStar_SMTEncoding_Term.Term_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu____16565
+                                                                    uu____16534
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____16564
+                                                                    uu____16533
                                                                      in
                                                                     let prec
                                                                     =
-                                                                    let uu____16577
+                                                                    let uu____16546
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -6424,71 +6413,71 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu____16600
+                                                                    (let uu____16569
                                                                     =
-                                                                    let uu____16601
+                                                                    let uu____16570
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v  in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu____16601
+                                                                    uu____16570
                                                                     dapp1  in
-                                                                    [uu____16600])))
+                                                                    [uu____16569])))
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____16577
+                                                                    uu____16546
                                                                     FStar_List.flatten
                                                                      in
-                                                                    let uu____16608
+                                                                    let uu____16577
                                                                     =
-                                                                    let uu____16616
+                                                                    let uu____16585
                                                                     =
-                                                                    let uu____16617
+                                                                    let uu____16586
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____16618
+                                                                    let uu____16587
                                                                     =
-                                                                    let uu____16629
+                                                                    let uu____16598
                                                                     =
-                                                                    let uu____16630
+                                                                    let uu____16599
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____16630
+                                                                    uu____16599
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____16632
+                                                                    let uu____16601
                                                                     =
-                                                                    let uu____16633
+                                                                    let uu____16602
                                                                     =
-                                                                    let uu____16638
+                                                                    let uu____16607
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec  in
                                                                     (ty_pred,
-                                                                    uu____16638)
+                                                                    uu____16607)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____16633
+                                                                    uu____16602
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____16629,
-                                                                    uu____16632)
+                                                                    uu____16598,
+                                                                    uu____16601)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____16617
-                                                                    uu____16618
+                                                                    uu____16586
+                                                                    uu____16587
                                                                      in
-                                                                    (uu____16616,
+                                                                    (uu____16585,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
@@ -6496,7 +6485,7 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____16608
+                                                                    uu____16577
                                                                      in
                                                                    (arg_decls,
                                                                     [typing_inversion;
@@ -6509,11 +6498,11 @@ and (encode_sigelt' :
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name
                                                             in
-                                                         let uu____16657 =
+                                                         let uu____16626 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env'
                                                             in
-                                                         (match uu____16657
+                                                         (match uu____16626
                                                           with
                                                           | (encoded_args,arg_decls)
                                                               ->
@@ -6527,26 +6516,26 @@ and (encode_sigelt' :
                                                                   | FStar_SMTEncoding_Term.FreeV
                                                                     fv1 ->
                                                                     fv1
-                                                                  | uu____16720
+                                                                  | uu____16689
                                                                     ->
-                                                                    let uu____16721
+                                                                    let uu____16690
                                                                     =
-                                                                    let uu____16727
+                                                                    let uu____16696
                                                                     =
-                                                                    let uu____16729
+                                                                    let uu____16698
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu____16729
+                                                                    uu____16698
                                                                      in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu____16727)
+                                                                    uu____16696)
                                                                      in
                                                                     FStar_Errors.raise_error
-                                                                    uu____16721
+                                                                    uu____16690
                                                                     orig_arg.FStar_Syntax_Syntax.pos
                                                                    in
                                                                 let guards1 =
@@ -6556,33 +6545,33 @@ and (encode_sigelt' :
                                                                     FStar_List.collect
                                                                     (fun g 
                                                                     ->
-                                                                    let uu____16752
+                                                                    let uu____16721
                                                                     =
-                                                                    let uu____16754
+                                                                    let uu____16723
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g  in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu____16754
+                                                                    uu____16723
                                                                      in
                                                                     if
-                                                                    uu____16752
+                                                                    uu____16721
                                                                     then
-                                                                    let uu____16776
+                                                                    let uu____16745
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv
                                                                      in
-                                                                    [uu____16776]
+                                                                    [uu____16745]
                                                                     else []))
                                                                    in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1
                                                                  in
-                                                              let uu____16779
+                                                              let uu____16748
                                                                 =
-                                                                let uu____16793
+                                                                let uu____16762
                                                                   =
                                                                   FStar_List.zip
                                                                     args
@@ -6590,22 +6579,22 @@ and (encode_sigelt' :
                                                                    in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu____16850
+                                                                    uu____16819
                                                                      ->
                                                                     fun
-                                                                    uu____16851
+                                                                    uu____16820
                                                                      ->
                                                                     match 
-                                                                    (uu____16850,
-                                                                    uu____16851)
+                                                                    (uu____16819,
+                                                                    uu____16820)
                                                                     with
                                                                     | 
                                                                     ((env2,arg_vars,eqns_or_guards,i),
                                                                     (orig_arg,arg))
                                                                     ->
-                                                                    let uu____16962
+                                                                    let uu____16931
                                                                     =
-                                                                    let uu____16970
+                                                                    let uu____16939
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
@@ -6613,35 +6602,35 @@ and (encode_sigelt' :
                                                                      in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu____16970
+                                                                    uu____16939
                                                                      in
-                                                                    (match uu____16962
+                                                                    (match uu____16931
                                                                     with
                                                                     | 
-                                                                    (uu____16984,xv,env3)
+                                                                    (uu____16953,xv,env3)
                                                                     ->
                                                                     let eqns
                                                                     =
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu____16995
+                                                                    let uu____16964
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv
                                                                      in
-                                                                    uu____16995
+                                                                    uu____16964
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu____17000
+                                                                    (let uu____16969
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv)
                                                                      in
-                                                                    uu____17000
+                                                                    uu____16969
                                                                     ::
                                                                     eqns_or_guards)
                                                                      in
@@ -6654,11 +6643,11 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu____16793
+                                                                  uu____16762
                                                                  in
-                                                              (match uu____16779
+                                                              (match uu____16748
                                                                with
-                                                               | (uu____17021,arg_vars,elim_eqns_or_guards,uu____17024)
+                                                               | (uu____16990,arg_vars,elim_eqns_or_guards,uu____16993)
                                                                    ->
                                                                    let arg_vars1
                                                                     =
@@ -6697,35 +6686,35 @@ and (encode_sigelt' :
                                                                      in
                                                                    let typing_inversion
                                                                     =
-                                                                    let uu____17051
+                                                                    let uu____17020
                                                                     =
-                                                                    let uu____17059
+                                                                    let uu____17028
                                                                     =
-                                                                    let uu____17060
+                                                                    let uu____17029
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17061
+                                                                    let uu____17030
                                                                     =
-                                                                    let uu____17072
+                                                                    let uu____17041
                                                                     =
-                                                                    let uu____17073
+                                                                    let uu____17042
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____17073
+                                                                    uu____17042
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____17075
+                                                                    let uu____17044
                                                                     =
-                                                                    let uu____17076
+                                                                    let uu____17045
                                                                     =
-                                                                    let uu____17081
+                                                                    let uu____17050
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
@@ -6733,21 +6722,21 @@ and (encode_sigelt' :
                                                                     guards)
                                                                      in
                                                                     (ty_pred,
-                                                                    uu____17081)
+                                                                    uu____17050)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____17076
+                                                                    uu____17045
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____17072,
-                                                                    uu____17075)
+                                                                    uu____17041,
+                                                                    uu____17044)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17060
-                                                                    uu____17061
+                                                                    uu____17029
+                                                                    uu____17030
                                                                      in
-                                                                    (uu____17059,
+                                                                    (uu____17028,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
@@ -6755,34 +6744,34 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____17051
+                                                                    uu____17020
                                                                      in
                                                                    let subterm_ordering
                                                                     =
                                                                     let lex_t
                                                                     =
-                                                                    let uu____17096
+                                                                    let uu____17065
                                                                     =
-                                                                    let uu____17097
+                                                                    let uu____17066
                                                                     =
-                                                                    let uu____17103
+                                                                    let uu____17072
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid
                                                                      in
-                                                                    (uu____17103,
+                                                                    (uu____17072,
                                                                     FStar_SMTEncoding_Term.Term_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu____17097
+                                                                    uu____17066
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu____17096
+                                                                    uu____17065
                                                                      in
                                                                     let prec
                                                                     =
-                                                                    let uu____17109
+                                                                    let uu____17078
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -6794,71 +6783,71 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu____17132
+                                                                    (let uu____17101
                                                                     =
-                                                                    let uu____17133
+                                                                    let uu____17102
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v  in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu____17133
+                                                                    uu____17102
                                                                     dapp1  in
-                                                                    [uu____17132])))
+                                                                    [uu____17101])))
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____17109
+                                                                    uu____17078
                                                                     FStar_List.flatten
                                                                      in
-                                                                    let uu____17140
+                                                                    let uu____17109
                                                                     =
-                                                                    let uu____17148
+                                                                    let uu____17117
                                                                     =
-                                                                    let uu____17149
+                                                                    let uu____17118
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17150
+                                                                    let uu____17119
                                                                     =
-                                                                    let uu____17161
+                                                                    let uu____17130
                                                                     =
-                                                                    let uu____17162
+                                                                    let uu____17131
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____17162
+                                                                    uu____17131
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders)
                                                                      in
-                                                                    let uu____17164
+                                                                    let uu____17133
                                                                     =
-                                                                    let uu____17165
+                                                                    let uu____17134
                                                                     =
-                                                                    let uu____17170
+                                                                    let uu____17139
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec  in
                                                                     (ty_pred,
-                                                                    uu____17170)
+                                                                    uu____17139)
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu____17165
+                                                                    uu____17134
                                                                      in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu____17161,
-                                                                    uu____17164)
+                                                                    uu____17130,
+                                                                    uu____17133)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17149
-                                                                    uu____17150
+                                                                    uu____17118
+                                                                    uu____17119
                                                                      in
-                                                                    (uu____17148,
+                                                                    (uu____17117,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
@@ -6866,98 +6855,98 @@ and (encode_sigelt' :
                                                                     ddconstrsym))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____17140
+                                                                    uu____17109
                                                                      in
                                                                    (arg_decls,
                                                                     [typing_inversion;
                                                                     subterm_ordering])))
-                                                     | uu____17187 ->
-                                                         ((let uu____17189 =
-                                                             let uu____17195
+                                                     | uu____17156 ->
+                                                         ((let uu____17158 =
+                                                             let uu____17164
                                                                =
-                                                               let uu____17197
+                                                               let uu____17166
                                                                  =
                                                                  FStar_Syntax_Print.lid_to_string
                                                                    d
                                                                   in
-                                                               let uu____17199
+                                                               let uu____17168
                                                                  =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    head
                                                                   in
                                                                FStar_Util.format2
                                                                  "Constructor %s builds an unexpected type %s\n"
-                                                                 uu____17197
-                                                                 uu____17199
+                                                                 uu____17166
+                                                                 uu____17168
                                                                 in
                                                              (FStar_Errors.Warning_ConstructorBuildsUnexpectedType,
-                                                               uu____17195)
+                                                               uu____17164)
                                                               in
                                                            FStar_Errors.log_issue
                                                              se.FStar_Syntax_Syntax.sigrng
-                                                             uu____17189);
+                                                             uu____17158);
                                                           ([], [])))
                                                  in
-                                              let uu____17207 =
+                                              let uu____17176 =
                                                 encode_elim ()  in
-                                              (match uu____17207 with
+                                              (match uu____17176 with
                                                | (decls2,elim) ->
                                                    let g =
-                                                     let uu____17233 =
-                                                       let uu____17236 =
-                                                         let uu____17239 =
-                                                           let uu____17242 =
-                                                             let uu____17245
+                                                     let uu____17202 =
+                                                       let uu____17205 =
+                                                         let uu____17208 =
+                                                           let uu____17211 =
+                                                             let uu____17214
                                                                =
-                                                               let uu____17248
+                                                               let uu____17217
                                                                  =
-                                                                 let uu____17251
+                                                                 let uu____17220
                                                                    =
-                                                                   let uu____17252
+                                                                   let uu____17221
                                                                     =
-                                                                    let uu____17264
+                                                                    let uu____17233
                                                                     =
-                                                                    let uu____17265
+                                                                    let uu____17234
                                                                     =
-                                                                    let uu____17267
+                                                                    let uu____17236
                                                                     =
                                                                     FStar_Syntax_Print.lid_to_string
                                                                     d  in
                                                                     FStar_Util.format1
                                                                     "data constructor proxy: %s"
-                                                                    uu____17267
+                                                                    uu____17236
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____17265
+                                                                    uu____17234
                                                                      in
                                                                     (ddtok,
                                                                     [],
                                                                     FStar_SMTEncoding_Term.Term_sort,
-                                                                    uu____17264)
+                                                                    uu____17233)
                                                                      in
                                                                    FStar_SMTEncoding_Term.DeclFun
-                                                                    uu____17252
+                                                                    uu____17221
                                                                     in
-                                                                 [uu____17251]
+                                                                 [uu____17220]
                                                                   in
                                                                FStar_List.append
-                                                                 uu____17248
+                                                                 uu____17217
                                                                  proxy_fresh
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____17245
+                                                               uu____17214
                                                                FStar_SMTEncoding_Term.mk_decls_trivial
                                                               in
-                                                           let uu____17278 =
-                                                             let uu____17281
+                                                           let uu____17247 =
+                                                             let uu____17250
                                                                =
-                                                               let uu____17284
+                                                               let uu____17253
                                                                  =
-                                                                 let uu____17287
+                                                                 let uu____17256
                                                                    =
-                                                                   let uu____17290
+                                                                   let uu____17259
                                                                     =
-                                                                    let uu____17293
+                                                                    let uu____17262
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     (tok_typing1,
@@ -6967,34 +6956,34 @@ and (encode_sigelt' :
                                                                     "typing_tok_"
                                                                     ddtok))
                                                                      in
-                                                                    let uu____17298
+                                                                    let uu____17267
                                                                     =
-                                                                    let uu____17301
+                                                                    let uu____17270
                                                                     =
-                                                                    let uu____17302
+                                                                    let uu____17271
                                                                     =
-                                                                    let uu____17310
+                                                                    let uu____17279
                                                                     =
-                                                                    let uu____17311
+                                                                    let uu____17280
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17312
+                                                                    let uu____17281
                                                                     =
-                                                                    let uu____17323
+                                                                    let uu____17292
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
                                                                     dapp)  in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu____17323)
+                                                                    uu____17292)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17311
-                                                                    uu____17312
+                                                                    uu____17280
+                                                                    uu____17281
                                                                      in
-                                                                    (uu____17310,
+                                                                    (uu____17279,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "equality for proxy"),
                                                                     (Prims.op_Hat
@@ -7002,34 +6991,34 @@ and (encode_sigelt' :
                                                                     ddtok))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____17302
+                                                                    uu____17271
                                                                      in
-                                                                    let uu____17336
+                                                                    let uu____17305
                                                                     =
-                                                                    let uu____17339
+                                                                    let uu____17308
                                                                     =
-                                                                    let uu____17340
+                                                                    let uu____17309
                                                                     =
-                                                                    let uu____17348
+                                                                    let uu____17317
                                                                     =
-                                                                    let uu____17349
+                                                                    let uu____17318
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d  in
-                                                                    let uu____17350
+                                                                    let uu____17319
                                                                     =
-                                                                    let uu____17361
+                                                                    let uu____17330
                                                                     =
-                                                                    let uu____17362
+                                                                    let uu____17331
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort)
                                                                      in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu____17362
+                                                                    uu____17331
                                                                     vars'  in
-                                                                    let uu____17364
+                                                                    let uu____17333
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard',
@@ -7037,14 +7026,14 @@ and (encode_sigelt' :
                                                                      in
                                                                     ([
                                                                     [ty_pred']],
-                                                                    uu____17361,
-                                                                    uu____17364)
+                                                                    uu____17330,
+                                                                    uu____17333)
                                                                      in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu____17349
-                                                                    uu____17350
+                                                                    uu____17318
+                                                                    uu____17319
                                                                      in
-                                                                    (uu____17348,
+                                                                    (uu____17317,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing intro"),
                                                                     (Prims.op_Hat
@@ -7052,58 +7041,58 @@ and (encode_sigelt' :
                                                                     ddtok))
                                                                      in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu____17340
+                                                                    uu____17309
                                                                      in
-                                                                    [uu____17339]
+                                                                    [uu____17308]
                                                                      in
-                                                                    uu____17301
+                                                                    uu____17270
                                                                     ::
-                                                                    uu____17336
+                                                                    uu____17305
                                                                      in
-                                                                    uu____17293
+                                                                    uu____17262
                                                                     ::
-                                                                    uu____17298
+                                                                    uu____17267
                                                                      in
                                                                    FStar_List.append
-                                                                    uu____17290
+                                                                    uu____17259
                                                                     elim
                                                                     in
                                                                  FStar_All.pipe_right
-                                                                   uu____17287
+                                                                   uu____17256
                                                                    FStar_SMTEncoding_Term.mk_decls_trivial
                                                                   in
                                                                FStar_List.append
                                                                  decls_pred
-                                                                 uu____17284
+                                                                 uu____17253
                                                                 in
                                                              FStar_List.append
                                                                decls_formals
-                                                               uu____17281
+                                                               uu____17250
                                                               in
                                                            FStar_List.append
-                                                             uu____17242
-                                                             uu____17278
+                                                             uu____17211
+                                                             uu____17247
                                                             in
                                                          FStar_List.append
-                                                           decls3 uu____17239
+                                                           decls3 uu____17208
                                                           in
                                                        FStar_List.append
-                                                         decls2 uu____17236
+                                                         decls2 uu____17205
                                                         in
                                                      FStar_List.append
                                                        binder_decls
-                                                       uu____17233
+                                                       uu____17202
                                                       in
-                                                   let uu____17381 =
-                                                     let uu____17382 =
+                                                   let uu____17350 =
+                                                     let uu____17351 =
                                                        FStar_All.pipe_right
                                                          datacons
                                                          FStar_SMTEncoding_Term.mk_decls_trivial
                                                         in
                                                      FStar_List.append
-                                                       uu____17382 g
+                                                       uu____17351 g
                                                       in
-                                                   (uu____17381, env1))))))))))
+                                                   (uu____17350, env1))))))))))
 
 and (encode_sigelts :
   FStar_SMTEncoding_Env.env_t ->
@@ -7114,12 +7103,12 @@ and (encode_sigelts :
     fun ses  ->
       FStar_All.pipe_right ses
         (FStar_List.fold_left
-           (fun uu____17416  ->
+           (fun uu____17385  ->
               fun se  ->
-                match uu____17416 with
+                match uu____17385 with
                 | (g,env1) ->
-                    let uu____17436 = encode_sigelt env1 se  in
-                    (match uu____17436 with
+                    let uu____17405 = encode_sigelt env1 se  in
+                    (match uu____17405 with
                      | (g',env2) -> ((FStar_List.append g g'), env2)))
            ([], env))
 
@@ -7130,74 +7119,74 @@ let (encode_env_bindings :
   =
   fun env  ->
     fun bindings  ->
-      let encode_binding b uu____17504 =
-        match uu____17504 with
+      let encode_binding b uu____17473 =
+        match uu____17473 with
         | (i,decls,env1) ->
             (match b with
-             | FStar_Syntax_Syntax.Binding_univ uu____17541 ->
+             | FStar_Syntax_Syntax.Binding_univ uu____17510 ->
                  ((i + Prims.int_one), decls, env1)
              | FStar_Syntax_Syntax.Binding_var x ->
                  let t1 =
                    norm_before_encoding env1 x.FStar_Syntax_Syntax.sort  in
-                 ((let uu____17549 =
+                 ((let uu____17518 =
                      FStar_All.pipe_left
                        (FStar_TypeChecker_Env.debug
                           env1.FStar_SMTEncoding_Env.tcenv)
                        (FStar_Options.Other "SMTEncoding")
                       in
-                   if uu____17549
+                   if uu____17518
                    then
-                     let uu____17554 = FStar_Syntax_Print.bv_to_string x  in
-                     let uu____17556 =
+                     let uu____17523 = FStar_Syntax_Print.bv_to_string x  in
+                     let uu____17525 =
                        FStar_Syntax_Print.term_to_string
                          x.FStar_Syntax_Syntax.sort
                         in
-                     let uu____17558 = FStar_Syntax_Print.term_to_string t1
+                     let uu____17527 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print3 "Normalized %s : %s to %s\n"
-                       uu____17554 uu____17556 uu____17558
+                       uu____17523 uu____17525 uu____17527
                    else ());
-                  (let uu____17563 =
+                  (let uu____17532 =
                      FStar_SMTEncoding_EncodeTerm.encode_term t1 env1  in
-                   match uu____17563 with
+                   match uu____17532 with
                    | (t,decls') ->
                        let t_hash = FStar_SMTEncoding_Term.hash_of_term t  in
-                       let uu____17581 =
-                         let uu____17589 =
-                           let uu____17591 =
-                             let uu____17593 =
+                       let uu____17550 =
+                         let uu____17558 =
+                           let uu____17560 =
+                             let uu____17562 =
                                FStar_Util.digest_of_string t_hash  in
-                             Prims.op_Hat uu____17593
+                             Prims.op_Hat uu____17562
                                (Prims.op_Hat "_" (Prims.string_of_int i))
                               in
-                           Prims.op_Hat "x_" uu____17591  in
+                           Prims.op_Hat "x_" uu____17560  in
                          FStar_SMTEncoding_Env.new_term_constant_from_string
-                           env1 x uu____17589
+                           env1 x uu____17558
                           in
-                       (match uu____17581 with
+                       (match uu____17550 with
                         | (xxsym,xx,env') ->
                             let t2 =
                               FStar_SMTEncoding_Term.mk_HasTypeWithFuel
                                 FStar_Pervasives_Native.None xx t
                                in
                             let caption =
-                              let uu____17613 = FStar_Options.log_queries ()
+                              let uu____17582 = FStar_Options.log_queries ()
                                  in
-                              if uu____17613
+                              if uu____17582
                               then
-                                let uu____17616 =
-                                  let uu____17618 =
+                                let uu____17585 =
+                                  let uu____17587 =
                                     FStar_Syntax_Print.bv_to_string x  in
-                                  let uu____17620 =
+                                  let uu____17589 =
                                     FStar_Syntax_Print.term_to_string
                                       x.FStar_Syntax_Syntax.sort
                                      in
-                                  let uu____17622 =
+                                  let uu____17591 =
                                     FStar_Syntax_Print.term_to_string t1  in
                                   FStar_Util.format3 "%s : %s (%s)"
-                                    uu____17618 uu____17620 uu____17622
+                                    uu____17587 uu____17589 uu____17591
                                    in
-                                FStar_Pervasives_Native.Some uu____17616
+                                FStar_Pervasives_Native.Some uu____17585
                               else FStar_Pervasives_Native.None  in
                             let ax =
                               let a_name = Prims.op_Hat "binder_" xxsym  in
@@ -7206,7 +7195,7 @@ let (encode_env_bindings :
                                   a_name)
                                in
                             let g =
-                              let uu____17638 =
+                              let uu____17607 =
                                 FStar_All.pipe_right
                                   [FStar_SMTEncoding_Term.DeclFun
                                      (xxsym, [],
@@ -7214,34 +7203,34 @@ let (encode_env_bindings :
                                        caption)]
                                   FStar_SMTEncoding_Term.mk_decls_trivial
                                  in
-                              let uu____17648 =
-                                let uu____17651 =
+                              let uu____17617 =
+                                let uu____17620 =
                                   FStar_All.pipe_right [ax]
                                     FStar_SMTEncoding_Term.mk_decls_trivial
                                    in
-                                FStar_List.append decls' uu____17651  in
-                              FStar_List.append uu____17638 uu____17648  in
+                                FStar_List.append decls' uu____17620  in
+                              FStar_List.append uu____17607 uu____17617  in
                             ((i + Prims.int_one),
                               (FStar_List.append decls g), env'))))
-             | FStar_Syntax_Syntax.Binding_lid (x,(uu____17663,t)) ->
+             | FStar_Syntax_Syntax.Binding_lid (x,(uu____17632,t)) ->
                  let t_norm = norm_before_encoding env1 t  in
                  let fv =
                    FStar_Syntax_Syntax.lid_as_fv x
                      FStar_Syntax_Syntax.delta_constant
                      FStar_Pervasives_Native.None
                     in
-                 let uu____17683 = encode_free_var false env1 fv t t_norm []
+                 let uu____17652 = encode_free_var false env1 fv t t_norm []
                     in
-                 (match uu____17683 with
+                 (match uu____17652 with
                   | (g,env') ->
                       ((i + Prims.int_one), (FStar_List.append decls g),
                         env')))
          in
-      let uu____17704 =
+      let uu____17673 =
         FStar_List.fold_right encode_binding bindings
           (Prims.int_zero, [], env)
          in
-      match uu____17704 with | (uu____17731,decls,env1) -> (decls, env1)
+      match uu____17673 with | (uu____17700,decls,env1) -> (decls, env1)
   
 let (encode_labels :
   FStar_SMTEncoding_Term.error_label Prims.list ->
@@ -7252,34 +7241,34 @@ let (encode_labels :
     let prefix =
       FStar_All.pipe_right labs
         (FStar_List.map
-           (fun uu____17784  ->
-              match uu____17784 with
-              | (l,uu____17793,uu____17794) ->
-                  let uu____17797 =
-                    let uu____17809 = FStar_SMTEncoding_Term.fv_name l  in
-                    (uu____17809, [], FStar_SMTEncoding_Term.Bool_sort,
+           (fun uu____17753  ->
+              match uu____17753 with
+              | (l,uu____17762,uu____17763) ->
+                  let uu____17766 =
+                    let uu____17778 = FStar_SMTEncoding_Term.fv_name l  in
+                    (uu____17778, [], FStar_SMTEncoding_Term.Bool_sort,
                       FStar_Pervasives_Native.None)
                      in
-                  FStar_SMTEncoding_Term.DeclFun uu____17797))
+                  FStar_SMTEncoding_Term.DeclFun uu____17766))
        in
     let suffix =
       FStar_All.pipe_right labs
         (FStar_List.collect
-           (fun uu____17842  ->
-              match uu____17842 with
-              | (l,uu____17853,uu____17854) ->
-                  let uu____17857 =
-                    let uu____17858 = FStar_SMTEncoding_Term.fv_name l  in
+           (fun uu____17811  ->
+              match uu____17811 with
+              | (l,uu____17822,uu____17823) ->
+                  let uu____17826 =
+                    let uu____17827 = FStar_SMTEncoding_Term.fv_name l  in
                     FStar_All.pipe_left
-                      (fun uu____17861  ->
-                         FStar_SMTEncoding_Term.Echo uu____17861) uu____17858
+                      (fun uu____17830  ->
+                         FStar_SMTEncoding_Term.Echo uu____17830) uu____17827
                      in
-                  let uu____17862 =
-                    let uu____17865 =
-                      let uu____17866 = FStar_SMTEncoding_Util.mkFreeV l  in
-                      FStar_SMTEncoding_Term.Eval uu____17866  in
-                    [uu____17865]  in
-                  uu____17857 :: uu____17862))
+                  let uu____17831 =
+                    let uu____17834 =
+                      let uu____17835 = FStar_SMTEncoding_Util.mkFreeV l  in
+                      FStar_SMTEncoding_Term.Eval uu____17835  in
+                    [uu____17834]  in
+                  uu____17826 :: uu____17831))
        in
     (prefix, suffix)
   
@@ -7287,31 +7276,31 @@ let (last_env : FStar_SMTEncoding_Env.env_t Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref [] 
 let (init_env : FStar_TypeChecker_Env.env -> unit) =
   fun tcenv  ->
-    let uu____17884 =
-      let uu____17887 =
-        let uu____17888 = FStar_Util.psmap_empty ()  in
-        let uu____17903 =
-          let uu____17912 = FStar_Util.psmap_empty ()  in (uu____17912, [])
+    let uu____17853 =
+      let uu____17856 =
+        let uu____17857 = FStar_Util.psmap_empty ()  in
+        let uu____17872 =
+          let uu____17881 = FStar_Util.psmap_empty ()  in (uu____17881, [])
            in
-        let uu____17919 =
-          let uu____17921 = FStar_TypeChecker_Env.current_module tcenv  in
-          FStar_All.pipe_right uu____17921 FStar_Ident.string_of_lid  in
-        let uu____17923 = FStar_Util.smap_create (Prims.of_int (100))  in
+        let uu____17888 =
+          let uu____17890 = FStar_TypeChecker_Env.current_module tcenv  in
+          FStar_All.pipe_right uu____17890 FStar_Ident.string_of_lid  in
+        let uu____17892 = FStar_Util.smap_create (Prims.of_int (100))  in
         {
-          FStar_SMTEncoding_Env.bvar_bindings = uu____17888;
-          FStar_SMTEncoding_Env.fvar_bindings = uu____17903;
+          FStar_SMTEncoding_Env.bvar_bindings = uu____17857;
+          FStar_SMTEncoding_Env.fvar_bindings = uu____17872;
           FStar_SMTEncoding_Env.depth = Prims.int_zero;
           FStar_SMTEncoding_Env.tcenv = tcenv;
           FStar_SMTEncoding_Env.warn = true;
           FStar_SMTEncoding_Env.nolabels = false;
           FStar_SMTEncoding_Env.use_zfuel_name = false;
           FStar_SMTEncoding_Env.encode_non_total_function_typ = true;
-          FStar_SMTEncoding_Env.current_module_name = uu____17919;
+          FStar_SMTEncoding_Env.current_module_name = uu____17888;
           FStar_SMTEncoding_Env.encoding_quantifier = false;
-          FStar_SMTEncoding_Env.global_cache = uu____17923
+          FStar_SMTEncoding_Env.global_cache = uu____17892
         }  in
-      [uu____17887]  in
-    FStar_ST.op_Colon_Equals last_env uu____17884
+      [uu____17856]  in
+    FStar_ST.op_Colon_Equals last_env uu____17853
   
 let (get_env :
   FStar_Ident.lident ->
@@ -7319,60 +7308,60 @@ let (get_env :
   =
   fun cmn  ->
     fun tcenv  ->
-      let uu____17967 = FStar_ST.op_Bang last_env  in
-      match uu____17967 with
+      let uu____17936 = FStar_ST.op_Bang last_env  in
+      match uu____17936 with
       | [] -> failwith "No env; call init first!"
-      | e::uu____17995 ->
-          let uu___1572_17998 = e  in
-          let uu____17999 = FStar_Ident.string_of_lid cmn  in
+      | e::uu____17964 ->
+          let uu___1572_17967 = e  in
+          let uu____17968 = FStar_Ident.string_of_lid cmn  in
           {
             FStar_SMTEncoding_Env.bvar_bindings =
-              (uu___1572_17998.FStar_SMTEncoding_Env.bvar_bindings);
+              (uu___1572_17967.FStar_SMTEncoding_Env.bvar_bindings);
             FStar_SMTEncoding_Env.fvar_bindings =
-              (uu___1572_17998.FStar_SMTEncoding_Env.fvar_bindings);
+              (uu___1572_17967.FStar_SMTEncoding_Env.fvar_bindings);
             FStar_SMTEncoding_Env.depth =
-              (uu___1572_17998.FStar_SMTEncoding_Env.depth);
+              (uu___1572_17967.FStar_SMTEncoding_Env.depth);
             FStar_SMTEncoding_Env.tcenv = tcenv;
             FStar_SMTEncoding_Env.warn =
-              (uu___1572_17998.FStar_SMTEncoding_Env.warn);
+              (uu___1572_17967.FStar_SMTEncoding_Env.warn);
             FStar_SMTEncoding_Env.nolabels =
-              (uu___1572_17998.FStar_SMTEncoding_Env.nolabels);
+              (uu___1572_17967.FStar_SMTEncoding_Env.nolabels);
             FStar_SMTEncoding_Env.use_zfuel_name =
-              (uu___1572_17998.FStar_SMTEncoding_Env.use_zfuel_name);
+              (uu___1572_17967.FStar_SMTEncoding_Env.use_zfuel_name);
             FStar_SMTEncoding_Env.encode_non_total_function_typ =
-              (uu___1572_17998.FStar_SMTEncoding_Env.encode_non_total_function_typ);
-            FStar_SMTEncoding_Env.current_module_name = uu____17999;
+              (uu___1572_17967.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            FStar_SMTEncoding_Env.current_module_name = uu____17968;
             FStar_SMTEncoding_Env.encoding_quantifier =
-              (uu___1572_17998.FStar_SMTEncoding_Env.encoding_quantifier);
+              (uu___1572_17967.FStar_SMTEncoding_Env.encoding_quantifier);
             FStar_SMTEncoding_Env.global_cache =
-              (uu___1572_17998.FStar_SMTEncoding_Env.global_cache)
+              (uu___1572_17967.FStar_SMTEncoding_Env.global_cache)
           }
   
 let (set_env : FStar_SMTEncoding_Env.env_t -> unit) =
   fun env  ->
-    let uu____18007 = FStar_ST.op_Bang last_env  in
-    match uu____18007 with
+    let uu____17976 = FStar_ST.op_Bang last_env  in
+    match uu____17976 with
     | [] -> failwith "Empty env stack"
-    | uu____18034::tl -> FStar_ST.op_Colon_Equals last_env (env :: tl)
+    | uu____18003::tl -> FStar_ST.op_Colon_Equals last_env (env :: tl)
   
 let (push_env : unit -> unit) =
-  fun uu____18066  ->
-    let uu____18067 = FStar_ST.op_Bang last_env  in
-    match uu____18067 with
+  fun uu____18035  ->
+    let uu____18036 = FStar_ST.op_Bang last_env  in
+    match uu____18036 with
     | [] -> failwith "Empty env stack"
     | hd::tl ->
         let top = copy_env hd  in
         FStar_ST.op_Colon_Equals last_env (top :: hd :: tl)
   
 let (pop_env : unit -> unit) =
-  fun uu____18127  ->
-    let uu____18128 = FStar_ST.op_Bang last_env  in
-    match uu____18128 with
+  fun uu____18096  ->
+    let uu____18097 = FStar_ST.op_Bang last_env  in
+    match uu____18097 with
     | [] -> failwith "Popping an empty stack"
-    | uu____18155::tl -> FStar_ST.op_Colon_Equals last_env tl
+    | uu____18124::tl -> FStar_ST.op_Colon_Equals last_env tl
   
 let (snapshot_env : unit -> (Prims.int * unit)) =
-  fun uu____18192  -> FStar_Common.snapshot push_env last_env () 
+  fun uu____18161  -> FStar_Common.snapshot push_env last_env () 
 let (rollback_env : Prims.int FStar_Pervasives_Native.option -> unit) =
   fun depth  -> FStar_Common.rollback pop_env last_env depth 
 let (init : FStar_TypeChecker_Env.env -> unit) =
@@ -7385,17 +7374,17 @@ let (snapshot :
   Prims.string -> (FStar_TypeChecker_Env.solver_depth_t * unit)) =
   fun msg  ->
     FStar_Util.atomically
-      (fun uu____18245  ->
-         let uu____18246 = snapshot_env ()  in
-         match uu____18246 with
+      (fun uu____18214  ->
+         let uu____18215 = snapshot_env ()  in
+         match uu____18215 with
          | (env_depth,()) ->
-             let uu____18268 =
+             let uu____18237 =
                FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.snapshot ()
                 in
-             (match uu____18268 with
+             (match uu____18237 with
               | (varops_depth,()) ->
-                  let uu____18290 = FStar_SMTEncoding_Z3.snapshot msg  in
-                  (match uu____18290 with
+                  let uu____18259 = FStar_SMTEncoding_Z3.snapshot msg  in
+                  (match uu____18259 with
                    | (z3_depth,()) ->
                        ((env_depth, varops_depth, z3_depth), ()))))
   
@@ -7407,8 +7396,8 @@ let (rollback :
   fun msg  ->
     fun depth  ->
       FStar_Util.atomically
-        (fun uu____18348  ->
-           let uu____18349 =
+        (fun uu____18317  ->
+           let uu____18318 =
              match depth with
              | FStar_Pervasives_Native.Some (s1,s2,s3) ->
                  ((FStar_Pervasives_Native.Some s1),
@@ -7418,7 +7407,7 @@ let (rollback :
                  (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None,
                    FStar_Pervasives_Native.None)
               in
-           match uu____18349 with
+           match uu____18318 with
            | (env_depth,varops_depth,z3_depth) ->
                (rollback_env env_depth;
                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.rollback
@@ -7426,7 +7415,7 @@ let (rollback :
                 FStar_SMTEncoding_Z3.rollback msg z3_depth))
   
 let (push : Prims.string -> unit) =
-  fun msg  -> let uu____18444 = snapshot msg  in () 
+  fun msg  -> let uu____18413 = snapshot msg  in () 
 let (pop : Prims.string -> unit) =
   fun msg  -> rollback msg FStar_Pervasives_Native.None 
 let (open_fact_db_tags :
@@ -7441,19 +7430,19 @@ let (place_decl_in_fact_dbs :
     fun fact_db_ids  ->
       fun d  ->
         match (fact_db_ids, d) with
-        | (uu____18490::uu____18491,FStar_SMTEncoding_Term.Assume a) ->
+        | (uu____18459::uu____18460,FStar_SMTEncoding_Term.Assume a) ->
             FStar_SMTEncoding_Term.Assume
-              (let uu___1633_18499 = a  in
+              (let uu___1633_18468 = a  in
                {
                  FStar_SMTEncoding_Term.assumption_term =
-                   (uu___1633_18499.FStar_SMTEncoding_Term.assumption_term);
+                   (uu___1633_18468.FStar_SMTEncoding_Term.assumption_term);
                  FStar_SMTEncoding_Term.assumption_caption =
-                   (uu___1633_18499.FStar_SMTEncoding_Term.assumption_caption);
+                   (uu___1633_18468.FStar_SMTEncoding_Term.assumption_caption);
                  FStar_SMTEncoding_Term.assumption_name =
-                   (uu___1633_18499.FStar_SMTEncoding_Term.assumption_name);
+                   (uu___1633_18468.FStar_SMTEncoding_Term.assumption_name);
                  FStar_SMTEncoding_Term.assumption_fact_ids = fact_db_ids
                })
-        | uu____18500 -> d
+        | uu____18469 -> d
   
 let (place_decl_elt_in_fact_dbs :
   FStar_SMTEncoding_Env.env_t ->
@@ -7463,19 +7452,19 @@ let (place_decl_elt_in_fact_dbs :
   fun env  ->
     fun fact_db_ids  ->
       fun elt  ->
-        let uu___1639_18527 = elt  in
-        let uu____18528 =
+        let uu___1639_18496 = elt  in
+        let uu____18497 =
           FStar_All.pipe_right elt.FStar_SMTEncoding_Term.decls
             (FStar_List.map (place_decl_in_fact_dbs env fact_db_ids))
            in
         {
           FStar_SMTEncoding_Term.sym_name =
-            (uu___1639_18527.FStar_SMTEncoding_Term.sym_name);
+            (uu___1639_18496.FStar_SMTEncoding_Term.sym_name);
           FStar_SMTEncoding_Term.key =
-            (uu___1639_18527.FStar_SMTEncoding_Term.key);
-          FStar_SMTEncoding_Term.decls = uu____18528;
+            (uu___1639_18496.FStar_SMTEncoding_Term.key);
+          FStar_SMTEncoding_Term.decls = uu____18497;
           FStar_SMTEncoding_Term.a_names =
-            (uu___1639_18527.FStar_SMTEncoding_Term.a_names)
+            (uu___1639_18496.FStar_SMTEncoding_Term.a_names)
         }
   
 let (fact_dbs_for_lid :
@@ -7484,16 +7473,16 @@ let (fact_dbs_for_lid :
   =
   fun env  ->
     fun lid  ->
-      let uu____18548 =
-        let uu____18551 =
-          let uu____18552 =
-            let uu____18553 = FStar_Ident.ns_of_lid lid  in
-            FStar_Ident.lid_of_ids uu____18553  in
-          FStar_SMTEncoding_Term.Namespace uu____18552  in
-        let uu____18554 = open_fact_db_tags env  in uu____18551 ::
-          uu____18554
+      let uu____18517 =
+        let uu____18520 =
+          let uu____18521 =
+            let uu____18522 = FStar_Ident.ns_of_lid lid  in
+            FStar_Ident.lid_of_ids uu____18522  in
+          FStar_SMTEncoding_Term.Namespace uu____18521  in
+        let uu____18523 = open_fact_db_tags env  in uu____18520 ::
+          uu____18523
          in
-      (FStar_SMTEncoding_Term.Name lid) :: uu____18548
+      (FStar_SMTEncoding_Term.Name lid) :: uu____18517
   
 let (encode_top_level_facts :
   FStar_SMTEncoding_Env.env_t ->
@@ -7507,8 +7496,8 @@ let (encode_top_level_facts :
         FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
           (FStar_List.collect (fact_dbs_for_lid env))
          in
-      let uu____18581 = encode_sigelt env se  in
-      match uu____18581 with
+      let uu____18550 = encode_sigelt env se  in
+      match uu____18550 with
       | (g,env1) ->
           let g1 =
             FStar_All.pipe_right g
@@ -7529,27 +7518,27 @@ let (recover_caching_and_update_env :
                 elt.FStar_SMTEncoding_Term.key = FStar_Pervasives_Native.None
               then [elt]
               else
-                (let uu____18627 =
-                   let uu____18630 =
+                (let uu____18596 =
+                   let uu____18599 =
                      FStar_All.pipe_right elt.FStar_SMTEncoding_Term.key
                        FStar_Util.must
                       in
                    FStar_Util.smap_try_find
-                     env.FStar_SMTEncoding_Env.global_cache uu____18630
+                     env.FStar_SMTEncoding_Env.global_cache uu____18599
                     in
-                 match uu____18627 with
+                 match uu____18596 with
                  | FStar_Pervasives_Native.Some cache_elt ->
                      FStar_All.pipe_right
                        [FStar_SMTEncoding_Term.RetainAssumptions
                           (cache_elt.FStar_SMTEncoding_Term.a_names)]
                        FStar_SMTEncoding_Term.mk_decls_trivial
                  | FStar_Pervasives_Native.None  ->
-                     ((let uu____18645 =
+                     ((let uu____18614 =
                          FStar_All.pipe_right elt.FStar_SMTEncoding_Term.key
                            FStar_Util.must
                           in
                        FStar_Util.smap_add
-                         env.FStar_SMTEncoding_Env.global_cache uu____18645
+                         env.FStar_SMTEncoding_Env.global_cache uu____18614
                          elt);
                       [elt]))))
   
@@ -7558,47 +7547,47 @@ let (encode_sig :
   fun tcenv  ->
     fun se  ->
       let caption decls =
-        let uu____18675 = FStar_Options.log_queries ()  in
-        if uu____18675
+        let uu____18644 = FStar_Options.log_queries ()  in
+        if uu____18644
         then
-          let uu____18680 =
-            let uu____18681 =
-              let uu____18683 =
-                let uu____18685 =
+          let uu____18649 =
+            let uu____18650 =
+              let uu____18652 =
+                let uu____18654 =
                   FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
                     (FStar_List.map FStar_Syntax_Print.lid_to_string)
                    in
-                FStar_All.pipe_right uu____18685 (FStar_String.concat ", ")
+                FStar_All.pipe_right uu____18654 (FStar_String.concat ", ")
                  in
-              Prims.op_Hat "encoding sigelt " uu____18683  in
-            FStar_SMTEncoding_Term.Caption uu____18681  in
-          uu____18680 :: decls
+              Prims.op_Hat "encoding sigelt " uu____18652  in
+            FStar_SMTEncoding_Term.Caption uu____18650  in
+          uu____18649 :: decls
         else decls  in
-      (let uu____18704 =
+      (let uu____18673 =
          FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-       if uu____18704
+       if uu____18673
        then
-         let uu____18707 = FStar_Syntax_Print.sigelt_to_string se  in
-         FStar_Util.print1 "+++++++++++Encoding sigelt %s\n" uu____18707
+         let uu____18676 = FStar_Syntax_Print.sigelt_to_string se  in
+         FStar_Util.print1 "+++++++++++Encoding sigelt %s\n" uu____18676
        else ());
       (let env =
-         let uu____18713 = FStar_TypeChecker_Env.current_module tcenv  in
-         get_env uu____18713 tcenv  in
-       let uu____18714 = encode_top_level_facts env se  in
-       match uu____18714 with
+         let uu____18682 = FStar_TypeChecker_Env.current_module tcenv  in
+         get_env uu____18682 tcenv  in
+       let uu____18683 = encode_top_level_facts env se  in
+       match uu____18683 with
        | (decls,env1) ->
            (set_env env1;
-            (let uu____18728 =
-               let uu____18731 =
-                 let uu____18734 =
+            (let uu____18697 =
+               let uu____18700 =
+                 let uu____18703 =
                    FStar_All.pipe_right decls
                      (recover_caching_and_update_env env1)
                     in
-                 FStar_All.pipe_right uu____18734
+                 FStar_All.pipe_right uu____18703
                    FStar_SMTEncoding_Term.decls_list_of
                   in
-               caption uu____18731  in
-             FStar_SMTEncoding_Z3.giveZ3 uu____18728)))
+               caption uu____18700  in
+             FStar_SMTEncoding_Z3.giveZ3 uu____18697)))
   
 let (give_decls_to_z3_and_set_env :
   FStar_SMTEncoding_Env.env_t ->
@@ -7608,8 +7597,8 @@ let (give_decls_to_z3_and_set_env :
     fun name  ->
       fun decls  ->
         let caption decls1 =
-          let uu____18767 = FStar_Options.log_queries ()  in
-          if uu____18767
+          let uu____18736 = FStar_Options.log_queries ()  in
+          if uu____18736
           then
             let msg = Prims.op_Hat "Externals for " name  in
             [FStar_SMTEncoding_Term.Module
@@ -7619,40 +7608,40 @@ let (give_decls_to_z3_and_set_env :
                     [FStar_SMTEncoding_Term.Caption (Prims.op_Hat "End " msg)]))]
           else [FStar_SMTEncoding_Term.Module (name, decls1)]  in
         set_env
-          (let uu___1677_18787 = env  in
+          (let uu___1677_18756 = env  in
            {
              FStar_SMTEncoding_Env.bvar_bindings =
-               (uu___1677_18787.FStar_SMTEncoding_Env.bvar_bindings);
+               (uu___1677_18756.FStar_SMTEncoding_Env.bvar_bindings);
              FStar_SMTEncoding_Env.fvar_bindings =
-               (uu___1677_18787.FStar_SMTEncoding_Env.fvar_bindings);
+               (uu___1677_18756.FStar_SMTEncoding_Env.fvar_bindings);
              FStar_SMTEncoding_Env.depth =
-               (uu___1677_18787.FStar_SMTEncoding_Env.depth);
+               (uu___1677_18756.FStar_SMTEncoding_Env.depth);
              FStar_SMTEncoding_Env.tcenv =
-               (uu___1677_18787.FStar_SMTEncoding_Env.tcenv);
+               (uu___1677_18756.FStar_SMTEncoding_Env.tcenv);
              FStar_SMTEncoding_Env.warn = true;
              FStar_SMTEncoding_Env.nolabels =
-               (uu___1677_18787.FStar_SMTEncoding_Env.nolabels);
+               (uu___1677_18756.FStar_SMTEncoding_Env.nolabels);
              FStar_SMTEncoding_Env.use_zfuel_name =
-               (uu___1677_18787.FStar_SMTEncoding_Env.use_zfuel_name);
+               (uu___1677_18756.FStar_SMTEncoding_Env.use_zfuel_name);
              FStar_SMTEncoding_Env.encode_non_total_function_typ =
-               (uu___1677_18787.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+               (uu___1677_18756.FStar_SMTEncoding_Env.encode_non_total_function_typ);
              FStar_SMTEncoding_Env.current_module_name =
-               (uu___1677_18787.FStar_SMTEncoding_Env.current_module_name);
+               (uu___1677_18756.FStar_SMTEncoding_Env.current_module_name);
              FStar_SMTEncoding_Env.encoding_quantifier =
-               (uu___1677_18787.FStar_SMTEncoding_Env.encoding_quantifier);
+               (uu___1677_18756.FStar_SMTEncoding_Env.encoding_quantifier);
              FStar_SMTEncoding_Env.global_cache =
-               (uu___1677_18787.FStar_SMTEncoding_Env.global_cache)
+               (uu___1677_18756.FStar_SMTEncoding_Env.global_cache)
            });
         (let z3_decls =
-           let uu____18792 =
-             let uu____18795 =
+           let uu____18761 =
+             let uu____18764 =
                FStar_All.pipe_right decls
                  (recover_caching_and_update_env env)
                 in
-             FStar_All.pipe_right uu____18795
+             FStar_All.pipe_right uu____18764
                FStar_SMTEncoding_Term.decls_list_of
               in
-           caption uu____18792  in
+           caption uu____18761  in
          FStar_SMTEncoding_Z3.giveZ3 z3_decls)
   
 let (encode_modul :
@@ -7663,100 +7652,100 @@ let (encode_modul :
   =
   fun tcenv  ->
     fun modul  ->
-      let uu____18815 = (FStar_Options.lax ()) && (FStar_Options.ml_ish ())
+      let uu____18784 = (FStar_Options.lax ()) && (FStar_Options.ml_ish ())
          in
-      if uu____18815
+      if uu____18784
       then ([], [])
       else
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____18848  ->
+          (fun uu____18817  ->
              FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.reset_fresh
                ();
              (let name =
-                let uu____18852 =
+                let uu____18821 =
                   FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name
                    in
                 FStar_Util.format2 "%s %s"
                   (if modul.FStar_Syntax_Syntax.is_interface
                    then "interface"
-                   else "module") uu____18852
+                   else "module") uu____18821
                  in
-              (let uu____18862 =
+              (let uu____18831 =
                  FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-               if uu____18862
+               if uu____18831
                then
-                 let uu____18865 =
+                 let uu____18834 =
                    FStar_All.pipe_right
                      (FStar_List.length modul.FStar_Syntax_Syntax.exports)
                      Prims.string_of_int
                     in
                  FStar_Util.print2
                    "+++++++++++Encoding externals for %s ... %s exports\n"
-                   name uu____18865
+                   name uu____18834
                else ());
               (let env =
-                 let uu____18873 =
+                 let uu____18842 =
                    get_env modul.FStar_Syntax_Syntax.name tcenv  in
-                 FStar_All.pipe_right uu____18873
+                 FStar_All.pipe_right uu____18842
                    FStar_SMTEncoding_Env.reset_current_module_fvbs
                   in
                let encode_signature env1 ses =
                  FStar_All.pipe_right ses
                    (FStar_List.fold_left
-                      (fun uu____18912  ->
+                      (fun uu____18881  ->
                          fun se  ->
-                           match uu____18912 with
+                           match uu____18881 with
                            | (g,env2) ->
-                               let uu____18932 =
+                               let uu____18901 =
                                  encode_top_level_facts env2 se  in
-                               (match uu____18932 with
+                               (match uu____18901 with
                                 | (g',env3) ->
                                     ((FStar_List.append g g'), env3)))
                       ([], env1))
                   in
-               let uu____18955 =
+               let uu____18924 =
                  encode_signature
-                   (let uu___1701_18964 = env  in
+                   (let uu___1701_18933 = env  in
                     {
                       FStar_SMTEncoding_Env.bvar_bindings =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.bvar_bindings);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.bvar_bindings);
                       FStar_SMTEncoding_Env.fvar_bindings =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.fvar_bindings);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.fvar_bindings);
                       FStar_SMTEncoding_Env.depth =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.depth);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.depth);
                       FStar_SMTEncoding_Env.tcenv =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.tcenv);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.tcenv);
                       FStar_SMTEncoding_Env.warn = false;
                       FStar_SMTEncoding_Env.nolabels =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.nolabels);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.nolabels);
                       FStar_SMTEncoding_Env.use_zfuel_name =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.use_zfuel_name);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.use_zfuel_name);
                       FStar_SMTEncoding_Env.encode_non_total_function_typ =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.encode_non_total_function_typ);
                       FStar_SMTEncoding_Env.current_module_name =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.current_module_name);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.current_module_name);
                       FStar_SMTEncoding_Env.encoding_quantifier =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.encoding_quantifier);
+                        (uu___1701_18933.FStar_SMTEncoding_Env.encoding_quantifier);
                       FStar_SMTEncoding_Env.global_cache =
-                        (uu___1701_18964.FStar_SMTEncoding_Env.global_cache)
+                        (uu___1701_18933.FStar_SMTEncoding_Env.global_cache)
                     }) modul.FStar_Syntax_Syntax.exports
                   in
-               match uu____18955 with
+               match uu____18924 with
                | (decls,env1) ->
                    (give_decls_to_z3_and_set_env env1 name decls;
-                    (let uu____18982 =
+                    (let uu____18951 =
                        FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium
                         in
-                     if uu____18982
+                     if uu____18951
                      then
                        FStar_Util.print1 "Done encoding externals for %s\n"
                          name
                      else ());
-                    (let uu____18988 =
+                    (let uu____18957 =
                        FStar_All.pipe_right env1
                          FStar_SMTEncoding_Env.get_current_module_fvbs
                         in
-                     (decls, uu____18988))))))
+                     (decls, uu____18957))))))
   
 let (encode_modul_from_cache :
   FStar_TypeChecker_Env.env ->
@@ -7766,45 +7755,45 @@ let (encode_modul_from_cache :
   =
   fun tcenv  ->
     fun tcmod  ->
-      fun uu____19018  ->
-        match uu____19018 with
+      fun uu____18987  ->
+        match uu____18987 with
         | (decls,fvbs) ->
-            let uu____19031 =
+            let uu____19000 =
               (FStar_Options.lax ()) && (FStar_Options.ml_ish ())  in
-            if uu____19031
+            if uu____19000
             then ()
             else
               (let name =
-                 let uu____19038 =
+                 let uu____19007 =
                    FStar_Ident.string_of_lid tcmod.FStar_Syntax_Syntax.name
                     in
                  FStar_Util.format2 "%s %s"
                    (if tcmod.FStar_Syntax_Syntax.is_interface
                     then "interface"
-                    else "module") uu____19038
+                    else "module") uu____19007
                   in
-               (let uu____19048 =
+               (let uu____19017 =
                   FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-                if uu____19048
+                if uu____19017
                 then
-                  let uu____19051 =
+                  let uu____19020 =
                     FStar_All.pipe_right (FStar_List.length decls)
                       Prims.string_of_int
                      in
                   FStar_Util.print2
                     "+++++++++++Encoding externals from cache for %s ... %s decls\n"
-                    name uu____19051
+                    name uu____19020
                 else ());
                (let env =
-                  let uu____19059 =
+                  let uu____19028 =
                     get_env tcmod.FStar_Syntax_Syntax.name tcenv  in
-                  FStar_All.pipe_right uu____19059
+                  FStar_All.pipe_right uu____19028
                     FStar_SMTEncoding_Env.reset_current_module_fvbs
                    in
                 let env1 =
-                  let uu____19061 = FStar_All.pipe_right fvbs FStar_List.rev
+                  let uu____19030 = FStar_All.pipe_right fvbs FStar_List.rev
                      in
-                  FStar_All.pipe_right uu____19061
+                  FStar_All.pipe_right uu____19030
                     (FStar_List.fold_left
                        (fun env1  ->
                           fun fvb  ->
@@ -7812,9 +7801,9 @@ let (encode_modul_from_cache :
                               env1) env)
                    in
                 give_decls_to_z3_and_set_env env1 name decls;
-                (let uu____19075 =
+                (let uu____19044 =
                    FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium  in
-                 if uu____19075
+                 if uu____19044
                  then
                    FStar_Util.print1
                      "Done encoding externals from cache for %s\n" name
@@ -7832,36 +7821,36 @@ let (encode_query :
   fun use_env_msg  ->
     fun tcenv  ->
       fun q  ->
-        (let uu____19137 =
-           let uu____19139 = FStar_TypeChecker_Env.current_module tcenv  in
-           FStar_Ident.string_of_lid uu____19139  in
+        (let uu____19106 =
+           let uu____19108 = FStar_TypeChecker_Env.current_module tcenv  in
+           FStar_Ident.string_of_lid uu____19108  in
          FStar_SMTEncoding_Z3.query_logging.FStar_SMTEncoding_Z3.set_module_name
-           uu____19137);
+           uu____19106);
         (let env =
-           let uu____19141 = FStar_TypeChecker_Env.current_module tcenv  in
-           get_env uu____19141 tcenv  in
-         let uu____19142 =
+           let uu____19110 = FStar_TypeChecker_Env.current_module tcenv  in
+           get_env uu____19110 tcenv  in
+         let uu____19111 =
            let rec aux bindings =
              match bindings with
              | (FStar_Syntax_Syntax.Binding_var x)::rest ->
-                 let uu____19179 = aux rest  in
-                 (match uu____19179 with
+                 let uu____19148 = aux rest  in
+                 (match uu____19148 with
                   | (out,rest1) ->
                       let t =
-                        let uu____19207 =
+                        let uu____19176 =
                           FStar_Syntax_Util.destruct_typ_as_formula
                             x.FStar_Syntax_Syntax.sort
                            in
-                        match uu____19207 with
-                        | FStar_Pervasives_Native.Some uu____19210 ->
-                            let uu____19211 =
+                        match uu____19176 with
+                        | FStar_Pervasives_Native.Some uu____19179 ->
+                            let uu____19180 =
                               FStar_Syntax_Syntax.new_bv
                                 FStar_Pervasives_Native.None
                                 FStar_Syntax_Syntax.t_unit
                                in
-                            FStar_Syntax_Util.refine uu____19211
+                            FStar_Syntax_Util.refine uu____19180
                               x.FStar_Syntax_Syntax.sort
-                        | uu____19212 -> x.FStar_Syntax_Syntax.sort  in
+                        | uu____19181 -> x.FStar_Syntax_Syntax.sort  in
                       let t1 =
                         norm_with_steps
                           [FStar_TypeChecker_Env.Eager_unfolding;
@@ -7871,36 +7860,36 @@ let (encode_query :
                           FStar_TypeChecker_Env.EraseUniverses]
                           env.FStar_SMTEncoding_Env.tcenv t
                          in
-                      let uu____19216 =
-                        let uu____19219 =
+                      let uu____19185 =
+                        let uu____19188 =
                           FStar_Syntax_Syntax.mk_binder
-                            (let uu___1744_19222 = x  in
+                            (let uu___1744_19191 = x  in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___1744_19222.FStar_Syntax_Syntax.ppname);
+                                 (uu___1744_19191.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___1744_19222.FStar_Syntax_Syntax.index);
+                                 (uu___1744_19191.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = t1
                              })
                            in
-                        uu____19219 :: out  in
-                      (uu____19216, rest1))
-             | uu____19227 -> ([], bindings)  in
-           let uu____19234 = aux tcenv.FStar_TypeChecker_Env.gamma  in
-           match uu____19234 with
+                        uu____19188 :: out  in
+                      (uu____19185, rest1))
+             | uu____19196 -> ([], bindings)  in
+           let uu____19203 = aux tcenv.FStar_TypeChecker_Env.gamma  in
+           match uu____19203 with
            | (closing,bindings) ->
-               let uu____19259 =
+               let uu____19228 =
                  FStar_Syntax_Util.close_forall_no_univs
                    (FStar_List.rev closing) q
                   in
-               (uu____19259, bindings)
+               (uu____19228, bindings)
             in
-         match uu____19142 with
+         match uu____19111 with
          | (q1,bindings) ->
-             let uu____19282 = encode_env_bindings env bindings  in
-             (match uu____19282 with
+             let uu____19251 = encode_env_bindings env bindings  in
+             (match uu____19251 with
               | (env_decls,env1) ->
-                  ((let uu____19304 =
+                  ((let uu____19273 =
                       ((FStar_TypeChecker_Env.debug tcenv
                           FStar_Options.Medium)
                          ||
@@ -7912,94 +7901,94 @@ let (encode_query :
                            (FStar_TypeChecker_Env.debug tcenv)
                            (FStar_Options.Other "SMTQuery"))
                        in
-                    if uu____19304
+                    if uu____19273
                     then
-                      let uu____19311 = FStar_Syntax_Print.term_to_string q1
+                      let uu____19280 = FStar_Syntax_Print.term_to_string q1
                          in
                       FStar_Util.print1 "Encoding query formula {: %s\n"
-                        uu____19311
+                        uu____19280
                     else ());
-                   (let uu____19316 =
+                   (let uu____19285 =
                       FStar_Util.record_time
-                        (fun uu____19331  ->
+                        (fun uu____19300  ->
                            FStar_SMTEncoding_EncodeTerm.encode_formula q1
                              env1)
                        in
-                    match uu____19316 with
+                    match uu____19285 with
                     | ((phi,qdecls),ms) ->
-                        let uu____19355 =
-                          let uu____19360 =
+                        let uu____19324 =
+                          let uu____19329 =
                             FStar_TypeChecker_Env.get_range tcenv  in
                           FStar_SMTEncoding_ErrorReporting.label_goals
-                            use_env_msg uu____19360 phi
+                            use_env_msg uu____19329 phi
                            in
-                        (match uu____19355 with
+                        (match uu____19324 with
                          | (labels,phi1) ->
-                             let uu____19377 = encode_labels labels  in
-                             (match uu____19377 with
+                             let uu____19346 = encode_labels labels  in
+                             (match uu____19346 with
                               | (label_prefix,label_suffix) ->
                                   let caption =
-                                    let uu____19413 =
+                                    let uu____19382 =
                                       FStar_Options.log_queries ()  in
-                                    if uu____19413
+                                    if uu____19382
                                     then
-                                      let uu____19418 =
-                                        let uu____19419 =
-                                          let uu____19421 =
+                                      let uu____19387 =
+                                        let uu____19388 =
+                                          let uu____19390 =
                                             FStar_Syntax_Print.term_to_string
                                               q1
                                              in
                                           Prims.op_Hat
                                             "Encoding query formula : "
-                                            uu____19421
+                                            uu____19390
                                            in
                                         FStar_SMTEncoding_Term.Caption
-                                          uu____19419
+                                          uu____19388
                                          in
-                                      [uu____19418]
+                                      [uu____19387]
                                     else []  in
                                   let query_prelude =
-                                    let uu____19429 =
-                                      let uu____19430 =
-                                        let uu____19431 =
-                                          let uu____19434 =
+                                    let uu____19398 =
+                                      let uu____19399 =
+                                        let uu____19400 =
+                                          let uu____19403 =
                                             FStar_All.pipe_right label_prefix
                                               FStar_SMTEncoding_Term.mk_decls_trivial
                                              in
-                                          let uu____19441 =
-                                            let uu____19444 =
+                                          let uu____19410 =
+                                            let uu____19413 =
                                               FStar_All.pipe_right caption
                                                 FStar_SMTEncoding_Term.mk_decls_trivial
                                                in
                                             FStar_List.append qdecls
-                                              uu____19444
+                                              uu____19413
                                              in
-                                          FStar_List.append uu____19434
-                                            uu____19441
+                                          FStar_List.append uu____19403
+                                            uu____19410
                                            in
                                         FStar_List.append env_decls
-                                          uu____19431
+                                          uu____19400
                                          in
-                                      FStar_All.pipe_right uu____19430
+                                      FStar_All.pipe_right uu____19399
                                         (recover_caching_and_update_env env1)
                                        in
-                                    FStar_All.pipe_right uu____19429
+                                    FStar_All.pipe_right uu____19398
                                       FStar_SMTEncoding_Term.decls_list_of
                                      in
                                   let qry =
-                                    let uu____19454 =
-                                      let uu____19462 =
+                                    let uu____19423 =
+                                      let uu____19431 =
                                         FStar_SMTEncoding_Util.mkNot phi1  in
-                                      let uu____19463 =
+                                      let uu____19432 =
                                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.mk_unique
                                           "@query"
                                          in
-                                      (uu____19462,
+                                      (uu____19431,
                                         (FStar_Pervasives_Native.Some "query"),
-                                        uu____19463)
+                                        uu____19432)
                                        in
                                     FStar_SMTEncoding_Util.mkAssume
-                                      uu____19454
+                                      uu____19423
                                      in
                                   let suffix =
                                     FStar_List.append
@@ -8009,7 +7998,7 @@ let (encode_query :
                                             "</labels>";
                                          FStar_SMTEncoding_Term.Echo "Done!"])
                                      in
-                                  ((let uu____19476 =
+                                  ((let uu____19445 =
                                       ((FStar_TypeChecker_Env.debug tcenv
                                           FStar_Options.Medium)
                                          ||
@@ -8023,12 +8012,12 @@ let (encode_query :
                                            (FStar_TypeChecker_Env.debug tcenv)
                                            (FStar_Options.Other "SMTQuery"))
                                        in
-                                    if uu____19476
+                                    if uu____19445
                                     then
                                       FStar_Util.print_string
                                         "} Done encoding\n"
                                     else ());
-                                   (let uu____19487 =
+                                   (let uu____19456 =
                                       (((FStar_TypeChecker_Env.debug tcenv
                                            FStar_Options.Medium)
                                           ||
@@ -8047,7 +8036,7 @@ let (encode_query :
                                            (FStar_TypeChecker_Env.debug tcenv)
                                            (FStar_Options.Other "Time"))
                                        in
-                                    if uu____19487
+                                    if uu____19456
                                     then
                                       FStar_Util.print1
                                         "Encoding took %sms\n"

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -2485,150 +2485,146 @@ and (encode_term :
                                 "Result of normalization %s\n" uu____7125
                             else ());
                            (let e =
-                              let uu____7133 =
-                                let uu____7138 =
-                                  FStar_TypeChecker_Util.remove_reify e0  in
-                                let uu____7139 = FStar_List.tl args_e1  in
-                                FStar_Syntax_Syntax.mk_Tm_app uu____7138
-                                  uu____7139
-                                 in
-                              uu____7133 FStar_Pervasives_Native.None
-                                t0.FStar_Syntax_Syntax.pos
+                              let uu____7131 =
+                                FStar_TypeChecker_Util.remove_reify e0  in
+                              let uu____7132 = FStar_List.tl args_e1  in
+                              FStar_Syntax_Syntax.mk_Tm_app uu____7131
+                                uu____7132 t0.FStar_Syntax_Syntax.pos
                                in
                             encode_term e env))
                       | (FStar_Syntax_Syntax.Tm_constant
                          (FStar_Const.Const_reflect
-                         uu____7148),(arg,uu____7150)::[]) ->
+                         uu____7141),(arg,uu____7143)::[]) ->
                           encode_term arg env
-                      | uu____7185 ->
-                          let uu____7200 = encode_args args_e1 env  in
-                          (match uu____7200 with
+                      | uu____7178 ->
+                          let uu____7193 = encode_args args_e1 env  in
+                          (match uu____7193 with
                            | (args,decls) ->
                                let encode_partial_app ht_opt =
-                                 let uu____7269 = encode_term head1 env  in
-                                 match uu____7269 with
+                                 let uu____7262 = encode_term head1 env  in
+                                 match uu____7262 with
                                  | (smt_head,decls') ->
                                      let app_tm = mk_Apply_args smt_head args
                                         in
                                      (match ht_opt with
-                                      | uu____7289 when
+                                      | uu____7282 when
                                           Prims.int_one = Prims.int_one ->
                                           (app_tm,
                                             (FStar_List.append decls decls'))
                                       | FStar_Pervasives_Native.Some
                                           (head_type,formals,c) ->
-                                          ((let uu____7361 =
+                                          ((let uu____7354 =
                                               FStar_TypeChecker_Env.debug
                                                 env.FStar_SMTEncoding_Env.tcenv
                                                 (FStar_Options.Other
                                                    "PartialApp")
                                                in
-                                            if uu____7361
+                                            if uu____7354
                                             then
-                                              let uu____7365 =
+                                              let uu____7358 =
                                                 FStar_Syntax_Print.term_to_string
                                                   head1
                                                  in
-                                              let uu____7367 =
+                                              let uu____7360 =
                                                 FStar_Syntax_Print.term_to_string
                                                   head_type
                                                  in
-                                              let uu____7369 =
+                                              let uu____7362 =
                                                 FStar_Syntax_Print.binders_to_string
                                                   ", " formals
                                                  in
-                                              let uu____7372 =
+                                              let uu____7365 =
                                                 FStar_Syntax_Print.comp_to_string
                                                   c
                                                  in
-                                              let uu____7374 =
+                                              let uu____7367 =
                                                 FStar_Syntax_Print.args_to_string
                                                   args_e1
                                                  in
                                               FStar_Util.print5
                                                 "Encoding partial application:\n\thead=%s\n\thead_type=%s\n\tformals=%s\n\tcomp=%s\n\tactual args=%s\n"
-                                                uu____7365 uu____7367
-                                                uu____7369 uu____7372
-                                                uu____7374
+                                                uu____7358 uu____7360
+                                                uu____7362 uu____7365
+                                                uu____7367
                                             else ());
-                                           (let uu____7379 =
+                                           (let uu____7372 =
                                               FStar_Util.first_N
                                                 (FStar_List.length args_e1)
                                                 formals
                                                in
-                                            match uu____7379 with
+                                            match uu____7372 with
                                             | (formals1,rest) ->
                                                 let subst =
                                                   FStar_List.map2
-                                                    (fun uu____7477  ->
-                                                       fun uu____7478  ->
-                                                         match (uu____7477,
-                                                                 uu____7478)
+                                                    (fun uu____7470  ->
+                                                       fun uu____7471  ->
+                                                         match (uu____7470,
+                                                                 uu____7471)
                                                          with
-                                                         | ((bv,uu____7508),
-                                                            (a,uu____7510))
+                                                         | ((bv,uu____7501),
+                                                            (a,uu____7503))
                                                              ->
                                                              FStar_Syntax_Syntax.NT
                                                                (bv, a))
                                                     formals1 args_e1
                                                    in
                                                 let ty =
-                                                  let uu____7542 =
+                                                  let uu____7535 =
                                                     FStar_Syntax_Util.arrow
                                                       rest c
                                                      in
                                                   FStar_All.pipe_right
-                                                    uu____7542
+                                                    uu____7535
                                                     (FStar_Syntax_Subst.subst
                                                        subst)
                                                    in
-                                                ((let uu____7546 =
+                                                ((let uu____7539 =
                                                     FStar_TypeChecker_Env.debug
                                                       env.FStar_SMTEncoding_Env.tcenv
                                                       (FStar_Options.Other
                                                          "PartialApp")
                                                      in
-                                                  if uu____7546
+                                                  if uu____7539
                                                   then
-                                                    let uu____7550 =
+                                                    let uu____7543 =
                                                       FStar_Syntax_Print.term_to_string
                                                         ty
                                                        in
                                                     FStar_Util.print1
                                                       "Encoding partial application, after subst:\n\tty=%s\n"
-                                                      uu____7550
+                                                      uu____7543
                                                   else ());
-                                                 (let uu____7555 =
-                                                    let uu____7568 =
+                                                 (let uu____7548 =
+                                                    let uu____7561 =
                                                       FStar_List.fold_left2
-                                                        (fun uu____7603  ->
-                                                           fun uu____7604  ->
+                                                        (fun uu____7596  ->
+                                                           fun uu____7597  ->
                                                              fun e  ->
                                                                match 
-                                                                 (uu____7603,
-                                                                   uu____7604)
+                                                                 (uu____7596,
+                                                                   uu____7597)
                                                                with
                                                                | ((t_hyps,decls1),
-                                                                  (bv,uu____7645))
+                                                                  (bv,uu____7638))
                                                                    ->
                                                                    let t2 =
                                                                     FStar_Syntax_Subst.subst
                                                                     subst
                                                                     bv.FStar_Syntax_Syntax.sort
                                                                      in
-                                                                   let uu____7673
+                                                                   let uu____7666
                                                                     =
                                                                     encode_term_pred
                                                                     FStar_Pervasives_Native.None
                                                                     t2 env e
                                                                      in
-                                                                   (match uu____7673
+                                                                   (match uu____7666
                                                                     with
                                                                     | 
                                                                     (t_hyp,decls'1)
                                                                     ->
                                                                     ((
-                                                                    let uu____7689
+                                                                    let uu____7682
                                                                     =
                                                                     FStar_TypeChecker_Env.debug
                                                                     env.FStar_SMTEncoding_Env.tcenv
@@ -2636,20 +2632,20 @@ and (encode_term :
                                                                     "PartialApp")
                                                                      in
                                                                     if
-                                                                    uu____7689
+                                                                    uu____7682
                                                                     then
-                                                                    let uu____7693
+                                                                    let uu____7686
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2  in
-                                                                    let uu____7695
+                                                                    let uu____7688
                                                                     =
                                                                     FStar_SMTEncoding_Term.print_smt_term
                                                                     t_hyp  in
                                                                     FStar_Util.print2
                                                                     "Encoded typing hypothesis for %s ... got %s\n"
-                                                                    uu____7693
-                                                                    uu____7695
+                                                                    uu____7686
+                                                                    uu____7688
                                                                     else ());
                                                                     ((t_hyp
                                                                     ::
@@ -2660,22 +2656,22 @@ and (encode_term :
                                                         ([], []) formals1
                                                         args
                                                        in
-                                                    match uu____7568 with
+                                                    match uu____7561 with
                                                     | (t_hyps,decls1) ->
-                                                        let uu____7730 =
+                                                        let uu____7723 =
                                                           match smt_head.FStar_SMTEncoding_Term.tm
                                                           with
                                                           | FStar_SMTEncoding_Term.FreeV
-                                                              uu____7739 ->
+                                                              uu____7732 ->
                                                               encode_term_pred
                                                                 FStar_Pervasives_Native.None
                                                                 head_type env
                                                                 smt_head
-                                                          | uu____7748 ->
+                                                          | uu____7741 ->
                                                               (FStar_SMTEncoding_Util.mkTrue,
                                                                 [])
                                                            in
-                                                        (match uu____7730
+                                                        (match uu____7723
                                                          with
                                                          | (t_head_hyp,decls'1)
                                                              ->
@@ -2685,13 +2681,13 @@ and (encode_term :
                                                                  :: t_hyps)
                                                                  FStar_Range.dummyRange
                                                                 in
-                                                             let uu____7764 =
+                                                             let uu____7757 =
                                                                encode_term_pred
                                                                  FStar_Pervasives_Native.None
                                                                  ty env
                                                                  app_tm
                                                                 in
-                                                             (match uu____7764
+                                                             (match uu____7757
                                                               with
                                                               | (has_type_conclusion,decls'')
                                                                   ->
@@ -2710,60 +2706,60 @@ and (encode_term :
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     app_tm
                                                                      in
-                                                                  let uu____7786
+                                                                  let uu____7779
                                                                     =
-                                                                    let uu____7793
+                                                                    let uu____7786
                                                                     =
                                                                     FStar_SMTEncoding_Term.fvs_subset_of
                                                                     cvars
                                                                     app_tm_vars
                                                                      in
                                                                     if
-                                                                    uu____7793
+                                                                    uu____7786
                                                                     then
                                                                     ([app_tm],
                                                                     app_tm_vars)
                                                                     else
-                                                                    (let uu____7806
+                                                                    (let uu____7799
                                                                     =
-                                                                    let uu____7808
+                                                                    let uu____7801
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     has_type_conclusion
                                                                      in
                                                                     FStar_SMTEncoding_Term.fvs_subset_of
                                                                     cvars
-                                                                    uu____7808
+                                                                    uu____7801
                                                                      in
                                                                     if
-                                                                    uu____7806
+                                                                    uu____7799
                                                                     then
                                                                     ([has_type_conclusion],
                                                                     cvars)
                                                                     else
                                                                     ((
-                                                                    let uu____7821
+                                                                    let uu____7814
                                                                     =
-                                                                    let uu____7827
+                                                                    let uu____7820
                                                                     =
-                                                                    let uu____7829
+                                                                    let uu____7822
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t0  in
                                                                     FStar_Util.format1
                                                                     "No SMT pattern for partial application %s"
-                                                                    uu____7829
+                                                                    uu____7822
                                                                      in
                                                                     (FStar_Errors.Warning_SMTPatternIllFormed,
-                                                                    uu____7827)
+                                                                    uu____7820)
                                                                      in
                                                                     FStar_Errors.log_issue
                                                                     t0.FStar_Syntax_Syntax.pos
-                                                                    uu____7821);
+                                                                    uu____7814);
                                                                     ([],
                                                                     cvars)))
                                                                      in
-                                                                  (match uu____7786
+                                                                  (match uu____7779
                                                                    with
                                                                    | 
                                                                    (pattern1,vars)
@@ -2777,65 +2773,65 @@ and (encode_term :
                                                                     decls'1
                                                                     decls''))))))
                                                      in
-                                                  match uu____7555 with
+                                                  match uu____7548 with
                                                   | (vars,pattern1,has_type,decls'')
                                                       ->
-                                                      ((let uu____7876 =
+                                                      ((let uu____7869 =
                                                           FStar_TypeChecker_Env.debug
                                                             env.FStar_SMTEncoding_Env.tcenv
                                                             (FStar_Options.Other
                                                                "PartialApp")
                                                            in
-                                                        if uu____7876
+                                                        if uu____7869
                                                         then
-                                                          let uu____7880 =
+                                                          let uu____7873 =
                                                             FStar_SMTEncoding_Term.print_smt_term
                                                               has_type
                                                              in
                                                           FStar_Util.print1
                                                             "Encoding partial application, after SMT encoded predicate:\n\t=%s\n"
-                                                            uu____7880
+                                                            uu____7873
                                                         else ());
                                                        (let tkey_hash =
                                                           FStar_SMTEncoding_Term.hash_of_term
                                                             app_tm
                                                            in
                                                         let e_typing =
-                                                          let uu____7888 =
-                                                            let uu____7896 =
+                                                          let uu____7881 =
+                                                            let uu____7889 =
                                                               FStar_SMTEncoding_Term.mkForall
                                                                 t0.FStar_Syntax_Syntax.pos
                                                                 ([pattern1],
                                                                   vars,
                                                                   has_type)
                                                                in
-                                                            let uu____7905 =
-                                                              let uu____7907
+                                                            let uu____7898 =
+                                                              let uu____7900
                                                                 =
-                                                                let uu____7909
+                                                                let uu____7902
                                                                   =
                                                                   FStar_SMTEncoding_Term.hash_of_term
                                                                     app_tm
                                                                    in
                                                                 FStar_Util.digest_of_string
-                                                                  uu____7909
+                                                                  uu____7902
                                                                  in
                                                               Prims.op_Hat
                                                                 "partial_app_typing_"
-                                                                uu____7907
+                                                                uu____7900
                                                                in
-                                                            (uu____7896,
+                                                            (uu____7889,
                                                               (FStar_Pervasives_Native.Some
                                                                  "Partial app typing"),
-                                                              uu____7905)
+                                                              uu____7898)
                                                              in
                                                           FStar_SMTEncoding_Util.mkAssume
-                                                            uu____7888
+                                                            uu____7881
                                                            in
-                                                        let uu____7915 =
-                                                          let uu____7918 =
-                                                            let uu____7921 =
-                                                              let uu____7924
+                                                        let uu____7908 =
+                                                          let uu____7911 =
+                                                            let uu____7914 =
+                                                              let uu____7917
                                                                 =
                                                                 FStar_SMTEncoding_Term.mk_decls
                                                                   ""
@@ -2849,25 +2845,25 @@ and (encode_term :
                                                                  in
                                                               FStar_List.append
                                                                 decls''
-                                                                uu____7924
+                                                                uu____7917
                                                                in
                                                             FStar_List.append
                                                               decls'
-                                                              uu____7921
+                                                              uu____7914
                                                              in
                                                           FStar_List.append
-                                                            decls uu____7918
+                                                            decls uu____7911
                                                            in
-                                                        (app_tm, uu____7915)))))))
+                                                        (app_tm, uu____7908)))))))
                                       | FStar_Pervasives_Native.None  ->
                                           failwith "impossible")
                                   in
                                let encode_full_app fv =
-                                 let uu____7969 =
+                                 let uu____7962 =
                                    FStar_SMTEncoding_Env.lookup_free_var_sym
                                      env fv
                                     in
-                                 match uu____7969 with
+                                 match uu____7962 with
                                  | (fname,fuel_args,arity) ->
                                      let tm =
                                        maybe_curry_app
@@ -2885,8 +2881,8 @@ and (encode_term :
                                      ({
                                         FStar_Syntax_Syntax.n =
                                           FStar_Syntax_Syntax.Tm_name x;
-                                        FStar_Syntax_Syntax.pos = uu____8012;
-                                        FStar_Syntax_Syntax.vars = uu____8013;_},uu____8014)
+                                        FStar_Syntax_Syntax.pos = uu____8005;
+                                        FStar_Syntax_Syntax.vars = uu____8006;_},uu____8007)
                                      ->
                                      FStar_Pervasives_Native.Some
                                        (x.FStar_Syntax_Syntax.sort)
@@ -2897,58 +2893,58 @@ and (encode_term :
                                      ({
                                         FStar_Syntax_Syntax.n =
                                           FStar_Syntax_Syntax.Tm_fvar fv;
-                                        FStar_Syntax_Syntax.pos = uu____8021;
-                                        FStar_Syntax_Syntax.vars = uu____8022;_},uu____8023)
+                                        FStar_Syntax_Syntax.pos = uu____8014;
+                                        FStar_Syntax_Syntax.vars = uu____8015;_},uu____8016)
                                      ->
-                                     let uu____8028 =
-                                       let uu____8029 =
-                                         let uu____8034 =
+                                     let uu____8021 =
+                                       let uu____8022 =
+                                         let uu____8027 =
                                            FStar_TypeChecker_Env.lookup_lid
                                              env.FStar_SMTEncoding_Env.tcenv
                                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                             in
-                                         FStar_All.pipe_right uu____8034
+                                         FStar_All.pipe_right uu____8027
                                            FStar_Pervasives_Native.fst
                                           in
-                                       FStar_All.pipe_right uu____8029
+                                       FStar_All.pipe_right uu____8022
                                          FStar_Pervasives_Native.snd
                                         in
-                                     FStar_Pervasives_Native.Some uu____8028
+                                     FStar_Pervasives_Native.Some uu____8021
                                  | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                     let uu____8064 =
-                                       let uu____8065 =
-                                         let uu____8070 =
+                                     let uu____8057 =
+                                       let uu____8058 =
+                                         let uu____8063 =
                                            FStar_TypeChecker_Env.lookup_lid
                                              env.FStar_SMTEncoding_Env.tcenv
                                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                             in
-                                         FStar_All.pipe_right uu____8070
+                                         FStar_All.pipe_right uu____8063
                                            FStar_Pervasives_Native.fst
                                           in
-                                       FStar_All.pipe_right uu____8065
+                                       FStar_All.pipe_right uu____8058
                                          FStar_Pervasives_Native.snd
                                         in
-                                     FStar_Pervasives_Native.Some uu____8064
+                                     FStar_Pervasives_Native.Some uu____8057
                                  | FStar_Syntax_Syntax.Tm_ascribed
-                                     (uu____8099,(FStar_Util.Inl
-                                                  t2,uu____8101),uu____8102)
+                                     (uu____8092,(FStar_Util.Inl
+                                                  t2,uu____8094),uu____8095)
                                      -> FStar_Pervasives_Native.Some t2
                                  | FStar_Syntax_Syntax.Tm_ascribed
-                                     (uu____8149,(FStar_Util.Inr
-                                                  c,uu____8151),uu____8152)
+                                     (uu____8142,(FStar_Util.Inr
+                                                  c,uu____8144),uu____8145)
                                      ->
                                      FStar_Pervasives_Native.Some
                                        (FStar_Syntax_Util.comp_result c)
-                                 | uu____8199 -> FStar_Pervasives_Native.None
+                                 | uu____8192 -> FStar_Pervasives_Native.None
                                   in
                                (match head_type with
                                 | FStar_Pervasives_Native.None  ->
                                     encode_partial_app
                                       FStar_Pervasives_Native.None
                                 | FStar_Pervasives_Native.Some head_type1 ->
-                                    let uu____8223 =
+                                    let uu____8216 =
                                       let head_type2 =
-                                        let uu____8245 =
+                                        let uu____8238 =
                                           normalize_refinement
                                             [FStar_TypeChecker_Env.Weak;
                                             FStar_TypeChecker_Env.HNF;
@@ -2958,19 +2954,19 @@ and (encode_term :
                                            in
                                         FStar_All.pipe_left
                                           FStar_Syntax_Util.unrefine
-                                          uu____8245
+                                          uu____8238
                                          in
-                                      let uu____8248 =
+                                      let uu____8241 =
                                         curried_arrow_formals_comp head_type2
                                          in
-                                      match uu____8248 with
+                                      match uu____8241 with
                                       | (formals,c) ->
                                           if
                                             (FStar_List.length formals) <
                                               (FStar_List.length args)
                                           then
                                             let head_type3 =
-                                              let uu____8299 =
+                                              let uu____8292 =
                                                 normalize_refinement
                                                   [FStar_TypeChecker_Env.Weak;
                                                   FStar_TypeChecker_Env.HNF;
@@ -2982,43 +2978,43 @@ and (encode_term :
                                                  in
                                               FStar_All.pipe_left
                                                 FStar_Syntax_Util.unrefine
-                                                uu____8299
+                                                uu____8292
                                                in
-                                            let uu____8300 =
+                                            let uu____8293 =
                                               curried_arrow_formals_comp
                                                 head_type3
                                                in
-                                            (match uu____8300 with
+                                            (match uu____8293 with
                                              | (formals1,c1) ->
                                                  (head_type3, formals1, c1))
                                           else (head_type2, formals, c)
                                        in
-                                    (match uu____8223 with
+                                    (match uu____8216 with
                                      | (head_type2,formals,c) ->
-                                         ((let uu____8383 =
+                                         ((let uu____8376 =
                                              FStar_TypeChecker_Env.debug
                                                env.FStar_SMTEncoding_Env.tcenv
                                                (FStar_Options.Other
                                                   "PartialApp")
                                               in
-                                           if uu____8383
+                                           if uu____8376
                                            then
-                                             let uu____8387 =
+                                             let uu____8380 =
                                                FStar_Syntax_Print.term_to_string
                                                  head_type2
                                                 in
-                                             let uu____8389 =
+                                             let uu____8382 =
                                                FStar_Syntax_Print.binders_to_string
                                                  ", " formals
                                                 in
-                                             let uu____8392 =
+                                             let uu____8385 =
                                                FStar_Syntax_Print.args_to_string
                                                  args_e1
                                                 in
                                              FStar_Util.print3
                                                "Encoding partial application, head_type = %s, formals = %s, args = %s\n"
-                                               uu____8387 uu____8389
-                                               uu____8392
+                                               uu____8380 uu____8382
+                                               uu____8385
                                            else ());
                                           (match head2.FStar_Syntax_Syntax.n
                                            with
@@ -3028,9 +3024,9 @@ and (encode_term :
                                                     FStar_Syntax_Syntax.Tm_fvar
                                                     fv;
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____8402;
+                                                    uu____8395;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____8403;_},uu____8404)
+                                                    uu____8396;_},uu____8397)
                                                when
                                                (FStar_List.length formals) =
                                                  (FStar_List.length args)
@@ -3044,7 +3040,7 @@ and (encode_term :
                                                ->
                                                encode_full_app
                                                  fv.FStar_Syntax_Syntax.fv_name
-                                           | uu____8422 ->
+                                           | uu____8415 ->
                                                if
                                                  (FStar_List.length formals)
                                                    > (FStar_List.length args)
@@ -3057,10 +3053,10 @@ and (encode_term :
                                                  encode_partial_app
                                                    FStar_Pervasives_Native.None))))))))
        | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
-           let uu____8511 = FStar_Syntax_Subst.open_term' bs body  in
-           (match uu____8511 with
+           let uu____8504 = FStar_Syntax_Subst.open_term' bs body  in
+           (match uu____8504 with
             | (bs1,body1,opening) ->
-                let fallback uu____8534 =
+                let fallback uu____8527 =
                   let f =
                     FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
                       env.FStar_SMTEncoding_Env.current_module_name "Tm_abs"
@@ -3071,178 +3067,178 @@ and (encode_term :
                         (FStar_Pervasives_Native.Some
                            "Imprecise function encoding"))
                      in
-                  let uu____8544 =
-                    let uu____8545 =
+                  let uu____8537 =
+                    let uu____8538 =
                       FStar_SMTEncoding_Term.mk_fv
                         (f, FStar_SMTEncoding_Term.Term_sort)
                        in
                     FStar_All.pipe_left FStar_SMTEncoding_Util.mkFreeV
-                      uu____8545
+                      uu____8538
                      in
-                  let uu____8547 =
+                  let uu____8540 =
                     FStar_All.pipe_right [decl]
                       FStar_SMTEncoding_Term.mk_decls_trivial
                      in
-                  (uu____8544, uu____8547)  in
+                  (uu____8537, uu____8540)  in
                 let is_impure rc =
-                  let uu____8557 =
+                  let uu____8550 =
                     FStar_TypeChecker_Util.is_pure_or_ghost_effect
                       env.FStar_SMTEncoding_Env.tcenv
                       rc.FStar_Syntax_Syntax.residual_effect
                      in
-                  FStar_All.pipe_right uu____8557 Prims.op_Negation  in
+                  FStar_All.pipe_right uu____8550 Prims.op_Negation  in
                 let codomain_eff rc =
                   let res_typ =
                     match rc.FStar_Syntax_Syntax.residual_typ with
                     | FStar_Pervasives_Native.None  ->
-                        let uu____8572 =
-                          let uu____8585 =
+                        let uu____8565 =
+                          let uu____8578 =
                             FStar_TypeChecker_Env.get_range
                               env.FStar_SMTEncoding_Env.tcenv
                              in
                           FStar_TypeChecker_Util.new_implicit_var
-                            "SMTEncoding codomain" uu____8585
+                            "SMTEncoding codomain" uu____8578
                             env.FStar_SMTEncoding_Env.tcenv
                             FStar_Syntax_Util.ktype0
                            in
-                        (match uu____8572 with
-                         | (t2,uu____8588,uu____8589) -> t2)
+                        (match uu____8565 with
+                         | (t2,uu____8581,uu____8582) -> t2)
                     | FStar_Pervasives_Native.Some t2 -> t2  in
-                  let uu____8607 =
+                  let uu____8600 =
                     FStar_Ident.lid_equals
                       rc.FStar_Syntax_Syntax.residual_effect
                       FStar_Parser_Const.effect_Tot_lid
                      in
-                  if uu____8607
+                  if uu____8600
                   then
-                    let uu____8612 = FStar_Syntax_Syntax.mk_Total res_typ  in
-                    FStar_Pervasives_Native.Some uu____8612
+                    let uu____8605 = FStar_Syntax_Syntax.mk_Total res_typ  in
+                    FStar_Pervasives_Native.Some uu____8605
                   else
-                    (let uu____8615 =
+                    (let uu____8608 =
                        FStar_Ident.lid_equals
                          rc.FStar_Syntax_Syntax.residual_effect
                          FStar_Parser_Const.effect_GTot_lid
                         in
-                     if uu____8615
+                     if uu____8608
                      then
-                       let uu____8620 = FStar_Syntax_Syntax.mk_GTotal res_typ
+                       let uu____8613 = FStar_Syntax_Syntax.mk_GTotal res_typ
                           in
-                       FStar_Pervasives_Native.Some uu____8620
+                       FStar_Pervasives_Native.Some uu____8613
                      else FStar_Pervasives_Native.None)
                    in
                 (match lopt with
                  | FStar_Pervasives_Native.None  ->
-                     ((let uu____8628 =
-                         let uu____8634 =
-                           let uu____8636 =
+                     ((let uu____8621 =
+                         let uu____8627 =
+                           let uu____8629 =
                              FStar_Syntax_Print.term_to_string t0  in
                            FStar_Util.format1
                              "Losing precision when encoding a function literal: %s\n(Unnannotated abstraction in the compiler ?)"
-                             uu____8636
+                             uu____8629
                             in
                          (FStar_Errors.Warning_FunctionLiteralPrecisionLoss,
-                           uu____8634)
+                           uu____8627)
                           in
                        FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                         uu____8628);
+                         uu____8621);
                       fallback ())
                  | FStar_Pervasives_Native.Some rc ->
-                     let uu____8641 =
+                     let uu____8634 =
                        (is_impure rc) &&
-                         (let uu____8644 =
+                         (let uu____8637 =
                             FStar_SMTEncoding_Util.is_smt_reifiable_rc
                               env.FStar_SMTEncoding_Env.tcenv rc
                              in
-                          Prims.op_Negation uu____8644)
+                          Prims.op_Negation uu____8637)
                         in
-                     if uu____8641
+                     if uu____8634
                      then fallback ()
                      else
-                       (let uu____8653 =
+                       (let uu____8646 =
                           encode_binders FStar_Pervasives_Native.None bs1 env
                            in
-                        match uu____8653 with
-                        | (vars,guards,envbody,decls,uu____8678) ->
+                        match uu____8646 with
+                        | (vars,guards,envbody,decls,uu____8671) ->
                             let body2 =
-                              let uu____8692 =
+                              let uu____8685 =
                                 FStar_SMTEncoding_Util.is_smt_reifiable_rc
                                   env.FStar_SMTEncoding_Env.tcenv rc
                                  in
-                              if uu____8692
+                              if uu____8685
                               then
                                 FStar_TypeChecker_Util.reify_body
                                   env.FStar_SMTEncoding_Env.tcenv [] body1
                               else body1  in
-                            let uu____8697 = encode_term body2 envbody  in
-                            (match uu____8697 with
+                            let uu____8690 = encode_term body2 envbody  in
+                            (match uu____8690 with
                              | (body3,decls') ->
                                  let is_pure =
                                    FStar_Syntax_Util.is_pure_effect
                                      rc.FStar_Syntax_Syntax.residual_effect
                                     in
-                                 let uu____8710 =
-                                   let uu____8719 = codomain_eff rc  in
-                                   match uu____8719 with
+                                 let uu____8703 =
+                                   let uu____8712 = codomain_eff rc  in
+                                   match uu____8712 with
                                    | FStar_Pervasives_Native.None  ->
                                        (FStar_Pervasives_Native.None, [])
                                    | FStar_Pervasives_Native.Some c ->
                                        let tfun =
                                          FStar_Syntax_Util.arrow bs1 c  in
-                                       let uu____8738 = encode_term tfun env
+                                       let uu____8731 = encode_term tfun env
                                           in
-                                       (match uu____8738 with
+                                       (match uu____8731 with
                                         | (t2,decls1) ->
                                             ((FStar_Pervasives_Native.Some t2),
                                               decls1))
                                     in
-                                 (match uu____8710 with
+                                 (match uu____8703 with
                                   | (arrow_t_opt,decls'') ->
                                       let key_body =
-                                        let uu____8772 =
-                                          let uu____8783 =
-                                            let uu____8784 =
-                                              let uu____8789 =
+                                        let uu____8765 =
+                                          let uu____8776 =
+                                            let uu____8777 =
+                                              let uu____8782 =
                                                 FStar_SMTEncoding_Util.mk_and_l
                                                   guards
                                                  in
-                                              (uu____8789, body3)  in
+                                              (uu____8782, body3)  in
                                             FStar_SMTEncoding_Util.mkImp
-                                              uu____8784
+                                              uu____8777
                                              in
-                                          ([], vars, uu____8783)  in
+                                          ([], vars, uu____8776)  in
                                         FStar_SMTEncoding_Term.mkForall
                                           t0.FStar_Syntax_Syntax.pos
-                                          uu____8772
+                                          uu____8765
                                          in
                                       let cvars =
                                         FStar_SMTEncoding_Term.free_variables
                                           key_body
                                          in
-                                      let uu____8797 =
+                                      let uu____8790 =
                                         match arrow_t_opt with
                                         | FStar_Pervasives_Native.None  ->
                                             (cvars, key_body)
                                         | FStar_Pervasives_Native.Some t2 ->
-                                            let uu____8813 =
-                                              let uu____8816 =
-                                                let uu____8827 =
+                                            let uu____8806 =
+                                              let uu____8809 =
+                                                let uu____8820 =
                                                   FStar_SMTEncoding_Term.free_variables
                                                     t2
                                                    in
-                                                FStar_List.append uu____8827
+                                                FStar_List.append uu____8820
                                                   cvars
                                                  in
                                               FStar_Util.remove_dups
                                                 FStar_SMTEncoding_Term.fv_eq
-                                                uu____8816
+                                                uu____8809
                                                in
-                                            let uu____8854 =
+                                            let uu____8847 =
                                               FStar_SMTEncoding_Util.mkAnd
                                                 (key_body, t2)
                                                in
-                                            (uu____8813, uu____8854)
+                                            (uu____8806, uu____8847)
                                          in
-                                      (match uu____8797 with
+                                      (match uu____8790 with
                                        | (cvars1,key_body1) ->
                                            let tkey =
                                              FStar_SMTEncoding_Term.mkForall
@@ -3253,56 +3249,56 @@ and (encode_term :
                                              FStar_SMTEncoding_Term.hash_of_term
                                                tkey
                                               in
-                                           ((let uu____8877 =
+                                           ((let uu____8870 =
                                                FStar_All.pipe_left
                                                  (FStar_TypeChecker_Env.debug
                                                     env.FStar_SMTEncoding_Env.tcenv)
                                                  (FStar_Options.Other
                                                     "PartialApp")
                                                 in
-                                             if uu____8877
+                                             if uu____8870
                                              then
-                                               let uu____8882 =
-                                                 let uu____8884 =
+                                               let uu____8875 =
+                                                 let uu____8877 =
                                                    FStar_List.map
                                                      FStar_SMTEncoding_Term.fv_name
                                                      vars
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____8884
+                                                   uu____8877
                                                    (FStar_String.concat ", ")
                                                   in
-                                               let uu____8894 =
+                                               let uu____8887 =
                                                  FStar_SMTEncoding_Term.print_smt_term
                                                    body3
                                                   in
                                                FStar_Util.print2
                                                  "Checking eta expansion of\n\tvars={%s}\n\tbody=%s\n"
-                                                 uu____8882 uu____8894
+                                                 uu____8875 uu____8887
                                              else ());
-                                            (let uu____8899 =
+                                            (let uu____8892 =
                                                is_an_eta_expansion env vars
                                                  body3
                                                 in
-                                             match uu____8899 with
+                                             match uu____8892 with
                                              | FStar_Pervasives_Native.Some
                                                  t2 ->
-                                                 ((let uu____8908 =
+                                                 ((let uu____8901 =
                                                      FStar_All.pipe_left
                                                        (FStar_TypeChecker_Env.debug
                                                           env.FStar_SMTEncoding_Env.tcenv)
                                                        (FStar_Options.Other
                                                           "PartialApp")
                                                       in
-                                                   if uu____8908
+                                                   if uu____8901
                                                    then
-                                                     let uu____8913 =
+                                                     let uu____8906 =
                                                        FStar_SMTEncoding_Term.print_smt_term
                                                          t2
                                                         in
                                                      FStar_Util.print1
                                                        "Yes, is an eta expansion of\n\tcore=%s\n"
-                                                       uu____8913
+                                                       uu____8906
                                                    else ());
                                                   (let decls1 =
                                                      FStar_List.append decls
@@ -3318,12 +3314,12 @@ and (encode_term :
                                                      cvars1
                                                     in
                                                  let fsym =
-                                                   let uu____8926 =
+                                                   let uu____8919 =
                                                      FStar_Util.digest_of_string
                                                        tkey_hash
                                                       in
                                                    Prims.op_Hat "Tm_abs_"
-                                                     uu____8926
+                                                     uu____8919
                                                     in
                                                  let fdecl =
                                                    FStar_SMTEncoding_Term.DeclFun
@@ -3332,15 +3328,15 @@ and (encode_term :
                                                        FStar_Pervasives_Native.None)
                                                     in
                                                  let f =
-                                                   let uu____8935 =
-                                                     let uu____8943 =
+                                                   let uu____8928 =
+                                                     let uu____8936 =
                                                        FStar_List.map
                                                          FStar_SMTEncoding_Util.mkFreeV
                                                          cvars1
                                                         in
-                                                     (fsym, uu____8943)  in
+                                                     (fsym, uu____8936)  in
                                                    FStar_SMTEncoding_Util.mkApp
-                                                     uu____8935
+                                                     uu____8928
                                                     in
                                                  let app = mk_Apply f vars
                                                     in
@@ -3350,24 +3346,24 @@ and (encode_term :
                                                         ->
                                                        let tot_fun_ax =
                                                          let ax =
-                                                           let uu____8957 =
+                                                           let uu____8950 =
                                                              FStar_All.pipe_right
                                                                vars
                                                                (FStar_List.map
                                                                   (fun
-                                                                    uu____8965
+                                                                    uu____8958
                                                                      ->
                                                                     FStar_SMTEncoding_Util.mkTrue))
                                                               in
                                                            isTotFun_axioms
                                                              t0.FStar_Syntax_Syntax.pos
                                                              f vars
-                                                             uu____8957
+                                                             uu____8950
                                                              is_pure
                                                             in
                                                          match cvars1 with
                                                          | [] -> ax
-                                                         | uu____8966 ->
+                                                         | uu____8959 ->
                                                              FStar_SMTEncoding_Term.mkForall
                                                                t0.FStar_Syntax_Syntax.pos
                                                                ([[f]],
@@ -3377,14 +3373,14 @@ and (encode_term :
                                                          Prims.op_Hat
                                                            "tot_fun_" fsym
                                                           in
-                                                       let uu____8980 =
+                                                       let uu____8973 =
                                                          FStar_SMTEncoding_Util.mkAssume
                                                            (tot_fun_ax,
                                                              (FStar_Pervasives_Native.Some
                                                                 a_name),
                                                              a_name)
                                                           in
-                                                       [uu____8980]
+                                                       [uu____8973]
                                                    | FStar_Pervasives_Native.Some
                                                        t2 ->
                                                        let f_has_t =
@@ -3396,61 +3392,61 @@ and (encode_term :
                                                          Prims.op_Hat
                                                            "typing_" fsym
                                                           in
-                                                       let uu____8988 =
-                                                         let uu____8989 =
-                                                           let uu____8997 =
+                                                       let uu____8981 =
+                                                         let uu____8982 =
+                                                           let uu____8990 =
                                                              FStar_SMTEncoding_Term.mkForall
                                                                t0.FStar_Syntax_Syntax.pos
                                                                ([[f]],
                                                                  cvars1,
                                                                  f_has_t)
                                                               in
-                                                           (uu____8997,
+                                                           (uu____8990,
                                                              (FStar_Pervasives_Native.Some
                                                                 a_name),
                                                              a_name)
                                                             in
                                                          FStar_SMTEncoding_Util.mkAssume
-                                                           uu____8989
+                                                           uu____8982
                                                           in
-                                                       [uu____8988]
+                                                       [uu____8981]
                                                     in
                                                  let interp_f =
                                                    let a_name =
                                                      Prims.op_Hat
                                                        "interpretation_" fsym
                                                       in
-                                                   let uu____9012 =
-                                                     let uu____9020 =
-                                                       let uu____9021 =
-                                                         let uu____9032 =
+                                                   let uu____9005 =
+                                                     let uu____9013 =
+                                                       let uu____9014 =
+                                                         let uu____9025 =
                                                            FStar_SMTEncoding_Util.mkEq
                                                              (app, body3)
                                                             in
                                                          ([[app]],
                                                            (FStar_List.append
                                                               vars cvars1),
-                                                           uu____9032)
+                                                           uu____9025)
                                                           in
                                                        FStar_SMTEncoding_Term.mkForall
                                                          t0.FStar_Syntax_Syntax.pos
-                                                         uu____9021
+                                                         uu____9014
                                                         in
-                                                     (uu____9020,
+                                                     (uu____9013,
                                                        (FStar_Pervasives_Native.Some
                                                           a_name), a_name)
                                                       in
                                                    FStar_SMTEncoding_Util.mkAssume
-                                                     uu____9012
+                                                     uu____9005
                                                     in
                                                  let f_decls =
                                                    FStar_List.append (fdecl
                                                      :: typing_f) [interp_f]
                                                     in
-                                                 let uu____9046 =
-                                                   let uu____9047 =
-                                                     let uu____9050 =
-                                                       let uu____9053 =
+                                                 let uu____9039 =
+                                                   let uu____9040 =
+                                                     let uu____9043 =
+                                                       let uu____9046 =
                                                          FStar_SMTEncoding_Term.mk_decls
                                                            fsym tkey_hash
                                                            f_decls
@@ -3461,61 +3457,61 @@ and (encode_term :
                                                                  decls''))
                                                           in
                                                        FStar_List.append
-                                                         decls'' uu____9053
+                                                         decls'' uu____9046
                                                         in
                                                      FStar_List.append decls'
-                                                       uu____9050
+                                                       uu____9043
                                                       in
                                                    FStar_List.append decls
-                                                     uu____9047
+                                                     uu____9040
                                                     in
-                                                 (f, uu____9046)))))))))
+                                                 (f, uu____9039)))))))))
        | FStar_Syntax_Syntax.Tm_let
-           ((uu____9056,{
+           ((uu____9049,{
                           FStar_Syntax_Syntax.lbname = FStar_Util.Inr
-                            uu____9057;
-                          FStar_Syntax_Syntax.lbunivs = uu____9058;
-                          FStar_Syntax_Syntax.lbtyp = uu____9059;
-                          FStar_Syntax_Syntax.lbeff = uu____9060;
-                          FStar_Syntax_Syntax.lbdef = uu____9061;
-                          FStar_Syntax_Syntax.lbattrs = uu____9062;
-                          FStar_Syntax_Syntax.lbpos = uu____9063;_}::uu____9064),uu____9065)
+                            uu____9050;
+                          FStar_Syntax_Syntax.lbunivs = uu____9051;
+                          FStar_Syntax_Syntax.lbtyp = uu____9052;
+                          FStar_Syntax_Syntax.lbeff = uu____9053;
+                          FStar_Syntax_Syntax.lbdef = uu____9054;
+                          FStar_Syntax_Syntax.lbattrs = uu____9055;
+                          FStar_Syntax_Syntax.lbpos = uu____9056;_}::uu____9057),uu____9058)
            -> failwith "Impossible: already handled by encoding of Sig_let"
        | FStar_Syntax_Syntax.Tm_let
            ((false
              ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inl x;
-                FStar_Syntax_Syntax.lbunivs = uu____9099;
+                FStar_Syntax_Syntax.lbunivs = uu____9092;
                 FStar_Syntax_Syntax.lbtyp = t11;
-                FStar_Syntax_Syntax.lbeff = uu____9101;
+                FStar_Syntax_Syntax.lbeff = uu____9094;
                 FStar_Syntax_Syntax.lbdef = e1;
-                FStar_Syntax_Syntax.lbattrs = uu____9103;
-                FStar_Syntax_Syntax.lbpos = uu____9104;_}::[]),e2)
+                FStar_Syntax_Syntax.lbattrs = uu____9096;
+                FStar_Syntax_Syntax.lbpos = uu____9097;_}::[]),e2)
            -> encode_let x t11 e1 e2 env encode_term
        | FStar_Syntax_Syntax.Tm_let
-           ((false ,uu____9131::uu____9132),uu____9133) ->
+           ((false ,uu____9124::uu____9125),uu____9126) ->
            failwith "Impossible: non-recursive let with multiple bindings"
-       | FStar_Syntax_Syntax.Tm_let ((uu____9156,lbs),uu____9158) ->
+       | FStar_Syntax_Syntax.Tm_let ((uu____9149,lbs),uu____9151) ->
            let names =
              FStar_All.pipe_right lbs
                (FStar_List.map
                   (fun lb  ->
-                     let uu____9211 = lb  in
-                     match uu____9211 with
+                     let uu____9204 = lb  in
+                     match uu____9204 with
                      | { FStar_Syntax_Syntax.lbname = lbname;
-                         FStar_Syntax_Syntax.lbunivs = uu____9218;
-                         FStar_Syntax_Syntax.lbtyp = uu____9219;
-                         FStar_Syntax_Syntax.lbeff = uu____9220;
-                         FStar_Syntax_Syntax.lbdef = uu____9221;
-                         FStar_Syntax_Syntax.lbattrs = uu____9222;
-                         FStar_Syntax_Syntax.lbpos = uu____9223;_} ->
+                         FStar_Syntax_Syntax.lbunivs = uu____9211;
+                         FStar_Syntax_Syntax.lbtyp = uu____9212;
+                         FStar_Syntax_Syntax.lbeff = uu____9213;
+                         FStar_Syntax_Syntax.lbdef = uu____9214;
+                         FStar_Syntax_Syntax.lbattrs = uu____9215;
+                         FStar_Syntax_Syntax.lbpos = uu____9216;_} ->
                          let x = FStar_Util.left lbname  in
-                         let uu____9239 =
+                         let uu____9232 =
                            FStar_Ident.text_of_id
                              x.FStar_Syntax_Syntax.ppname
                             in
-                         let uu____9241 = FStar_Syntax_Syntax.range_of_bv x
+                         let uu____9234 = FStar_Syntax_Syntax.range_of_bv x
                             in
-                         (uu____9239, uu____9241)))
+                         (uu____9232, uu____9234)))
               in
            FStar_Exn.raise (FStar_SMTEncoding_Env.Inner_let_rec names)
        | FStar_Syntax_Syntax.Tm_match (e,pats) ->
@@ -3541,28 +3537,28 @@ and (encode_let :
         fun e2  ->
           fun env  ->
             fun encode_body  ->
-              let uu____9299 =
-                let uu____9304 =
+              let uu____9292 =
+                let uu____9297 =
                   FStar_Syntax_Util.ascribe e1
                     ((FStar_Util.Inl t1), FStar_Pervasives_Native.None)
                    in
-                encode_term uu____9304 env  in
-              match uu____9299 with
+                encode_term uu____9297 env  in
+              match uu____9292 with
               | (ee1,decls1) ->
-                  let uu____9329 =
+                  let uu____9322 =
                     FStar_Syntax_Subst.open_term
                       [(x, FStar_Pervasives_Native.None)] e2
                      in
-                  (match uu____9329 with
+                  (match uu____9322 with
                    | (xs,e21) ->
-                       let uu____9354 = FStar_List.hd xs  in
-                       (match uu____9354 with
-                        | (x1,uu____9372) ->
+                       let uu____9347 = FStar_List.hd xs  in
+                       (match uu____9347 with
+                        | (x1,uu____9365) ->
                             let env' =
                               FStar_SMTEncoding_Env.push_term_var env x1 ee1
                                in
-                            let uu____9378 = encode_body e21 env'  in
-                            (match uu____9378 with
+                            let uu____9371 = encode_body e21 env'  in
+                            (match uu____9371 with
                              | (ee2,decls2) ->
                                  (ee2, (FStar_List.append decls1 decls2)))))
 
@@ -3581,29 +3577,29 @@ and (encode_match :
       fun default_case  ->
         fun env  ->
           fun encode_br  ->
-            let uu____9408 =
-              let uu____9416 =
-                let uu____9417 =
+            let uu____9401 =
+              let uu____9409 =
+                let uu____9410 =
                   FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-                    FStar_Pervasives_Native.None FStar_Range.dummyRange
+                    FStar_Range.dummyRange
                    in
-                FStar_Syntax_Syntax.null_bv uu____9417  in
-              FStar_SMTEncoding_Env.gen_term_var env uu____9416  in
-            match uu____9408 with
+                FStar_Syntax_Syntax.null_bv uu____9410  in
+              FStar_SMTEncoding_Env.gen_term_var env uu____9409  in
+            match uu____9401 with
             | (scrsym,scr',env1) ->
-                let uu____9427 = encode_term e env1  in
-                (match uu____9427 with
+                let uu____9420 = encode_term e env1  in
+                (match uu____9420 with
                  | (scr,decls) ->
-                     let uu____9438 =
-                       let encode_branch b uu____9467 =
-                         match uu____9467 with
+                     let uu____9431 =
+                       let encode_branch b uu____9460 =
+                         match uu____9460 with
                          | (else_case,decls1) ->
-                             let uu____9486 =
+                             let uu____9479 =
                                FStar_Syntax_Subst.open_branch b  in
-                             (match uu____9486 with
+                             (match uu____9479 with
                               | (p,w,br) ->
-                                  let uu____9512 = encode_pat env1 p  in
-                                  (match uu____9512 with
+                                  let uu____9505 = encode_pat env1 p  in
+                                  (match uu____9505 with
                                    | (env0,pattern1) ->
                                        let guard = pattern1.guard scr'  in
                                        let projections =
@@ -3612,51 +3608,51 @@ and (encode_match :
                                          FStar_All.pipe_right projections
                                            (FStar_List.fold_left
                                               (fun env2  ->
-                                                 fun uu____9549  ->
-                                                   match uu____9549 with
+                                                 fun uu____9542  ->
+                                                   match uu____9542 with
                                                    | (x,t) ->
                                                        FStar_SMTEncoding_Env.push_term_var
                                                          env2 x t) env1)
                                           in
-                                       let uu____9556 =
+                                       let uu____9549 =
                                          match w with
                                          | FStar_Pervasives_Native.None  ->
                                              (guard, [])
                                          | FStar_Pervasives_Native.Some w1 ->
-                                             let uu____9578 =
+                                             let uu____9571 =
                                                encode_term w1 env2  in
-                                             (match uu____9578 with
+                                             (match uu____9571 with
                                               | (w2,decls2) ->
-                                                  let uu____9591 =
-                                                    let uu____9592 =
-                                                      let uu____9597 =
-                                                        let uu____9598 =
-                                                          let uu____9603 =
+                                                  let uu____9584 =
+                                                    let uu____9585 =
+                                                      let uu____9590 =
+                                                        let uu____9591 =
+                                                          let uu____9596 =
                                                             FStar_SMTEncoding_Term.boxBool
                                                               FStar_SMTEncoding_Util.mkTrue
                                                              in
-                                                          (w2, uu____9603)
+                                                          (w2, uu____9596)
                                                            in
                                                         FStar_SMTEncoding_Util.mkEq
-                                                          uu____9598
+                                                          uu____9591
                                                          in
-                                                      (guard, uu____9597)  in
+                                                      (guard, uu____9590)  in
                                                     FStar_SMTEncoding_Util.mkAnd
-                                                      uu____9592
+                                                      uu____9585
                                                      in
-                                                  (uu____9591, decls2))
+                                                  (uu____9584, decls2))
                                           in
-                                       (match uu____9556 with
+                                       (match uu____9549 with
                                         | (guard1,decls2) ->
-                                            let uu____9618 =
+                                            let uu____9611 =
                                               encode_br br env2  in
-                                            (match uu____9618 with
+                                            (match uu____9611 with
                                              | (br1,decls3) ->
-                                                 let uu____9631 =
+                                                 let uu____9624 =
                                                    FStar_SMTEncoding_Util.mkITE
                                                      (guard1, br1, else_case)
                                                     in
-                                                 (uu____9631,
+                                                 (uu____9624,
                                                    (FStar_List.append decls1
                                                       (FStar_List.append
                                                          decls2 decls3)))))))
@@ -3664,24 +3660,24 @@ and (encode_match :
                        FStar_List.fold_right encode_branch pats
                          (default_case, decls)
                         in
-                     (match uu____9438 with
+                     (match uu____9431 with
                       | (match_tm,decls1) ->
-                          let uu____9652 =
-                            let uu____9653 =
-                              let uu____9664 =
-                                let uu____9671 =
-                                  let uu____9676 =
+                          let uu____9645 =
+                            let uu____9646 =
+                              let uu____9657 =
+                                let uu____9664 =
+                                  let uu____9669 =
                                     FStar_SMTEncoding_Term.mk_fv
                                       (scrsym,
                                         FStar_SMTEncoding_Term.Term_sort)
                                      in
-                                  (uu____9676, scr)  in
-                                [uu____9671]  in
-                              (uu____9664, match_tm)  in
-                            FStar_SMTEncoding_Term.mkLet' uu____9653
+                                  (uu____9669, scr)  in
+                                [uu____9664]  in
+                              (uu____9657, match_tm)  in
+                            FStar_SMTEncoding_Term.mkLet' uu____9646
                               FStar_Range.dummyRange
                              in
-                          (uu____9652, decls1)))
+                          (uu____9645, decls1)))
 
 and (encode_pat :
   FStar_SMTEncoding_Env.env_t ->
@@ -3689,60 +3685,60 @@ and (encode_pat :
   =
   fun env  ->
     fun pat  ->
-      (let uu____9699 =
+      (let uu____9692 =
          FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
            FStar_Options.Medium
           in
-       if uu____9699
+       if uu____9692
        then
-         let uu____9702 = FStar_Syntax_Print.pat_to_string pat  in
-         FStar_Util.print1 "Encoding pattern %s\n" uu____9702
+         let uu____9695 = FStar_Syntax_Print.pat_to_string pat  in
+         FStar_Util.print1 "Encoding pattern %s\n" uu____9695
        else ());
-      (let uu____9707 = FStar_TypeChecker_Util.decorated_pattern_as_term pat
+      (let uu____9700 = FStar_TypeChecker_Util.decorated_pattern_as_term pat
           in
-       match uu____9707 with
+       match uu____9700 with
        | (vars,pat_term) ->
-           let uu____9724 =
+           let uu____9717 =
              FStar_All.pipe_right vars
                (FStar_List.fold_left
-                  (fun uu____9766  ->
+                  (fun uu____9759  ->
                      fun v  ->
-                       match uu____9766 with
+                       match uu____9759 with
                        | (env1,vars1) ->
-                           let uu____9802 =
+                           let uu____9795 =
                              FStar_SMTEncoding_Env.gen_term_var env1 v  in
-                           (match uu____9802 with
-                            | (xx,uu____9821,env2) ->
-                                let uu____9825 =
-                                  let uu____9832 =
-                                    let uu____9837 =
+                           (match uu____9795 with
+                            | (xx,uu____9814,env2) ->
+                                let uu____9818 =
+                                  let uu____9825 =
+                                    let uu____9830 =
                                       FStar_SMTEncoding_Term.mk_fv
                                         (xx,
                                           FStar_SMTEncoding_Term.Term_sort)
                                        in
-                                    (v, uu____9837)  in
-                                  uu____9832 :: vars1  in
-                                (env2, uu____9825))) (env, []))
+                                    (v, uu____9830)  in
+                                  uu____9825 :: vars1  in
+                                (env2, uu____9818))) (env, []))
               in
-           (match uu____9724 with
+           (match uu____9717 with
             | (env1,vars1) ->
                 let rec mk_guard pat1 scrutinee =
                   match pat1.FStar_Syntax_Syntax.v with
-                  | FStar_Syntax_Syntax.Pat_var uu____9892 ->
+                  | FStar_Syntax_Syntax.Pat_var uu____9885 ->
                       FStar_SMTEncoding_Util.mkTrue
-                  | FStar_Syntax_Syntax.Pat_wild uu____9893 ->
+                  | FStar_Syntax_Syntax.Pat_wild uu____9886 ->
                       FStar_SMTEncoding_Util.mkTrue
-                  | FStar_Syntax_Syntax.Pat_dot_term uu____9894 ->
+                  | FStar_Syntax_Syntax.Pat_dot_term uu____9887 ->
                       FStar_SMTEncoding_Util.mkTrue
                   | FStar_Syntax_Syntax.Pat_constant c ->
-                      let uu____9902 = encode_const c env1  in
-                      (match uu____9902 with
+                      let uu____9895 = encode_const c env1  in
+                      (match uu____9895 with
                        | (tm,decls) ->
                            ((match decls with
-                             | uu____9910::uu____9911 ->
+                             | uu____9903::uu____9904 ->
                                  failwith
                                    "Unexpected encoding of constant pattern"
-                             | uu____9915 -> ());
+                             | uu____9908 -> ());
                             FStar_SMTEncoding_Util.mkEq (scrutinee, tm)))
                   | FStar_Syntax_Syntax.Pat_cons (f,args) ->
                       let is_f =
@@ -3751,14 +3747,14 @@ and (encode_pat :
                             env1.FStar_SMTEncoding_Env.tcenv
                             (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                            in
-                        let uu____9938 =
+                        let uu____9931 =
                           FStar_TypeChecker_Env.datacons_of_typ
                             env1.FStar_SMTEncoding_Env.tcenv tc_name
                            in
-                        match uu____9938 with
-                        | (uu____9946,uu____9947::[]) ->
+                        match uu____9931 with
+                        | (uu____9939,uu____9940::[]) ->
                             FStar_SMTEncoding_Util.mkTrue
-                        | uu____9952 ->
+                        | uu____9945 ->
                             FStar_SMTEncoding_Env.mk_data_tester env1
                               (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                               scrutinee
@@ -3767,54 +3763,54 @@ and (encode_pat :
                         FStar_All.pipe_right args
                           (FStar_List.mapi
                              (fun i  ->
-                                fun uu____9988  ->
-                                  match uu____9988 with
-                                  | (arg,uu____9998) ->
+                                fun uu____9981  ->
+                                  match uu____9981 with
+                                  | (arg,uu____9991) ->
                                       let proj =
                                         FStar_SMTEncoding_Env.primitive_projector_by_pos
                                           env1.FStar_SMTEncoding_Env.tcenv
                                           (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                           i
                                          in
-                                      let uu____10007 =
+                                      let uu____10000 =
                                         FStar_SMTEncoding_Util.mkApp
                                           (proj, [scrutinee])
                                          in
-                                      mk_guard arg uu____10007))
+                                      mk_guard arg uu____10000))
                          in
                       FStar_SMTEncoding_Util.mk_and_l (is_f ::
                         sub_term_guards)
                    in
                 let rec mk_projections pat1 scrutinee =
                   match pat1.FStar_Syntax_Syntax.v with
-                  | FStar_Syntax_Syntax.Pat_dot_term (x,uu____10039) ->
+                  | FStar_Syntax_Syntax.Pat_dot_term (x,uu____10032) ->
                       [(x, scrutinee)]
                   | FStar_Syntax_Syntax.Pat_var x -> [(x, scrutinee)]
                   | FStar_Syntax_Syntax.Pat_wild x -> [(x, scrutinee)]
-                  | FStar_Syntax_Syntax.Pat_constant uu____10070 -> []
+                  | FStar_Syntax_Syntax.Pat_constant uu____10063 -> []
                   | FStar_Syntax_Syntax.Pat_cons (f,args) ->
-                      let uu____10095 =
+                      let uu____10088 =
                         FStar_All.pipe_right args
                           (FStar_List.mapi
                              (fun i  ->
-                                fun uu____10141  ->
-                                  match uu____10141 with
-                                  | (arg,uu____10157) ->
+                                fun uu____10134  ->
+                                  match uu____10134 with
+                                  | (arg,uu____10150) ->
                                       let proj =
                                         FStar_SMTEncoding_Env.primitive_projector_by_pos
                                           env1.FStar_SMTEncoding_Env.tcenv
                                           (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                           i
                                          in
-                                      let uu____10166 =
+                                      let uu____10159 =
                                         FStar_SMTEncoding_Util.mkApp
                                           (proj, [scrutinee])
                                          in
-                                      mk_projections arg uu____10166))
+                                      mk_projections arg uu____10159))
                          in
-                      FStar_All.pipe_right uu____10095 FStar_List.flatten
+                      FStar_All.pipe_right uu____10088 FStar_List.flatten
                    in
-                let pat_term1 uu____10197 = encode_term pat_term env1  in
+                let pat_term1 uu____10190 = encode_term pat_term env1  in
                 let pattern1 =
                   {
                     pat_vars = vars1;
@@ -3832,20 +3828,20 @@ and (encode_args :
   =
   fun l  ->
     fun env  ->
-      let uu____10207 =
+      let uu____10200 =
         FStar_All.pipe_right l
           (FStar_List.fold_left
-             (fun uu____10255  ->
-                fun uu____10256  ->
-                  match (uu____10255, uu____10256) with
-                  | ((tms,decls),(t,uu____10296)) ->
-                      let uu____10323 = encode_term t env  in
-                      (match uu____10323 with
+             (fun uu____10248  ->
+                fun uu____10249  ->
+                  match (uu____10248, uu____10249) with
+                  | ((tms,decls),(t,uu____10289)) ->
+                      let uu____10316 = encode_term t env  in
+                      (match uu____10316 with
                        | (t1,decls') ->
                            ((t1 :: tms), (FStar_List.append decls decls'))))
              ([], []))
          in
-      match uu____10207 with | (l1,decls) -> ((FStar_List.rev l1), decls)
+      match uu____10200 with | (l1,decls) -> ((FStar_List.rev l1), decls)
 
 and (encode_function_type_as_formula :
   FStar_Syntax_Syntax.typ ->
@@ -3855,35 +3851,35 @@ and (encode_function_type_as_formula :
   fun t  ->
     fun env  ->
       let universe_of_binders binders =
-        FStar_List.map (fun uu____10401  -> FStar_Syntax_Syntax.U_zero)
+        FStar_List.map (fun uu____10394  -> FStar_Syntax_Syntax.U_zero)
           binders
          in
       let quant = FStar_Syntax_Util.smt_lemma_as_forall t universe_of_binders
          in
       let env1 =
-        let uu___1425_10410 = env  in
+        let uu___1425_10403 = env  in
         {
           FStar_SMTEncoding_Env.bvar_bindings =
-            (uu___1425_10410.FStar_SMTEncoding_Env.bvar_bindings);
+            (uu___1425_10403.FStar_SMTEncoding_Env.bvar_bindings);
           FStar_SMTEncoding_Env.fvar_bindings =
-            (uu___1425_10410.FStar_SMTEncoding_Env.fvar_bindings);
+            (uu___1425_10403.FStar_SMTEncoding_Env.fvar_bindings);
           FStar_SMTEncoding_Env.depth =
-            (uu___1425_10410.FStar_SMTEncoding_Env.depth);
+            (uu___1425_10403.FStar_SMTEncoding_Env.depth);
           FStar_SMTEncoding_Env.tcenv =
-            (uu___1425_10410.FStar_SMTEncoding_Env.tcenv);
+            (uu___1425_10403.FStar_SMTEncoding_Env.tcenv);
           FStar_SMTEncoding_Env.warn =
-            (uu___1425_10410.FStar_SMTEncoding_Env.warn);
+            (uu___1425_10403.FStar_SMTEncoding_Env.warn);
           FStar_SMTEncoding_Env.nolabels =
-            (uu___1425_10410.FStar_SMTEncoding_Env.nolabels);
+            (uu___1425_10403.FStar_SMTEncoding_Env.nolabels);
           FStar_SMTEncoding_Env.use_zfuel_name = true;
           FStar_SMTEncoding_Env.encode_non_total_function_typ =
-            (uu___1425_10410.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            (uu___1425_10403.FStar_SMTEncoding_Env.encode_non_total_function_typ);
           FStar_SMTEncoding_Env.current_module_name =
-            (uu___1425_10410.FStar_SMTEncoding_Env.current_module_name);
+            (uu___1425_10403.FStar_SMTEncoding_Env.current_module_name);
           FStar_SMTEncoding_Env.encoding_quantifier =
-            (uu___1425_10410.FStar_SMTEncoding_Env.encoding_quantifier);
+            (uu___1425_10403.FStar_SMTEncoding_Env.encoding_quantifier);
           FStar_SMTEncoding_Env.global_cache =
-            (uu___1425_10410.FStar_SMTEncoding_Env.global_cache)
+            (uu___1425_10403.FStar_SMTEncoding_Env.global_cache)
         }  in
       encode_formula quant env1
 
@@ -3896,101 +3892,101 @@ and (encode_smt_patterns :
   fun pats_l  ->
     fun env  ->
       let env1 =
-        let uu___1430_10427 = env  in
+        let uu___1430_10420 = env  in
         {
           FStar_SMTEncoding_Env.bvar_bindings =
-            (uu___1430_10427.FStar_SMTEncoding_Env.bvar_bindings);
+            (uu___1430_10420.FStar_SMTEncoding_Env.bvar_bindings);
           FStar_SMTEncoding_Env.fvar_bindings =
-            (uu___1430_10427.FStar_SMTEncoding_Env.fvar_bindings);
+            (uu___1430_10420.FStar_SMTEncoding_Env.fvar_bindings);
           FStar_SMTEncoding_Env.depth =
-            (uu___1430_10427.FStar_SMTEncoding_Env.depth);
+            (uu___1430_10420.FStar_SMTEncoding_Env.depth);
           FStar_SMTEncoding_Env.tcenv =
-            (uu___1430_10427.FStar_SMTEncoding_Env.tcenv);
+            (uu___1430_10420.FStar_SMTEncoding_Env.tcenv);
           FStar_SMTEncoding_Env.warn =
-            (uu___1430_10427.FStar_SMTEncoding_Env.warn);
+            (uu___1430_10420.FStar_SMTEncoding_Env.warn);
           FStar_SMTEncoding_Env.nolabels =
-            (uu___1430_10427.FStar_SMTEncoding_Env.nolabels);
+            (uu___1430_10420.FStar_SMTEncoding_Env.nolabels);
           FStar_SMTEncoding_Env.use_zfuel_name = true;
           FStar_SMTEncoding_Env.encode_non_total_function_typ =
-            (uu___1430_10427.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+            (uu___1430_10420.FStar_SMTEncoding_Env.encode_non_total_function_typ);
           FStar_SMTEncoding_Env.current_module_name =
-            (uu___1430_10427.FStar_SMTEncoding_Env.current_module_name);
+            (uu___1430_10420.FStar_SMTEncoding_Env.current_module_name);
           FStar_SMTEncoding_Env.encoding_quantifier =
-            (uu___1430_10427.FStar_SMTEncoding_Env.encoding_quantifier);
+            (uu___1430_10420.FStar_SMTEncoding_Env.encoding_quantifier);
           FStar_SMTEncoding_Env.global_cache =
-            (uu___1430_10427.FStar_SMTEncoding_Env.global_cache)
+            (uu___1430_10420.FStar_SMTEncoding_Env.global_cache)
         }  in
       let encode_smt_pattern t =
-        let uu____10443 = FStar_Syntax_Util.head_and_args t  in
-        match uu____10443 with
+        let uu____10436 = FStar_Syntax_Util.head_and_args t  in
+        match uu____10436 with
         | (head,args) ->
             let head1 = FStar_Syntax_Util.un_uinst head  in
             (match ((head1.FStar_Syntax_Syntax.n), args) with
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,uu____10506::(x,uu____10508)::(t1,uu____10510)::[]) when
+                fv,uu____10499::(x,uu____10501)::(t1,uu____10503)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.has_type_lid
                  ->
-                 let uu____10577 = encode_term x env1  in
-                 (match uu____10577 with
+                 let uu____10570 = encode_term x env1  in
+                 (match uu____10570 with
                   | (x1,decls) ->
-                      let uu____10588 = encode_term t1 env1  in
-                      (match uu____10588 with
+                      let uu____10581 = encode_term t1 env1  in
+                      (match uu____10581 with
                        | (t2,decls') ->
-                           let uu____10599 =
+                           let uu____10592 =
                              FStar_SMTEncoding_Term.mk_HasType x1 t2  in
-                           (uu____10599, (FStar_List.append decls decls'))))
-             | uu____10600 -> encode_term t env1)
+                           (uu____10592, (FStar_List.append decls decls'))))
+             | uu____10593 -> encode_term t env1)
          in
       FStar_List.fold_right
         (fun pats  ->
-           fun uu____10643  ->
-             match uu____10643 with
+           fun uu____10636  ->
+             match uu____10636 with
              | (pats_l1,decls) ->
-                 let uu____10688 =
+                 let uu____10681 =
                    FStar_List.fold_right
-                     (fun uu____10723  ->
-                        fun uu____10724  ->
-                          match (uu____10723, uu____10724) with
-                          | ((p,uu____10766),(pats1,decls1)) ->
-                              let uu____10801 = encode_smt_pattern p  in
-                              (match uu____10801 with
+                     (fun uu____10716  ->
+                        fun uu____10717  ->
+                          match (uu____10716, uu____10717) with
+                          | ((p,uu____10759),(pats1,decls1)) ->
+                              let uu____10794 = encode_smt_pattern p  in
+                              (match uu____10794 with
                                | (t,d) ->
-                                   let uu____10816 =
+                                   let uu____10809 =
                                      FStar_SMTEncoding_Term.check_pattern_ok
                                        t
                                       in
-                                   (match uu____10816 with
+                                   (match uu____10809 with
                                     | FStar_Pervasives_Native.None  ->
                                         ((t :: pats1),
                                           (FStar_List.append d decls1))
                                     | FStar_Pervasives_Native.Some
                                         illegal_subterm ->
-                                        ((let uu____10833 =
-                                            let uu____10839 =
-                                              let uu____10841 =
+                                        ((let uu____10826 =
+                                            let uu____10832 =
+                                              let uu____10834 =
                                                 FStar_Syntax_Print.term_to_string
                                                   p
                                                  in
-                                              let uu____10843 =
+                                              let uu____10836 =
                                                 FStar_SMTEncoding_Term.print_smt_term
                                                   illegal_subterm
                                                  in
                                               FStar_Util.format2
                                                 "Pattern %s contains illegal sub-term (%s); dropping it"
-                                                uu____10841 uu____10843
+                                                uu____10834 uu____10836
                                                in
                                             (FStar_Errors.Warning_SMTPatternIllFormed,
-                                              uu____10839)
+                                              uu____10832)
                                              in
                                           FStar_Errors.log_issue
                                             p.FStar_Syntax_Syntax.pos
-                                            uu____10833);
+                                            uu____10826);
                                          (pats1,
                                            (FStar_List.append d decls1))))))
                      pats ([], decls)
                     in
-                 (match uu____10688 with
+                 (match uu____10681 with
                   | (pats1,decls1) -> ((pats1 :: pats_l1), decls1))) pats_l
         ([], [])
 
@@ -4002,215 +3998,215 @@ and (encode_formula :
   fun phi  ->
     fun env  ->
       let debug phi1 =
-        let uu____10903 =
+        let uu____10896 =
           FStar_All.pipe_left
             (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
             (FStar_Options.Other "SMTEncoding")
            in
-        if uu____10903
+        if uu____10896
         then
-          let uu____10908 = FStar_Syntax_Print.tag_of_term phi1  in
-          let uu____10910 = FStar_Syntax_Print.term_to_string phi1  in
-          FStar_Util.print2 "Formula (%s)  %s\n" uu____10908 uu____10910
+          let uu____10901 = FStar_Syntax_Print.tag_of_term phi1  in
+          let uu____10903 = FStar_Syntax_Print.term_to_string phi1  in
+          FStar_Util.print2 "Formula (%s)  %s\n" uu____10901 uu____10903
         else ()  in
       let enc f r l =
-        let uu____10952 =
+        let uu____10945 =
           FStar_Util.fold_map
             (fun decls  ->
                fun x  ->
-                 let uu____10984 =
+                 let uu____10977 =
                    encode_term (FStar_Pervasives_Native.fst x) env  in
-                 match uu____10984 with
+                 match uu____10977 with
                  | (t,decls') -> ((FStar_List.append decls decls'), t)) [] l
            in
-        match uu____10952 with
+        match uu____10945 with
         | (decls,args) ->
-            let uu____11015 =
-              let uu___1494_11016 = f args  in
+            let uu____11008 =
+              let uu___1494_11009 = f args  in
               {
                 FStar_SMTEncoding_Term.tm =
-                  (uu___1494_11016.FStar_SMTEncoding_Term.tm);
+                  (uu___1494_11009.FStar_SMTEncoding_Term.tm);
                 FStar_SMTEncoding_Term.freevars =
-                  (uu___1494_11016.FStar_SMTEncoding_Term.freevars);
+                  (uu___1494_11009.FStar_SMTEncoding_Term.freevars);
                 FStar_SMTEncoding_Term.rng = r
               }  in
-            (uu____11015, decls)
+            (uu____11008, decls)
          in
-      let const_op f r uu____11051 =
-        let uu____11064 = f r  in (uu____11064, [])  in
+      let const_op f r uu____11044 =
+        let uu____11057 = f r  in (uu____11057, [])  in
       let un_op f l =
-        let uu____11087 = FStar_List.hd l  in
-        FStar_All.pipe_left f uu____11087  in
-      let bin_op f uu___2_11107 =
-        match uu___2_11107 with
+        let uu____11080 = FStar_List.hd l  in
+        FStar_All.pipe_left f uu____11080  in
+      let bin_op f uu___2_11100 =
+        match uu___2_11100 with
         | t1::t2::[] -> f (t1, t2)
-        | uu____11118 -> failwith "Impossible"  in
+        | uu____11111 -> failwith "Impossible"  in
       let enc_prop_c f r l =
-        let uu____11159 =
+        let uu____11152 =
           FStar_Util.fold_map
             (fun decls  ->
-               fun uu____11184  ->
-                 match uu____11184 with
-                 | (t,uu____11200) ->
-                     let uu____11205 = encode_formula t env  in
-                     (match uu____11205 with
+               fun uu____11177  ->
+                 match uu____11177 with
+                 | (t,uu____11193) ->
+                     let uu____11198 = encode_formula t env  in
+                     (match uu____11198 with
                       | (phi1,decls') ->
                           ((FStar_List.append decls decls'), phi1))) [] l
            in
-        match uu____11159 with
+        match uu____11152 with
         | (decls,phis) ->
-            let uu____11234 =
-              let uu___1524_11235 = f phis  in
+            let uu____11227 =
+              let uu___1524_11228 = f phis  in
               {
                 FStar_SMTEncoding_Term.tm =
-                  (uu___1524_11235.FStar_SMTEncoding_Term.tm);
+                  (uu___1524_11228.FStar_SMTEncoding_Term.tm);
                 FStar_SMTEncoding_Term.freevars =
-                  (uu___1524_11235.FStar_SMTEncoding_Term.freevars);
+                  (uu___1524_11228.FStar_SMTEncoding_Term.freevars);
                 FStar_SMTEncoding_Term.rng = r
               }  in
-            (uu____11234, decls)
+            (uu____11227, decls)
          in
       let eq_op r args =
         let rf =
           FStar_List.filter
-            (fun uu____11298  ->
-               match uu____11298 with
+            (fun uu____11291  ->
+               match uu____11291 with
                | (a,q) ->
                    (match q with
                     | FStar_Pervasives_Native.Some
-                        (FStar_Syntax_Syntax.Implicit uu____11319) -> false
-                    | uu____11322 -> true)) args
+                        (FStar_Syntax_Syntax.Implicit uu____11312) -> false
+                    | uu____11315 -> true)) args
            in
         if (FStar_List.length rf) <> (Prims.of_int (2))
         then
-          let uu____11341 =
+          let uu____11334 =
             FStar_Util.format1
               "eq_op: got %s non-implicit arguments instead of 2?"
               (Prims.string_of_int (FStar_List.length rf))
              in
-          failwith uu____11341
+          failwith uu____11334
         else
-          (let uu____11358 = enc (bin_op FStar_SMTEncoding_Util.mkEq)  in
-           uu____11358 r rf)
+          (let uu____11351 = enc (bin_op FStar_SMTEncoding_Util.mkEq)  in
+           uu____11351 r rf)
          in
       let eq3_op r args =
         let n = FStar_List.length args  in
         if n = (Prims.of_int (4))
         then
-          let uu____11426 =
+          let uu____11419 =
             enc
               (fun terms  ->
                  match terms with
                  | t0::t1::v0::v1::[] ->
-                     let uu____11458 =
-                       let uu____11463 = FStar_SMTEncoding_Util.mkEq (t0, t1)
+                     let uu____11451 =
+                       let uu____11456 = FStar_SMTEncoding_Util.mkEq (t0, t1)
                           in
-                       let uu____11464 = FStar_SMTEncoding_Util.mkEq (v0, v1)
+                       let uu____11457 = FStar_SMTEncoding_Util.mkEq (v0, v1)
                           in
-                       (uu____11463, uu____11464)  in
-                     FStar_SMTEncoding_Util.mkAnd uu____11458
-                 | uu____11465 -> failwith "Impossible")
+                       (uu____11456, uu____11457)  in
+                     FStar_SMTEncoding_Util.mkAnd uu____11451
+                 | uu____11458 -> failwith "Impossible")
              in
-          uu____11426 r args
+          uu____11419 r args
         else
-          (let uu____11471 =
+          (let uu____11464 =
              FStar_Util.format1
                "eq3_op: got %s non-implicit arguments instead of 4?"
                (Prims.string_of_int n)
               in
-           failwith uu____11471)
+           failwith uu____11464)
          in
       let h_equals_op r args =
         let n = FStar_List.length args  in
         if n = (Prims.of_int (4))
         then
-          let uu____11533 =
+          let uu____11526 =
             enc
               (fun terms  ->
                  match terms with
                  | t0::v0::t1::v1::[] ->
-                     let uu____11565 =
-                       let uu____11570 = FStar_SMTEncoding_Util.mkEq (t0, t1)
+                     let uu____11558 =
+                       let uu____11563 = FStar_SMTEncoding_Util.mkEq (t0, t1)
                           in
-                       let uu____11571 = FStar_SMTEncoding_Util.mkEq (v0, v1)
+                       let uu____11564 = FStar_SMTEncoding_Util.mkEq (v0, v1)
                           in
-                       (uu____11570, uu____11571)  in
-                     FStar_SMTEncoding_Util.mkAnd uu____11565
-                 | uu____11572 -> failwith "Impossible")
+                       (uu____11563, uu____11564)  in
+                     FStar_SMTEncoding_Util.mkAnd uu____11558
+                 | uu____11565 -> failwith "Impossible")
              in
-          uu____11533 r args
+          uu____11526 r args
         else
-          (let uu____11578 =
+          (let uu____11571 =
              FStar_Util.format1
                "eq3_op: got %s non-implicit arguments instead of 4?"
                (Prims.string_of_int n)
               in
-           failwith uu____11578)
+           failwith uu____11571)
          in
-      let mk_imp r uu___3_11607 =
-        match uu___3_11607 with
-        | (lhs,uu____11613)::(rhs,uu____11615)::[] ->
-            let uu____11656 = encode_formula rhs env  in
-            (match uu____11656 with
+      let mk_imp r uu___3_11600 =
+        match uu___3_11600 with
+        | (lhs,uu____11606)::(rhs,uu____11608)::[] ->
+            let uu____11649 = encode_formula rhs env  in
+            (match uu____11649 with
              | (l1,decls1) ->
                  (match l1.FStar_SMTEncoding_Term.tm with
                   | FStar_SMTEncoding_Term.App
-                      (FStar_SMTEncoding_Term.TrueOp ,uu____11671) ->
+                      (FStar_SMTEncoding_Term.TrueOp ,uu____11664) ->
                       (l1, decls1)
-                  | uu____11676 ->
-                      let uu____11677 = encode_formula lhs env  in
-                      (match uu____11677 with
+                  | uu____11669 ->
+                      let uu____11670 = encode_formula lhs env  in
+                      (match uu____11670 with
                        | (l2,decls2) ->
-                           let uu____11688 =
+                           let uu____11681 =
                              FStar_SMTEncoding_Term.mkImp (l2, l1) r  in
-                           (uu____11688, (FStar_List.append decls1 decls2)))))
-        | uu____11689 -> failwith "impossible"  in
-      let mk_ite r uu___4_11717 =
-        match uu___4_11717 with
-        | (guard,uu____11723)::(_then,uu____11725)::(_else,uu____11727)::[]
+                           (uu____11681, (FStar_List.append decls1 decls2)))))
+        | uu____11682 -> failwith "impossible"  in
+      let mk_ite r uu___4_11710 =
+        match uu___4_11710 with
+        | (guard,uu____11716)::(_then,uu____11718)::(_else,uu____11720)::[]
             ->
-            let uu____11784 = encode_formula guard env  in
-            (match uu____11784 with
+            let uu____11777 = encode_formula guard env  in
+            (match uu____11777 with
              | (g,decls1) ->
-                 let uu____11795 = encode_formula _then env  in
-                 (match uu____11795 with
+                 let uu____11788 = encode_formula _then env  in
+                 (match uu____11788 with
                   | (t,decls2) ->
-                      let uu____11806 = encode_formula _else env  in
-                      (match uu____11806 with
+                      let uu____11799 = encode_formula _else env  in
+                      (match uu____11799 with
                        | (e,decls3) ->
                            let res = FStar_SMTEncoding_Term.mkITE (g, t, e) r
                               in
                            (res,
                              (FStar_List.append decls1
                                 (FStar_List.append decls2 decls3))))))
-        | uu____11818 -> failwith "impossible"  in
+        | uu____11811 -> failwith "impossible"  in
       let unboxInt_l f l =
-        let uu____11848 = FStar_List.map FStar_SMTEncoding_Term.unboxInt l
+        let uu____11841 = FStar_List.map FStar_SMTEncoding_Term.unboxInt l
            in
-        f uu____11848  in
+        f uu____11841  in
       let connectives =
-        let uu____11878 =
-          let uu____11903 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd)
+        let uu____11871 =
+          let uu____11896 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkAnd)
              in
-          (FStar_Parser_Const.and_lid, uu____11903)  in
-        let uu____11946 =
-          let uu____11973 =
-            let uu____11998 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr)
+          (FStar_Parser_Const.and_lid, uu____11896)  in
+        let uu____11939 =
+          let uu____11966 =
+            let uu____11991 = enc_prop_c (bin_op FStar_SMTEncoding_Util.mkOr)
                in
-            (FStar_Parser_Const.or_lid, uu____11998)  in
-          let uu____12041 =
-            let uu____12068 =
-              let uu____12095 =
-                let uu____12120 =
+            (FStar_Parser_Const.or_lid, uu____11991)  in
+          let uu____12034 =
+            let uu____12061 =
+              let uu____12088 =
+                let uu____12113 =
                   enc_prop_c (bin_op FStar_SMTEncoding_Util.mkIff)  in
-                (FStar_Parser_Const.iff_lid, uu____12120)  in
-              let uu____12163 =
-                let uu____12190 =
-                  let uu____12217 =
-                    let uu____12242 =
+                (FStar_Parser_Const.iff_lid, uu____12113)  in
+              let uu____12156 =
+                let uu____12183 =
+                  let uu____12210 =
+                    let uu____12235 =
                       enc_prop_c (un_op FStar_SMTEncoding_Util.mkNot)  in
-                    (FStar_Parser_Const.not_lid, uu____12242)  in
-                  [uu____12217;
+                    (FStar_Parser_Const.not_lid, uu____12235)  in
+                  [uu____12210;
                   (FStar_Parser_Const.eq2_lid, eq_op);
                   (FStar_Parser_Const.c_eq2_lid, eq_op);
                   (FStar_Parser_Const.eq3_lid, eq3_op);
@@ -4220,82 +4216,82 @@ and (encode_formula :
                   (FStar_Parser_Const.false_lid,
                     (const_op FStar_SMTEncoding_Term.mkFalse))]
                    in
-                (FStar_Parser_Const.ite_lid, mk_ite) :: uu____12190  in
-              uu____12095 :: uu____12163  in
-            (FStar_Parser_Const.imp_lid, mk_imp) :: uu____12068  in
-          uu____11973 :: uu____12041  in
-        uu____11878 :: uu____11946  in
+                (FStar_Parser_Const.ite_lid, mk_ite) :: uu____12183  in
+              uu____12088 :: uu____12156  in
+            (FStar_Parser_Const.imp_lid, mk_imp) :: uu____12061  in
+          uu____11966 :: uu____12034  in
+        uu____11871 :: uu____11939  in
       let rec fallback phi1 =
         match phi1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_meta
             (phi',FStar_Syntax_Syntax.Meta_labeled (msg,r,b)) ->
-            let uu____12787 = encode_formula phi' env  in
-            (match uu____12787 with
+            let uu____12780 = encode_formula phi' env  in
+            (match uu____12780 with
              | (phi2,decls) ->
-                 let uu____12798 =
+                 let uu____12791 =
                    FStar_SMTEncoding_Term.mk
                      (FStar_SMTEncoding_Term.Labeled (phi2, msg, r)) r
                     in
-                 (uu____12798, decls))
-        | FStar_Syntax_Syntax.Tm_meta uu____12800 ->
-            let uu____12807 = FStar_Syntax_Util.unmeta phi1  in
-            encode_formula uu____12807 env
+                 (uu____12791, decls))
+        | FStar_Syntax_Syntax.Tm_meta uu____12793 ->
+            let uu____12800 = FStar_Syntax_Util.unmeta phi1  in
+            encode_formula uu____12800 env
         | FStar_Syntax_Syntax.Tm_match (e,pats) ->
-            let uu____12846 =
+            let uu____12839 =
               encode_match e pats FStar_SMTEncoding_Util.mkFalse env
                 encode_formula
                in
-            (match uu____12846 with | (t,decls) -> (t, decls))
+            (match uu____12839 with | (t,decls) -> (t, decls))
         | FStar_Syntax_Syntax.Tm_let
             ((false
               ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inl x;
-                 FStar_Syntax_Syntax.lbunivs = uu____12858;
+                 FStar_Syntax_Syntax.lbunivs = uu____12851;
                  FStar_Syntax_Syntax.lbtyp = t1;
-                 FStar_Syntax_Syntax.lbeff = uu____12860;
+                 FStar_Syntax_Syntax.lbeff = uu____12853;
                  FStar_Syntax_Syntax.lbdef = e1;
-                 FStar_Syntax_Syntax.lbattrs = uu____12862;
-                 FStar_Syntax_Syntax.lbpos = uu____12863;_}::[]),e2)
+                 FStar_Syntax_Syntax.lbattrs = uu____12855;
+                 FStar_Syntax_Syntax.lbpos = uu____12856;_}::[]),e2)
             ->
-            let uu____12890 = encode_let x t1 e1 e2 env encode_formula  in
-            (match uu____12890 with | (t,decls) -> (t, decls))
+            let uu____12883 = encode_let x t1 e1 e2 env encode_formula  in
+            (match uu____12883 with | (t,decls) -> (t, decls))
         | FStar_Syntax_Syntax.Tm_app (head,args) ->
             let head1 = FStar_Syntax_Util.un_uinst head  in
             (match ((head1.FStar_Syntax_Syntax.n), args) with
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,uu____12943::(x,uu____12945)::(t,uu____12947)::[]) when
+                fv,uu____12936::(x,uu____12938)::(t,uu____12940)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.has_type_lid
                  ->
-                 let uu____13014 = encode_term x env  in
-                 (match uu____13014 with
+                 let uu____13007 = encode_term x env  in
+                 (match uu____13007 with
                   | (x1,decls) ->
-                      let uu____13025 = encode_term t env  in
-                      (match uu____13025 with
+                      let uu____13018 = encode_term t env  in
+                      (match uu____13018 with
                        | (t1,decls') ->
-                           let uu____13036 =
+                           let uu____13029 =
                              FStar_SMTEncoding_Term.mk_HasType x1 t1  in
-                           (uu____13036, (FStar_List.append decls decls'))))
+                           (uu____13029, (FStar_List.append decls decls'))))
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,(r,uu____13039)::(msg,uu____13041)::(phi2,uu____13043)::[])
+                fv,(r,uu____13032)::(msg,uu____13034)::(phi2,uu____13036)::[])
                  when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.labeled_lid
                  ->
-                 let uu____13110 =
-                   let uu____13120 =
-                     let uu____13123 =
+                 let uu____13103 =
+                   let uu____13113 =
+                     let uu____13116 =
                        FStar_Syntax_Embeddings.unembed
                          FStar_Syntax_Embeddings.e_range r
                         in
-                     uu____13123 false FStar_Syntax_Embeddings.id_norm_cb  in
-                   let uu____13131 =
-                     let uu____13135 =
+                     uu____13116 false FStar_Syntax_Embeddings.id_norm_cb  in
+                   let uu____13124 =
+                     let uu____13128 =
                        FStar_Syntax_Embeddings.unembed
                          FStar_Syntax_Embeddings.e_string msg
                         in
-                     uu____13135 false FStar_Syntax_Embeddings.id_norm_cb  in
-                   (uu____13120, uu____13131)  in
-                 (match uu____13110 with
+                     uu____13128 false FStar_Syntax_Embeddings.id_norm_cb  in
+                   (uu____13113, uu____13124)  in
+                 (match uu____13103 with
                   | (FStar_Pervasives_Native.Some
                      r1,FStar_Pervasives_Native.Some s) ->
                       let phi3 =
@@ -4303,8 +4299,7 @@ and (encode_formula :
                           (FStar_Syntax_Syntax.Tm_meta
                              (phi2,
                                (FStar_Syntax_Syntax.Meta_labeled
-                                  (s, r1, false))))
-                          FStar_Pervasives_Native.None r1
+                                  (s, r1, false)))) r1
                          in
                       fallback phi3
                   | (FStar_Pervasives_Native.None
@@ -4315,99 +4310,98 @@ and (encode_formula :
                              (phi2,
                                (FStar_Syntax_Syntax.Meta_labeled
                                   (s, (phi2.FStar_Syntax_Syntax.pos), false))))
-                          FStar_Pervasives_Native.None
                           phi2.FStar_Syntax_Syntax.pos
                          in
                       fallback phi3
-                  | uu____13187 -> fallback phi2)
-             | (FStar_Syntax_Syntax.Tm_fvar fv,(t,uu____13199)::[]) when
+                  | uu____13180 -> fallback phi2)
+             | (FStar_Syntax_Syntax.Tm_fvar fv,(t,uu____13192)::[]) when
                  (FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.squash_lid)
                    ||
                    (FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.auto_squash_lid)
                  -> encode_formula t env
-             | uu____13234 ->
-                 let encode_valid uu____13258 =
-                   let uu____13259 = encode_term phi1 env  in
-                   match uu____13259 with
+             | uu____13227 ->
+                 let encode_valid uu____13251 =
+                   let uu____13252 = encode_term phi1 env  in
+                   match uu____13252 with
                    | (tt,decls) ->
                        let tt1 =
-                         let uu____13271 =
-                           let uu____13273 =
+                         let uu____13264 =
+                           let uu____13266 =
                              FStar_Range.use_range
                                tt.FStar_SMTEncoding_Term.rng
                               in
-                           let uu____13274 =
+                           let uu____13267 =
                              FStar_Range.use_range
                                phi1.FStar_Syntax_Syntax.pos
                               in
-                           FStar_Range.rng_included uu____13273 uu____13274
+                           FStar_Range.rng_included uu____13266 uu____13267
                             in
-                         if uu____13271
+                         if uu____13264
                          then tt
                          else
-                           (let uu___1713_13278 = tt  in
+                           (let uu___1713_13271 = tt  in
                             {
                               FStar_SMTEncoding_Term.tm =
-                                (uu___1713_13278.FStar_SMTEncoding_Term.tm);
+                                (uu___1713_13271.FStar_SMTEncoding_Term.tm);
                               FStar_SMTEncoding_Term.freevars =
-                                (uu___1713_13278.FStar_SMTEncoding_Term.freevars);
+                                (uu___1713_13271.FStar_SMTEncoding_Term.freevars);
                               FStar_SMTEncoding_Term.rng =
                                 (phi1.FStar_Syntax_Syntax.pos)
                             })
                           in
-                       let uu____13279 = FStar_SMTEncoding_Term.mk_Valid tt1
+                       let uu____13272 = FStar_SMTEncoding_Term.mk_Valid tt1
                           in
-                       (uu____13279, decls)
+                       (uu____13272, decls)
                     in
-                 let uu____13280 = head_redex env head1  in
-                 if uu____13280
+                 let uu____13273 = head_redex env head1  in
+                 if uu____13273
                  then
-                   let uu____13287 = maybe_whnf env head1  in
-                   (match uu____13287 with
+                   let uu____13280 = maybe_whnf env head1  in
+                   (match uu____13280 with
                     | FStar_Pervasives_Native.None  -> encode_valid ()
                     | FStar_Pervasives_Native.Some phi2 ->
                         encode_formula phi2 env)
                  else encode_valid ())
-        | uu____13297 ->
-            let uu____13298 = encode_term phi1 env  in
-            (match uu____13298 with
+        | uu____13290 ->
+            let uu____13291 = encode_term phi1 env  in
+            (match uu____13291 with
              | (tt,decls) ->
                  let tt1 =
-                   let uu____13310 =
-                     let uu____13312 =
+                   let uu____13303 =
+                     let uu____13305 =
                        FStar_Range.use_range tt.FStar_SMTEncoding_Term.rng
                         in
-                     let uu____13313 =
+                     let uu____13306 =
                        FStar_Range.use_range phi1.FStar_Syntax_Syntax.pos  in
-                     FStar_Range.rng_included uu____13312 uu____13313  in
-                   if uu____13310
+                     FStar_Range.rng_included uu____13305 uu____13306  in
+                   if uu____13303
                    then tt
                    else
-                     (let uu___1725_13317 = tt  in
+                     (let uu___1725_13310 = tt  in
                       {
                         FStar_SMTEncoding_Term.tm =
-                          (uu___1725_13317.FStar_SMTEncoding_Term.tm);
+                          (uu___1725_13310.FStar_SMTEncoding_Term.tm);
                         FStar_SMTEncoding_Term.freevars =
-                          (uu___1725_13317.FStar_SMTEncoding_Term.freevars);
+                          (uu___1725_13310.FStar_SMTEncoding_Term.freevars);
                         FStar_SMTEncoding_Term.rng =
                           (phi1.FStar_Syntax_Syntax.pos)
                       })
                     in
-                 let uu____13318 = FStar_SMTEncoding_Term.mk_Valid tt1  in
-                 (uu____13318, decls))
+                 let uu____13311 = FStar_SMTEncoding_Term.mk_Valid tt1  in
+                 (uu____13311, decls))
          in
       let encode_q_body env1 bs ps body =
-        let uu____13362 = encode_binders FStar_Pervasives_Native.None bs env1
+        let uu____13355 = encode_binders FStar_Pervasives_Native.None bs env1
            in
-        match uu____13362 with
-        | (vars,guards,env2,decls,uu____13401) ->
-            let uu____13414 = encode_smt_patterns ps env2  in
-            (match uu____13414 with
+        match uu____13355 with
+        | (vars,guards,env2,decls,uu____13394) ->
+            let uu____13407 = encode_smt_patterns ps env2  in
+            (match uu____13407 with
              | (pats,decls') ->
-                 let uu____13451 = encode_formula body env2  in
-                 (match uu____13451 with
+                 let uu____13444 = encode_formula body env2  in
+                 (match uu____13444 with
                   | (body1,decls'') ->
                       let guards1 =
                         match pats with
@@ -4415,68 +4409,68 @@ and (encode_formula :
                              FStar_SMTEncoding_Term.tm =
                                FStar_SMTEncoding_Term.App
                                (FStar_SMTEncoding_Term.Var gf,p::[]);
-                             FStar_SMTEncoding_Term.freevars = uu____13483;
-                             FStar_SMTEncoding_Term.rng = uu____13484;_}::[])::[]
+                             FStar_SMTEncoding_Term.freevars = uu____13476;
+                             FStar_SMTEncoding_Term.rng = uu____13477;_}::[])::[]
                             when
-                            let uu____13504 =
+                            let uu____13497 =
                               FStar_Ident.string_of_lid
                                 FStar_Parser_Const.guard_free
                                in
-                            uu____13504 = gf -> []
-                        | uu____13507 -> guards  in
-                      let uu____13512 =
+                            uu____13497 = gf -> []
+                        | uu____13500 -> guards  in
+                      let uu____13505 =
                         FStar_SMTEncoding_Util.mk_and_l guards1  in
-                      (vars, pats, uu____13512, body1,
+                      (vars, pats, uu____13505, body1,
                         (FStar_List.append decls
                            (FStar_List.append decls' decls'')))))
          in
       debug phi;
       (let phi1 = FStar_Syntax_Util.unascribe phi  in
-       let uu____13523 = FStar_Syntax_Util.destruct_typ_as_formula phi1  in
-       match uu____13523 with
+       let uu____13516 = FStar_Syntax_Util.destruct_typ_as_formula phi1  in
+       match uu____13516 with
        | FStar_Pervasives_Native.None  -> fallback phi1
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn (op,arms))
            ->
-           let uu____13532 =
+           let uu____13525 =
              FStar_All.pipe_right connectives
                (FStar_List.tryFind
-                  (fun uu____13638  ->
-                     match uu____13638 with
-                     | (l,uu____13663) -> FStar_Ident.lid_equals op l))
+                  (fun uu____13631  ->
+                     match uu____13631 with
+                     | (l,uu____13656) -> FStar_Ident.lid_equals op l))
               in
-           (match uu____13532 with
+           (match uu____13525 with
             | FStar_Pervasives_Native.None  -> fallback phi1
-            | FStar_Pervasives_Native.Some (uu____13732,f) ->
+            | FStar_Pervasives_Native.Some (uu____13725,f) ->
                 f phi1.FStar_Syntax_Syntax.pos arms)
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
            (vars,pats,body)) ->
            (FStar_All.pipe_right pats
               (FStar_List.iter (check_pattern_vars env vars));
-            (let uu____13824 = encode_q_body env vars pats body  in
-             match uu____13824 with
+            (let uu____13817 = encode_q_body env vars pats body  in
+             match uu____13817 with
              | (vars1,pats1,guard,body1,decls) ->
                  let tm =
-                   let uu____13869 =
-                     let uu____13880 =
+                   let uu____13862 =
+                     let uu____13873 =
                        FStar_SMTEncoding_Util.mkImp (guard, body1)  in
-                     (pats1, vars1, uu____13880)  in
+                     (pats1, vars1, uu____13873)  in
                    FStar_SMTEncoding_Term.mkForall
-                     phi1.FStar_Syntax_Syntax.pos uu____13869
+                     phi1.FStar_Syntax_Syntax.pos uu____13862
                     in
                  (tm, decls)))
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QEx
            (vars,pats,body)) ->
            (FStar_All.pipe_right pats
               (FStar_List.iter (check_pattern_vars env vars));
-            (let uu____13911 = encode_q_body env vars pats body  in
-             match uu____13911 with
+            (let uu____13904 = encode_q_body env vars pats body  in
+             match uu____13904 with
              | (vars1,pats1,guard,body1,decls) ->
-                 let uu____13955 =
-                   let uu____13956 =
-                     let uu____13967 =
+                 let uu____13948 =
+                   let uu____13949 =
+                     let uu____13960 =
                        FStar_SMTEncoding_Util.mkAnd (guard, body1)  in
-                     (pats1, vars1, uu____13967)  in
+                     (pats1, vars1, uu____13960)  in
                    FStar_SMTEncoding_Term.mkExists
-                     phi1.FStar_Syntax_Syntax.pos uu____13956
+                     phi1.FStar_Syntax_Syntax.pos uu____13949
                     in
-                 (uu____13955, decls))))
+                 (uu____13948, decls))))

--- a/src/ocaml-output/FStar_Syntax_DsEnv.ml
+++ b/src/ocaml-output/FStar_Syntax_DsEnv.ml
@@ -1415,7 +1415,7 @@ let (try_lookup_name :
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_constant
                                    (FStar_Const.Const_reflect refl_monad))
-                                FStar_Pervasives_Native.None occurrence_range
+                                occurrence_range
                                in
                             FStar_Pervasives_Native.Some
                               (Term_name
@@ -3005,60 +3005,55 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                                       let uu____11307 =
                                         let uu____11314 =
                                           let uu____11315 =
-                                            FStar_Ident.range_of_lid lid  in
-                                          let uu____11316 =
-                                            let uu____11323 =
-                                              let uu____11324 =
-                                                let uu____11339 =
-                                                  FStar_Syntax_Syntax.mk_Total
-                                                    typ
-                                                   in
-                                                (binders, uu____11339)  in
-                                              FStar_Syntax_Syntax.Tm_arrow
-                                                uu____11324
-                                               in
-                                            FStar_Syntax_Syntax.mk
-                                              uu____11323
+                                            let uu____11316 =
+                                              let uu____11331 =
+                                                FStar_Syntax_Syntax.mk_Total
+                                                  typ
+                                                 in
+                                              (binders, uu____11331)  in
+                                            FStar_Syntax_Syntax.Tm_arrow
+                                              uu____11316
                                              in
-                                          uu____11316
-                                            FStar_Pervasives_Native.None
-                                            uu____11315
+                                          let uu____11344 =
+                                            FStar_Ident.range_of_lid lid  in
+                                          FStar_Syntax_Syntax.mk uu____11315
+                                            uu____11344
                                            in
                                         (lid, univ_names, uu____11314)  in
                                       FStar_Syntax_Syntax.Sig_declare_typ
                                         uu____11307
                                        in
                                     let se2 =
-                                      let uu___1325_11353 = se1  in
+                                      let uu___1325_11346 = se1  in
                                       {
                                         FStar_Syntax_Syntax.sigel = sigel;
                                         FStar_Syntax_Syntax.sigrng =
-                                          (uu___1325_11353.FStar_Syntax_Syntax.sigrng);
+                                          (uu___1325_11346.FStar_Syntax_Syntax.sigrng);
                                         FStar_Syntax_Syntax.sigquals =
                                           (FStar_Syntax_Syntax.Assumption ::
                                           quals);
                                         FStar_Syntax_Syntax.sigmeta =
-                                          (uu___1325_11353.FStar_Syntax_Syntax.sigmeta);
+                                          (uu___1325_11346.FStar_Syntax_Syntax.sigmeta);
                                         FStar_Syntax_Syntax.sigattrs =
-                                          (uu___1325_11353.FStar_Syntax_Syntax.sigattrs);
+                                          (uu___1325_11346.FStar_Syntax_Syntax.sigattrs);
                                         FStar_Syntax_Syntax.sigopts =
-                                          (uu___1325_11353.FStar_Syntax_Syntax.sigopts)
+                                          (uu___1325_11346.FStar_Syntax_Syntax.sigopts)
                                       }  in
-                                    let uu____11354 =
+                                    let uu____11347 =
                                       FStar_Ident.string_of_lid lid  in
                                     FStar_Util.smap_add (sigmap env1)
-                                      uu____11354 (se2, false))
+                                      uu____11347 (se2, false))
                                  else ())
-                            | uu____11365 -> ()))
+                            | uu____11358 -> ()))
                   else ()
               | FStar_Syntax_Syntax.Sig_declare_typ
-                  (lid,uu____11369,uu____11370) ->
+                  (lid,uu____11362,uu____11363) ->
                   if FStar_List.contains FStar_Syntax_Syntax.Private quals
                   then
-                    let uu____11372 = FStar_Ident.string_of_lid lid  in
-                    FStar_Util.smap_remove (sigmap env1) uu____11372
+                    let uu____11365 = FStar_Ident.string_of_lid lid  in
+                    FStar_Util.smap_remove (sigmap env1) uu____11365
                   else ()
-              | FStar_Syntax_Syntax.Sig_let ((uu____11381,lbs),uu____11383)
+              | FStar_Syntax_Syntax.Sig_let ((uu____11374,lbs),uu____11376)
                   ->
                   (if
                      (FStar_List.contains FStar_Syntax_Syntax.Private quals)
@@ -3069,18 +3064,18 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                      FStar_All.pipe_right lbs
                        (FStar_List.iter
                           (fun lb  ->
-                             let uu____11401 =
-                               let uu____11403 =
-                                 let uu____11404 =
-                                   let uu____11407 =
+                             let uu____11394 =
+                               let uu____11396 =
+                                 let uu____11397 =
+                                   let uu____11400 =
                                      FStar_Util.right
                                        lb.FStar_Syntax_Syntax.lbname
                                       in
-                                   uu____11407.FStar_Syntax_Syntax.fv_name
+                                   uu____11400.FStar_Syntax_Syntax.fv_name
                                     in
-                                 uu____11404.FStar_Syntax_Syntax.v  in
-                               FStar_Ident.string_of_lid uu____11403  in
-                             FStar_Util.smap_remove (sigmap env1) uu____11401))
+                                 uu____11397.FStar_Syntax_Syntax.v  in
+                               FStar_Ident.string_of_lid uu____11396  in
+                             FStar_Util.smap_remove (sigmap env1) uu____11394))
                    else ();
                    if
                      (FStar_List.contains FStar_Syntax_Syntax.Abstract quals)
@@ -3093,129 +3088,129 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
                        (FStar_List.iter
                           (fun lb  ->
                              let lid =
-                               let uu____11425 =
-                                 let uu____11428 =
+                               let uu____11418 =
+                                 let uu____11421 =
                                    FStar_Util.right
                                      lb.FStar_Syntax_Syntax.lbname
                                     in
-                                 uu____11428.FStar_Syntax_Syntax.fv_name  in
-                               uu____11425.FStar_Syntax_Syntax.v  in
+                                 uu____11421.FStar_Syntax_Syntax.fv_name  in
+                               uu____11418.FStar_Syntax_Syntax.v  in
                              let quals1 = FStar_Syntax_Syntax.Assumption ::
                                quals  in
                              let decl =
-                               let uu___1348_11433 = se  in
+                               let uu___1348_11426 = se  in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_declare_typ
                                       (lid, (lb.FStar_Syntax_Syntax.lbunivs),
                                         (lb.FStar_Syntax_Syntax.lbtyp)));
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___1348_11433.FStar_Syntax_Syntax.sigrng);
+                                   (uu___1348_11426.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals = quals1;
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___1348_11433.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___1348_11426.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___1348_11433.FStar_Syntax_Syntax.sigattrs);
+                                   (uu___1348_11426.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (uu___1348_11433.FStar_Syntax_Syntax.sigopts)
+                                   (uu___1348_11426.FStar_Syntax_Syntax.sigopts)
                                }  in
-                             let uu____11434 = FStar_Ident.string_of_lid lid
+                             let uu____11427 = FStar_Ident.string_of_lid lid
                                 in
-                             FStar_Util.smap_add (sigmap env1) uu____11434
+                             FStar_Util.smap_add (sigmap env1) uu____11427
                                (decl, false)))
                    else ())
-              | uu____11445 -> ()));
+              | uu____11438 -> ()));
       (let curmod =
-         let uu____11448 = current_module env1  in
-         FStar_Ident.string_of_lid uu____11448  in
-       (let uu____11450 =
-          let uu____11547 = get_exported_id_set env1 curmod  in
-          let uu____11594 = get_trans_exported_id_set env1 curmod  in
-          (uu____11547, uu____11594)  in
-        match uu____11450 with
+         let uu____11441 = current_module env1  in
+         FStar_Ident.string_of_lid uu____11441  in
+       (let uu____11443 =
+          let uu____11540 = get_exported_id_set env1 curmod  in
+          let uu____11587 = get_trans_exported_id_set env1 curmod  in
+          (uu____11540, uu____11587)  in
+        match uu____11443 with
         | (FStar_Pervasives_Native.Some cur_ex,FStar_Pervasives_Native.Some
            cur_trans_ex) ->
             let update_exports eikind =
               let cur_ex_set =
-                let uu____12013 = cur_ex eikind  in
-                FStar_ST.op_Bang uu____12013  in
+                let uu____12006 = cur_ex eikind  in
+                FStar_ST.op_Bang uu____12006  in
               let cur_trans_ex_set_ref = cur_trans_ex eikind  in
-              let uu____12119 =
-                let uu____12123 = FStar_ST.op_Bang cur_trans_ex_set_ref  in
-                FStar_Util.set_union cur_ex_set uu____12123  in
-              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____12119  in
+              let uu____12112 =
+                let uu____12116 = FStar_ST.op_Bang cur_trans_ex_set_ref  in
+                FStar_Util.set_union cur_ex_set uu____12116  in
+              FStar_ST.op_Colon_Equals cur_trans_ex_set_ref uu____12112  in
             FStar_List.iter update_exports all_exported_id_kinds
-        | uu____12172 -> ());
+        | uu____12165 -> ());
        (match () with
         | () ->
             (filter_record_cache ();
              (match () with
               | () ->
-                  let uu___1366_12270 = env1  in
+                  let uu___1366_12263 = env1  in
                   {
                     curmodule = FStar_Pervasives_Native.None;
-                    curmonad = (uu___1366_12270.curmonad);
+                    curmonad = (uu___1366_12263.curmonad);
                     modules = (((modul.FStar_Syntax_Syntax.name), modul) ::
                       (env1.modules));
                     scope_mods = [];
-                    exported_ids = (uu___1366_12270.exported_ids);
-                    trans_exported_ids = (uu___1366_12270.trans_exported_ids);
-                    includes = (uu___1366_12270.includes);
+                    exported_ids = (uu___1366_12263.exported_ids);
+                    trans_exported_ids = (uu___1366_12263.trans_exported_ids);
+                    includes = (uu___1366_12263.includes);
                     sigaccum = [];
-                    sigmap = (uu___1366_12270.sigmap);
-                    iface = (uu___1366_12270.iface);
-                    admitted_iface = (uu___1366_12270.admitted_iface);
-                    expect_typ = (uu___1366_12270.expect_typ);
+                    sigmap = (uu___1366_12263.sigmap);
+                    iface = (uu___1366_12263.iface);
+                    admitted_iface = (uu___1366_12263.admitted_iface);
+                    expect_typ = (uu___1366_12263.expect_typ);
                     remaining_iface_decls =
-                      (uu___1366_12270.remaining_iface_decls);
-                    syntax_only = (uu___1366_12270.syntax_only);
-                    ds_hooks = (uu___1366_12270.ds_hooks);
-                    dep_graph = (uu___1366_12270.dep_graph)
+                      (uu___1366_12263.remaining_iface_decls);
+                    syntax_only = (uu___1366_12263.syntax_only);
+                    ds_hooks = (uu___1366_12263.ds_hooks);
+                    dep_graph = (uu___1366_12263.dep_graph)
                   }))))
   
 let (stack : env Prims.list FStar_ST.ref) = FStar_Util.mk_ref [] 
 let (push : env -> env) =
   fun env1  ->
     FStar_Util.atomically
-      (fun uu____12296  ->
+      (fun uu____12289  ->
          push_record_cache ();
-         (let uu____12299 =
-            let uu____12302 = FStar_ST.op_Bang stack  in env1 :: uu____12302
+         (let uu____12292 =
+            let uu____12295 = FStar_ST.op_Bang stack  in env1 :: uu____12295
              in
-          FStar_ST.op_Colon_Equals stack uu____12299);
-         (let uu___1372_12351 = env1  in
-          let uu____12352 = FStar_Util.smap_copy env1.exported_ids  in
-          let uu____12357 = FStar_Util.smap_copy env1.trans_exported_ids  in
-          let uu____12362 = FStar_Util.smap_copy env1.includes  in
-          let uu____12373 = FStar_Util.smap_copy env1.sigmap  in
+          FStar_ST.op_Colon_Equals stack uu____12292);
+         (let uu___1372_12344 = env1  in
+          let uu____12345 = FStar_Util.smap_copy env1.exported_ids  in
+          let uu____12350 = FStar_Util.smap_copy env1.trans_exported_ids  in
+          let uu____12355 = FStar_Util.smap_copy env1.includes  in
+          let uu____12366 = FStar_Util.smap_copy env1.sigmap  in
           {
-            curmodule = (uu___1372_12351.curmodule);
-            curmonad = (uu___1372_12351.curmonad);
-            modules = (uu___1372_12351.modules);
-            scope_mods = (uu___1372_12351.scope_mods);
-            exported_ids = uu____12352;
-            trans_exported_ids = uu____12357;
-            includes = uu____12362;
-            sigaccum = (uu___1372_12351.sigaccum);
-            sigmap = uu____12373;
-            iface = (uu___1372_12351.iface);
-            admitted_iface = (uu___1372_12351.admitted_iface);
-            expect_typ = (uu___1372_12351.expect_typ);
-            remaining_iface_decls = (uu___1372_12351.remaining_iface_decls);
-            syntax_only = (uu___1372_12351.syntax_only);
-            ds_hooks = (uu___1372_12351.ds_hooks);
-            dep_graph = (uu___1372_12351.dep_graph)
+            curmodule = (uu___1372_12344.curmodule);
+            curmonad = (uu___1372_12344.curmonad);
+            modules = (uu___1372_12344.modules);
+            scope_mods = (uu___1372_12344.scope_mods);
+            exported_ids = uu____12345;
+            trans_exported_ids = uu____12350;
+            includes = uu____12355;
+            sigaccum = (uu___1372_12344.sigaccum);
+            sigmap = uu____12366;
+            iface = (uu___1372_12344.iface);
+            admitted_iface = (uu___1372_12344.admitted_iface);
+            expect_typ = (uu___1372_12344.expect_typ);
+            remaining_iface_decls = (uu___1372_12344.remaining_iface_decls);
+            syntax_only = (uu___1372_12344.syntax_only);
+            ds_hooks = (uu___1372_12344.ds_hooks);
+            dep_graph = (uu___1372_12344.dep_graph)
           }))
   
 let (pop : unit -> env) =
-  fun uu____12391  ->
+  fun uu____12384  ->
     FStar_Util.atomically
-      (fun uu____12398  ->
-         let uu____12399 = FStar_ST.op_Bang stack  in
-         match uu____12399 with
+      (fun uu____12391  ->
+         let uu____12392 = FStar_ST.op_Bang stack  in
+         match uu____12392 with
          | env1::tl ->
              (pop_record_cache (); FStar_ST.op_Colon_Equals stack tl; env1)
-         | uu____12454 -> failwith "Impossible: Too many pops")
+         | uu____12447 -> failwith "Impossible: Too many pops")
   
 let (snapshot : env -> (Prims.int * env)) =
   fun env1  -> FStar_Common.snapshot push stack env1 
@@ -3226,11 +3221,11 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
     fun env1  ->
       let sigelt_in_m se =
         match FStar_Syntax_Util.lids_of_sigelt se with
-        | l::uu____12501 ->
-            let uu____12504 = FStar_Ident.nsstr l  in
-            let uu____12506 = FStar_Ident.string_of_lid m  in
-            uu____12504 = uu____12506
-        | uu____12509 -> false  in
+        | l::uu____12494 ->
+            let uu____12497 = FStar_Ident.nsstr l  in
+            let uu____12499 = FStar_Ident.string_of_lid m  in
+            uu____12497 = uu____12499
+        | uu____12502 -> false  in
       let sm = sigmap env1  in
       let env2 = pop ()  in
       let keys = FStar_Util.smap_keys sm  in
@@ -3238,33 +3233,33 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
       FStar_All.pipe_right keys
         (FStar_List.iter
            (fun k  ->
-              let uu____12551 = FStar_Util.smap_try_find sm' k  in
-              match uu____12551 with
+              let uu____12544 = FStar_Util.smap_try_find sm' k  in
+              match uu____12544 with
               | FStar_Pervasives_Native.Some (se,true ) when sigelt_in_m se
                   ->
                   (FStar_Util.smap_remove sm' k;
                    (let se1 =
                       match se.FStar_Syntax_Syntax.sigel with
                       | FStar_Syntax_Syntax.Sig_declare_typ (l,u,t) ->
-                          let uu___1407_12582 = se  in
+                          let uu___1407_12575 = se  in
                           {
                             FStar_Syntax_Syntax.sigel =
-                              (uu___1407_12582.FStar_Syntax_Syntax.sigel);
+                              (uu___1407_12575.FStar_Syntax_Syntax.sigel);
                             FStar_Syntax_Syntax.sigrng =
-                              (uu___1407_12582.FStar_Syntax_Syntax.sigrng);
+                              (uu___1407_12575.FStar_Syntax_Syntax.sigrng);
                             FStar_Syntax_Syntax.sigquals =
                               (FStar_Syntax_Syntax.Assumption ::
                               (se.FStar_Syntax_Syntax.sigquals));
                             FStar_Syntax_Syntax.sigmeta =
-                              (uu___1407_12582.FStar_Syntax_Syntax.sigmeta);
+                              (uu___1407_12575.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
-                              (uu___1407_12582.FStar_Syntax_Syntax.sigattrs);
+                              (uu___1407_12575.FStar_Syntax_Syntax.sigattrs);
                             FStar_Syntax_Syntax.sigopts =
-                              (uu___1407_12582.FStar_Syntax_Syntax.sigopts)
+                              (uu___1407_12575.FStar_Syntax_Syntax.sigopts)
                           }
-                      | uu____12583 -> se  in
+                      | uu____12576 -> se  in
                     FStar_Util.smap_add sm' k (se1, false)))
-              | uu____12591 -> ()));
+              | uu____12584 -> ()));
       env2
   
 let (finish_module_or_interface :
@@ -3275,7 +3270,7 @@ let (finish_module_or_interface :
         if Prims.op_Negation modul.FStar_Syntax_Syntax.is_interface
         then check_admits env1 modul
         else modul  in
-      let uu____12618 = finish env1 modul1  in (uu____12618, modul1)
+      let uu____12611 = finish env1 modul1  in (uu____12611, modul1)
   
 type exported_ids =
   {
@@ -3296,15 +3291,15 @@ let (__proj__Mkexported_ids__item__exported_id_fields :
 let (as_exported_ids : exported_id_set -> exported_ids) =
   fun e  ->
     let terms =
-      let uu____12687 =
-        let uu____12691 = e Exported_id_term_type  in
-        FStar_ST.op_Bang uu____12691  in
-      FStar_Util.set_elements uu____12687  in
+      let uu____12680 =
+        let uu____12684 = e Exported_id_term_type  in
+        FStar_ST.op_Bang uu____12684  in
+      FStar_Util.set_elements uu____12680  in
     let fields =
-      let uu____12754 =
-        let uu____12758 = e Exported_id_field  in
-        FStar_ST.op_Bang uu____12758  in
-      FStar_Util.set_elements uu____12754  in
+      let uu____12747 =
+        let uu____12751 = e Exported_id_field  in
+        FStar_ST.op_Bang uu____12751  in
+      FStar_Util.set_elements uu____12747  in
     { exported_id_terms = terms; exported_id_fields = fields }
   
 let (as_exported_id_set :
@@ -3316,15 +3311,15 @@ let (as_exported_id_set :
     | FStar_Pervasives_Native.None  -> exported_id_set_new ()
     | FStar_Pervasives_Native.Some e1 ->
         let terms =
-          let uu____12850 =
+          let uu____12843 =
             FStar_Util.as_set e1.exported_id_terms FStar_Util.compare  in
-          FStar_Util.mk_ref uu____12850  in
+          FStar_Util.mk_ref uu____12843  in
         let fields =
-          let uu____12864 =
+          let uu____12857 =
             FStar_Util.as_set e1.exported_id_fields FStar_Util.compare  in
-          FStar_Util.mk_ref uu____12864  in
-        (fun uu___30_12872  ->
-           match uu___30_12872 with
+          FStar_Util.mk_ref uu____12857  in
+        (fun uu___30_12865  ->
+           match uu___30_12865 with
            | Exported_id_term_type  -> terms
            | Exported_id_field  -> fields)
   
@@ -3363,12 +3358,12 @@ let (default_mii : module_inclusion_info) =
     mii_includes = FStar_Pervasives_Native.None
   } 
 let as_includes :
-  'uuuuuu12976 .
-    'uuuuuu12976 Prims.list FStar_Pervasives_Native.option ->
-      'uuuuuu12976 Prims.list FStar_ST.ref
+  'uuuuuu12969 .
+    'uuuuuu12969 Prims.list FStar_Pervasives_Native.option ->
+      'uuuuuu12969 Prims.list FStar_ST.ref
   =
-  fun uu___31_12989  ->
-    match uu___31_12989 with
+  fun uu___31_12982  ->
+    match uu___31_12982 with
     | FStar_Pervasives_Native.None  -> FStar_Util.mk_ref []
     | FStar_Pervasives_Native.Some l -> FStar_Util.mk_ref l
   
@@ -3377,17 +3372,17 @@ let (inclusion_info : env -> FStar_Ident.lident -> module_inclusion_info) =
     fun l  ->
       let mname = FStar_Ident.string_of_lid l  in
       let as_ids_opt m =
-        let uu____13032 = FStar_Util.smap_try_find m mname  in
-        FStar_Util.map_opt uu____13032 as_exported_ids  in
-      let uu____13038 = as_ids_opt env1.exported_ids  in
-      let uu____13041 = as_ids_opt env1.trans_exported_ids  in
-      let uu____13044 =
-        let uu____13049 = FStar_Util.smap_try_find env1.includes mname  in
-        FStar_Util.map_opt uu____13049 (fun r  -> FStar_ST.op_Bang r)  in
+        let uu____13025 = FStar_Util.smap_try_find m mname  in
+        FStar_Util.map_opt uu____13025 as_exported_ids  in
+      let uu____13031 = as_ids_opt env1.exported_ids  in
+      let uu____13034 = as_ids_opt env1.trans_exported_ids  in
+      let uu____13037 =
+        let uu____13042 = FStar_Util.smap_try_find env1.includes mname  in
+        FStar_Util.map_opt uu____13042 (fun r  -> FStar_ST.op_Bang r)  in
       {
-        mii_exported_ids = uu____13038;
-        mii_trans_exported_ids = uu____13041;
-        mii_includes = uu____13044
+        mii_exported_ids = uu____13031;
+        mii_trans_exported_ids = uu____13034;
+        mii_includes = uu____13037
       }
   
 let (prepare_module_or_interface :
@@ -3403,61 +3398,61 @@ let (prepare_module_or_interface :
           fun mii  ->
             let prep env2 =
               let filename =
-                let uu____13138 = FStar_Ident.string_of_lid mname  in
-                FStar_Util.strcat uu____13138 ".fst"  in
+                let uu____13131 = FStar_Ident.string_of_lid mname  in
+                FStar_Util.strcat uu____13131 ".fst"  in
               let auto_open =
                 FStar_Parser_Dep.hard_coded_dependencies filename  in
               let auto_open1 =
-                let convert_kind uu___32_13160 =
-                  match uu___32_13160 with
+                let convert_kind uu___32_13153 =
+                  match uu___32_13153 with
                   | FStar_Parser_Dep.Open_namespace  -> Open_namespace
                   | FStar_Parser_Dep.Open_module  -> Open_module  in
                 FStar_List.map
-                  (fun uu____13172  ->
-                     match uu____13172 with
+                  (fun uu____13165  ->
+                     match uu____13165 with
                      | (lid,kind) -> (lid, (convert_kind kind))) auto_open
                  in
               let namespace_of_module =
-                let uu____13190 =
-                  let uu____13192 =
-                    let uu____13194 = FStar_Ident.ns_of_lid mname  in
-                    FStar_List.length uu____13194  in
-                  uu____13192 > Prims.int_zero  in
-                if uu____13190
+                let uu____13183 =
+                  let uu____13185 =
+                    let uu____13187 = FStar_Ident.ns_of_lid mname  in
+                    FStar_List.length uu____13187  in
+                  uu____13185 > Prims.int_zero  in
+                if uu____13183
                 then
-                  let uu____13205 =
-                    let uu____13210 =
-                      let uu____13211 = FStar_Ident.ns_of_lid mname  in
-                      FStar_Ident.lid_of_ids uu____13211  in
-                    (uu____13210, Open_namespace)  in
-                  [uu____13205]
+                  let uu____13198 =
+                    let uu____13203 =
+                      let uu____13204 = FStar_Ident.ns_of_lid mname  in
+                      FStar_Ident.lid_of_ids uu____13204  in
+                    (uu____13203, Open_namespace)  in
+                  [uu____13198]
                 else []  in
               let auto_open2 =
                 FStar_List.append namespace_of_module
                   (FStar_List.rev auto_open1)
                  in
-              (let uu____13242 = FStar_Ident.string_of_lid mname  in
-               let uu____13244 = as_exported_id_set mii.mii_exported_ids  in
-               FStar_Util.smap_add env2.exported_ids uu____13242 uu____13244);
+              (let uu____13235 = FStar_Ident.string_of_lid mname  in
+               let uu____13237 = as_exported_id_set mii.mii_exported_ids  in
+               FStar_Util.smap_add env2.exported_ids uu____13235 uu____13237);
               (match () with
                | () ->
-                   ((let uu____13249 = FStar_Ident.string_of_lid mname  in
-                     let uu____13251 =
+                   ((let uu____13242 = FStar_Ident.string_of_lid mname  in
+                     let uu____13244 =
                        as_exported_id_set mii.mii_trans_exported_ids  in
-                     FStar_Util.smap_add env2.trans_exported_ids uu____13249
-                       uu____13251);
+                     FStar_Util.smap_add env2.trans_exported_ids uu____13242
+                       uu____13244);
                     (match () with
                      | () ->
-                         ((let uu____13256 = FStar_Ident.string_of_lid mname
+                         ((let uu____13249 = FStar_Ident.string_of_lid mname
                               in
-                           let uu____13258 = as_includes mii.mii_includes  in
-                           FStar_Util.smap_add env2.includes uu____13256
-                             uu____13258);
+                           let uu____13251 = as_includes mii.mii_includes  in
+                           FStar_Util.smap_add env2.includes uu____13249
+                             uu____13251);
                           (match () with
                            | () ->
                                let env' =
-                                 let uu___1477_13268 = env2  in
-                                 let uu____13269 =
+                                 let uu___1477_13261 = env2  in
+                                 let uu____13262 =
                                    FStar_List.map
                                      (fun x  -> Open_module_or_namespace x)
                                      auto_open2
@@ -3465,25 +3460,25 @@ let (prepare_module_or_interface :
                                  {
                                    curmodule =
                                      (FStar_Pervasives_Native.Some mname);
-                                   curmonad = (uu___1477_13268.curmonad);
-                                   modules = (uu___1477_13268.modules);
-                                   scope_mods = uu____13269;
+                                   curmonad = (uu___1477_13261.curmonad);
+                                   modules = (uu___1477_13261.modules);
+                                   scope_mods = uu____13262;
                                    exported_ids =
-                                     (uu___1477_13268.exported_ids);
+                                     (uu___1477_13261.exported_ids);
                                    trans_exported_ids =
-                                     (uu___1477_13268.trans_exported_ids);
-                                   includes = (uu___1477_13268.includes);
-                                   sigaccum = (uu___1477_13268.sigaccum);
+                                     (uu___1477_13261.trans_exported_ids);
+                                   includes = (uu___1477_13261.includes);
+                                   sigaccum = (uu___1477_13261.sigaccum);
                                    sigmap = (env2.sigmap);
                                    iface = intf;
                                    admitted_iface = admitted;
-                                   expect_typ = (uu___1477_13268.expect_typ);
+                                   expect_typ = (uu___1477_13261.expect_typ);
                                    remaining_iface_decls =
-                                     (uu___1477_13268.remaining_iface_decls);
+                                     (uu___1477_13261.remaining_iface_decls);
                                    syntax_only =
-                                     (uu___1477_13268.syntax_only);
-                                   ds_hooks = (uu___1477_13268.ds_hooks);
-                                   dep_graph = (uu___1477_13268.dep_graph)
+                                     (uu___1477_13261.syntax_only);
+                                   ds_hooks = (uu___1477_13261.ds_hooks);
+                                   dep_graph = (uu___1477_13261.dep_graph)
                                  }  in
                                (FStar_List.iter
                                   (fun op  ->
@@ -3491,79 +3486,79 @@ let (prepare_module_or_interface :
                                        op) (FStar_List.rev auto_open2);
                                 env'))))))
                in
-            let uu____13281 =
+            let uu____13274 =
               FStar_All.pipe_right env1.modules
                 (FStar_Util.find_opt
-                   (fun uu____13307  ->
-                      match uu____13307 with
-                      | (l,uu____13314) -> FStar_Ident.lid_equals l mname))
+                   (fun uu____13300  ->
+                      match uu____13300 with
+                      | (l,uu____13307) -> FStar_Ident.lid_equals l mname))
                in
-            match uu____13281 with
+            match uu____13274 with
             | FStar_Pervasives_Native.None  ->
-                let uu____13324 = prep env1  in (uu____13324, false)
-            | FStar_Pervasives_Native.Some (uu____13327,m) ->
-                ((let uu____13334 =
-                    (let uu____13338 = FStar_Options.interactive ()  in
-                     Prims.op_Negation uu____13338) &&
+                let uu____13317 = prep env1  in (uu____13317, false)
+            | FStar_Pervasives_Native.Some (uu____13320,m) ->
+                ((let uu____13327 =
+                    (let uu____13331 = FStar_Options.interactive ()  in
+                     Prims.op_Negation uu____13331) &&
                       ((Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)
                          || intf)
                      in
-                  if uu____13334
+                  if uu____13327
                   then
-                    let uu____13341 =
-                      let uu____13347 =
-                        let uu____13349 = FStar_Ident.string_of_lid mname  in
+                    let uu____13334 =
+                      let uu____13340 =
+                        let uu____13342 = FStar_Ident.string_of_lid mname  in
                         FStar_Util.format1
                           "Duplicate module or interface name: %s"
-                          uu____13349
+                          uu____13342
                          in
                       (FStar_Errors.Fatal_DuplicateModuleOrInterface,
-                        uu____13347)
+                        uu____13340)
                        in
-                    let uu____13353 = FStar_Ident.range_of_lid mname  in
-                    FStar_Errors.raise_error uu____13341 uu____13353
+                    let uu____13346 = FStar_Ident.range_of_lid mname  in
+                    FStar_Errors.raise_error uu____13334 uu____13346
                   else ());
-                 (let uu____13356 =
-                    let uu____13357 = push env1  in prep uu____13357  in
-                  (uu____13356, true)))
+                 (let uu____13349 =
+                    let uu____13350 = push env1  in prep uu____13350  in
+                  (uu____13349, true)))
   
 let (enter_monad_scope : env -> FStar_Ident.ident -> env) =
   fun env1  ->
     fun mname  ->
       match env1.curmonad with
       | FStar_Pervasives_Native.Some mname' ->
-          let uu____13372 =
-            let uu____13378 =
-              let uu____13380 =
-                let uu____13382 = FStar_Ident.text_of_id mname  in
-                let uu____13384 =
-                  let uu____13386 = FStar_Ident.text_of_id mname'  in
-                  Prims.op_Hat ", but already in monad scope " uu____13386
+          let uu____13365 =
+            let uu____13371 =
+              let uu____13373 =
+                let uu____13375 = FStar_Ident.text_of_id mname  in
+                let uu____13377 =
+                  let uu____13379 = FStar_Ident.text_of_id mname'  in
+                  Prims.op_Hat ", but already in monad scope " uu____13379
                    in
-                Prims.op_Hat uu____13382 uu____13384  in
-              Prims.op_Hat "Trying to define monad " uu____13380  in
-            (FStar_Errors.Fatal_MonadAlreadyDefined, uu____13378)  in
-          let uu____13391 = FStar_Ident.range_of_id mname  in
-          FStar_Errors.raise_error uu____13372 uu____13391
+                Prims.op_Hat uu____13375 uu____13377  in
+              Prims.op_Hat "Trying to define monad " uu____13373  in
+            (FStar_Errors.Fatal_MonadAlreadyDefined, uu____13371)  in
+          let uu____13384 = FStar_Ident.range_of_id mname  in
+          FStar_Errors.raise_error uu____13365 uu____13384
       | FStar_Pervasives_Native.None  ->
-          let uu___1498_13392 = env1  in
+          let uu___1498_13385 = env1  in
           {
-            curmodule = (uu___1498_13392.curmodule);
+            curmodule = (uu___1498_13385.curmodule);
             curmonad = (FStar_Pervasives_Native.Some mname);
-            modules = (uu___1498_13392.modules);
-            scope_mods = (uu___1498_13392.scope_mods);
-            exported_ids = (uu___1498_13392.exported_ids);
-            trans_exported_ids = (uu___1498_13392.trans_exported_ids);
-            includes = (uu___1498_13392.includes);
-            sigaccum = (uu___1498_13392.sigaccum);
-            sigmap = (uu___1498_13392.sigmap);
-            iface = (uu___1498_13392.iface);
-            admitted_iface = (uu___1498_13392.admitted_iface);
-            expect_typ = (uu___1498_13392.expect_typ);
-            remaining_iface_decls = (uu___1498_13392.remaining_iface_decls);
-            syntax_only = (uu___1498_13392.syntax_only);
-            ds_hooks = (uu___1498_13392.ds_hooks);
-            dep_graph = (uu___1498_13392.dep_graph)
+            modules = (uu___1498_13385.modules);
+            scope_mods = (uu___1498_13385.scope_mods);
+            exported_ids = (uu___1498_13385.exported_ids);
+            trans_exported_ids = (uu___1498_13385.trans_exported_ids);
+            includes = (uu___1498_13385.includes);
+            sigaccum = (uu___1498_13385.sigaccum);
+            sigmap = (uu___1498_13385.sigmap);
+            iface = (uu___1498_13385.iface);
+            admitted_iface = (uu___1498_13385.admitted_iface);
+            expect_typ = (uu___1498_13385.expect_typ);
+            remaining_iface_decls = (uu___1498_13385.remaining_iface_decls);
+            syntax_only = (uu___1498_13385.syntax_only);
+            ds_hooks = (uu___1498_13385.ds_hooks);
+            dep_graph = (uu___1498_13385.dep_graph)
           }
   
 let fail_or :
@@ -3575,71 +3570,71 @@ let fail_or :
   fun env1  ->
     fun lookup  ->
       fun lid  ->
-        let uu____13427 = lookup lid  in
-        match uu____13427 with
+        let uu____13420 = lookup lid  in
+        match uu____13420 with
         | FStar_Pervasives_Native.None  ->
             let opened_modules =
               FStar_List.map
-                (fun uu____13442  ->
-                   match uu____13442 with
-                   | (lid1,uu____13449) -> FStar_Ident.string_of_lid lid1)
+                (fun uu____13435  ->
+                   match uu____13435 with
+                   | (lid1,uu____13442) -> FStar_Ident.string_of_lid lid1)
                 env1.modules
                in
             let msg =
-              let uu____13452 = FStar_Ident.string_of_lid lid  in
-              FStar_Util.format1 "Identifier not found: [%s]" uu____13452  in
+              let uu____13445 = FStar_Ident.string_of_lid lid  in
+              FStar_Util.format1 "Identifier not found: [%s]" uu____13445  in
             let msg1 =
-              let uu____13457 =
-                let uu____13459 =
-                  let uu____13461 = FStar_Ident.ns_of_lid lid  in
-                  FStar_List.length uu____13461  in
-                uu____13459 = Prims.int_zero  in
-              if uu____13457
+              let uu____13450 =
+                let uu____13452 =
+                  let uu____13454 = FStar_Ident.ns_of_lid lid  in
+                  FStar_List.length uu____13454  in
+                uu____13452 = Prims.int_zero  in
+              if uu____13450
               then msg
               else
                 (let modul =
-                   let uu____13471 =
-                     let uu____13472 = FStar_Ident.ns_of_lid lid  in
-                     FStar_Ident.lid_of_ids uu____13472  in
-                   let uu____13473 = FStar_Ident.range_of_lid lid  in
-                   FStar_Ident.set_lid_range uu____13471 uu____13473  in
-                 let uu____13474 = resolve_module_name env1 modul true  in
-                 match uu____13474 with
+                   let uu____13464 =
+                     let uu____13465 = FStar_Ident.ns_of_lid lid  in
+                     FStar_Ident.lid_of_ids uu____13465  in
+                   let uu____13466 = FStar_Ident.range_of_lid lid  in
+                   FStar_Ident.set_lid_range uu____13464 uu____13466  in
+                 let uu____13467 = resolve_module_name env1 modul true  in
+                 match uu____13467 with
                  | FStar_Pervasives_Native.None  ->
                      let opened_modules1 =
                        FStar_String.concat ", " opened_modules  in
-                     let uu____13482 = FStar_Ident.string_of_lid modul  in
+                     let uu____13475 = FStar_Ident.string_of_lid modul  in
                      FStar_Util.format3
                        "%s\nModule %s does not belong to the list of modules in scope, namely %s"
-                       msg uu____13482 opened_modules1
+                       msg uu____13475 opened_modules1
                  | FStar_Pervasives_Native.Some modul' when
                      Prims.op_Negation
                        (FStar_List.existsb
                           (fun m  ->
-                             let uu____13491 =
+                             let uu____13484 =
                                FStar_Ident.string_of_lid modul'  in
-                             m = uu____13491) opened_modules)
+                             m = uu____13484) opened_modules)
                      ->
                      let opened_modules1 =
                        FStar_String.concat ", " opened_modules  in
-                     let uu____13497 = FStar_Ident.string_of_lid modul  in
-                     let uu____13499 = FStar_Ident.string_of_lid modul'  in
+                     let uu____13490 = FStar_Ident.string_of_lid modul  in
+                     let uu____13492 = FStar_Ident.string_of_lid modul'  in
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, which does not belong to the list of modules in scope, namely %s"
-                       msg uu____13497 uu____13499 opened_modules1
+                       msg uu____13490 uu____13492 opened_modules1
                  | FStar_Pervasives_Native.Some modul' ->
-                     let uu____13503 = FStar_Ident.string_of_lid modul  in
-                     let uu____13505 = FStar_Ident.string_of_lid modul'  in
-                     let uu____13507 =
-                       let uu____13509 = FStar_Ident.ident_of_lid lid  in
-                       FStar_Ident.text_of_id uu____13509  in
+                     let uu____13496 = FStar_Ident.string_of_lid modul  in
+                     let uu____13498 = FStar_Ident.string_of_lid modul'  in
+                     let uu____13500 =
+                       let uu____13502 = FStar_Ident.ident_of_lid lid  in
+                       FStar_Ident.text_of_id uu____13502  in
                      FStar_Util.format4
                        "%s\nModule %s resolved into %s, definition %s not found"
-                       msg uu____13503 uu____13505 uu____13507)
+                       msg uu____13496 uu____13498 uu____13500)
                in
-            let uu____13511 = FStar_Ident.range_of_lid lid  in
+            let uu____13504 = FStar_Ident.range_of_lid lid  in
             FStar_Errors.raise_error
-              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu____13511
+              (FStar_Errors.Fatal_IdentifierNotFound, msg1) uu____13504
         | FStar_Pervasives_Native.Some r -> r
   
 let fail_or2 :
@@ -3649,17 +3644,17 @@ let fail_or2 :
   =
   fun lookup  ->
     fun id  ->
-      let uu____13541 = lookup id  in
-      match uu____13541 with
+      let uu____13534 = lookup id  in
+      match uu____13534 with
       | FStar_Pervasives_Native.None  ->
-          let uu____13544 =
-            let uu____13550 =
-              let uu____13552 =
-                let uu____13554 = FStar_Ident.text_of_id id  in
-                Prims.op_Hat uu____13554 "]"  in
-              Prims.op_Hat "Identifier not found [" uu____13552  in
-            (FStar_Errors.Fatal_IdentifierNotFound, uu____13550)  in
-          let uu____13559 = FStar_Ident.range_of_id id  in
-          FStar_Errors.raise_error uu____13544 uu____13559
+          let uu____13537 =
+            let uu____13543 =
+              let uu____13545 =
+                let uu____13547 = FStar_Ident.text_of_id id  in
+                Prims.op_Hat uu____13547 "]"  in
+              Prims.op_Hat "Identifier not found [" uu____13545  in
+            (FStar_Errors.Fatal_IdentifierNotFound, uu____13543)  in
+          let uu____13552 = FStar_Ident.range_of_id id  in
+          FStar_Errors.raise_error uu____13537 uu____13552
       | FStar_Pervasives_Native.Some r -> r
   

--- a/src/ocaml-output/FStar_Syntax_Embeddings.ml
+++ b/src/ocaml-output/FStar_Syntax_Embeddings.ml
@@ -219,19 +219,17 @@ let lazy_embed :
                else
                  (let thunk = FStar_Thunk.mk f  in
                   let uu____998 =
-                    let uu____1005 =
-                      let uu____1006 =
-                        let uu____1007 = FStar_Dyn.mkdyn x  in
-                        {
-                          FStar_Syntax_Syntax.blob = uu____1007;
-                          FStar_Syntax_Syntax.lkind =
-                            (FStar_Syntax_Syntax.Lazy_embedding (et, thunk));
-                          FStar_Syntax_Syntax.ltyp = FStar_Syntax_Syntax.tun;
-                          FStar_Syntax_Syntax.rng = rng
-                        }  in
-                      FStar_Syntax_Syntax.Tm_lazy uu____1006  in
-                    FStar_Syntax_Syntax.mk uu____1005  in
-                  uu____998 FStar_Pervasives_Native.None rng))
+                    let uu____999 =
+                      let uu____1000 = FStar_Dyn.mkdyn x  in
+                      {
+                        FStar_Syntax_Syntax.blob = uu____1000;
+                        FStar_Syntax_Syntax.lkind =
+                          (FStar_Syntax_Syntax.Lazy_embedding (et, thunk));
+                        FStar_Syntax_Syntax.ltyp = FStar_Syntax_Syntax.tun;
+                        FStar_Syntax_Syntax.rng = rng
+                      }  in
+                    FStar_Syntax_Syntax.Tm_lazy uu____999  in
+                  FStar_Syntax_Syntax.mk uu____998 rng))
   
 let lazy_unembed :
   'a .
@@ -253,70 +251,70 @@ let lazy_unembed :
                 { FStar_Syntax_Syntax.blob = b;
                   FStar_Syntax_Syntax.lkind =
                     FStar_Syntax_Syntax.Lazy_embedding (et',t);
-                  FStar_Syntax_Syntax.ltyp = uu____1074;
-                  FStar_Syntax_Syntax.rng = uu____1075;_}
+                  FStar_Syntax_Syntax.ltyp = uu____1067;
+                  FStar_Syntax_Syntax.rng = uu____1068;_}
                 ->
-                let uu____1086 =
+                let uu____1079 =
                   (et <> et') ||
                     (FStar_ST.op_Bang FStar_Options.eager_embedding)
                    in
-                if uu____1086
+                if uu____1079
                 then
                   let res =
-                    let uu____1115 = FStar_Thunk.force t  in f uu____1115  in
-                  ((let uu____1119 =
+                    let uu____1108 = FStar_Thunk.force t  in f uu____1108  in
+                  ((let uu____1112 =
                       FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                    if uu____1119
+                    if uu____1112
                     then
-                      let uu____1143 =
+                      let uu____1136 =
                         FStar_Syntax_Print.emb_typ_to_string et  in
-                      let uu____1145 =
+                      let uu____1138 =
                         FStar_Syntax_Print.emb_typ_to_string et'  in
-                      let uu____1147 =
+                      let uu____1140 =
                         match res with
                         | FStar_Pervasives_Native.None  -> "None"
                         | FStar_Pervasives_Native.Some x2 ->
-                            let uu____1152 = pa x2  in
-                            Prims.op_Hat "Some " uu____1152
+                            let uu____1145 = pa x2  in
+                            Prims.op_Hat "Some " uu____1145
                          in
                       FStar_Util.print3
                         "Unembed cancellation failed\n\t%s <> %s\nvalue is %s\n"
-                        uu____1143 uu____1145 uu____1147
+                        uu____1136 uu____1138 uu____1140
                     else ());
                    res)
                 else
                   (let a1 = FStar_Dyn.undyn b  in
-                   (let uu____1162 =
+                   (let uu____1155 =
                       FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                    if uu____1162
+                    if uu____1155
                     then
-                      let uu____1186 =
+                      let uu____1179 =
                         FStar_Syntax_Print.emb_typ_to_string et  in
-                      let uu____1188 = pa a1  in
+                      let uu____1181 = pa a1  in
                       FStar_Util.print2
                         "Unembed cancelled for %s\n\tvalue is %s\n"
-                        uu____1186 uu____1188
+                        uu____1179 uu____1181
                     else ());
                    FStar_Pervasives_Native.Some a1)
-            | uu____1193 ->
+            | uu____1186 ->
                 let aopt = f x1  in
-                ((let uu____1198 =
+                ((let uu____1191 =
                     FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                  if uu____1198
+                  if uu____1191
                   then
-                    let uu____1222 = FStar_Syntax_Print.emb_typ_to_string et
+                    let uu____1215 = FStar_Syntax_Print.emb_typ_to_string et
                        in
-                    let uu____1224 = FStar_Syntax_Print.term_to_string x1  in
-                    let uu____1226 =
+                    let uu____1217 = FStar_Syntax_Print.term_to_string x1  in
+                    let uu____1219 =
                       match aopt with
                       | FStar_Pervasives_Native.None  -> "None"
                       | FStar_Pervasives_Native.Some a1 ->
-                          let uu____1231 = pa a1  in
-                          Prims.op_Hat "Some " uu____1231
+                          let uu____1224 = pa a1  in
+                          Prims.op_Hat "Some " uu____1224
                        in
                     FStar_Util.print3
                       "Unembedding:\n\temb_typ=%s\n\tterm is %s\n\tvalue is %s\n"
-                      uu____1222 uu____1224 uu____1226
+                      uu____1215 uu____1217 uu____1219
                   else ());
                  aopt)
   
@@ -324,19 +322,19 @@ let (mk_any_emb :
   FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.term embedding) =
   fun typ  ->
     let em t _r _topt _norm =
-      (let uu____1269 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
-       if uu____1269
+      (let uu____1262 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
+       if uu____1262
        then
-         let uu____1293 = unknown_printer typ t  in
-         FStar_Util.print1 "Embedding abstract: %s\n" uu____1293
+         let uu____1286 = unknown_printer typ t  in
+         FStar_Util.print1 "Embedding abstract: %s\n" uu____1286
        else ());
       t  in
     let un t _w _n =
-      (let uu____1321 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
-       if uu____1321
+      (let uu____1314 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
+       if uu____1314
        then
-         let uu____1345 = unknown_printer typ t  in
-         FStar_Util.print1 "Unembedding abstract: %s\n" uu____1345
+         let uu____1338 = unknown_printer typ t  in
+         FStar_Util.print1 "Unembedding abstract: %s\n" uu____1338
        else ());
       FStar_Pervasives_Native.Some t  in
     mk_emb_full em un typ (unknown_printer typ)
@@ -345,52 +343,52 @@ let (mk_any_emb :
 let (e_any : FStar_Syntax_Syntax.term embedding) =
   let em t _r _topt _norm = t  in
   let un t _w _n = FStar_Pervasives_Native.Some t  in
-  let uu____1398 =
-    let uu____1399 =
-      let uu____1407 =
+  let uu____1391 =
+    let uu____1392 =
+      let uu____1400 =
         FStar_All.pipe_right FStar_Parser_Const.term_lid
           FStar_Ident.string_of_lid
          in
-      (uu____1407, [])  in
-    FStar_Syntax_Syntax.ET_app uu____1399  in
+      (uu____1400, [])  in
+    FStar_Syntax_Syntax.ET_app uu____1392  in
   mk_emb_full em un FStar_Syntax_Syntax.t_term
-    FStar_Syntax_Print.term_to_string uu____1398
+    FStar_Syntax_Print.term_to_string uu____1391
   
 let (e_unit : unit embedding) =
   let em u rng _topt _norm =
-    let uu___167_1439 = FStar_Syntax_Util.exp_unit  in
+    let uu___167_1432 = FStar_Syntax_Util.exp_unit  in
     {
-      FStar_Syntax_Syntax.n = (uu___167_1439.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___167_1432.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___167_1439.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___167_1432.FStar_Syntax_Syntax.vars)
     }  in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unascribe t0  in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_unit ) ->
         FStar_Pervasives_Native.Some ()
-    | uu____1467 ->
+    | uu____1460 ->
         (if w
          then
-           (let uu____1470 =
-              let uu____1476 =
-                let uu____1478 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded unit: %s" uu____1478  in
-              (FStar_Errors.Warning_NotEmbedded, uu____1476)  in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1470)
+           (let uu____1463 =
+              let uu____1469 =
+                let uu____1471 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded unit: %s" uu____1471  in
+              (FStar_Errors.Warning_NotEmbedded, uu____1469)  in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1463)
          else ();
          FStar_Pervasives_Native.None)
      in
-  let uu____1484 =
-    let uu____1485 =
-      let uu____1493 =
+  let uu____1477 =
+    let uu____1478 =
+      let uu____1486 =
         FStar_All.pipe_right FStar_Parser_Const.unit_lid
           FStar_Ident.string_of_lid
          in
-      (uu____1493, [])  in
-    FStar_Syntax_Syntax.ET_app uu____1485  in
-  mk_emb_full em un FStar_Syntax_Syntax.t_unit (fun uu____1500  -> "()")
-    uu____1484
+      (uu____1486, [])  in
+    FStar_Syntax_Syntax.ET_app uu____1478  in
+  mk_emb_full em un FStar_Syntax_Syntax.t_unit (fun uu____1493  -> "()")
+    uu____1477
   
 let (e_bool : Prims.bool embedding) =
   let em b rng _topt _norm =
@@ -398,92 +396,92 @@ let (e_bool : Prims.bool embedding) =
       if b
       then FStar_Syntax_Util.exp_true_bool
       else FStar_Syntax_Util.exp_false_bool  in
-    let uu___187_1539 = t  in
+    let uu___187_1532 = t  in
     {
-      FStar_Syntax_Syntax.n = (uu___187_1539.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___187_1532.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___187_1539.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___187_1532.FStar_Syntax_Syntax.vars)
     }  in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0  in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool b) ->
         FStar_Pervasives_Native.Some b
-    | uu____1575 ->
+    | uu____1568 ->
         (if w
          then
-           (let uu____1578 =
-              let uu____1584 =
-                let uu____1586 = FStar_Syntax_Print.term_to_string t0  in
-                FStar_Util.format1 "Not an embedded bool: %s" uu____1586  in
-              (FStar_Errors.Warning_NotEmbedded, uu____1584)  in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1578)
+           (let uu____1571 =
+              let uu____1577 =
+                let uu____1579 = FStar_Syntax_Print.term_to_string t0  in
+                FStar_Util.format1 "Not an embedded bool: %s" uu____1579  in
+              (FStar_Errors.Warning_NotEmbedded, uu____1577)  in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1571)
          else ();
          FStar_Pervasives_Native.None)
      in
-  let uu____1593 =
-    let uu____1594 =
-      let uu____1602 =
+  let uu____1586 =
+    let uu____1587 =
+      let uu____1595 =
         FStar_All.pipe_right FStar_Parser_Const.bool_lid
           FStar_Ident.string_of_lid
          in
-      (uu____1602, [])  in
-    FStar_Syntax_Syntax.ET_app uu____1594  in
+      (uu____1595, [])  in
+    FStar_Syntax_Syntax.ET_app uu____1587  in
   mk_emb_full em un FStar_Syntax_Syntax.t_bool FStar_Util.string_of_bool
-    uu____1593
+    uu____1586
   
 let (e_char : FStar_Char.char embedding) =
   let em c rng _topt _norm =
     let t = FStar_Syntax_Util.exp_char c  in
-    let uu___206_1639 = t  in
+    let uu___206_1632 = t  in
     {
-      FStar_Syntax_Syntax.n = (uu___206_1639.FStar_Syntax_Syntax.n);
+      FStar_Syntax_Syntax.n = (uu___206_1632.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (uu___206_1639.FStar_Syntax_Syntax.vars)
+      FStar_Syntax_Syntax.vars = (uu___206_1632.FStar_Syntax_Syntax.vars)
     }  in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0  in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c) ->
         FStar_Pervasives_Native.Some c
-    | uu____1673 ->
+    | uu____1666 ->
         (if w
          then
-           (let uu____1676 =
-              let uu____1682 =
-                let uu____1684 = FStar_Syntax_Print.term_to_string t0  in
-                FStar_Util.format1 "Not an embedded char: %s" uu____1684  in
-              (FStar_Errors.Warning_NotEmbedded, uu____1682)  in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1676)
+           (let uu____1669 =
+              let uu____1675 =
+                let uu____1677 = FStar_Syntax_Print.term_to_string t0  in
+                FStar_Util.format1 "Not an embedded char: %s" uu____1677  in
+              (FStar_Errors.Warning_NotEmbedded, uu____1675)  in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1669)
          else ();
          FStar_Pervasives_Native.None)
      in
-  let uu____1691 =
-    let uu____1692 =
-      let uu____1700 =
+  let uu____1684 =
+    let uu____1685 =
+      let uu____1693 =
         FStar_All.pipe_right FStar_Parser_Const.char_lid
           FStar_Ident.string_of_lid
          in
-      (uu____1700, [])  in
-    FStar_Syntax_Syntax.ET_app uu____1692  in
+      (uu____1693, [])  in
+    FStar_Syntax_Syntax.ET_app uu____1685  in
   mk_emb_full em un FStar_Syntax_Syntax.t_char FStar_Util.string_of_char
-    uu____1691
+    uu____1684
   
 let (e_int : FStar_BigInt.t embedding) =
   let t_int = FStar_Syntax_Util.fvar_const FStar_Parser_Const.int_lid  in
   let emb_t_int =
-    let uu____1712 =
-      let uu____1720 =
+    let uu____1705 =
+      let uu____1713 =
         FStar_All.pipe_right FStar_Parser_Const.int_lid
           FStar_Ident.string_of_lid
          in
-      (uu____1720, [])  in
-    FStar_Syntax_Syntax.ET_app uu____1712  in
+      (uu____1713, [])  in
+    FStar_Syntax_Syntax.ET_app uu____1705  in
   let em i rng _topt _norm =
     lazy_embed FStar_BigInt.string_of_big_int emb_t_int rng t_int i
-      (fun uu____1751  ->
-         let uu____1752 = FStar_BigInt.string_of_big_int i  in
-         FStar_Syntax_Util.exp_int uu____1752)
+      (fun uu____1744  ->
+         let uu____1745 = FStar_BigInt.string_of_big_int i  in
+         FStar_Syntax_Util.exp_int uu____1745)
      in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0  in
@@ -491,20 +489,20 @@ let (e_int : FStar_BigInt.t embedding) =
       (fun t1  ->
          match t1.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
-             (s,uu____1787)) ->
-             let uu____1802 = FStar_BigInt.big_int_of_string s  in
-             FStar_Pervasives_Native.Some uu____1802
-         | uu____1803 ->
+             (s,uu____1780)) ->
+             let uu____1795 = FStar_BigInt.big_int_of_string s  in
+             FStar_Pervasives_Native.Some uu____1795
+         | uu____1796 ->
              (if w
               then
-                (let uu____1806 =
-                   let uu____1812 =
-                     let uu____1814 = FStar_Syntax_Print.term_to_string t0
+                (let uu____1799 =
+                   let uu____1805 =
+                     let uu____1807 = FStar_Syntax_Print.term_to_string t0
                         in
-                     FStar_Util.format1 "Not an embedded int: %s" uu____1814
+                     FStar_Util.format1 "Not an embedded int: %s" uu____1807
                       in
-                   (FStar_Errors.Warning_NotEmbedded, uu____1812)  in
-                 FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1806)
+                   (FStar_Errors.Warning_NotEmbedded, uu____1805)  in
+                 FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1799)
               else ();
               FStar_Pervasives_Native.None))
      in
@@ -513,33 +511,33 @@ let (e_int : FStar_BigInt.t embedding) =
   
 let (e_string : Prims.string embedding) =
   let emb_t_string =
-    let uu____1825 =
-      let uu____1833 =
+    let uu____1818 =
+      let uu____1826 =
         FStar_All.pipe_right FStar_Parser_Const.string_lid
           FStar_Ident.string_of_lid
          in
-      (uu____1833, [])  in
-    FStar_Syntax_Syntax.ET_app uu____1825  in
+      (uu____1826, [])  in
+    FStar_Syntax_Syntax.ET_app uu____1818  in
   let em s rng _topt _norm =
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string (s, rng)))
-      FStar_Pervasives_Native.None rng
+      rng
      in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0  in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_string
-        (s,uu____1896)) -> FStar_Pervasives_Native.Some s
-    | uu____1900 ->
+        (s,uu____1889)) -> FStar_Pervasives_Native.Some s
+    | uu____1893 ->
         (if w
          then
-           (let uu____1903 =
-              let uu____1909 =
-                let uu____1911 = FStar_Syntax_Print.term_to_string t0  in
-                FStar_Util.format1 "Not an embedded string: %s" uu____1911
+           (let uu____1896 =
+              let uu____1902 =
+                let uu____1904 = FStar_Syntax_Print.term_to_string t0  in
+                FStar_Util.format1 "Not an embedded string: %s" uu____1904
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____1909)  in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1903)
+              (FStar_Errors.Warning_NotEmbedded, uu____1902)  in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____1896)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -552,49 +550,46 @@ let e_option :
     let t_option_a =
       let t_opt = FStar_Syntax_Util.fvar_const FStar_Parser_Const.option_lid
          in
-      let uu____1947 =
-        let uu____1952 =
-          let uu____1953 = FStar_Syntax_Syntax.as_arg ea.typ  in [uu____1953]
-           in
-        FStar_Syntax_Syntax.mk_Tm_app t_opt uu____1952  in
-      uu____1947 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+      let uu____1938 =
+        let uu____1939 = FStar_Syntax_Syntax.as_arg ea.typ  in [uu____1939]
+         in
+      FStar_Syntax_Syntax.mk_Tm_app t_opt uu____1938 FStar_Range.dummyRange
+       in
     let emb_t_option_a =
-      let uu____1979 =
-        let uu____1987 =
+      let uu____1965 =
+        let uu____1973 =
           FStar_All.pipe_right FStar_Parser_Const.option_lid
             FStar_Ident.string_of_lid
            in
-        (uu____1987, [ea.emb_typ])  in
-      FStar_Syntax_Syntax.ET_app uu____1979  in
-    let printer1 uu___1_2001 =
-      match uu___1_2001 with
+        (uu____1973, [ea.emb_typ])  in
+      FStar_Syntax_Syntax.ET_app uu____1965  in
+    let printer1 uu___1_1987 =
+      match uu___1_1987 with
       | FStar_Pervasives_Native.None  -> "None"
       | FStar_Pervasives_Native.Some x ->
-          let uu____2007 =
-            let uu____2009 = ea.print x  in Prims.op_Hat uu____2009 ")"  in
-          Prims.op_Hat "(Some " uu____2007
+          let uu____1993 =
+            let uu____1995 = ea.print x  in Prims.op_Hat uu____1995 ")"  in
+          Prims.op_Hat "(Some " uu____1993
        in
     let em o rng topt norm =
       lazy_embed printer1 emb_t_option_a rng t_option_a o
-        (fun uu____2044  ->
+        (fun uu____2031  ->
            match o with
            | FStar_Pervasives_Native.None  ->
-               let uu____2045 =
-                 let uu____2050 =
-                   let uu____2051 =
-                     FStar_Syntax_Syntax.tdataconstr
-                       FStar_Parser_Const.none_lid
-                      in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____2051
-                     [FStar_Syntax_Syntax.U_zero]
+               let uu____2032 =
+                 let uu____2033 =
+                   FStar_Syntax_Syntax.tdataconstr
+                     FStar_Parser_Const.none_lid
                     in
-                 let uu____2052 =
-                   let uu____2053 =
-                     let uu____2062 = type_of ea  in
-                     FStar_Syntax_Syntax.iarg uu____2062  in
-                   [uu____2053]  in
-                 FStar_Syntax_Syntax.mk_Tm_app uu____2050 uu____2052  in
-               uu____2045 FStar_Pervasives_Native.None rng
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu____2033
+                   [FStar_Syntax_Syntax.U_zero]
+                  in
+               let uu____2034 =
+                 let uu____2035 =
+                   let uu____2044 = type_of ea  in
+                   FStar_Syntax_Syntax.iarg uu____2044  in
+                 [uu____2035]  in
+               FStar_Syntax_Syntax.mk_Tm_app uu____2032 uu____2034 rng
            | FStar_Pervasives_Native.Some a1 ->
                let shadow_a =
                  map_shadow topt
@@ -605,103 +600,98 @@ let e_option :
                           FStar_Parser_Const.some_lid v
                          in
                       let some_v_tm =
-                        let uu____2092 =
+                        let uu____2075 =
                           FStar_Syntax_Syntax.lid_as_fv some_v
                             FStar_Syntax_Syntax.delta_equational
                             FStar_Pervasives_Native.None
                            in
-                        FStar_Syntax_Syntax.fv_to_tm uu____2092  in
-                      let uu____2093 =
-                        let uu____2098 =
-                          FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
-                            [FStar_Syntax_Syntax.U_zero]
-                           in
-                        let uu____2099 =
-                          let uu____2100 =
-                            let uu____2109 = type_of ea  in
-                            FStar_Syntax_Syntax.iarg uu____2109  in
-                          let uu____2110 =
-                            let uu____2121 = FStar_Syntax_Syntax.as_arg t  in
-                            [uu____2121]  in
-                          uu____2100 :: uu____2110  in
-                        FStar_Syntax_Syntax.mk_Tm_app uu____2098 uu____2099
+                        FStar_Syntax_Syntax.fv_to_tm uu____2075  in
+                      let uu____2076 =
+                        FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
+                          [FStar_Syntax_Syntax.U_zero]
                          in
-                      uu____2093 FStar_Pervasives_Native.None rng)
+                      let uu____2077 =
+                        let uu____2078 =
+                          let uu____2087 = type_of ea  in
+                          FStar_Syntax_Syntax.iarg uu____2087  in
+                        let uu____2088 =
+                          let uu____2099 = FStar_Syntax_Syntax.as_arg t  in
+                          [uu____2099]  in
+                        uu____2078 :: uu____2088  in
+                      FStar_Syntax_Syntax.mk_Tm_app uu____2076 uu____2077 rng)
                   in
-               let uu____2154 =
-                 let uu____2159 =
-                   let uu____2160 =
-                     FStar_Syntax_Syntax.tdataconstr
-                       FStar_Parser_Const.some_lid
-                      in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____2160
-                     [FStar_Syntax_Syntax.U_zero]
+               let uu____2132 =
+                 let uu____2133 =
+                   FStar_Syntax_Syntax.tdataconstr
+                     FStar_Parser_Const.some_lid
                     in
-                 let uu____2161 =
-                   let uu____2162 =
-                     let uu____2171 = type_of ea  in
-                     FStar_Syntax_Syntax.iarg uu____2171  in
-                   let uu____2172 =
-                     let uu____2183 =
-                       let uu____2192 =
-                         let uu____2193 = embed ea a1  in
-                         uu____2193 rng shadow_a norm  in
-                       FStar_Syntax_Syntax.as_arg uu____2192  in
-                     [uu____2183]  in
-                   uu____2162 :: uu____2172  in
-                 FStar_Syntax_Syntax.mk_Tm_app uu____2159 uu____2161  in
-               uu____2154 FStar_Pervasives_Native.None rng)
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu____2133
+                   [FStar_Syntax_Syntax.U_zero]
+                  in
+               let uu____2134 =
+                 let uu____2135 =
+                   let uu____2144 = type_of ea  in
+                   FStar_Syntax_Syntax.iarg uu____2144  in
+                 let uu____2145 =
+                   let uu____2156 =
+                     let uu____2165 =
+                       let uu____2166 = embed ea a1  in
+                       uu____2166 rng shadow_a norm  in
+                     FStar_Syntax_Syntax.as_arg uu____2165  in
+                   [uu____2156]  in
+                 uu____2135 :: uu____2145  in
+               FStar_Syntax_Syntax.mk_Tm_app uu____2132 uu____2134 rng)
        in
     let un t0 w norm =
       let t = FStar_Syntax_Util.unmeta_safe t0  in
       lazy_unembed printer1 emb_t_option_a t t_option_a
         (fun t1  ->
-           let uu____2263 = FStar_Syntax_Util.head_and_args' t1  in
-           match uu____2263 with
+           let uu____2236 = FStar_Syntax_Util.head_and_args' t1  in
+           match uu____2236 with
            | (hd,args) ->
-               let uu____2304 =
-                 let uu____2319 =
-                   let uu____2320 = FStar_Syntax_Util.un_uinst hd  in
-                   uu____2320.FStar_Syntax_Syntax.n  in
-                 (uu____2319, args)  in
-               (match uu____2304 with
-                | (FStar_Syntax_Syntax.Tm_fvar fv,uu____2338) when
+               let uu____2277 =
+                 let uu____2292 =
+                   let uu____2293 = FStar_Syntax_Util.un_uinst hd  in
+                   uu____2293.FStar_Syntax_Syntax.n  in
+                 (uu____2292, args)  in
+               (match uu____2277 with
+                | (FStar_Syntax_Syntax.Tm_fvar fv,uu____2311) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.none_lid
                     ->
                     FStar_Pervasives_Native.Some FStar_Pervasives_Native.None
                 | (FStar_Syntax_Syntax.Tm_fvar
-                   fv,uu____2362::(a1,uu____2364)::[]) when
+                   fv,uu____2335::(a1,uu____2337)::[]) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.some_lid
                     ->
-                    let uu____2415 =
-                      let uu____2418 = unembed ea a1  in uu____2418 w norm
+                    let uu____2388 =
+                      let uu____2391 = unembed ea a1  in uu____2391 w norm
                        in
-                    FStar_Util.bind_opt uu____2415
+                    FStar_Util.bind_opt uu____2388
                       (fun a2  ->
                          FStar_Pervasives_Native.Some
                            (FStar_Pervasives_Native.Some a2))
-                | uu____2431 ->
+                | uu____2404 ->
                     (if w
                      then
-                       (let uu____2448 =
-                          let uu____2454 =
-                            let uu____2456 =
+                       (let uu____2421 =
+                          let uu____2427 =
+                            let uu____2429 =
                               FStar_Syntax_Print.term_to_string t0  in
                             FStar_Util.format1 "Not an embedded option: %s"
-                              uu____2456
+                              uu____2429
                              in
-                          (FStar_Errors.Warning_NotEmbedded, uu____2454)  in
+                          (FStar_Errors.Warning_NotEmbedded, uu____2427)  in
                         FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                          uu____2448)
+                          uu____2421)
                      else ();
                      FStar_Pervasives_Native.None)))
        in
-    let uu____2464 =
-      let uu____2465 = type_of ea  in
-      FStar_Syntax_Syntax.t_option_of uu____2465  in
-    mk_emb_full em un uu____2464 printer1 emb_t_option_a
+    let uu____2437 =
+      let uu____2438 = type_of ea  in
+      FStar_Syntax_Syntax.t_option_of uu____2438  in
+    mk_emb_full em un uu____2437 printer1 emb_t_option_a
   
 let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
   fun ea  ->
@@ -709,163 +699,159 @@ let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
       let t_pair_a_b =
         let t_tup2 =
           FStar_Syntax_Util.fvar_const FStar_Parser_Const.lid_tuple2  in
-        let uu____2507 =
-          let uu____2512 =
-            let uu____2513 = FStar_Syntax_Syntax.as_arg ea.typ  in
-            let uu____2522 =
-              let uu____2533 = FStar_Syntax_Syntax.as_arg eb.typ  in
-              [uu____2533]  in
-            uu____2513 :: uu____2522  in
-          FStar_Syntax_Syntax.mk_Tm_app t_tup2 uu____2512  in
-        uu____2507 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        let uu____2478 =
+          let uu____2479 = FStar_Syntax_Syntax.as_arg ea.typ  in
+          let uu____2488 =
+            let uu____2499 = FStar_Syntax_Syntax.as_arg eb.typ  in
+            [uu____2499]  in
+          uu____2479 :: uu____2488  in
+        FStar_Syntax_Syntax.mk_Tm_app t_tup2 uu____2478
+          FStar_Range.dummyRange
+         in
       let emb_t_pair_a_b =
-        let uu____2567 =
-          let uu____2575 =
+        let uu____2533 =
+          let uu____2541 =
             FStar_All.pipe_right FStar_Parser_Const.lid_tuple2
               FStar_Ident.string_of_lid
              in
-          (uu____2575, [ea.emb_typ; eb.emb_typ])  in
-        FStar_Syntax_Syntax.ET_app uu____2567  in
-      let printer1 uu____2591 =
-        match uu____2591 with
+          (uu____2541, [ea.emb_typ; eb.emb_typ])  in
+        FStar_Syntax_Syntax.ET_app uu____2533  in
+      let printer1 uu____2557 =
+        match uu____2557 with
         | (x,y) ->
-            let uu____2599 = ea.print x  in
-            let uu____2601 = eb.print y  in
-            FStar_Util.format2 "(%s, %s)" uu____2599 uu____2601
+            let uu____2565 = ea.print x  in
+            let uu____2567 = eb.print y  in
+            FStar_Util.format2 "(%s, %s)" uu____2565 uu____2567
          in
       let em x rng topt norm =
         lazy_embed printer1 emb_t_pair_a_b rng t_pair_a_b x
-          (fun uu____2644  ->
+          (fun uu____2611  ->
              let proj i ab =
                let proj_1 =
-                 let uu____2661 =
+                 let uu____2626 =
                    FStar_Parser_Const.mk_tuple_data_lid (Prims.of_int (2))
                      rng
                     in
-                 let uu____2663 =
+                 let uu____2628 =
                    FStar_Syntax_Syntax.null_bv FStar_Syntax_Syntax.tun  in
-                 FStar_Syntax_Util.mk_field_projector_name uu____2661
-                   uu____2663 i
+                 FStar_Syntax_Util.mk_field_projector_name uu____2626
+                   uu____2628 i
                   in
                let proj_1_tm =
-                 let uu____2665 =
+                 let uu____2630 =
                    FStar_Syntax_Syntax.lid_as_fv proj_1
                      FStar_Syntax_Syntax.delta_equational
                      FStar_Pervasives_Native.None
                     in
-                 FStar_Syntax_Syntax.fv_to_tm uu____2665  in
-               let uu____2666 =
-                 let uu____2671 =
-                   FStar_Syntax_Syntax.mk_Tm_uinst proj_1_tm
-                     [FStar_Syntax_Syntax.U_zero]
-                    in
-                 let uu____2672 =
-                   let uu____2673 =
-                     let uu____2682 = type_of ea  in
-                     FStar_Syntax_Syntax.iarg uu____2682  in
-                   let uu____2683 =
-                     let uu____2694 =
-                       let uu____2703 = type_of eb  in
-                       FStar_Syntax_Syntax.iarg uu____2703  in
-                     let uu____2704 =
-                       let uu____2715 = FStar_Syntax_Syntax.as_arg ab  in
-                       [uu____2715]  in
-                     uu____2694 :: uu____2704  in
-                   uu____2673 :: uu____2683  in
-                 FStar_Syntax_Syntax.mk_Tm_app uu____2671 uu____2672  in
-               uu____2666 FStar_Pervasives_Native.None rng  in
+                 FStar_Syntax_Syntax.fv_to_tm uu____2630  in
+               let uu____2631 =
+                 FStar_Syntax_Syntax.mk_Tm_uinst proj_1_tm
+                   [FStar_Syntax_Syntax.U_zero]
+                  in
+               let uu____2632 =
+                 let uu____2633 =
+                   let uu____2642 = type_of ea  in
+                   FStar_Syntax_Syntax.iarg uu____2642  in
+                 let uu____2643 =
+                   let uu____2654 =
+                     let uu____2663 = type_of eb  in
+                     FStar_Syntax_Syntax.iarg uu____2663  in
+                   let uu____2664 =
+                     let uu____2675 = FStar_Syntax_Syntax.as_arg ab  in
+                     [uu____2675]  in
+                   uu____2654 :: uu____2664  in
+                 uu____2633 :: uu____2643  in
+               FStar_Syntax_Syntax.mk_Tm_app uu____2631 uu____2632 rng  in
              let shadow_a = map_shadow topt (proj Prims.int_one)  in
              let shadow_b = map_shadow topt (proj (Prims.of_int (2)))  in
-             let uu____2760 =
-               let uu____2765 =
-                 let uu____2766 =
-                   FStar_Syntax_Syntax.tdataconstr
-                     FStar_Parser_Const.lid_Mktuple2
-                    in
-                 FStar_Syntax_Syntax.mk_Tm_uinst uu____2766
-                   [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
+             let uu____2720 =
+               let uu____2721 =
+                 FStar_Syntax_Syntax.tdataconstr
+                   FStar_Parser_Const.lid_Mktuple2
                   in
-               let uu____2767 =
-                 let uu____2768 =
-                   let uu____2777 = type_of ea  in
-                   FStar_Syntax_Syntax.iarg uu____2777  in
-                 let uu____2778 =
-                   let uu____2789 =
-                     let uu____2798 = type_of eb  in
-                     FStar_Syntax_Syntax.iarg uu____2798  in
-                   let uu____2799 =
-                     let uu____2810 =
-                       let uu____2819 =
-                         let uu____2820 =
-                           embed ea (FStar_Pervasives_Native.fst x)  in
-                         uu____2820 rng shadow_a norm  in
-                       FStar_Syntax_Syntax.as_arg uu____2819  in
-                     let uu____2827 =
-                       let uu____2838 =
-                         let uu____2847 =
-                           let uu____2848 =
-                             embed eb (FStar_Pervasives_Native.snd x)  in
-                           uu____2848 rng shadow_b norm  in
-                         FStar_Syntax_Syntax.as_arg uu____2847  in
-                       [uu____2838]  in
-                     uu____2810 :: uu____2827  in
-                   uu____2789 :: uu____2799  in
-                 uu____2768 :: uu____2778  in
-               FStar_Syntax_Syntax.mk_Tm_app uu____2765 uu____2767  in
-             uu____2760 FStar_Pervasives_Native.None rng)
+               FStar_Syntax_Syntax.mk_Tm_uinst uu____2721
+                 [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]
+                in
+             let uu____2722 =
+               let uu____2723 =
+                 let uu____2732 = type_of ea  in
+                 FStar_Syntax_Syntax.iarg uu____2732  in
+               let uu____2733 =
+                 let uu____2744 =
+                   let uu____2753 = type_of eb  in
+                   FStar_Syntax_Syntax.iarg uu____2753  in
+                 let uu____2754 =
+                   let uu____2765 =
+                     let uu____2774 =
+                       let uu____2775 =
+                         embed ea (FStar_Pervasives_Native.fst x)  in
+                       uu____2775 rng shadow_a norm  in
+                     FStar_Syntax_Syntax.as_arg uu____2774  in
+                   let uu____2782 =
+                     let uu____2793 =
+                       let uu____2802 =
+                         let uu____2803 =
+                           embed eb (FStar_Pervasives_Native.snd x)  in
+                         uu____2803 rng shadow_b norm  in
+                       FStar_Syntax_Syntax.as_arg uu____2802  in
+                     [uu____2793]  in
+                   uu____2765 :: uu____2782  in
+                 uu____2744 :: uu____2754  in
+               uu____2723 :: uu____2733  in
+             FStar_Syntax_Syntax.mk_Tm_app uu____2720 uu____2722 rng)
          in
       let un t0 w norm =
         let t = FStar_Syntax_Util.unmeta_safe t0  in
         lazy_unembed printer1 emb_t_pair_a_b t t_pair_a_b
           (fun t1  ->
-             let uu____2946 = FStar_Syntax_Util.head_and_args' t1  in
-             match uu____2946 with
+             let uu____2901 = FStar_Syntax_Util.head_and_args' t1  in
+             match uu____2901 with
              | (hd,args) ->
-                 let uu____2989 =
-                   let uu____3002 =
-                     let uu____3003 = FStar_Syntax_Util.un_uinst hd  in
-                     uu____3003.FStar_Syntax_Syntax.n  in
-                   (uu____3002, args)  in
-                 (match uu____2989 with
+                 let uu____2944 =
+                   let uu____2957 =
+                     let uu____2958 = FStar_Syntax_Util.un_uinst hd  in
+                     uu____2958.FStar_Syntax_Syntax.n  in
+                   (uu____2957, args)  in
+                 (match uu____2944 with
                   | (FStar_Syntax_Syntax.Tm_fvar
-                     fv,uu____3021::uu____3022::(a1,uu____3024)::(b1,uu____3026)::[])
+                     fv,uu____2976::uu____2977::(a1,uu____2979)::(b1,uu____2981)::[])
                       when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.lid_Mktuple2
                       ->
-                      let uu____3085 =
-                        let uu____3088 = unembed ea a1  in uu____3088 w norm
+                      let uu____3040 =
+                        let uu____3043 = unembed ea a1  in uu____3043 w norm
                          in
-                      FStar_Util.bind_opt uu____3085
+                      FStar_Util.bind_opt uu____3040
                         (fun a2  ->
-                           let uu____3102 =
-                             let uu____3105 = unembed eb b1  in
-                             uu____3105 w norm  in
-                           FStar_Util.bind_opt uu____3102
+                           let uu____3057 =
+                             let uu____3060 = unembed eb b1  in
+                             uu____3060 w norm  in
+                           FStar_Util.bind_opt uu____3057
                              (fun b2  ->
                                 FStar_Pervasives_Native.Some (a2, b2)))
-                  | uu____3122 ->
+                  | uu____3077 ->
                       (if w
                        then
-                         (let uu____3137 =
-                            let uu____3143 =
-                              let uu____3145 =
+                         (let uu____3092 =
+                            let uu____3098 =
+                              let uu____3100 =
                                 FStar_Syntax_Print.term_to_string t0  in
                               FStar_Util.format1 "Not an embedded pair: %s"
-                                uu____3145
+                                uu____3100
                                in
-                            (FStar_Errors.Warning_NotEmbedded, uu____3143)
+                            (FStar_Errors.Warning_NotEmbedded, uu____3098)
                              in
                           FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                            uu____3137)
+                            uu____3092)
                        else ();
                        FStar_Pervasives_Native.None)))
          in
-      let uu____3155 =
-        let uu____3156 = type_of ea  in
-        let uu____3157 = type_of eb  in
-        FStar_Syntax_Syntax.t_tuple2_of uu____3156 uu____3157  in
-      mk_emb_full em un uu____3155 printer1 emb_t_pair_a_b
+      let uu____3110 =
+        let uu____3111 = type_of ea  in
+        let uu____3112 = type_of eb  in
+        FStar_Syntax_Syntax.t_tuple2_of uu____3111 uu____3112  in
+      mk_emb_full em un uu____3110 printer1 emb_t_pair_a_b
   
 let e_either :
   'a 'b . 'a embedding -> 'b embedding -> ('a,'b) FStar_Util.either embedding
@@ -875,37 +861,37 @@ let e_either :
       let t_sum_a_b =
         let t_either =
           FStar_Syntax_Util.fvar_const FStar_Parser_Const.either_lid  in
-        let uu____3201 =
-          let uu____3206 =
-            let uu____3207 = FStar_Syntax_Syntax.as_arg ea.typ  in
-            let uu____3216 =
-              let uu____3227 = FStar_Syntax_Syntax.as_arg eb.typ  in
-              [uu____3227]  in
-            uu____3207 :: uu____3216  in
-          FStar_Syntax_Syntax.mk_Tm_app t_either uu____3206  in
-        uu____3201 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        let uu____3154 =
+          let uu____3155 = FStar_Syntax_Syntax.as_arg ea.typ  in
+          let uu____3164 =
+            let uu____3175 = FStar_Syntax_Syntax.as_arg eb.typ  in
+            [uu____3175]  in
+          uu____3155 :: uu____3164  in
+        FStar_Syntax_Syntax.mk_Tm_app t_either uu____3154
+          FStar_Range.dummyRange
+         in
       let emb_t_sum_a_b =
-        let uu____3261 =
-          let uu____3269 =
+        let uu____3209 =
+          let uu____3217 =
             FStar_All.pipe_right FStar_Parser_Const.either_lid
               FStar_Ident.string_of_lid
              in
-          (uu____3269, [ea.emb_typ; eb.emb_typ])  in
-        FStar_Syntax_Syntax.ET_app uu____3261  in
+          (uu____3217, [ea.emb_typ; eb.emb_typ])  in
+        FStar_Syntax_Syntax.ET_app uu____3209  in
       let printer1 s =
         match s with
         | FStar_Util.Inl a1 ->
-            let uu____3292 = ea.print a1  in
-            FStar_Util.format1 "Inl %s" uu____3292
+            let uu____3240 = ea.print a1  in
+            FStar_Util.format1 "Inl %s" uu____3240
         | FStar_Util.Inr b1 ->
-            let uu____3296 = eb.print b1  in
-            FStar_Util.format1 "Inr %s" uu____3296
+            let uu____3244 = eb.print b1  in
+            FStar_Util.format1 "Inr %s" uu____3244
          in
       let em s rng topt norm =
         lazy_embed printer1 emb_t_sum_a_b rng t_sum_a_b s
           (match s with
            | FStar_Util.Inl a1 ->
-               (fun uu____3342  ->
+               (fun uu____3291  ->
                   let shadow_a =
                     map_shadow topt
                       (fun t  ->
@@ -915,67 +901,62 @@ let e_either :
                              FStar_Parser_Const.inl_lid v
                             in
                          let some_v_tm =
-                           let uu____3355 =
+                           let uu____3305 =
                              FStar_Syntax_Syntax.lid_as_fv some_v
                                FStar_Syntax_Syntax.delta_equational
                                FStar_Pervasives_Native.None
                               in
-                           FStar_Syntax_Syntax.fv_to_tm uu____3355  in
-                         let uu____3356 =
-                           let uu____3361 =
-                             FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
-                               [FStar_Syntax_Syntax.U_zero]
-                              in
-                           let uu____3362 =
-                             let uu____3363 =
-                               let uu____3372 = type_of ea  in
-                               FStar_Syntax_Syntax.iarg uu____3372  in
-                             let uu____3373 =
-                               let uu____3384 =
-                                 let uu____3393 = type_of eb  in
-                                 FStar_Syntax_Syntax.iarg uu____3393  in
-                               let uu____3394 =
-                                 let uu____3405 =
-                                   FStar_Syntax_Syntax.as_arg t  in
-                                 [uu____3405]  in
-                               uu____3384 :: uu____3394  in
-                             uu____3363 :: uu____3373  in
-                           FStar_Syntax_Syntax.mk_Tm_app uu____3361
-                             uu____3362
+                           FStar_Syntax_Syntax.fv_to_tm uu____3305  in
+                         let uu____3306 =
+                           FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
+                             [FStar_Syntax_Syntax.U_zero]
                             in
-                         uu____3356 FStar_Pervasives_Native.None rng)
+                         let uu____3307 =
+                           let uu____3308 =
+                             let uu____3317 = type_of ea  in
+                             FStar_Syntax_Syntax.iarg uu____3317  in
+                           let uu____3318 =
+                             let uu____3329 =
+                               let uu____3338 = type_of eb  in
+                               FStar_Syntax_Syntax.iarg uu____3338  in
+                             let uu____3339 =
+                               let uu____3350 = FStar_Syntax_Syntax.as_arg t
+                                  in
+                               [uu____3350]  in
+                             uu____3329 :: uu____3339  in
+                           uu____3308 :: uu____3318  in
+                         FStar_Syntax_Syntax.mk_Tm_app uu____3306 uu____3307
+                           rng)
                      in
-                  let uu____3446 =
-                    let uu____3451 =
-                      let uu____3452 =
-                        FStar_Syntax_Syntax.tdataconstr
-                          FStar_Parser_Const.inl_lid
-                         in
-                      FStar_Syntax_Syntax.mk_Tm_uinst uu____3452
-                        [FStar_Syntax_Syntax.U_zero;
-                        FStar_Syntax_Syntax.U_zero]
+                  let uu____3391 =
+                    let uu____3392 =
+                      FStar_Syntax_Syntax.tdataconstr
+                        FStar_Parser_Const.inl_lid
                        in
-                    let uu____3453 =
-                      let uu____3454 =
-                        let uu____3463 = type_of ea  in
-                        FStar_Syntax_Syntax.iarg uu____3463  in
-                      let uu____3464 =
-                        let uu____3475 =
-                          let uu____3484 = type_of eb  in
-                          FStar_Syntax_Syntax.iarg uu____3484  in
-                        let uu____3485 =
-                          let uu____3496 =
-                            let uu____3505 =
-                              let uu____3506 = embed ea a1  in
-                              uu____3506 rng shadow_a norm  in
-                            FStar_Syntax_Syntax.as_arg uu____3505  in
-                          [uu____3496]  in
-                        uu____3475 :: uu____3485  in
-                      uu____3454 :: uu____3464  in
-                    FStar_Syntax_Syntax.mk_Tm_app uu____3451 uu____3453  in
-                  uu____3446 FStar_Pervasives_Native.None rng)
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____3392
+                      [FStar_Syntax_Syntax.U_zero;
+                      FStar_Syntax_Syntax.U_zero]
+                     in
+                  let uu____3393 =
+                    let uu____3394 =
+                      let uu____3403 = type_of ea  in
+                      FStar_Syntax_Syntax.iarg uu____3403  in
+                    let uu____3404 =
+                      let uu____3415 =
+                        let uu____3424 = type_of eb  in
+                        FStar_Syntax_Syntax.iarg uu____3424  in
+                      let uu____3425 =
+                        let uu____3436 =
+                          let uu____3445 =
+                            let uu____3446 = embed ea a1  in
+                            uu____3446 rng shadow_a norm  in
+                          FStar_Syntax_Syntax.as_arg uu____3445  in
+                        [uu____3436]  in
+                      uu____3415 :: uu____3425  in
+                    uu____3394 :: uu____3404  in
+                  FStar_Syntax_Syntax.mk_Tm_app uu____3391 uu____3393 rng)
            | FStar_Util.Inr b1 ->
-               (fun uu____3546  ->
+               (fun uu____3486  ->
                   let shadow_b =
                     map_shadow topt
                       (fun t  ->
@@ -985,176 +966,167 @@ let e_either :
                              FStar_Parser_Const.inr_lid v
                             in
                          let some_v_tm =
-                           let uu____3559 =
+                           let uu____3500 =
                              FStar_Syntax_Syntax.lid_as_fv some_v
                                FStar_Syntax_Syntax.delta_equational
                                FStar_Pervasives_Native.None
                               in
-                           FStar_Syntax_Syntax.fv_to_tm uu____3559  in
-                         let uu____3560 =
-                           let uu____3565 =
-                             FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
-                               [FStar_Syntax_Syntax.U_zero]
-                              in
-                           let uu____3566 =
-                             let uu____3567 =
-                               let uu____3576 = type_of ea  in
-                               FStar_Syntax_Syntax.iarg uu____3576  in
-                             let uu____3577 =
-                               let uu____3588 =
-                                 let uu____3597 = type_of eb  in
-                                 FStar_Syntax_Syntax.iarg uu____3597  in
-                               let uu____3598 =
-                                 let uu____3609 =
-                                   FStar_Syntax_Syntax.as_arg t  in
-                                 [uu____3609]  in
-                               uu____3588 :: uu____3598  in
-                             uu____3567 :: uu____3577  in
-                           FStar_Syntax_Syntax.mk_Tm_app uu____3565
-                             uu____3566
+                           FStar_Syntax_Syntax.fv_to_tm uu____3500  in
+                         let uu____3501 =
+                           FStar_Syntax_Syntax.mk_Tm_uinst some_v_tm
+                             [FStar_Syntax_Syntax.U_zero]
                             in
-                         uu____3560 FStar_Pervasives_Native.None rng)
+                         let uu____3502 =
+                           let uu____3503 =
+                             let uu____3512 = type_of ea  in
+                             FStar_Syntax_Syntax.iarg uu____3512  in
+                           let uu____3513 =
+                             let uu____3524 =
+                               let uu____3533 = type_of eb  in
+                               FStar_Syntax_Syntax.iarg uu____3533  in
+                             let uu____3534 =
+                               let uu____3545 = FStar_Syntax_Syntax.as_arg t
+                                  in
+                               [uu____3545]  in
+                             uu____3524 :: uu____3534  in
+                           uu____3503 :: uu____3513  in
+                         FStar_Syntax_Syntax.mk_Tm_app uu____3501 uu____3502
+                           rng)
                      in
-                  let uu____3650 =
-                    let uu____3655 =
-                      let uu____3656 =
-                        FStar_Syntax_Syntax.tdataconstr
-                          FStar_Parser_Const.inr_lid
-                         in
-                      FStar_Syntax_Syntax.mk_Tm_uinst uu____3656
-                        [FStar_Syntax_Syntax.U_zero;
-                        FStar_Syntax_Syntax.U_zero]
+                  let uu____3586 =
+                    let uu____3587 =
+                      FStar_Syntax_Syntax.tdataconstr
+                        FStar_Parser_Const.inr_lid
                        in
-                    let uu____3657 =
-                      let uu____3658 =
-                        let uu____3667 = type_of ea  in
-                        FStar_Syntax_Syntax.iarg uu____3667  in
-                      let uu____3668 =
-                        let uu____3679 =
-                          let uu____3688 = type_of eb  in
-                          FStar_Syntax_Syntax.iarg uu____3688  in
-                        let uu____3689 =
-                          let uu____3700 =
-                            let uu____3709 =
-                              let uu____3710 = embed eb b1  in
-                              uu____3710 rng shadow_b norm  in
-                            FStar_Syntax_Syntax.as_arg uu____3709  in
-                          [uu____3700]  in
-                        uu____3679 :: uu____3689  in
-                      uu____3658 :: uu____3668  in
-                    FStar_Syntax_Syntax.mk_Tm_app uu____3655 uu____3657  in
-                  uu____3650 FStar_Pervasives_Native.None rng))
+                    FStar_Syntax_Syntax.mk_Tm_uinst uu____3587
+                      [FStar_Syntax_Syntax.U_zero;
+                      FStar_Syntax_Syntax.U_zero]
+                     in
+                  let uu____3588 =
+                    let uu____3589 =
+                      let uu____3598 = type_of ea  in
+                      FStar_Syntax_Syntax.iarg uu____3598  in
+                    let uu____3599 =
+                      let uu____3610 =
+                        let uu____3619 = type_of eb  in
+                        FStar_Syntax_Syntax.iarg uu____3619  in
+                      let uu____3620 =
+                        let uu____3631 =
+                          let uu____3640 =
+                            let uu____3641 = embed eb b1  in
+                            uu____3641 rng shadow_b norm  in
+                          FStar_Syntax_Syntax.as_arg uu____3640  in
+                        [uu____3631]  in
+                      uu____3610 :: uu____3620  in
+                    uu____3589 :: uu____3599  in
+                  FStar_Syntax_Syntax.mk_Tm_app uu____3586 uu____3588 rng))
          in
       let un t0 w norm =
         let t = FStar_Syntax_Util.unmeta_safe t0  in
         lazy_unembed printer1 emb_t_sum_a_b t t_sum_a_b
           (fun t1  ->
-             let uu____3798 = FStar_Syntax_Util.head_and_args' t1  in
-             match uu____3798 with
+             let uu____3729 = FStar_Syntax_Util.head_and_args' t1  in
+             match uu____3729 with
              | (hd,args) ->
-                 let uu____3841 =
-                   let uu____3856 =
-                     let uu____3857 = FStar_Syntax_Util.un_uinst hd  in
-                     uu____3857.FStar_Syntax_Syntax.n  in
-                   (uu____3856, args)  in
-                 (match uu____3841 with
+                 let uu____3772 =
+                   let uu____3787 =
+                     let uu____3788 = FStar_Syntax_Util.un_uinst hd  in
+                     uu____3788.FStar_Syntax_Syntax.n  in
+                   (uu____3787, args)  in
+                 (match uu____3772 with
                   | (FStar_Syntax_Syntax.Tm_fvar
-                     fv,uu____3877::uu____3878::(a1,uu____3880)::[]) when
+                     fv,uu____3808::uu____3809::(a1,uu____3811)::[]) when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.inl_lid
                       ->
-                      let uu____3947 =
-                        let uu____3950 = unembed ea a1  in uu____3950 w norm
+                      let uu____3878 =
+                        let uu____3881 = unembed ea a1  in uu____3881 w norm
                          in
-                      FStar_Util.bind_opt uu____3947
+                      FStar_Util.bind_opt uu____3878
                         (fun a2  ->
                            FStar_Pervasives_Native.Some (FStar_Util.Inl a2))
                   | (FStar_Syntax_Syntax.Tm_fvar
-                     fv,uu____3968::uu____3969::(b1,uu____3971)::[]) when
+                     fv,uu____3899::uu____3900::(b1,uu____3902)::[]) when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.inr_lid
                       ->
-                      let uu____4038 =
-                        let uu____4041 = unembed eb b1  in uu____4041 w norm
+                      let uu____3969 =
+                        let uu____3972 = unembed eb b1  in uu____3972 w norm
                          in
-                      FStar_Util.bind_opt uu____4038
+                      FStar_Util.bind_opt uu____3969
                         (fun b2  ->
                            FStar_Pervasives_Native.Some (FStar_Util.Inr b2))
-                  | uu____4058 ->
+                  | uu____3989 ->
                       (if w
                        then
-                         (let uu____4075 =
-                            let uu____4081 =
-                              let uu____4083 =
+                         (let uu____4006 =
+                            let uu____4012 =
+                              let uu____4014 =
                                 FStar_Syntax_Print.term_to_string t0  in
                               FStar_Util.format1 "Not an embedded sum: %s"
-                                uu____4083
+                                uu____4014
                                in
-                            (FStar_Errors.Warning_NotEmbedded, uu____4081)
+                            (FStar_Errors.Warning_NotEmbedded, uu____4012)
                              in
                           FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                            uu____4075)
+                            uu____4006)
                        else ();
                        FStar_Pervasives_Native.None)))
          in
-      let uu____4093 =
-        let uu____4094 = type_of ea  in
-        let uu____4095 = type_of eb  in
-        FStar_Syntax_Syntax.t_either_of uu____4094 uu____4095  in
-      mk_emb_full em un uu____4093 printer1 emb_t_sum_a_b
+      let uu____4024 =
+        let uu____4025 = type_of ea  in
+        let uu____4026 = type_of eb  in
+        FStar_Syntax_Syntax.t_either_of uu____4025 uu____4026  in
+      mk_emb_full em un uu____4024 printer1 emb_t_sum_a_b
   
 let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
   fun ea  ->
     let t_list_a =
       let t_list = FStar_Syntax_Util.fvar_const FStar_Parser_Const.list_lid
          in
-      let uu____4123 =
-        let uu____4128 =
-          let uu____4129 = FStar_Syntax_Syntax.as_arg ea.typ  in [uu____4129]
-           in
-        FStar_Syntax_Syntax.mk_Tm_app t_list uu____4128  in
-      uu____4123 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+      let uu____4052 =
+        let uu____4053 = FStar_Syntax_Syntax.as_arg ea.typ  in [uu____4053]
+         in
+      FStar_Syntax_Syntax.mk_Tm_app t_list uu____4052 FStar_Range.dummyRange
+       in
     let emb_t_list_a =
-      let uu____4155 =
-        let uu____4163 =
+      let uu____4079 =
+        let uu____4087 =
           FStar_All.pipe_right FStar_Parser_Const.list_lid
             FStar_Ident.string_of_lid
            in
-        (uu____4163, [ea.emb_typ])  in
-      FStar_Syntax_Syntax.ET_app uu____4155  in
+        (uu____4087, [ea.emb_typ])  in
+      FStar_Syntax_Syntax.ET_app uu____4079  in
     let printer1 l =
-      let uu____4180 =
-        let uu____4182 =
-          let uu____4184 = FStar_List.map ea.print l  in
-          FStar_All.pipe_right uu____4184 (FStar_String.concat "; ")  in
-        Prims.op_Hat uu____4182 "]"  in
-      Prims.op_Hat "[" uu____4180  in
+      let uu____4104 =
+        let uu____4106 =
+          let uu____4108 = FStar_List.map ea.print l  in
+          FStar_All.pipe_right uu____4108 (FStar_String.concat "; ")  in
+        Prims.op_Hat uu____4106 "]"  in
+      Prims.op_Hat "[" uu____4104  in
     let rec em l rng shadow_l norm =
       lazy_embed printer1 emb_t_list_a rng t_list_a l
-        (fun uu____4228  ->
+        (fun uu____4152  ->
            let t =
-             let uu____4230 = type_of ea  in
-             FStar_Syntax_Syntax.iarg uu____4230  in
+             let uu____4154 = type_of ea  in
+             FStar_Syntax_Syntax.iarg uu____4154  in
            match l with
            | [] ->
-               let uu____4231 =
-                 let uu____4236 =
-                   let uu____4237 =
-                     FStar_Syntax_Syntax.tdataconstr
-                       FStar_Parser_Const.nil_lid
-                      in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____4237
-                     [FStar_Syntax_Syntax.U_zero]
+               let uu____4155 =
+                 let uu____4156 =
+                   FStar_Syntax_Syntax.tdataconstr FStar_Parser_Const.nil_lid
                     in
-                 FStar_Syntax_Syntax.mk_Tm_app uu____4236 [t]  in
-               uu____4231 FStar_Pervasives_Native.None rng
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu____4156
+                   [FStar_Syntax_Syntax.U_zero]
+                  in
+               FStar_Syntax_Syntax.mk_Tm_app uu____4155 [t] rng
            | hd::tl ->
                let cons =
-                 let uu____4259 =
+                 let uu____4178 =
                    FStar_Syntax_Syntax.tdataconstr
                      FStar_Parser_Const.cons_lid
                     in
-                 FStar_Syntax_Syntax.mk_Tm_uinst uu____4259
+                 FStar_Syntax_Syntax.mk_Tm_uinst uu____4178
                    [FStar_Syntax_Syntax.U_zero]
                   in
                let proj f cons_tm =
@@ -1164,80 +1136,75 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
                      FStar_Parser_Const.cons_lid fid
                     in
                  let proj_tm =
-                   let uu____4279 =
+                   let uu____4196 =
                      FStar_Syntax_Syntax.lid_as_fv proj
                        FStar_Syntax_Syntax.delta_equational
                        FStar_Pervasives_Native.None
                       in
-                   FStar_Syntax_Syntax.fv_to_tm uu____4279  in
-                 let uu____4280 =
-                   let uu____4285 =
-                     FStar_Syntax_Syntax.mk_Tm_uinst proj_tm
-                       [FStar_Syntax_Syntax.U_zero]
-                      in
-                   let uu____4286 =
-                     let uu____4287 =
-                       let uu____4296 = type_of ea  in
-                       FStar_Syntax_Syntax.iarg uu____4296  in
-                     let uu____4297 =
-                       let uu____4308 = FStar_Syntax_Syntax.as_arg cons_tm
-                          in
-                       [uu____4308]  in
-                     uu____4287 :: uu____4297  in
-                   FStar_Syntax_Syntax.mk_Tm_app uu____4285 uu____4286  in
-                 uu____4280 FStar_Pervasives_Native.None rng  in
+                   FStar_Syntax_Syntax.fv_to_tm uu____4196  in
+                 let uu____4197 =
+                   FStar_Syntax_Syntax.mk_Tm_uinst proj_tm
+                     [FStar_Syntax_Syntax.U_zero]
+                    in
+                 let uu____4198 =
+                   let uu____4199 =
+                     let uu____4208 = type_of ea  in
+                     FStar_Syntax_Syntax.iarg uu____4208  in
+                   let uu____4209 =
+                     let uu____4220 = FStar_Syntax_Syntax.as_arg cons_tm  in
+                     [uu____4220]  in
+                   uu____4199 :: uu____4209  in
+                 FStar_Syntax_Syntax.mk_Tm_app uu____4197 uu____4198 rng  in
                let shadow_hd = map_shadow shadow_l (proj "hd")  in
                let shadow_tl = map_shadow shadow_l (proj "tl")  in
-               let uu____4345 =
-                 let uu____4350 =
-                   let uu____4351 =
-                     let uu____4362 =
-                       let uu____4371 =
-                         let uu____4372 = embed ea hd  in
-                         uu____4372 rng shadow_hd norm  in
-                       FStar_Syntax_Syntax.as_arg uu____4371  in
-                     let uu____4379 =
-                       let uu____4390 =
-                         let uu____4399 = em tl rng shadow_tl norm  in
-                         FStar_Syntax_Syntax.as_arg uu____4399  in
-                       [uu____4390]  in
-                     uu____4362 :: uu____4379  in
-                   t :: uu____4351  in
-                 FStar_Syntax_Syntax.mk_Tm_app cons uu____4350  in
-               uu____4345 FStar_Pervasives_Native.None rng)
+               let uu____4257 =
+                 let uu____4258 =
+                   let uu____4269 =
+                     let uu____4278 =
+                       let uu____4279 = embed ea hd  in
+                       uu____4279 rng shadow_hd norm  in
+                     FStar_Syntax_Syntax.as_arg uu____4278  in
+                   let uu____4286 =
+                     let uu____4297 =
+                       let uu____4306 = em tl rng shadow_tl norm  in
+                       FStar_Syntax_Syntax.as_arg uu____4306  in
+                     [uu____4297]  in
+                   uu____4269 :: uu____4286  in
+                 t :: uu____4258  in
+               FStar_Syntax_Syntax.mk_Tm_app cons uu____4257 rng)
        in
     let rec un t0 w norm =
       let t = FStar_Syntax_Util.unmeta_safe t0  in
       lazy_unembed printer1 emb_t_list_a t t_list_a
         (fun t1  ->
-           let uu____4471 = FStar_Syntax_Util.head_and_args' t1  in
-           match uu____4471 with
+           let uu____4378 = FStar_Syntax_Util.head_and_args' t1  in
+           match uu____4378 with
            | (hd,args) ->
-               let uu____4512 =
-                 let uu____4525 =
-                   let uu____4526 = FStar_Syntax_Util.un_uinst hd  in
-                   uu____4526.FStar_Syntax_Syntax.n  in
-                 (uu____4525, args)  in
-               (match uu____4512 with
-                | (FStar_Syntax_Syntax.Tm_fvar fv,uu____4542) when
+               let uu____4419 =
+                 let uu____4432 =
+                   let uu____4433 = FStar_Syntax_Util.un_uinst hd  in
+                   uu____4433.FStar_Syntax_Syntax.n  in
+                 (uu____4432, args)  in
+               (match uu____4419 with
+                | (FStar_Syntax_Syntax.Tm_fvar fv,uu____4449) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.nil_lid
                     -> FStar_Pervasives_Native.Some []
                 | (FStar_Syntax_Syntax.Tm_fvar
-                   fv,(uu____4562,FStar_Pervasives_Native.Some
-                       (FStar_Syntax_Syntax.Implicit uu____4563))::(hd1,FStar_Pervasives_Native.None
+                   fv,(uu____4469,FStar_Pervasives_Native.Some
+                       (FStar_Syntax_Syntax.Implicit uu____4470))::(hd1,FStar_Pervasives_Native.None
                                                                     )::
                    (tl,FStar_Pervasives_Native.None )::[]) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.cons_lid
                     ->
-                    let uu____4605 =
-                      let uu____4608 = unembed ea hd1  in uu____4608 w norm
+                    let uu____4512 =
+                      let uu____4515 = unembed ea hd1  in uu____4515 w norm
                        in
-                    FStar_Util.bind_opt uu____4605
+                    FStar_Util.bind_opt uu____4512
                       (fun hd2  ->
-                         let uu____4620 = un tl w norm  in
-                         FStar_Util.bind_opt uu____4620
+                         let uu____4527 = un tl w norm  in
+                         FStar_Util.bind_opt uu____4527
                            (fun tl1  ->
                               FStar_Pervasives_Native.Some (hd2 :: tl1)))
                 | (FStar_Syntax_Syntax.Tm_fvar
@@ -1247,35 +1214,35 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.cons_lid
                     ->
-                    let uu____4668 =
-                      let uu____4671 = unembed ea hd1  in uu____4671 w norm
+                    let uu____4575 =
+                      let uu____4578 = unembed ea hd1  in uu____4578 w norm
                        in
-                    FStar_Util.bind_opt uu____4668
+                    FStar_Util.bind_opt uu____4575
                       (fun hd2  ->
-                         let uu____4683 = un tl w norm  in
-                         FStar_Util.bind_opt uu____4683
+                         let uu____4590 = un tl w norm  in
+                         FStar_Util.bind_opt uu____4590
                            (fun tl1  ->
                               FStar_Pervasives_Native.Some (hd2 :: tl1)))
-                | uu____4698 ->
+                | uu____4605 ->
                     (if w
                      then
-                       (let uu____4713 =
-                          let uu____4719 =
-                            let uu____4721 =
+                       (let uu____4620 =
+                          let uu____4626 =
+                            let uu____4628 =
                               FStar_Syntax_Print.term_to_string t0  in
                             FStar_Util.format1 "Not an embedded list: %s"
-                              uu____4721
+                              uu____4628
                              in
-                          (FStar_Errors.Warning_NotEmbedded, uu____4719)  in
+                          (FStar_Errors.Warning_NotEmbedded, uu____4626)  in
                         FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                          uu____4713)
+                          uu____4620)
                      else ();
                      FStar_Pervasives_Native.None)))
        in
-    let uu____4729 =
-      let uu____4730 = type_of ea  in
-      FStar_Syntax_Syntax.t_list_of uu____4730  in
-    mk_emb_full em un uu____4729 printer1 emb_t_list_a
+    let uu____4636 =
+      let uu____4637 = type_of ea  in
+      FStar_Syntax_Syntax.t_list_of uu____4637  in
+    mk_emb_full em un uu____4636 printer1 emb_t_list_a
   
 let (e_string_list : Prims.string Prims.list embedding) = e_list e_string 
 type norm_step =
@@ -1294,58 +1261,58 @@ type norm_step =
   | NBE 
 let (uu___is_Simpl : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Simpl  -> true | uu____4773 -> false
+    match projectee with | Simpl  -> true | uu____4680 -> false
   
 let (uu___is_Weak : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Weak  -> true | uu____4784 -> false
+    match projectee with | Weak  -> true | uu____4691 -> false
   
 let (uu___is_HNF : norm_step -> Prims.bool) =
-  fun projectee  -> match projectee with | HNF  -> true | uu____4795 -> false 
+  fun projectee  -> match projectee with | HNF  -> true | uu____4702 -> false 
 let (uu___is_Primops : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primops  -> true | uu____4806 -> false
+    match projectee with | Primops  -> true | uu____4713 -> false
   
 let (uu___is_Delta : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Delta  -> true | uu____4817 -> false
+    match projectee with | Delta  -> true | uu____4724 -> false
   
 let (uu___is_Zeta : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Zeta  -> true | uu____4828 -> false
+    match projectee with | Zeta  -> true | uu____4735 -> false
   
 let (uu___is_ZetaFull : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | ZetaFull  -> true | uu____4839 -> false
+    match projectee with | ZetaFull  -> true | uu____4746 -> false
   
 let (uu___is_Iota : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Iota  -> true | uu____4850 -> false
+    match projectee with | Iota  -> true | uu____4757 -> false
   
 let (uu___is_Reify : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reify  -> true | uu____4861 -> false
+    match projectee with | Reify  -> true | uu____4768 -> false
   
 let (uu___is_UnfoldOnly : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldOnly _0 -> true | uu____4876 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu____4783 -> false
   
 let (__proj__UnfoldOnly__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
 let (uu___is_UnfoldFully : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldFully _0 -> true | uu____4907 -> false
+    match projectee with | UnfoldFully _0 -> true | uu____4814 -> false
   
 let (__proj__UnfoldFully__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldFully _0 -> _0 
 let (uu___is_UnfoldAttr : norm_step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldAttr _0 -> true | uu____4938 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu____4845 -> false
   
 let (__proj__UnfoldAttr__item___0 : norm_step -> Prims.string Prims.list) =
   fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 
 let (uu___is_NBE : norm_step -> Prims.bool) =
-  fun projectee  -> match projectee with | NBE  -> true | uu____4965 -> false 
+  fun projectee  -> match projectee with | NBE  -> true | uu____4872 -> false 
 let (steps_Simpl : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.tconst FStar_Parser_Const.steps_simpl 
 let (steps_Weak : FStar_Syntax_Syntax.term) =
@@ -1374,21 +1341,21 @@ let (steps_NBE : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.tconst FStar_Parser_Const.steps_nbe 
 let (e_norm_step : norm_step embedding) =
   let t_norm_step =
-    let uu____4984 =
+    let uu____4891 =
       FStar_Ident.lid_of_str "FStar.Syntax.Embeddings.norm_step"  in
-    FStar_Syntax_Util.fvar_const uu____4984  in
+    FStar_Syntax_Util.fvar_const uu____4891  in
   let emb_t_norm_step =
-    let uu____4987 =
-      let uu____4995 =
+    let uu____4894 =
+      let uu____4902 =
         FStar_All.pipe_right FStar_Parser_Const.norm_step_lid
           FStar_Ident.string_of_lid
          in
-      (uu____4995, [])  in
-    FStar_Syntax_Syntax.ET_app uu____4987  in
-  let printer1 uu____5007 = "norm_step"  in
+      (uu____4902, [])  in
+    FStar_Syntax_Syntax.ET_app uu____4894  in
+  let printer1 uu____4914 = "norm_step"  in
   let em n rng _topt norm =
     lazy_embed printer1 emb_t_norm_step rng t_norm_step n
-      (fun uu____5033  ->
+      (fun uu____4940  ->
          match n with
          | Simpl  -> steps_Simpl
          | Weak  -> steps_Weak
@@ -1401,58 +1368,52 @@ let (e_norm_step : norm_step embedding) =
          | NBE  -> steps_NBE
          | Reify  -> steps_Reify
          | UnfoldOnly l ->
-             let uu____5038 =
-               let uu____5043 =
-                 let uu____5044 =
-                   let uu____5053 =
-                     let uu____5054 =
-                       let uu____5061 = e_list e_string  in
-                       embed uu____5061 l  in
-                     uu____5054 rng FStar_Pervasives_Native.None norm  in
-                   FStar_Syntax_Syntax.as_arg uu____5053  in
-                 [uu____5044]  in
-               FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldOnly uu____5043  in
-             uu____5038 FStar_Pervasives_Native.None rng
+             let uu____4945 =
+               let uu____4946 =
+                 let uu____4955 =
+                   let uu____4956 =
+                     let uu____4963 = e_list e_string  in embed uu____4963 l
+                      in
+                   uu____4956 rng FStar_Pervasives_Native.None norm  in
+                 FStar_Syntax_Syntax.as_arg uu____4955  in
+               [uu____4946]  in
+             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldOnly uu____4945 rng
          | UnfoldFully l ->
-             let uu____5093 =
-               let uu____5098 =
-                 let uu____5099 =
-                   let uu____5108 =
-                     let uu____5109 =
-                       let uu____5116 = e_list e_string  in
-                       embed uu____5116 l  in
-                     uu____5109 rng FStar_Pervasives_Native.None norm  in
-                   FStar_Syntax_Syntax.as_arg uu____5108  in
-                 [uu____5099]  in
-               FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldFully uu____5098  in
-             uu____5093 FStar_Pervasives_Native.None rng
+             let uu____4995 =
+               let uu____4996 =
+                 let uu____5005 =
+                   let uu____5006 =
+                     let uu____5013 = e_list e_string  in embed uu____5013 l
+                      in
+                   uu____5006 rng FStar_Pervasives_Native.None norm  in
+                 FStar_Syntax_Syntax.as_arg uu____5005  in
+               [uu____4996]  in
+             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldFully uu____4995 rng
          | UnfoldAttr l ->
-             let uu____5148 =
-               let uu____5153 =
-                 let uu____5154 =
-                   let uu____5163 =
-                     let uu____5164 =
-                       let uu____5171 = e_list e_string  in
-                       embed uu____5171 l  in
-                     uu____5164 rng FStar_Pervasives_Native.None norm  in
-                   FStar_Syntax_Syntax.as_arg uu____5163  in
-                 [uu____5154]  in
-               FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldAttr uu____5153  in
-             uu____5148 FStar_Pervasives_Native.None rng)
+             let uu____5045 =
+               let uu____5046 =
+                 let uu____5055 =
+                   let uu____5056 =
+                     let uu____5063 = e_list e_string  in embed uu____5063 l
+                      in
+                   uu____5056 rng FStar_Pervasives_Native.None norm  in
+                 FStar_Syntax_Syntax.as_arg uu____5055  in
+               [uu____5046]  in
+             FStar_Syntax_Syntax.mk_Tm_app steps_UnfoldAttr uu____5045 rng)
      in
   let un t0 w norm =
     let t = FStar_Syntax_Util.unmeta_safe t0  in
     lazy_unembed printer1 emb_t_norm_step t t_norm_step
       (fun t1  ->
-         let uu____5231 = FStar_Syntax_Util.head_and_args t1  in
-         match uu____5231 with
+         let uu____5123 = FStar_Syntax_Util.head_and_args t1  in
+         match uu____5123 with
          | (hd,args) ->
-             let uu____5276 =
-               let uu____5291 =
-                 let uu____5292 = FStar_Syntax_Util.un_uinst hd  in
-                 uu____5292.FStar_Syntax_Syntax.n  in
-               (uu____5291, args)  in
-             (match uu____5276 with
+             let uu____5168 =
+               let uu____5183 =
+                 let uu____5184 = FStar_Syntax_Util.un_uinst hd  in
+                 uu____5184.FStar_Syntax_Syntax.n  in
+               (uu____5183, args)  in
+             (match uu____5168 with
               | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_simpl
@@ -1493,64 +1454,64 @@ let (e_norm_step : norm_step embedding) =
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_reify
                   -> FStar_Pervasives_Native.Some Reify
-              | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____5499)::[]) when
+              | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____5391)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_unfoldonly
                   ->
-                  let uu____5534 =
-                    let uu____5540 =
-                      let uu____5550 = e_list e_string  in
-                      unembed uu____5550 l  in
-                    uu____5540 w norm  in
-                  FStar_Util.bind_opt uu____5534
+                  let uu____5426 =
+                    let uu____5432 =
+                      let uu____5442 = e_list e_string  in
+                      unembed uu____5442 l  in
+                    uu____5432 w norm  in
+                  FStar_Util.bind_opt uu____5426
                     (fun ss  ->
                        FStar_All.pipe_left
-                         (fun uu____5570  ->
-                            FStar_Pervasives_Native.Some uu____5570)
+                         (fun uu____5462  ->
+                            FStar_Pervasives_Native.Some uu____5462)
                          (UnfoldOnly ss))
-              | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____5573)::[]) when
+              | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____5465)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_unfoldfully
                   ->
-                  let uu____5608 =
-                    let uu____5614 =
-                      let uu____5624 = e_list e_string  in
-                      unembed uu____5624 l  in
-                    uu____5614 w norm  in
-                  FStar_Util.bind_opt uu____5608
+                  let uu____5500 =
+                    let uu____5506 =
+                      let uu____5516 = e_list e_string  in
+                      unembed uu____5516 l  in
+                    uu____5506 w norm  in
+                  FStar_Util.bind_opt uu____5500
                     (fun ss  ->
                        FStar_All.pipe_left
-                         (fun uu____5644  ->
-                            FStar_Pervasives_Native.Some uu____5644)
+                         (fun uu____5536  ->
+                            FStar_Pervasives_Native.Some uu____5536)
                          (UnfoldFully ss))
-              | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____5647)::[]) when
+              | (FStar_Syntax_Syntax.Tm_fvar fv,(l,uu____5539)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.steps_unfoldattr
                   ->
-                  let uu____5682 =
-                    let uu____5688 =
-                      let uu____5698 = e_list e_string  in
-                      unembed uu____5698 l  in
-                    uu____5688 w norm  in
-                  FStar_Util.bind_opt uu____5682
+                  let uu____5574 =
+                    let uu____5580 =
+                      let uu____5590 = e_list e_string  in
+                      unembed uu____5590 l  in
+                    uu____5580 w norm  in
+                  FStar_Util.bind_opt uu____5574
                     (fun ss  ->
                        FStar_All.pipe_left
-                         (fun uu____5718  ->
-                            FStar_Pervasives_Native.Some uu____5718)
+                         (fun uu____5610  ->
+                            FStar_Pervasives_Native.Some uu____5610)
                          (UnfoldAttr ss))
-              | uu____5719 ->
+              | uu____5611 ->
                   (if w
                    then
-                     (let uu____5736 =
-                        let uu____5742 =
-                          let uu____5744 =
+                     (let uu____5628 =
+                        let uu____5634 =
+                          let uu____5636 =
                             FStar_Syntax_Print.term_to_string t0  in
                           FStar_Util.format1 "Not an embedded norm_step: %s"
-                            uu____5744
+                            uu____5636
                            in
-                        (FStar_Errors.Warning_NotEmbedded, uu____5742)  in
+                        (FStar_Errors.Warning_NotEmbedded, uu____5634)  in
                       FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos
-                        uu____5736)
+                        uu____5628)
                    else ();
                    FStar_Pervasives_Native.None)))
      in
@@ -1558,36 +1519,35 @@ let (e_norm_step : norm_step embedding) =
 let (e_range : FStar_Range.range embedding) =
   let em r rng _shadow _norm =
     FStar_Syntax_Syntax.mk
-      (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range r))
-      FStar_Pervasives_Native.None rng
+      (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range r)) rng
      in
   let un t0 w _norm =
     let t = FStar_Syntax_Util.unmeta_safe t0  in
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range r) ->
         FStar_Pervasives_Native.Some r
-    | uu____5804 ->
+    | uu____5696 ->
         (if w
          then
-           (let uu____5807 =
-              let uu____5813 =
-                let uu____5815 = FStar_Syntax_Print.term_to_string t0  in
-                FStar_Util.format1 "Not an embedded range: %s" uu____5815  in
-              (FStar_Errors.Warning_NotEmbedded, uu____5813)  in
-            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____5807)
+           (let uu____5699 =
+              let uu____5705 =
+                let uu____5707 = FStar_Syntax_Print.term_to_string t0  in
+                FStar_Util.format1 "Not an embedded range: %s" uu____5707  in
+              (FStar_Errors.Warning_NotEmbedded, uu____5705)  in
+            FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu____5699)
          else ();
          FStar_Pervasives_Native.None)
      in
-  let uu____5821 =
-    let uu____5822 =
-      let uu____5830 =
+  let uu____5713 =
+    let uu____5714 =
+      let uu____5722 =
         FStar_All.pipe_right FStar_Parser_Const.range_lid
           FStar_Ident.string_of_lid
          in
-      (uu____5830, [])  in
-    FStar_Syntax_Syntax.ET_app uu____5822  in
+      (uu____5722, [])  in
+    FStar_Syntax_Syntax.ET_app uu____5714  in
   mk_emb_full em un FStar_Syntax_Syntax.t_range FStar_Range.string_of_range
-    uu____5821
+    uu____5713
   
 let or_else : 'a . 'a FStar_Pervasives_Native.option -> (unit -> 'a) -> 'a =
   fun f  ->
@@ -1600,54 +1560,52 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
   fun ea  ->
     fun eb  ->
       let t_arrow =
-        let uu____5901 =
-          let uu____5908 =
-            let uu____5909 =
-              let uu____5924 =
-                let uu____5933 =
-                  let uu____5940 = FStar_Syntax_Syntax.null_bv ea.typ  in
-                  (uu____5940, FStar_Pervasives_Native.None)  in
-                [uu____5933]  in
-              let uu____5955 = FStar_Syntax_Syntax.mk_Total eb.typ  in
-              (uu____5924, uu____5955)  in
-            FStar_Syntax_Syntax.Tm_arrow uu____5909  in
-          FStar_Syntax_Syntax.mk uu____5908  in
-        uu____5901 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
+        let uu____5793 =
+          let uu____5794 =
+            let uu____5809 =
+              let uu____5818 =
+                let uu____5825 = FStar_Syntax_Syntax.null_bv ea.typ  in
+                (uu____5825, FStar_Pervasives_Native.None)  in
+              [uu____5818]  in
+            let uu____5840 = FStar_Syntax_Syntax.mk_Total eb.typ  in
+            (uu____5809, uu____5840)  in
+          FStar_Syntax_Syntax.Tm_arrow uu____5794  in
+        FStar_Syntax_Syntax.mk uu____5793 FStar_Range.dummyRange  in
       let emb_t_arr_a_b =
         FStar_Syntax_Syntax.ET_fun ((ea.emb_typ), (eb.emb_typ))  in
       let printer1 f = "<fun>"  in
       let em f rng shadow_f norm =
-        lazy_embed (fun uu____6027  -> "<fun>") emb_t_arr_a_b rng t_arrow f
-          (fun uu____6033  ->
-             let uu____6034 = force_shadow shadow_f  in
-             match uu____6034 with
+        lazy_embed (fun uu____5912  -> "<fun>") emb_t_arr_a_b rng t_arrow f
+          (fun uu____5918  ->
+             let uu____5919 = force_shadow shadow_f  in
+             match uu____5919 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Exn.raise Embedding_failure
              | FStar_Pervasives_Native.Some repr_f ->
-                 ((let uu____6039 =
+                 ((let uu____5924 =
                      FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                   if uu____6039
+                   if uu____5924
                    then
-                     let uu____6063 =
+                     let uu____5948 =
                        FStar_Syntax_Print.term_to_string repr_f  in
-                     let uu____6065 = FStar_Util.stack_dump ()  in
+                     let uu____5950 = FStar_Util.stack_dump ()  in
                      FStar_Util.print2
                        "e_arrow forced back to term using shadow %s; repr=%s\n"
-                       uu____6063 uu____6065
+                       uu____5948 uu____5950
                    else ());
                   (let res = norm (FStar_Util.Inr repr_f)  in
-                   (let uu____6072 =
+                   (let uu____5957 =
                       FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                    if uu____6072
+                    if uu____5957
                     then
-                      let uu____6096 =
+                      let uu____5981 =
                         FStar_Syntax_Print.term_to_string repr_f  in
-                      let uu____6098 = FStar_Syntax_Print.term_to_string res
+                      let uu____5983 = FStar_Syntax_Print.term_to_string res
                          in
-                      let uu____6100 = FStar_Util.stack_dump ()  in
+                      let uu____5985 = FStar_Util.stack_dump ()  in
                       FStar_Util.print3
                         "e_arrow forced back to term using shadow %s; repr=%s\n\t%s\n"
-                        uu____6096 uu____6098 uu____6100
+                        uu____5981 uu____5983 uu____5985
                     else ());
                    res)))
          in
@@ -1655,38 +1613,35 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
         lazy_unembed printer1 emb_t_arr_a_b f t_arrow
           (fun f1  ->
              let f_wrapped a1 =
-               (let uu____6159 =
+               (let uu____6044 =
                   FStar_ST.op_Bang FStar_Options.debug_embedding  in
-                if uu____6159
+                if uu____6044
                 then
-                  let uu____6183 = FStar_Syntax_Print.term_to_string f1  in
-                  let uu____6185 = FStar_Util.stack_dump ()  in
+                  let uu____6068 = FStar_Syntax_Print.term_to_string f1  in
+                  let uu____6070 = FStar_Util.stack_dump ()  in
                   FStar_Util.print2
-                    "Calling back into normalizer for %s\n%s\n" uu____6183
-                    uu____6185
+                    "Calling back into normalizer for %s\n%s\n" uu____6068
+                    uu____6070
                 else ());
                (let a_tm =
-                  let uu____6191 = embed ea a1  in
-                  uu____6191 f1.FStar_Syntax_Syntax.pos
+                  let uu____6076 = embed ea a1  in
+                  uu____6076 f1.FStar_Syntax_Syntax.pos
                     FStar_Pervasives_Native.None norm
                    in
                 let b_tm =
-                  let uu____6201 =
-                    let uu____6206 =
-                      let uu____6207 =
-                        let uu____6212 =
-                          let uu____6213 = FStar_Syntax_Syntax.as_arg a_tm
-                             in
-                          [uu____6213]  in
-                        FStar_Syntax_Syntax.mk_Tm_app f1 uu____6212  in
-                      uu____6207 FStar_Pervasives_Native.None
+                  let uu____6086 =
+                    let uu____6091 =
+                      let uu____6092 =
+                        let uu____6093 = FStar_Syntax_Syntax.as_arg a_tm  in
+                        [uu____6093]  in
+                      FStar_Syntax_Syntax.mk_Tm_app f1 uu____6092
                         f1.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Util.Inr uu____6206  in
-                  norm uu____6201  in
-                let uu____6238 =
-                  let uu____6241 = unembed eb b_tm  in uu____6241 w norm  in
-                match uu____6238 with
+                    FStar_Util.Inr uu____6091  in
+                  norm uu____6086  in
+                let uu____6118 =
+                  let uu____6121 = unembed eb b_tm  in uu____6121 w norm  in
+                match uu____6118 with
                 | FStar_Pervasives_Native.None  ->
                     FStar_Exn.raise Unembedding_failure
                 | FStar_Pervasives_Native.Some b1 -> b1)
@@ -1714,37 +1669,34 @@ let arrow_as_prim_step_1 :
             fun norm  ->
               let rng = FStar_Ident.range_of_lid fv_lid  in
               let f_wrapped args =
-                let uu____6335 = FStar_List.splitAt n_tvars args  in
-                match uu____6335 with
+                let uu____6215 = FStar_List.splitAt n_tvars args  in
+                match uu____6215 with
                 | (_tvar_args,rest_args) ->
-                    let uu____6412 = FStar_List.hd rest_args  in
-                    (match uu____6412 with
-                     | (x,uu____6432) ->
+                    let uu____6292 = FStar_List.hd rest_args  in
+                    (match uu____6292 with
+                     | (x,uu____6312) ->
                          let shadow_app =
-                           let uu____6446 =
+                           let uu____6326 =
                              FStar_Thunk.mk
-                               (fun uu____6453  ->
-                                  let uu____6454 =
-                                    let uu____6459 =
-                                      norm (FStar_Util.Inl fv_lid)  in
-                                    FStar_Syntax_Syntax.mk_Tm_app uu____6459
-                                      args
-                                     in
-                                  uu____6454 FStar_Pervasives_Native.None rng)
+                               (fun uu____6331  ->
+                                  let uu____6332 =
+                                    norm (FStar_Util.Inl fv_lid)  in
+                                  FStar_Syntax_Syntax.mk_Tm_app uu____6332
+                                    args rng)
                               in
-                           FStar_Pervasives_Native.Some uu____6446  in
-                         let uu____6462 =
-                           let uu____6465 =
-                             let uu____6468 = unembed ea x  in
-                             uu____6468 true norm  in
-                           FStar_Util.map_opt uu____6465
+                           FStar_Pervasives_Native.Some uu____6326  in
+                         let uu____6335 =
+                           let uu____6338 =
+                             let uu____6341 = unembed ea x  in
+                             uu____6341 true norm  in
+                           FStar_Util.map_opt uu____6338
                              (fun x1  ->
-                                let uu____6479 =
-                                  let uu____6486 = f x1  in
-                                  embed eb uu____6486  in
-                                uu____6479 rng shadow_app norm)
+                                let uu____6352 =
+                                  let uu____6359 = f x1  in
+                                  embed eb uu____6359  in
+                                uu____6352 rng shadow_app norm)
                             in
-                         (match uu____6462 with
+                         (match uu____6335 with
                           | FStar_Pervasives_Native.Some x1 ->
                               FStar_Pervasives_Native.Some x1
                           | FStar_Pervasives_Native.None  ->
@@ -1773,52 +1725,48 @@ let arrow_as_prim_step_2 :
               fun norm  ->
                 let rng = FStar_Ident.range_of_lid fv_lid  in
                 let f_wrapped args =
-                  let uu____6589 = FStar_List.splitAt n_tvars args  in
-                  match uu____6589 with
+                  let uu____6462 = FStar_List.splitAt n_tvars args  in
+                  match uu____6462 with
                   | (_tvar_args,rest_args) ->
-                      let uu____6652 = FStar_List.hd rest_args  in
-                      (match uu____6652 with
-                       | (x,uu____6668) ->
-                           let uu____6673 =
-                             let uu____6680 = FStar_List.tl rest_args  in
-                             FStar_List.hd uu____6680  in
-                           (match uu____6673 with
-                            | (y,uu____6704) ->
+                      let uu____6525 = FStar_List.hd rest_args  in
+                      (match uu____6525 with
+                       | (x,uu____6541) ->
+                           let uu____6546 =
+                             let uu____6553 = FStar_List.tl rest_args  in
+                             FStar_List.hd uu____6553  in
+                           (match uu____6546 with
+                            | (y,uu____6577) ->
                                 let shadow_app =
-                                  let uu____6714 =
+                                  let uu____6587 =
                                     FStar_Thunk.mk
-                                      (fun uu____6721  ->
-                                         let uu____6722 =
-                                           let uu____6727 =
-                                             norm (FStar_Util.Inl fv_lid)  in
-                                           FStar_Syntax_Syntax.mk_Tm_app
-                                             uu____6727 args
-                                            in
-                                         uu____6722
-                                           FStar_Pervasives_Native.None rng)
+                                      (fun uu____6592  ->
+                                         let uu____6593 =
+                                           norm (FStar_Util.Inl fv_lid)  in
+                                         FStar_Syntax_Syntax.mk_Tm_app
+                                           uu____6593 args rng)
                                      in
-                                  FStar_Pervasives_Native.Some uu____6714  in
-                                let uu____6730 =
-                                  let uu____6733 =
-                                    let uu____6736 = unembed ea x  in
-                                    uu____6736 true norm  in
-                                  FStar_Util.bind_opt uu____6733
+                                  FStar_Pervasives_Native.Some uu____6587  in
+                                let uu____6596 =
+                                  let uu____6599 =
+                                    let uu____6602 = unembed ea x  in
+                                    uu____6602 true norm  in
+                                  FStar_Util.bind_opt uu____6599
                                     (fun x1  ->
-                                       let uu____6747 =
-                                         let uu____6750 = unembed eb y  in
-                                         uu____6750 true norm  in
-                                       FStar_Util.bind_opt uu____6747
+                                       let uu____6613 =
+                                         let uu____6616 = unembed eb y  in
+                                         uu____6616 true norm  in
+                                       FStar_Util.bind_opt uu____6613
                                          (fun y1  ->
-                                            let uu____6761 =
-                                              let uu____6762 =
-                                                let uu____6769 = f x1 y1  in
-                                                embed ec uu____6769  in
-                                              uu____6762 rng shadow_app norm
+                                            let uu____6627 =
+                                              let uu____6628 =
+                                                let uu____6635 = f x1 y1  in
+                                                embed ec uu____6635  in
+                                              uu____6628 rng shadow_app norm
                                                in
                                             FStar_Pervasives_Native.Some
-                                              uu____6761))
+                                              uu____6627))
                                    in
-                                (match uu____6730 with
+                                (match uu____6596 with
                                  | FStar_Pervasives_Native.Some x1 ->
                                      FStar_Pervasives_Native.Some x1
                                  | FStar_Pervasives_Native.None  ->
@@ -1849,77 +1797,72 @@ let arrow_as_prim_step_3 :
                 fun norm  ->
                   let rng = FStar_Ident.range_of_lid fv_lid  in
                   let f_wrapped args =
-                    let uu____6891 = FStar_List.splitAt n_tvars args  in
-                    match uu____6891 with
+                    let uu____6757 = FStar_List.splitAt n_tvars args  in
+                    match uu____6757 with
                     | (_tvar_args,rest_args) ->
-                        let uu____6954 = FStar_List.hd rest_args  in
-                        (match uu____6954 with
-                         | (x,uu____6970) ->
-                             let uu____6975 =
-                               let uu____6982 = FStar_List.tl rest_args  in
-                               FStar_List.hd uu____6982  in
-                             (match uu____6975 with
-                              | (y,uu____7006) ->
-                                  let uu____7011 =
-                                    let uu____7018 =
-                                      let uu____7027 =
+                        let uu____6820 = FStar_List.hd rest_args  in
+                        (match uu____6820 with
+                         | (x,uu____6836) ->
+                             let uu____6841 =
+                               let uu____6848 = FStar_List.tl rest_args  in
+                               FStar_List.hd uu____6848  in
+                             (match uu____6841 with
+                              | (y,uu____6872) ->
+                                  let uu____6877 =
+                                    let uu____6884 =
+                                      let uu____6893 =
                                         FStar_List.tl rest_args  in
-                                      FStar_List.tl uu____7027  in
-                                    FStar_List.hd uu____7018  in
-                                  (match uu____7011 with
-                                   | (z,uu____7057) ->
+                                      FStar_List.tl uu____6893  in
+                                    FStar_List.hd uu____6884  in
+                                  (match uu____6877 with
+                                   | (z,uu____6923) ->
                                        let shadow_app =
-                                         let uu____7067 =
+                                         let uu____6933 =
                                            FStar_Thunk.mk
-                                             (fun uu____7074  ->
-                                                let uu____7075 =
-                                                  let uu____7080 =
-                                                    norm
-                                                      (FStar_Util.Inl fv_lid)
-                                                     in
-                                                  FStar_Syntax_Syntax.mk_Tm_app
-                                                    uu____7080 args
+                                             (fun uu____6938  ->
+                                                let uu____6939 =
+                                                  norm
+                                                    (FStar_Util.Inl fv_lid)
                                                    in
-                                                uu____7075
-                                                  FStar_Pervasives_Native.None
-                                                  rng)
+                                                FStar_Syntax_Syntax.mk_Tm_app
+                                                  uu____6939 args rng)
                                             in
                                          FStar_Pervasives_Native.Some
-                                           uu____7067
+                                           uu____6933
                                           in
-                                       let uu____7083 =
-                                         let uu____7086 =
-                                           let uu____7089 = unembed ea x  in
-                                           uu____7089 true norm  in
-                                         FStar_Util.bind_opt uu____7086
+                                       let uu____6942 =
+                                         let uu____6945 =
+                                           let uu____6948 = unembed ea x  in
+                                           uu____6948 true norm  in
+                                         FStar_Util.bind_opt uu____6945
                                            (fun x1  ->
-                                              let uu____7100 =
-                                                let uu____7103 = unembed eb y
+                                              let uu____6959 =
+                                                let uu____6962 = unembed eb y
                                                    in
-                                                uu____7103 true norm  in
-                                              FStar_Util.bind_opt uu____7100
+                                                uu____6962 true norm  in
+                                              FStar_Util.bind_opt uu____6959
                                                 (fun y1  ->
-                                                   let uu____7114 =
-                                                     let uu____7117 =
+                                                   let uu____6973 =
+                                                     let uu____6976 =
                                                        unembed ec z  in
-                                                     uu____7117 true norm  in
+                                                     uu____6976 true norm  in
                                                    FStar_Util.bind_opt
-                                                     uu____7114
+                                                     uu____6973
                                                      (fun z1  ->
-                                                        let uu____7128 =
-                                                          let uu____7129 =
-                                                            let uu____7136 =
+                                                        let uu____6987 =
+                                                          let uu____6988 =
+                                                            let uu____6995 =
                                                               f x1 y1 z1  in
                                                             embed ed
-                                                              uu____7136
+                                                              uu____6995
                                                              in
-                                                          uu____7129 rng
+                                                          uu____6988 rng
                                                             shadow_app norm
                                                            in
                                                         FStar_Pervasives_Native.Some
-                                                          uu____7128)))
+                                                          uu____6987)))
                                           in
-                                       (match uu____7083 with
+                                       (match uu____6942 with
                                         | FStar_Pervasives_Native.Some x1 ->
                                             FStar_Pervasives_Native.Some x1
                                         | FStar_Pervasives_Native.None  ->
@@ -1930,10 +1873,10 @@ let arrow_as_prim_step_3 :
 let debug_wrap : 'a . Prims.string -> (unit -> 'a) -> 'a =
   fun s  ->
     fun f  ->
-      (let uu____7166 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
-       if uu____7166 then FStar_Util.print1 "++++starting %s\n" s else ());
+      (let uu____7025 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
+       if uu____7025 then FStar_Util.print1 "++++starting %s\n" s else ());
       (let res = f ()  in
-       (let uu____7195 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
-        if uu____7195 then FStar_Util.print1 "------ending %s\n" s else ());
+       (let uu____7054 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
+        if uu____7054 then FStar_Util.print1 "------ending %s\n" s else ());
        res)
   

--- a/src/ocaml-output/FStar_Syntax_InstFV.ml
+++ b/src/ocaml-output/FStar_Syntax_InstFV.ml
@@ -4,12 +4,7 @@ let mk :
   'uuuuuu14 'uuuuuu15 .
     'uuuuuu14 FStar_Syntax_Syntax.syntax ->
       'uuuuuu15 -> 'uuuuuu15 FStar_Syntax_Syntax.syntax
-  =
-  fun t  ->
-    fun s  ->
-      FStar_Syntax_Syntax.mk s FStar_Pervasives_Native.None
-        t.FStar_Syntax_Syntax.pos
-  
+  = fun t  -> fun s  -> FStar_Syntax_Syntax.mk s t.FStar_Syntax_Syntax.pos 
 let rec (inst :
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -1610,7 +1610,7 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
               let uu____4278 =
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (tps, c))
-                  FStar_Pervasives_Native.None FStar_Range.dummyRange
+                  FStar_Range.dummyRange
                  in
               FStar_Syntax_Subst.open_univ_vars univs uu____4278  in
             (match uu____4273 with

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -2762,9 +2762,7 @@ let (resugar_sigelt' :
           then FStar_Pervasives_Native.None
           else
             (let mk e =
-               FStar_Syntax_Syntax.mk e FStar_Pervasives_Native.None
-                 se.FStar_Syntax_Syntax.sigrng
-                in
+               FStar_Syntax_Syntax.mk e se.FStar_Syntax_Syntax.sigrng  in
              let dummy = mk FStar_Syntax_Syntax.Tm_unknown  in
              let desugared_let = mk (FStar_Syntax_Syntax.Tm_let (lbs, dummy))
                 in

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -373,17 +373,15 @@ let rec (subst' :
                apply_until_some_then_map (subst_nm a)
                  (FStar_Pervasives_Native.fst s) subst_tail t0
            | FStar_Syntax_Syntax.Tm_type u ->
-               let uu____1014 = mk_range t0.FStar_Syntax_Syntax.pos s  in
-               let uu____1015 =
-                 let uu____1022 =
-                   let uu____1023 =
-                     subst_univ (FStar_Pervasives_Native.fst s) u  in
-                   FStar_Syntax_Syntax.Tm_type uu____1023  in
-                 FStar_Syntax_Syntax.mk uu____1022  in
-               uu____1015 FStar_Pervasives_Native.None uu____1014
-           | uu____1028 ->
-               let uu____1029 = mk_range t.FStar_Syntax_Syntax.pos s  in
-               FStar_Syntax_Syntax.mk_Tm_delayed (t0, s) uu____1029)
+               let uu____1014 =
+                 let uu____1015 =
+                   subst_univ (FStar_Pervasives_Native.fst s) u  in
+                 FStar_Syntax_Syntax.Tm_type uu____1015  in
+               let uu____1020 = mk_range t0.FStar_Syntax_Syntax.pos s  in
+               FStar_Syntax_Syntax.mk uu____1014 uu____1020
+           | uu____1021 ->
+               let uu____1022 = mk_range t.FStar_Syntax_Syntax.pos s  in
+               FStar_Syntax_Syntax.mk_Tm_delayed (t0, s) uu____1022)
   
 let (subst_flags' :
   FStar_Syntax_Syntax.subst_ts ->
@@ -394,11 +392,11 @@ let (subst_flags' :
     fun flags  ->
       FStar_All.pipe_right flags
         (FStar_List.map
-           (fun uu___5_1054  ->
-              match uu___5_1054 with
+           (fun uu___5_1047  ->
+              match uu___5_1047 with
               | FStar_Syntax_Syntax.DECREASES a ->
-                  let uu____1058 = subst' s a  in
-                  FStar_Syntax_Syntax.DECREASES uu____1058
+                  let uu____1051 = subst' s a  in
+                  FStar_Syntax_Syntax.DECREASES uu____1051
               | f -> f))
   
 let (subst_imp' :
@@ -410,10 +408,10 @@ let (subst_imp' :
     fun i  ->
       match i with
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-          let uu____1084 =
-            let uu____1085 = subst' s t  in
-            FStar_Syntax_Syntax.Meta uu____1085  in
-          FStar_Pervasives_Native.Some uu____1084
+          let uu____1077 =
+            let uu____1078 = subst' s t  in
+            FStar_Syntax_Syntax.Meta uu____1078  in
+          FStar_Pervasives_Native.Some uu____1077
       | i1 -> i1
   
 let (subst_comp_typ' :
@@ -426,32 +424,32 @@ let (subst_comp_typ' :
       match s with
       | ([],FStar_Syntax_Syntax.NoUseRange ) -> t
       | ([]::[],FStar_Syntax_Syntax.NoUseRange ) -> t
-      | uu____1132 ->
-          let uu___216_1141 = t  in
-          let uu____1142 =
+      | uu____1125 ->
+          let uu___216_1134 = t  in
+          let uu____1135 =
             FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s))
               t.FStar_Syntax_Syntax.comp_univs
              in
-          let uu____1147 =
+          let uu____1140 =
             tag_lid_with_range t.FStar_Syntax_Syntax.effect_name s  in
-          let uu____1152 = subst' s t.FStar_Syntax_Syntax.result_typ  in
-          let uu____1155 =
+          let uu____1145 = subst' s t.FStar_Syntax_Syntax.result_typ  in
+          let uu____1148 =
             FStar_List.map
-              (fun uu____1183  ->
-                 match uu____1183 with
+              (fun uu____1176  ->
+                 match uu____1176 with
                  | (t1,imp) ->
-                     let uu____1202 = subst' s t1  in
-                     let uu____1203 = subst_imp' s imp  in
-                     (uu____1202, uu____1203))
+                     let uu____1195 = subst' s t1  in
+                     let uu____1196 = subst_imp' s imp  in
+                     (uu____1195, uu____1196))
               t.FStar_Syntax_Syntax.effect_args
              in
-          let uu____1208 = subst_flags' s t.FStar_Syntax_Syntax.flags  in
+          let uu____1201 = subst_flags' s t.FStar_Syntax_Syntax.flags  in
           {
-            FStar_Syntax_Syntax.comp_univs = uu____1142;
-            FStar_Syntax_Syntax.effect_name = uu____1147;
-            FStar_Syntax_Syntax.result_typ = uu____1152;
-            FStar_Syntax_Syntax.effect_args = uu____1155;
-            FStar_Syntax_Syntax.flags = uu____1208
+            FStar_Syntax_Syntax.comp_univs = uu____1135;
+            FStar_Syntax_Syntax.effect_name = uu____1140;
+            FStar_Syntax_Syntax.result_typ = uu____1145;
+            FStar_Syntax_Syntax.effect_args = uu____1148;
+            FStar_Syntax_Syntax.flags = uu____1201
           }
   
 let (subst_comp' :
@@ -465,25 +463,25 @@ let (subst_comp' :
       match s with
       | ([],FStar_Syntax_Syntax.NoUseRange ) -> t
       | ([]::[],FStar_Syntax_Syntax.NoUseRange ) -> t
-      | uu____1260 ->
+      | uu____1253 ->
           (match t.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Total (t1,uopt) ->
-               let uu____1281 = subst' s t1  in
-               let uu____1282 =
+               let uu____1274 = subst' s t1  in
+               let uu____1275 =
                  FStar_Option.map
                    (subst_univ (FStar_Pervasives_Native.fst s)) uopt
                   in
-               FStar_Syntax_Syntax.mk_Total' uu____1281 uu____1282
+               FStar_Syntax_Syntax.mk_Total' uu____1274 uu____1275
            | FStar_Syntax_Syntax.GTotal (t1,uopt) ->
-               let uu____1299 = subst' s t1  in
-               let uu____1300 =
+               let uu____1292 = subst' s t1  in
+               let uu____1293 =
                  FStar_Option.map
                    (subst_univ (FStar_Pervasives_Native.fst s)) uopt
                   in
-               FStar_Syntax_Syntax.mk_GTotal' uu____1299 uu____1300
+               FStar_Syntax_Syntax.mk_GTotal' uu____1292 uu____1293
            | FStar_Syntax_Syntax.Comp ct ->
-               let uu____1308 = subst_comp_typ' s ct  in
-               FStar_Syntax_Syntax.mk_Comp uu____1308)
+               let uu____1301 = subst_comp_typ' s ct  in
+               FStar_Syntax_Syntax.mk_Comp uu____1301)
   
 let (shift :
   Prims.int -> FStar_Syntax_Syntax.subst_elt -> FStar_Syntax_Syntax.subst_elt)
@@ -495,24 +493,24 @@ let (shift :
       | FStar_Syntax_Syntax.UN (i,t) -> FStar_Syntax_Syntax.UN ((i + n), t)
       | FStar_Syntax_Syntax.NM (x,i) -> FStar_Syntax_Syntax.NM (x, (i + n))
       | FStar_Syntax_Syntax.UD (x,i) -> FStar_Syntax_Syntax.UD (x, (i + n))
-      | FStar_Syntax_Syntax.NT uu____1342 -> s
+      | FStar_Syntax_Syntax.NT uu____1335 -> s
   
 let (shift_subst :
   Prims.int -> FStar_Syntax_Syntax.subst_t -> FStar_Syntax_Syntax.subst_t) =
   fun n  -> fun s  -> FStar_List.map (shift n) s 
 let shift_subst' :
-  'uuuuuu1369 .
+  'uuuuuu1362 .
     Prims.int ->
-      (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1369) ->
-        (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1369)
+      (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1362) ->
+        (FStar_Syntax_Syntax.subst_t Prims.list * 'uuuuuu1362)
   =
   fun n  ->
     fun s  ->
-      let uu____1400 =
+      let uu____1393 =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst s)
           (FStar_List.map (shift_subst n))
          in
-      (uu____1400, (FStar_Pervasives_Native.snd s))
+      (uu____1393, (FStar_Pervasives_Native.snd s))
   
 let (subst_binder' :
   FStar_Syntax_Syntax.subst_ts ->
@@ -522,20 +520,20 @@ let (subst_binder' :
         FStar_Pervasives_Native.option))
   =
   fun s  ->
-    fun uu____1435  ->
-      match uu____1435 with
+    fun uu____1428  ->
+      match uu____1428 with
       | (x,imp) ->
-          let uu____1454 =
-            let uu___269_1455 = x  in
-            let uu____1456 = subst' s x.FStar_Syntax_Syntax.sort  in
+          let uu____1447 =
+            let uu___269_1448 = x  in
+            let uu____1449 = subst' s x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___269_1455.FStar_Syntax_Syntax.ppname);
+                (uu___269_1448.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___269_1455.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____1456
+                (uu___269_1448.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____1449
             }  in
-          let uu____1459 = subst_imp' s imp  in (uu____1454, uu____1459)
+          let uu____1452 = subst_imp' s imp  in (uu____1447, uu____1452)
   
 let (subst_binders' :
   (FStar_Syntax_Syntax.subst_elt Prims.list Prims.list *
@@ -554,8 +552,8 @@ let (subst_binders' :
                 if i = Prims.int_zero
                 then subst_binder' s b
                 else
-                  (let uu____1565 = shift_subst' i s  in
-                   subst_binder' uu____1565 b)))
+                  (let uu____1558 = shift_subst' i s  in
+                   subst_binder' uu____1558 b)))
   
 let (subst_binders :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -565,21 +563,21 @@ let (subst_binders :
     fun bs  -> subst_binders' ([s], FStar_Syntax_Syntax.NoUseRange) bs
   
 let subst_arg' :
-  'uuuuuu1596 .
+  'uuuuuu1589 .
     FStar_Syntax_Syntax.subst_ts ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu1596) ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu1596)
+      (FStar_Syntax_Syntax.term * 'uuuuuu1589) ->
+        (FStar_Syntax_Syntax.term * 'uuuuuu1589)
   =
   fun s  ->
-    fun uu____1614  ->
-      match uu____1614 with
-      | (t,imp) -> let uu____1621 = subst' s t  in (uu____1621, imp)
+    fun uu____1607  ->
+      match uu____1607 with
+      | (t,imp) -> let uu____1614 = subst' s t  in (uu____1614, imp)
   
 let subst_args' :
-  'uuuuuu1628 .
+  'uuuuuu1621 .
     FStar_Syntax_Syntax.subst_ts ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu1628) Prims.list ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu1628) Prims.list
+      (FStar_Syntax_Syntax.term * 'uuuuuu1621) Prims.list ->
+        (FStar_Syntax_Syntax.term * 'uuuuuu1621) Prims.list
   = fun s  -> FStar_List.map (subst_arg' s) 
 let (subst_pat' :
   (FStar_Syntax_Syntax.subst_t Prims.list *
@@ -591,82 +589,82 @@ let (subst_pat' :
     fun p  ->
       let rec aux n p1 =
         match p1.FStar_Syntax_Syntax.v with
-        | FStar_Syntax_Syntax.Pat_constant uu____1722 -> (p1, n)
+        | FStar_Syntax_Syntax.Pat_constant uu____1715 -> (p1, n)
         | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-            let uu____1744 =
+            let uu____1737 =
               FStar_All.pipe_right pats
                 (FStar_List.fold_left
-                   (fun uu____1806  ->
-                      fun uu____1807  ->
-                        match (uu____1806, uu____1807) with
+                   (fun uu____1799  ->
+                      fun uu____1800  ->
+                        match (uu____1799, uu____1800) with
                         | ((pats1,n1),(p2,imp)) ->
-                            let uu____1903 = aux n1 p2  in
-                            (match uu____1903 with
+                            let uu____1896 = aux n1 p2  in
+                            (match uu____1896 with
                              | (p3,m) -> (((p3, imp) :: pats1), m))) 
                    ([], n))
                in
-            (match uu____1744 with
+            (match uu____1737 with
              | (pats1,n1) ->
-                 ((let uu___306_1977 = p1  in
+                 ((let uu___306_1970 = p1  in
                    {
                      FStar_Syntax_Syntax.v =
                        (FStar_Syntax_Syntax.Pat_cons
                           (fv, (FStar_List.rev pats1)));
                      FStar_Syntax_Syntax.p =
-                       (uu___306_1977.FStar_Syntax_Syntax.p)
+                       (uu___306_1970.FStar_Syntax_Syntax.p)
                    }), n1))
         | FStar_Syntax_Syntax.Pat_var x ->
             let s1 = shift_subst' n s  in
             let x1 =
-              let uu___311_2003 = x  in
-              let uu____2004 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___311_1996 = x  in
+              let uu____1997 = subst' s1 x.FStar_Syntax_Syntax.sort  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___311_2003.FStar_Syntax_Syntax.ppname);
+                  (uu___311_1996.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___311_2003.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____2004
+                  (uu___311_1996.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____1997
               }  in
-            ((let uu___314_2009 = p1  in
+            ((let uu___314_2002 = p1  in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-                FStar_Syntax_Syntax.p = (uu___314_2009.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___314_2002.FStar_Syntax_Syntax.p)
               }), (n + Prims.int_one))
         | FStar_Syntax_Syntax.Pat_wild x ->
             let s1 = shift_subst' n s  in
             let x1 =
-              let uu___319_2022 = x  in
-              let uu____2023 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___319_2015 = x  in
+              let uu____2016 = subst' s1 x.FStar_Syntax_Syntax.sort  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___319_2022.FStar_Syntax_Syntax.ppname);
+                  (uu___319_2015.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___319_2022.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____2023
+                  (uu___319_2015.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____2016
               }  in
-            ((let uu___322_2028 = p1  in
+            ((let uu___322_2021 = p1  in
               {
                 FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-                FStar_Syntax_Syntax.p = (uu___322_2028.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___322_2021.FStar_Syntax_Syntax.p)
               }), (n + Prims.int_one))
         | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
             let s1 = shift_subst' n s  in
             let x1 =
-              let uu___329_2046 = x  in
-              let uu____2047 = subst' s1 x.FStar_Syntax_Syntax.sort  in
+              let uu___329_2039 = x  in
+              let uu____2040 = subst' s1 x.FStar_Syntax_Syntax.sort  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___329_2046.FStar_Syntax_Syntax.ppname);
+                  (uu___329_2039.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___329_2046.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____2047
+                  (uu___329_2039.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____2040
               }  in
             let t01 = subst' s1 t0  in
-            ((let uu___333_2053 = p1  in
+            ((let uu___333_2046 = p1  in
               {
                 FStar_Syntax_Syntax.v =
                   (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-                FStar_Syntax_Syntax.p = (uu___333_2053.FStar_Syntax_Syntax.p)
+                FStar_Syntax_Syntax.p = (uu___333_2046.FStar_Syntax_Syntax.p)
               }), n)
          in
       aux Prims.int_zero p
@@ -681,20 +679,20 @@ let (push_subst_lcomp :
       match lopt with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some rc ->
-          let uu____2079 =
-            let uu___340_2080 = rc  in
-            let uu____2081 =
+          let uu____2072 =
+            let uu___340_2073 = rc  in
+            let uu____2074 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                 (subst' s)
                in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___340_2080.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____2081;
+                (uu___340_2073.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu____2074;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___340_2080.FStar_Syntax_Syntax.residual_flags)
+                (uu___340_2073.FStar_Syntax_Syntax.residual_flags)
             }  in
-          FStar_Pervasives_Native.Some uu____2079
+          FStar_Pervasives_Native.Some uu____2072
   
 let (compose_uvar_subst :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -707,46 +705,46 @@ let (compose_uvar_subst :
         let should_retain x =
           FStar_All.pipe_right u.FStar_Syntax_Syntax.ctx_uvar_binders
             (FStar_Util.for_some
-               (fun uu____2131  ->
-                  match uu____2131 with
-                  | (x',uu____2140) -> FStar_Syntax_Syntax.bv_eq x x'))
+               (fun uu____2124  ->
+                  match uu____2124 with
+                  | (x',uu____2133) -> FStar_Syntax_Syntax.bv_eq x x'))
            in
-        let rec aux uu___7_2156 =
-          match uu___7_2156 with
+        let rec aux uu___7_2149 =
+          match uu___7_2149 with
           | [] -> []
           | hd_subst::rest ->
               let hd =
                 FStar_All.pipe_right hd_subst
                   (FStar_List.collect
-                     (fun uu___6_2187  ->
-                        match uu___6_2187 with
+                     (fun uu___6_2180  ->
+                        match uu___6_2180 with
                         | FStar_Syntax_Syntax.NT (x,t) ->
-                            let uu____2196 = should_retain x  in
-                            if uu____2196
+                            let uu____2189 = should_retain x  in
+                            if uu____2189
                             then
-                              let uu____2201 =
-                                let uu____2202 =
-                                  let uu____2209 =
+                              let uu____2194 =
+                                let uu____2195 =
+                                  let uu____2202 =
                                     delay t
                                       (rest, FStar_Syntax_Syntax.NoUseRange)
                                      in
-                                  (x, uu____2209)  in
-                                FStar_Syntax_Syntax.NT uu____2202  in
-                              [uu____2201]
+                                  (x, uu____2202)  in
+                                FStar_Syntax_Syntax.NT uu____2195  in
+                              [uu____2194]
                             else []
                         | FStar_Syntax_Syntax.NM (x,i) ->
-                            let uu____2224 = should_retain x  in
-                            if uu____2224
+                            let uu____2217 = should_retain x  in
+                            if uu____2217
                             then
                               let x_i =
                                 FStar_Syntax_Syntax.bv_to_tm
-                                  (let uu___367_2232 = x  in
+                                  (let uu___367_2225 = x  in
                                    {
                                      FStar_Syntax_Syntax.ppname =
-                                       (uu___367_2232.FStar_Syntax_Syntax.ppname);
+                                       (uu___367_2225.FStar_Syntax_Syntax.ppname);
                                      FStar_Syntax_Syntax.index = i;
                                      FStar_Syntax_Syntax.sort =
-                                       (uu___367_2232.FStar_Syntax_Syntax.sort)
+                                       (uu___367_2225.FStar_Syntax_Syntax.sort)
                                    })
                                  in
                               let t =
@@ -757,19 +755,19 @@ let (compose_uvar_subst :
                                | FStar_Syntax_Syntax.Tm_bvar x_j ->
                                    [FStar_Syntax_Syntax.NM
                                       (x, (x_j.FStar_Syntax_Syntax.index))]
-                               | uu____2242 ->
+                               | uu____2235 ->
                                    [FStar_Syntax_Syntax.NT (x, t)])
                             else []
-                        | uu____2247 -> []))
+                        | uu____2240 -> []))
                  in
-              let uu____2248 = aux rest  in FStar_List.append hd uu____2248
+              let uu____2241 = aux rest  in FStar_List.append hd uu____2241
            in
-        let uu____2251 =
+        let uu____2244 =
           aux
             (FStar_List.append (FStar_Pervasives_Native.fst s0)
                (FStar_Pervasives_Native.fst s))
            in
-        match uu____2251 with
+        match uu____2244 with
         | [] -> ([], (FStar_Pervasives_Native.snd s))
         | s' -> ([s'], (FStar_Pervasives_Native.snd s))
   
@@ -781,129 +779,129 @@ let rec (push_subst :
   fun s  ->
     fun t  ->
       let mk t' =
-        let uu____2314 = mk_range t.FStar_Syntax_Syntax.pos s  in
-        FStar_Syntax_Syntax.mk t' FStar_Pervasives_Native.None uu____2314  in
+        let uu____2307 = mk_range t.FStar_Syntax_Syntax.pos s  in
+        FStar_Syntax_Syntax.mk t' uu____2307  in
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____2317 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____2310 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
           (match i.FStar_Syntax_Syntax.lkind with
-           | FStar_Syntax_Syntax.Lazy_embedding uu____2338 ->
+           | FStar_Syntax_Syntax.Lazy_embedding uu____2331 ->
                let t1 =
-                 let uu____2348 =
-                   let uu____2357 =
+                 let uu____2341 =
+                   let uu____2350 =
                      FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
-                   FStar_Util.must uu____2357  in
-                 uu____2348 i.FStar_Syntax_Syntax.lkind i  in
+                   FStar_Util.must uu____2350  in
+                 uu____2341 i.FStar_Syntax_Syntax.lkind i  in
                push_subst s t1
-           | uu____2407 -> t)
-      | FStar_Syntax_Syntax.Tm_constant uu____2408 -> tag_with_range t s
-      | FStar_Syntax_Syntax.Tm_fvar uu____2413 -> tag_with_range t s
+           | uu____2400 -> t)
+      | FStar_Syntax_Syntax.Tm_constant uu____2401 -> tag_with_range t s
+      | FStar_Syntax_Syntax.Tm_fvar uu____2406 -> tag_with_range t s
       | FStar_Syntax_Syntax.Tm_unknown  -> tag_with_range t s
       | FStar_Syntax_Syntax.Tm_uvar (uv,s0) ->
-          let uu____2440 =
+          let uu____2433 =
             FStar_Syntax_Unionfind.find uv.FStar_Syntax_Syntax.ctx_uvar_head
              in
-          (match uu____2440 with
+          (match uu____2433 with
            | FStar_Pervasives_Native.None  ->
-               let uu____2445 =
-                 let uu___400_2448 = t  in
-                 let uu____2451 =
-                   let uu____2452 =
-                     let uu____2465 = compose_uvar_subst uv s0 s  in
-                     (uv, uu____2465)  in
-                   FStar_Syntax_Syntax.Tm_uvar uu____2452  in
+               let uu____2438 =
+                 let uu___400_2441 = t  in
+                 let uu____2444 =
+                   let uu____2445 =
+                     let uu____2458 = compose_uvar_subst uv s0 s  in
+                     (uv, uu____2458)  in
+                   FStar_Syntax_Syntax.Tm_uvar uu____2445  in
                  {
-                   FStar_Syntax_Syntax.n = uu____2451;
+                   FStar_Syntax_Syntax.n = uu____2444;
                    FStar_Syntax_Syntax.pos =
-                     (uu___400_2448.FStar_Syntax_Syntax.pos);
+                     (uu___400_2441.FStar_Syntax_Syntax.pos);
                    FStar_Syntax_Syntax.vars =
-                     (uu___400_2448.FStar_Syntax_Syntax.vars)
+                     (uu___400_2441.FStar_Syntax_Syntax.vars)
                  }  in
-               tag_with_range uu____2445 s
+               tag_with_range uu____2438 s
            | FStar_Pervasives_Native.Some t1 ->
                push_subst (compose_subst s0 s) t1)
-      | FStar_Syntax_Syntax.Tm_type uu____2489 -> subst' s t
-      | FStar_Syntax_Syntax.Tm_bvar uu____2490 -> subst' s t
-      | FStar_Syntax_Syntax.Tm_name uu____2491 -> subst' s t
+      | FStar_Syntax_Syntax.Tm_type uu____2482 -> subst' s t
+      | FStar_Syntax_Syntax.Tm_bvar uu____2483 -> subst' s t
+      | FStar_Syntax_Syntax.Tm_name uu____2484 -> subst' s t
       | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
           let us1 =
             FStar_List.map (subst_univ (FStar_Pervasives_Native.fst s)) us
              in
-          let uu____2505 = mk (FStar_Syntax_Syntax.Tm_uinst (t', us1))  in
-          tag_with_range uu____2505 s
+          let uu____2498 = mk (FStar_Syntax_Syntax.Tm_uinst (t', us1))  in
+          tag_with_range uu____2498 s
       | FStar_Syntax_Syntax.Tm_app (t0,args) ->
-          let uu____2540 =
-            let uu____2541 =
-              let uu____2558 = subst' s t0  in
-              let uu____2561 = subst_args' s args  in
-              (uu____2558, uu____2561)  in
-            FStar_Syntax_Syntax.Tm_app uu____2541  in
-          mk uu____2540
+          let uu____2533 =
+            let uu____2534 =
+              let uu____2551 = subst' s t0  in
+              let uu____2554 = subst_args' s args  in
+              (uu____2551, uu____2554)  in
+            FStar_Syntax_Syntax.Tm_app uu____2534  in
+          mk uu____2533
       | FStar_Syntax_Syntax.Tm_ascribed (t0,(annot,topt),lopt) ->
           let annot1 =
             match annot with
             | FStar_Util.Inl t1 ->
-                let uu____2662 = subst' s t1  in FStar_Util.Inl uu____2662
+                let uu____2655 = subst' s t1  in FStar_Util.Inl uu____2655
             | FStar_Util.Inr c ->
-                let uu____2676 = subst_comp' s c  in
-                FStar_Util.Inr uu____2676
+                let uu____2669 = subst_comp' s c  in
+                FStar_Util.Inr uu____2669
              in
-          let uu____2683 =
-            let uu____2684 =
-              let uu____2711 = subst' s t0  in
-              let uu____2714 =
-                let uu____2731 = FStar_Util.map_opt topt (subst' s)  in
-                (annot1, uu____2731)  in
-              (uu____2711, uu____2714, lopt)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____2684  in
-          mk uu____2683
+          let uu____2676 =
+            let uu____2677 =
+              let uu____2704 = subst' s t0  in
+              let uu____2707 =
+                let uu____2724 = FStar_Util.map_opt topt (subst' s)  in
+                (annot1, uu____2724)  in
+              (uu____2704, uu____2707, lopt)  in
+            FStar_Syntax_Syntax.Tm_ascribed uu____2677  in
+          mk uu____2676
       | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
           let n = FStar_List.length bs  in
           let s' = shift_subst' n s  in
-          let uu____2813 =
-            let uu____2814 =
-              let uu____2833 = subst_binders' s bs  in
-              let uu____2842 = subst' s' body  in
-              let uu____2845 = push_subst_lcomp s' lopt  in
-              (uu____2833, uu____2842, uu____2845)  in
-            FStar_Syntax_Syntax.Tm_abs uu____2814  in
-          mk uu____2813
+          let uu____2806 =
+            let uu____2807 =
+              let uu____2826 = subst_binders' s bs  in
+              let uu____2835 = subst' s' body  in
+              let uu____2838 = push_subst_lcomp s' lopt  in
+              (uu____2826, uu____2835, uu____2838)  in
+            FStar_Syntax_Syntax.Tm_abs uu____2807  in
+          mk uu____2806
       | FStar_Syntax_Syntax.Tm_arrow (bs,comp) ->
           let n = FStar_List.length bs  in
-          let uu____2889 =
-            let uu____2890 =
-              let uu____2905 = subst_binders' s bs  in
-              let uu____2914 =
-                let uu____2917 = shift_subst' n s  in
-                subst_comp' uu____2917 comp  in
-              (uu____2905, uu____2914)  in
-            FStar_Syntax_Syntax.Tm_arrow uu____2890  in
-          mk uu____2889
+          let uu____2882 =
+            let uu____2883 =
+              let uu____2898 = subst_binders' s bs  in
+              let uu____2907 =
+                let uu____2910 = shift_subst' n s  in
+                subst_comp' uu____2910 comp  in
+              (uu____2898, uu____2907)  in
+            FStar_Syntax_Syntax.Tm_arrow uu____2883  in
+          mk uu____2882
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
           let x1 =
-            let uu___447_2943 = x  in
-            let uu____2944 = subst' s x.FStar_Syntax_Syntax.sort  in
+            let uu___447_2936 = x  in
+            let uu____2937 = subst' s x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___447_2943.FStar_Syntax_Syntax.ppname);
+                (uu___447_2936.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___447_2943.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____2944
+                (uu___447_2936.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____2937
             }  in
           let phi1 =
-            let uu____2948 = shift_subst' Prims.int_one s  in
-            subst' uu____2948 phi  in
+            let uu____2941 = shift_subst' Prims.int_one s  in
+            subst' uu____2941 phi  in
           mk (FStar_Syntax_Syntax.Tm_refine (x1, phi1))
       | FStar_Syntax_Syntax.Tm_match (t0,pats) ->
           let t01 = subst' s t0  in
           let pats1 =
             FStar_All.pipe_right pats
               (FStar_List.map
-                 (fun uu____3064  ->
-                    match uu____3064 with
+                 (fun uu____3057  ->
+                    match uu____3057 with
                     | (pat,wopt,branch) ->
-                        let uu____3094 = subst_pat' s pat  in
-                        (match uu____3094 with
+                        let uu____3087 = subst_pat' s pat  in
+                        (match uu____3087 with
                          | (pat1,n) ->
                              let s1 = shift_subst' n s  in
                              let wopt1 =
@@ -911,8 +909,8 @@ let rec (push_subst :
                                | FStar_Pervasives_Native.None  ->
                                    FStar_Pervasives_Native.None
                                | FStar_Pervasives_Native.Some w ->
-                                   let uu____3125 = subst' s1 w  in
-                                   FStar_Pervasives_Native.Some uu____3125
+                                   let uu____3118 = subst' s1 w  in
+                                   FStar_Pervasives_Native.Some uu____3118
                                 in
                              let branch1 = subst' s1 branch  in
                              (pat1, wopt1, branch1))))
@@ -928,23 +926,23 @@ let rec (push_subst :
                  (fun lb  ->
                     let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp  in
                     let lbd =
-                      let uu____3194 =
+                      let uu____3187 =
                         is_rec &&
                           (FStar_Util.is_left lb.FStar_Syntax_Syntax.lbname)
                          in
-                      if uu____3194
+                      if uu____3187
                       then subst' sn lb.FStar_Syntax_Syntax.lbdef
                       else subst' s lb.FStar_Syntax_Syntax.lbdef  in
                     let lbname =
                       match lb.FStar_Syntax_Syntax.lbname with
                       | FStar_Util.Inl x ->
                           FStar_Util.Inl
-                            (let uu___485_3212 = x  in
+                            (let uu___485_3205 = x  in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___485_3212.FStar_Syntax_Syntax.ppname);
+                                 (uu___485_3205.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___485_3212.FStar_Syntax_Syntax.index);
+                                 (uu___485_3205.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort = lbt
                              })
                       | FStar_Util.Inr fv -> FStar_Util.Inr fv  in
@@ -952,78 +950,78 @@ let rec (push_subst :
                       FStar_List.map (subst' s)
                         lb.FStar_Syntax_Syntax.lbattrs
                        in
-                    let uu___491_3223 = lb  in
+                    let uu___491_3216 = lb  in
                     {
                       FStar_Syntax_Syntax.lbname = lbname;
                       FStar_Syntax_Syntax.lbunivs =
-                        (uu___491_3223.FStar_Syntax_Syntax.lbunivs);
+                        (uu___491_3216.FStar_Syntax_Syntax.lbunivs);
                       FStar_Syntax_Syntax.lbtyp = lbt;
                       FStar_Syntax_Syntax.lbeff =
-                        (uu___491_3223.FStar_Syntax_Syntax.lbeff);
+                        (uu___491_3216.FStar_Syntax_Syntax.lbeff);
                       FStar_Syntax_Syntax.lbdef = lbd;
                       FStar_Syntax_Syntax.lbattrs = lbattrs;
                       FStar_Syntax_Syntax.lbpos =
-                        (uu___491_3223.FStar_Syntax_Syntax.lbpos)
+                        (uu___491_3216.FStar_Syntax_Syntax.lbpos)
                     }))
              in
           mk (FStar_Syntax_Syntax.Tm_let ((is_rec, lbs1), body1))
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_pattern (bs,ps)) ->
-          let uu____3275 =
-            let uu____3276 =
-              let uu____3283 = subst' s t0  in
-              let uu____3286 =
-                let uu____3287 =
-                  let uu____3308 = FStar_List.map (subst' s) bs  in
-                  let uu____3317 =
+          let uu____3268 =
+            let uu____3269 =
+              let uu____3276 = subst' s t0  in
+              let uu____3279 =
+                let uu____3280 =
+                  let uu____3301 = FStar_List.map (subst' s) bs  in
+                  let uu____3310 =
                     FStar_All.pipe_right ps (FStar_List.map (subst_args' s))
                      in
-                  (uu____3308, uu____3317)  in
-                FStar_Syntax_Syntax.Meta_pattern uu____3287  in
-              (uu____3283, uu____3286)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3276  in
-          mk uu____3275
+                  (uu____3301, uu____3310)  in
+                FStar_Syntax_Syntax.Meta_pattern uu____3280  in
+              (uu____3276, uu____3279)  in
+            FStar_Syntax_Syntax.Tm_meta uu____3269  in
+          mk uu____3268
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_monadic (m,t1)) ->
-          let uu____3399 =
-            let uu____3400 =
-              let uu____3407 = subst' s t0  in
-              let uu____3410 =
-                let uu____3411 =
-                  let uu____3418 = subst' s t1  in (m, uu____3418)  in
-                FStar_Syntax_Syntax.Meta_monadic uu____3411  in
-              (uu____3407, uu____3410)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3400  in
-          mk uu____3399
+          let uu____3392 =
+            let uu____3393 =
+              let uu____3400 = subst' s t0  in
+              let uu____3403 =
+                let uu____3404 =
+                  let uu____3411 = subst' s t1  in (m, uu____3411)  in
+                FStar_Syntax_Syntax.Meta_monadic uu____3404  in
+              (uu____3400, uu____3403)  in
+            FStar_Syntax_Syntax.Tm_meta uu____3393  in
+          mk uu____3392
       | FStar_Syntax_Syntax.Tm_meta
           (t0,FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,t1)) ->
-          let uu____3437 =
-            let uu____3438 =
-              let uu____3445 = subst' s t0  in
-              let uu____3448 =
-                let uu____3449 =
-                  let uu____3458 = subst' s t1  in (m1, m2, uu____3458)  in
-                FStar_Syntax_Syntax.Meta_monadic_lift uu____3449  in
-              (uu____3445, uu____3448)  in
-            FStar_Syntax_Syntax.Tm_meta uu____3438  in
-          mk uu____3437
+          let uu____3430 =
+            let uu____3431 =
+              let uu____3438 = subst' s t0  in
+              let uu____3441 =
+                let uu____3442 =
+                  let uu____3451 = subst' s t1  in (m1, m2, uu____3451)  in
+                FStar_Syntax_Syntax.Meta_monadic_lift uu____3442  in
+              (uu____3438, uu____3441)  in
+            FStar_Syntax_Syntax.Tm_meta uu____3431  in
+          mk uu____3430
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           (match qi.FStar_Syntax_Syntax.qkind with
            | FStar_Syntax_Syntax.Quote_dynamic  ->
-               let uu____3473 =
-                 let uu____3474 =
-                   let uu____3481 = subst' s tm  in (uu____3481, qi)  in
-                 FStar_Syntax_Syntax.Tm_quoted uu____3474  in
-               mk uu____3473
+               let uu____3466 =
+                 let uu____3467 =
+                   let uu____3474 = subst' s tm  in (uu____3474, qi)  in
+                 FStar_Syntax_Syntax.Tm_quoted uu____3467  in
+               mk uu____3466
            | FStar_Syntax_Syntax.Quote_static  ->
                let qi1 = FStar_Syntax_Syntax.on_antiquoted (subst' s) qi  in
                mk (FStar_Syntax_Syntax.Tm_quoted (tm, qi1)))
       | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
-          let uu____3495 =
-            let uu____3496 = let uu____3503 = subst' s t1  in (uu____3503, m)
+          let uu____3488 =
+            let uu____3489 = let uu____3496 = subst' s t1  in (uu____3496, m)
                in
-            FStar_Syntax_Syntax.Tm_meta uu____3496  in
-          mk uu____3495
+            FStar_Syntax_Syntax.Tm_meta uu____3489  in
+          mk uu____3488
   
 let (compress_slow :
   FStar_Syntax_Syntax.term ->
@@ -1033,15 +1031,15 @@ let (compress_slow :
     let t1 = force_uvar t  in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_delayed (t',s) -> push_subst s t'
-    | uu____3543 -> t1
+    | uu____3536 -> t1
   
 let (compress : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed (uu____3550,uu____3551) ->
+    | FStar_Syntax_Syntax.Tm_delayed (uu____3543,uu____3544) ->
         compress_slow t
-    | FStar_Syntax_Syntax.Tm_uvar (uu____3572,uu____3573) -> compress_slow t
-    | uu____3590 -> t
+    | FStar_Syntax_Syntax.Tm_uvar (uu____3565,uu____3566) -> compress_slow t
+    | uu____3583 -> t
   
 let (subst :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -1052,14 +1050,14 @@ let (set_use_range :
   =
   fun r  ->
     fun t  ->
-      let uu____3625 =
-        let uu____3626 =
-          let uu____3627 =
-            let uu____3628 = FStar_Range.use_range r  in
-            FStar_Range.set_def_range r uu____3628  in
-          FStar_Syntax_Syntax.SomeUseRange uu____3627  in
-        ([], uu____3626)  in
-      subst' uu____3625 t
+      let uu____3618 =
+        let uu____3619 =
+          let uu____3620 =
+            let uu____3621 = FStar_Range.use_range r  in
+            FStar_Range.set_def_range r uu____3621  in
+          FStar_Syntax_Syntax.SomeUseRange uu____3620  in
+        ([], uu____3619)  in
+      subst' uu____3618 t
   
 let (subst_comp :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
@@ -1073,16 +1071,16 @@ let (subst_imp :
 let (closing_subst :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_elt Prims.list) =
   fun bs  ->
-    let uu____3689 =
+    let uu____3682 =
       FStar_List.fold_right
-        (fun uu____3716  ->
-           fun uu____3717  ->
-             match (uu____3716, uu____3717) with
-             | ((x,uu____3752),(subst1,n)) ->
+        (fun uu____3709  ->
+           fun uu____3710  ->
+             match (uu____3709, uu____3710) with
+             | ((x,uu____3745),(subst1,n)) ->
                  (((FStar_Syntax_Syntax.NM (x, n)) :: subst1),
                    (n + Prims.int_one))) bs ([], Prims.int_zero)
        in
-    FStar_All.pipe_right uu____3689 FStar_Pervasives_Native.fst
+    FStar_All.pipe_right uu____3682 FStar_Pervasives_Native.fst
   
 let (open_binders' :
   FStar_Syntax_Syntax.binders ->
@@ -1094,29 +1092,29 @@ let (open_binders' :
       | [] -> ([], o)
       | (x,imp)::bs' ->
           let x' =
-            let uu___569_3890 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____3891 = subst o x.FStar_Syntax_Syntax.sort  in
+            let uu___569_3883 = FStar_Syntax_Syntax.freshen_bv x  in
+            let uu____3884 = subst o x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___569_3890.FStar_Syntax_Syntax.ppname);
+                (uu___569_3883.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___569_3890.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____3891
+                (uu___569_3883.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____3884
             }  in
           let imp1 = subst_imp o imp  in
           let o1 =
-            let uu____3898 = shift_subst Prims.int_one o  in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____3898  in
-          let uu____3904 = aux bs' o1  in
-          (match uu____3904 with | (bs'1,o2) -> (((x', imp1) :: bs'1), o2))
+            let uu____3891 = shift_subst Prims.int_one o  in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____3891  in
+          let uu____3897 = aux bs' o1  in
+          (match uu____3897 with | (bs'1,o2) -> (((x', imp1) :: bs'1), o2))
        in
     aux bs []
   
 let (open_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
   fun bs  ->
-    let uu____3965 = open_binders' bs  in
-    FStar_Pervasives_Native.fst uu____3965
+    let uu____3958 = open_binders' bs  in
+    FStar_Pervasives_Native.fst uu____3958
   
 let (open_term' :
   FStar_Syntax_Syntax.binders ->
@@ -1126,10 +1124,10 @@ let (open_term' :
   =
   fun bs  ->
     fun t  ->
-      let uu____3987 = open_binders' bs  in
-      match uu____3987 with
+      let uu____3980 = open_binders' bs  in
+      match uu____3980 with
       | (bs',opening) ->
-          let uu____4000 = subst opening t  in (bs', uu____4000, opening)
+          let uu____3993 = subst opening t  in (bs', uu____3993, opening)
   
 let (open_term :
   FStar_Syntax_Syntax.binders ->
@@ -1138,8 +1136,8 @@ let (open_term :
   =
   fun bs  ->
     fun t  ->
-      let uu____4016 = open_term' bs t  in
-      match uu____4016 with | (b,t1,uu____4029) -> (b, t1)
+      let uu____4009 = open_term' bs t  in
+      match uu____4009 with | (b,t1,uu____4022) -> (b, t1)
   
 let (open_comp :
   FStar_Syntax_Syntax.binders ->
@@ -1148,10 +1146,10 @@ let (open_comp :
   =
   fun bs  ->
     fun t  ->
-      let uu____4045 = open_binders' bs  in
-      match uu____4045 with
+      let uu____4038 = open_binders' bs  in
+      match uu____4038 with
       | (bs',opening) ->
-          let uu____4056 = subst_comp opening t  in (bs', uu____4056)
+          let uu____4049 = subst_comp opening t  in (bs', uu____4049)
   
 let (open_pat :
   FStar_Syntax_Syntax.pat ->
@@ -1160,85 +1158,85 @@ let (open_pat :
   fun p  ->
     let rec open_pat_aux sub p1 =
       match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_constant uu____4106 -> (p1, sub)
+      | FStar_Syntax_Syntax.Pat_constant uu____4099 -> (p1, sub)
       | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-          let uu____4131 =
+          let uu____4124 =
             FStar_All.pipe_right pats
               (FStar_List.fold_left
-                 (fun uu____4202  ->
-                    fun uu____4203  ->
-                      match (uu____4202, uu____4203) with
+                 (fun uu____4195  ->
+                    fun uu____4196  ->
+                      match (uu____4195, uu____4196) with
                       | ((pats1,sub1),(p2,imp)) ->
-                          let uu____4317 = open_pat_aux sub1 p2  in
-                          (match uu____4317 with
+                          let uu____4310 = open_pat_aux sub1 p2  in
+                          (match uu____4310 with
                            | (p3,sub2) -> (((p3, imp) :: pats1), sub2)))
                  ([], sub))
              in
-          (match uu____4131 with
+          (match uu____4124 with
            | (pats1,sub1) ->
-               ((let uu___616_4427 = p1  in
+               ((let uu___616_4420 = p1  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
                         (fv, (FStar_List.rev pats1)));
                    FStar_Syntax_Syntax.p =
-                     (uu___616_4427.FStar_Syntax_Syntax.p)
+                     (uu___616_4420.FStar_Syntax_Syntax.p)
                  }), sub1))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x' =
-            let uu___620_4448 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____4449 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___620_4441 = FStar_Syntax_Syntax.freshen_bv x  in
+            let uu____4442 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___620_4448.FStar_Syntax_Syntax.ppname);
+                (uu___620_4441.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___620_4448.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4449
+                (uu___620_4441.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4442
             }  in
           let sub1 =
-            let uu____4455 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4455  in
-          ((let uu___624_4466 = p1  in
+            let uu____4448 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4448  in
+          ((let uu___624_4459 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x');
-              FStar_Syntax_Syntax.p = (uu___624_4466.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___624_4459.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x' =
-            let uu___628_4471 = FStar_Syntax_Syntax.freshen_bv x  in
-            let uu____4472 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___628_4464 = FStar_Syntax_Syntax.freshen_bv x  in
+            let uu____4465 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___628_4471.FStar_Syntax_Syntax.ppname);
+                (uu___628_4464.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___628_4471.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4472
+                (uu___628_4464.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4465
             }  in
           let sub1 =
-            let uu____4478 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4478  in
-          ((let uu___632_4489 = p1  in
+            let uu____4471 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu____4471  in
+          ((let uu___632_4482 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x');
-              FStar_Syntax_Syntax.p = (uu___632_4489.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___632_4482.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
           let x1 =
-            let uu___638_4499 = x  in
-            let uu____4500 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___638_4492 = x  in
+            let uu____4493 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___638_4499.FStar_Syntax_Syntax.ppname);
+                (uu___638_4492.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___638_4499.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4500
+                (uu___638_4492.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4493
             }  in
           let t01 = subst sub t0  in
-          ((let uu___642_4509 = p1  in
+          ((let uu___642_4502 = p1  in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.p = (uu___642_4509.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___642_4502.FStar_Syntax_Syntax.p)
             }), sub)
        in
     open_pat_aux [] p
@@ -1247,41 +1245,41 @@ let (open_branch' :
   FStar_Syntax_Syntax.branch ->
     (FStar_Syntax_Syntax.branch * FStar_Syntax_Syntax.subst_t))
   =
-  fun uu____4523  ->
-    match uu____4523 with
+  fun uu____4516  ->
+    match uu____4516 with
     | (p,wopt,e) ->
-        let uu____4547 = open_pat p  in
-        (match uu____4547 with
+        let uu____4540 = open_pat p  in
+        (match uu____4540 with
          | (p1,opening) ->
              let wopt1 =
                match wopt with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____4576 = subst opening w  in
-                   FStar_Pervasives_Native.Some uu____4576
+                   let uu____4569 = subst opening w  in
+                   FStar_Pervasives_Native.Some uu____4569
                 in
              let e1 = subst opening e  in ((p1, wopt1, e1), opening))
   
 let (open_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
   =
   fun br  ->
-    let uu____4596 = open_branch' br  in
-    match uu____4596 with | (br1,uu____4602) -> br1
+    let uu____4589 = open_branch' br  in
+    match uu____4589 with | (br1,uu____4595) -> br1
   
 let (close :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun bs  ->
-    fun t  -> let uu____4614 = closing_subst bs  in subst uu____4614 t
+    fun t  -> let uu____4607 = closing_subst bs  in subst uu____4607 t
   
 let (close_comp :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
   =
   fun bs  ->
-    fun c  -> let uu____4628 = closing_subst bs  in subst_comp uu____4628 c
+    fun c  -> let uu____4621 = closing_subst bs  in subst_comp uu____4621 c
   
 let (close_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders) =
@@ -1291,20 +1289,20 @@ let (close_binders :
       | [] -> []
       | (x,imp)::tl ->
           let x1 =
-            let uu___674_4696 = x  in
-            let uu____4697 = subst s x.FStar_Syntax_Syntax.sort  in
+            let uu___674_4689 = x  in
+            let uu____4690 = subst s x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___674_4696.FStar_Syntax_Syntax.ppname);
+                (uu___674_4689.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___674_4696.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____4697
+                (uu___674_4689.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____4690
             }  in
           let imp1 = subst_imp s imp  in
           let s' =
-            let uu____4704 = shift_subst Prims.int_one s  in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____4704  in
-          let uu____4710 = aux s' tl  in (x1, imp1) :: uu____4710
+            let uu____4697 = shift_subst Prims.int_one s  in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____4697  in
+          let uu____4703 = aux s' tl  in (x1, imp1) :: uu____4703
        in
     aux [] bs
   
@@ -1316,104 +1314,104 @@ let (close_pat :
   fun p  ->
     let rec aux sub p1 =
       match p1.FStar_Syntax_Syntax.v with
-      | FStar_Syntax_Syntax.Pat_constant uu____4774 -> (p1, sub)
+      | FStar_Syntax_Syntax.Pat_constant uu____4767 -> (p1, sub)
       | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-          let uu____4799 =
+          let uu____4792 =
             FStar_All.pipe_right pats
               (FStar_List.fold_left
-                 (fun uu____4870  ->
-                    fun uu____4871  ->
-                      match (uu____4870, uu____4871) with
+                 (fun uu____4863  ->
+                    fun uu____4864  ->
+                      match (uu____4863, uu____4864) with
                       | ((pats1,sub1),(p2,imp)) ->
-                          let uu____4985 = aux sub1 p2  in
-                          (match uu____4985 with
+                          let uu____4978 = aux sub1 p2  in
+                          (match uu____4978 with
                            | (p3,sub2) -> (((p3, imp) :: pats1), sub2)))
                  ([], sub))
              in
-          (match uu____4799 with
+          (match uu____4792 with
            | (pats1,sub1) ->
-               ((let uu___701_5095 = p1  in
+               ((let uu___701_5088 = p1  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons
                         (fv, (FStar_List.rev pats1)));
                    FStar_Syntax_Syntax.p =
-                     (uu___701_5095.FStar_Syntax_Syntax.p)
+                     (uu___701_5088.FStar_Syntax_Syntax.p)
                  }), sub1))
       | FStar_Syntax_Syntax.Pat_var x ->
           let x1 =
-            let uu___705_5116 = x  in
-            let uu____5117 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___705_5109 = x  in
+            let uu____5110 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___705_5116.FStar_Syntax_Syntax.ppname);
+                (uu___705_5109.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___705_5116.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____5117
+                (uu___705_5109.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____5110
             }  in
           let sub1 =
-            let uu____5123 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5123  in
-          ((let uu___709_5134 = p1  in
+            let uu____5116 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5116  in
+          ((let uu___709_5127 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
-              FStar_Syntax_Syntax.p = (uu___709_5134.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___709_5127.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_wild x ->
           let x1 =
-            let uu___713_5139 = x  in
-            let uu____5140 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___713_5132 = x  in
+            let uu____5133 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___713_5139.FStar_Syntax_Syntax.ppname);
+                (uu___713_5132.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___713_5139.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____5140
+                (uu___713_5132.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____5133
             }  in
           let sub1 =
-            let uu____5146 = shift_subst Prims.int_one sub  in
-            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5146  in
-          ((let uu___717_5157 = p1  in
+            let uu____5139 = shift_subst Prims.int_one sub  in
+            (FStar_Syntax_Syntax.NM (x1, Prims.int_zero)) :: uu____5139  in
+          ((let uu___717_5150 = p1  in
             {
               FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
-              FStar_Syntax_Syntax.p = (uu___717_5157.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___717_5150.FStar_Syntax_Syntax.p)
             }), sub1)
       | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
           let x1 =
-            let uu___723_5167 = x  in
-            let uu____5168 = subst sub x.FStar_Syntax_Syntax.sort  in
+            let uu___723_5160 = x  in
+            let uu____5161 = subst sub x.FStar_Syntax_Syntax.sort  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___723_5167.FStar_Syntax_Syntax.ppname);
+                (uu___723_5160.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___723_5167.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu____5168
+                (uu___723_5160.FStar_Syntax_Syntax.index);
+              FStar_Syntax_Syntax.sort = uu____5161
             }  in
           let t01 = subst sub t0  in
-          ((let uu___727_5177 = p1  in
+          ((let uu___727_5170 = p1  in
             {
               FStar_Syntax_Syntax.v =
                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
-              FStar_Syntax_Syntax.p = (uu___727_5177.FStar_Syntax_Syntax.p)
+              FStar_Syntax_Syntax.p = (uu___727_5170.FStar_Syntax_Syntax.p)
             }), sub)
        in
     aux [] p
   
 let (close_branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch)
   =
-  fun uu____5187  ->
-    match uu____5187 with
+  fun uu____5180  ->
+    match uu____5180 with
     | (p,wopt,e) ->
-        let uu____5207 = close_pat p  in
-        (match uu____5207 with
+        let uu____5200 = close_pat p  in
+        (match uu____5200 with
          | (p1,closing) ->
              let wopt1 =
                match wopt with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some w ->
-                   let uu____5244 = subst closing w  in
-                   FStar_Pervasives_Native.Some uu____5244
+                   let uu____5237 = subst closing w  in
+                   FStar_Pervasives_Native.Some uu____5237
                 in
              let e1 = subst closing e  in (p1, wopt1, e1))
   
@@ -1450,8 +1448,8 @@ let (open_univ_vars :
   =
   fun us  ->
     fun t  ->
-      let uu____5332 = univ_var_opening us  in
-      match uu____5332 with | (s,us') -> let t1 = subst s t  in (us', t1)
+      let uu____5325 = univ_var_opening us  in
+      match uu____5325 with | (s,us') -> let t1 = subst s t  in (us', t1)
   
 let (open_univ_vars_comp :
   FStar_Syntax_Syntax.univ_names ->
@@ -1460,9 +1458,9 @@ let (open_univ_vars_comp :
   =
   fun us  ->
     fun c  ->
-      let uu____5375 = univ_var_opening us  in
-      match uu____5375 with
-      | (s,us') -> let uu____5398 = subst_comp s c  in (us', uu____5398)
+      let uu____5368 = univ_var_opening us  in
+      match uu____5368 with
+      | (s,us') -> let uu____5391 = subst_comp s c  in (us', uu____5391)
   
 let (close_univ_vars :
   FStar_Syntax_Syntax.univ_names ->
@@ -1489,50 +1487,50 @@ let (open_let_rec :
   =
   fun lbs  ->
     fun t  ->
-      let uu____5461 =
-        let uu____5473 = FStar_Syntax_Syntax.is_top_level lbs  in
-        if uu____5473
+      let uu____5454 =
+        let uu____5466 = FStar_Syntax_Syntax.is_top_level lbs  in
+        if uu____5466
         then (Prims.int_zero, lbs, [])
         else
           FStar_List.fold_right
             (fun lb  ->
-               fun uu____5513  ->
-                 match uu____5513 with
+               fun uu____5506  ->
+                 match uu____5506 with
                  | (i,lbs1,out) ->
                      let x =
-                       let uu____5550 =
+                       let uu____5543 =
                          FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                       FStar_Syntax_Syntax.freshen_bv uu____5550  in
+                       FStar_Syntax_Syntax.freshen_bv uu____5543  in
                      ((i + Prims.int_one),
-                       ((let uu___779_5558 = lb  in
+                       ((let uu___779_5551 = lb  in
                          {
                            FStar_Syntax_Syntax.lbname = (FStar_Util.Inl x);
                            FStar_Syntax_Syntax.lbunivs =
-                             (uu___779_5558.FStar_Syntax_Syntax.lbunivs);
+                             (uu___779_5551.FStar_Syntax_Syntax.lbunivs);
                            FStar_Syntax_Syntax.lbtyp =
-                             (uu___779_5558.FStar_Syntax_Syntax.lbtyp);
+                             (uu___779_5551.FStar_Syntax_Syntax.lbtyp);
                            FStar_Syntax_Syntax.lbeff =
-                             (uu___779_5558.FStar_Syntax_Syntax.lbeff);
+                             (uu___779_5551.FStar_Syntax_Syntax.lbeff);
                            FStar_Syntax_Syntax.lbdef =
-                             (uu___779_5558.FStar_Syntax_Syntax.lbdef);
+                             (uu___779_5551.FStar_Syntax_Syntax.lbdef);
                            FStar_Syntax_Syntax.lbattrs =
-                             (uu___779_5558.FStar_Syntax_Syntax.lbattrs);
+                             (uu___779_5551.FStar_Syntax_Syntax.lbattrs);
                            FStar_Syntax_Syntax.lbpos =
-                             (uu___779_5558.FStar_Syntax_Syntax.lbpos)
+                             (uu___779_5551.FStar_Syntax_Syntax.lbpos)
                          }) :: lbs1), ((FStar_Syntax_Syntax.DB (i, x)) ::
                        out))) lbs (Prims.int_zero, [], [])
          in
-      match uu____5461 with
+      match uu____5454 with
       | (n_let_recs,lbs1,let_rec_opening) ->
           let lbs2 =
             FStar_All.pipe_right lbs1
               (FStar_List.map
                  (fun lb  ->
-                    let uu____5601 =
+                    let uu____5594 =
                       FStar_List.fold_right
                         (fun u  ->
-                           fun uu____5631  ->
-                             match uu____5631 with
+                           fun uu____5624  ->
+                             match uu____5624 with
                              | (i,us,out) ->
                                  let u1 =
                                    FStar_Syntax_Syntax.new_univ_name
@@ -1544,29 +1542,29 @@ let (open_let_rec :
                                    :: out))) lb.FStar_Syntax_Syntax.lbunivs
                         (n_let_recs, [], let_rec_opening)
                        in
-                    match uu____5601 with
-                    | (uu____5680,us,u_let_rec_opening) ->
-                        let uu___796_5693 = lb  in
-                        let uu____5694 =
+                    match uu____5594 with
+                    | (uu____5673,us,u_let_rec_opening) ->
+                        let uu___796_5686 = lb  in
+                        let uu____5687 =
                           subst u_let_rec_opening
                             lb.FStar_Syntax_Syntax.lbtyp
                            in
-                        let uu____5697 =
+                        let uu____5690 =
                           subst u_let_rec_opening
                             lb.FStar_Syntax_Syntax.lbdef
                            in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___796_5693.FStar_Syntax_Syntax.lbname);
+                            (uu___796_5686.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = us;
-                          FStar_Syntax_Syntax.lbtyp = uu____5694;
+                          FStar_Syntax_Syntax.lbtyp = uu____5687;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___796_5693.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____5697;
+                            (uu___796_5686.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu____5690;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___796_5693.FStar_Syntax_Syntax.lbattrs);
+                            (uu___796_5686.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___796_5693.FStar_Syntax_Syntax.lbpos)
+                            (uu___796_5686.FStar_Syntax_Syntax.lbpos)
                         }))
              in
           let t1 = subst let_rec_opening t  in (lbs2, t1)
@@ -1578,69 +1576,69 @@ let (close_let_rec :
   =
   fun lbs  ->
     fun t  ->
-      let uu____5724 =
-        let uu____5732 = FStar_Syntax_Syntax.is_top_level lbs  in
-        if uu____5732
+      let uu____5717 =
+        let uu____5725 = FStar_Syntax_Syntax.is_top_level lbs  in
+        if uu____5725
         then (Prims.int_zero, [])
         else
           FStar_List.fold_right
             (fun lb  ->
-               fun uu____5761  ->
-                 match uu____5761 with
+               fun uu____5754  ->
+                 match uu____5754 with
                  | (i,out) ->
-                     let uu____5784 =
-                       let uu____5787 =
-                         let uu____5788 =
-                           let uu____5794 =
+                     let uu____5777 =
+                       let uu____5780 =
+                         let uu____5781 =
+                           let uu____5787 =
                              FStar_Util.left lb.FStar_Syntax_Syntax.lbname
                               in
-                           (uu____5794, i)  in
-                         FStar_Syntax_Syntax.NM uu____5788  in
-                       uu____5787 :: out  in
-                     ((i + Prims.int_one), uu____5784)) lbs
+                           (uu____5787, i)  in
+                         FStar_Syntax_Syntax.NM uu____5781  in
+                       uu____5780 :: out  in
+                     ((i + Prims.int_one), uu____5777)) lbs
             (Prims.int_zero, [])
          in
-      match uu____5724 with
+      match uu____5717 with
       | (n_let_recs,let_rec_closing) ->
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb  ->
-                    let uu____5833 =
+                    let uu____5826 =
                       FStar_List.fold_right
                         (fun u  ->
-                           fun uu____5853  ->
-                             match uu____5853 with
+                           fun uu____5846  ->
+                             match uu____5846 with
                              | (i,out) ->
                                  ((i + Prims.int_one),
                                    ((FStar_Syntax_Syntax.UD (u, i)) :: out)))
                         lb.FStar_Syntax_Syntax.lbunivs
                         (n_let_recs, let_rec_closing)
                        in
-                    match uu____5833 with
-                    | (uu____5884,u_let_rec_closing) ->
-                        let uu___818_5892 = lb  in
-                        let uu____5893 =
+                    match uu____5826 with
+                    | (uu____5877,u_let_rec_closing) ->
+                        let uu___818_5885 = lb  in
+                        let uu____5886 =
                           subst u_let_rec_closing
                             lb.FStar_Syntax_Syntax.lbtyp
                            in
-                        let uu____5896 =
+                        let uu____5889 =
                           subst u_let_rec_closing
                             lb.FStar_Syntax_Syntax.lbdef
                            in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___818_5892.FStar_Syntax_Syntax.lbname);
+                            (uu___818_5885.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___818_5892.FStar_Syntax_Syntax.lbunivs);
-                          FStar_Syntax_Syntax.lbtyp = uu____5893;
+                            (uu___818_5885.FStar_Syntax_Syntax.lbunivs);
+                          FStar_Syntax_Syntax.lbtyp = uu____5886;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___818_5892.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu____5896;
+                            (uu___818_5885.FStar_Syntax_Syntax.lbeff);
+                          FStar_Syntax_Syntax.lbdef = uu____5889;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___818_5892.FStar_Syntax_Syntax.lbattrs);
+                            (uu___818_5885.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___818_5892.FStar_Syntax_Syntax.lbpos)
+                            (uu___818_5885.FStar_Syntax_Syntax.lbpos)
                         }))
              in
           let t1 = subst let_rec_closing t  in (lbs1, t1)
@@ -1650,17 +1648,17 @@ let (close_tscheme :
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun binders  ->
-    fun uu____5912  ->
-      match uu____5912 with
+    fun uu____5905  ->
+      match uu____5905 with
       | (us,t) ->
           let n = (FStar_List.length binders) - Prims.int_one  in
           let k = FStar_List.length us  in
           let s =
             FStar_List.mapi
               (fun i  ->
-                 fun uu____5947  ->
-                   match uu____5947 with
-                   | (x,uu____5956) ->
+                 fun uu____5940  ->
+                   match uu____5940 with
+                   | (x,uu____5949) ->
                        FStar_Syntax_Syntax.NM (x, (k + (n - i)))) binders
              in
           let t1 = subst s t  in (us, t1)
@@ -1670,8 +1668,8 @@ let (close_univ_vars_tscheme :
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun us  ->
-    fun uu____5977  ->
-      match uu____5977 with
+    fun uu____5970  ->
+      match uu____5970 with
       | (us',t) ->
           let n = (FStar_List.length us) - Prims.int_one  in
           let k = FStar_List.length us'  in
@@ -1680,18 +1678,18 @@ let (close_univ_vars_tscheme :
               (fun i  -> fun x  -> FStar_Syntax_Syntax.UD (x, (k + (n - i))))
               us
              in
-          let uu____6001 = subst s t  in (us', uu____6001)
+          let uu____5994 = subst s t  in (us', uu____5994)
   
 let (subst_tscheme :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme)
   =
   fun s  ->
-    fun uu____6020  ->
-      match uu____6020 with
+    fun uu____6013  ->
+      match uu____6013 with
       | (us,t) ->
           let s1 = shift_subst (FStar_List.length us) s  in
-          let uu____6034 = subst s1 t  in (us, uu____6034)
+          let uu____6027 = subst s1 t  in (us, uu____6027)
   
 let (opening_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
@@ -1700,9 +1698,9 @@ let (opening_of_binders :
     FStar_All.pipe_right bs
       (FStar_List.mapi
          (fun i  ->
-            fun uu____6075  ->
-              match uu____6075 with
-              | (x,uu____6084) -> FStar_Syntax_Syntax.DB ((n - i), x)))
+            fun uu____6068  ->
+              match uu____6068 with
+              | (x,uu____6077) -> FStar_Syntax_Syntax.DB ((n - i), x)))
   
 let (closing_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
@@ -1714,10 +1712,10 @@ let (open_term_1 :
   =
   fun b  ->
     fun t  ->
-      let uu____6111 = open_term [b] t  in
-      match uu____6111 with
+      let uu____6104 = open_term [b] t  in
+      match uu____6104 with
       | (b1::[],t1) -> (b1, t1)
-      | uu____6152 -> failwith "impossible: open_term_1"
+      | uu____6145 -> failwith "impossible: open_term_1"
   
 let (open_term_bvs :
   FStar_Syntax_Syntax.bv Prims.list ->
@@ -1726,13 +1724,13 @@ let (open_term_bvs :
   =
   fun bvs  ->
     fun t  ->
-      let uu____6183 =
-        let uu____6188 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs  in
-        open_term uu____6188 t  in
-      match uu____6183 with
+      let uu____6176 =
+        let uu____6181 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs  in
+        open_term uu____6181 t  in
+      match uu____6176 with
       | (bs,t1) ->
-          let uu____6203 = FStar_List.map FStar_Pervasives_Native.fst bs  in
-          (uu____6203, t1)
+          let uu____6196 = FStar_List.map FStar_Pervasives_Native.fst bs  in
+          (uu____6196, t1)
   
 let (open_term_bv :
   FStar_Syntax_Syntax.bv ->
@@ -1741,8 +1739,8 @@ let (open_term_bv :
   =
   fun bv  ->
     fun t  ->
-      let uu____6231 = open_term_bvs [bv] t  in
-      match uu____6231 with
+      let uu____6224 = open_term_bvs [bv] t  in
+      match uu____6224 with
       | (bv1::[],t1) -> (bv1, t1)
-      | uu____6246 -> failwith "impossible: open_term_bv"
+      | uu____6239 -> failwith "impossible: open_term_bv"
   

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -1699,16 +1699,13 @@ let (__proj__Mkmodul__item__is_interface : modul -> Prims.bool) =
 let (mod_name : modul -> FStar_Ident.lident) = fun m  -> m.name 
 type path = Prims.string Prims.list
 type subst_t = subst_elt Prims.list
-type 'a mk_t_a =
-  unit FStar_Pervasives_Native.option -> FStar_Range.range -> 'a syntax
-type mk_t = term' mk_t_a
 let (contains_reflectable : qualifier Prims.list -> Prims.bool) =
   fun l  ->
     FStar_Util.for_some
-      (fun uu___0_8164  ->
-         match uu___0_8164 with
-         | Reflectable uu____8166 -> true
-         | uu____8168 -> false) l
+      (fun uu___0_8146  ->
+         match uu___0_8146 with
+         | Reflectable uu____8148 -> true
+         | uu____8150 -> false) l
   
 let withinfo : 'a . 'a -> FStar_Range.range -> 'a withinfo_t =
   fun v  -> fun r  -> { v; p = r } 
@@ -1724,24 +1721,24 @@ let (order_bv : bv -> bv -> Prims.int) =
   fun x  ->
     fun y  ->
       let i =
-        let uu____8230 = FStar_Ident.text_of_id x.ppname  in
-        let uu____8232 = FStar_Ident.text_of_id y.ppname  in
-        FStar_String.compare uu____8230 uu____8232  in
+        let uu____8212 = FStar_Ident.text_of_id x.ppname  in
+        let uu____8214 = FStar_Ident.text_of_id y.ppname  in
+        FStar_String.compare uu____8212 uu____8214  in
       if i = Prims.int_zero then x.index - y.index else i
   
 let (order_ident : FStar_Ident.ident -> FStar_Ident.ident -> Prims.int) =
   fun x  ->
     fun y  ->
-      let uu____8252 = FStar_Ident.text_of_id x  in
-      let uu____8254 = FStar_Ident.text_of_id y  in
-      FStar_String.compare uu____8252 uu____8254
+      let uu____8234 = FStar_Ident.text_of_id x  in
+      let uu____8236 = FStar_Ident.text_of_id y  in
+      FStar_String.compare uu____8234 uu____8236
   
 let (order_fv : FStar_Ident.lident -> FStar_Ident.lident -> Prims.int) =
   fun x  ->
     fun y  ->
-      let uu____8268 = FStar_Ident.string_of_lid x  in
-      let uu____8270 = FStar_Ident.string_of_lid y  in
-      FStar_String.compare uu____8268 uu____8270
+      let uu____8250 = FStar_Ident.string_of_lid x  in
+      let uu____8252 = FStar_Ident.string_of_lid y  in
+      FStar_String.compare uu____8250 uu____8252
   
 let (range_of_lbname : lbname -> FStar_Range.range) =
   fun l  ->
@@ -1754,12 +1751,12 @@ let (range_of_bv : bv -> FStar_Range.range) =
 let (set_range_of_bv : bv -> FStar_Range.range -> bv) =
   fun x  ->
     fun r  ->
-      let uu___416_8297 = x  in
-      let uu____8298 = FStar_Ident.set_id_range r x.ppname  in
+      let uu___415_8279 = x  in
+      let uu____8280 = FStar_Ident.set_id_range r x.ppname  in
       {
-        ppname = uu____8298;
-        index = (uu___416_8297.index);
-        sort = (uu___416_8297.sort)
+        ppname = uu____8280;
+        index = (uu___415_8279.index);
+        sort = (uu___415_8279.sort)
       }
   
 let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
@@ -1767,66 +1764,66 @@ let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
     fun qi  ->
       let aq =
         FStar_List.map
-          (fun uu____8334  ->
-             match uu____8334 with
-             | (bv1,t) -> let uu____8345 = f t  in (bv1, uu____8345))
+          (fun uu____8316  ->
+             match uu____8316 with
+             | (bv1,t) -> let uu____8327 = f t  in (bv1, uu____8327))
           qi.antiquotes
          in
-      let uu___424_8346 = qi  in
-      { qkind = (uu___424_8346.qkind); antiquotes = aq }
+      let uu___423_8328 = qi  in
+      { qkind = (uu___423_8328.qkind); antiquotes = aq }
   
 let (lookup_aq : bv -> antiquotations -> term FStar_Pervasives_Native.option)
   =
   fun bv1  ->
     fun aq  ->
-      let uu____8362 =
+      let uu____8344 =
         FStar_List.tryFind
-          (fun uu____8380  ->
-             match uu____8380 with | (bv',uu____8389) -> bv_eq bv1 bv') aq
+          (fun uu____8362  ->
+             match uu____8362 with | (bv',uu____8371) -> bv_eq bv1 bv') aq
          in
-      match uu____8362 with
-      | FStar_Pervasives_Native.Some (uu____8396,e) ->
+      match uu____8344 with
+      | FStar_Pervasives_Native.Some (uu____8378,e) ->
           FStar_Pervasives_Native.Some e
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
   
 let syn :
-  'uuuuuu8427 'uuuuuu8428 'uuuuuu8429 .
-    'uuuuuu8427 ->
-      'uuuuuu8428 ->
-        ('uuuuuu8428 -> 'uuuuuu8427 -> 'uuuuuu8429) -> 'uuuuuu8429
+  'uuuuuu8409 'uuuuuu8410 'uuuuuu8411 .
+    'uuuuuu8409 ->
+      'uuuuuu8410 ->
+        ('uuuuuu8410 -> 'uuuuuu8409 -> 'uuuuuu8411) -> 'uuuuuu8411
   = fun p  -> fun k  -> fun f  -> f k p 
 let mk_fvs :
-  'uuuuuu8460 .
-    unit -> 'uuuuuu8460 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8469  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
+  'uuuuuu8442 .
+    unit -> 'uuuuuu8442 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8451  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
 let mk_uvs :
-  'uuuuuu8477 .
-    unit -> 'uuuuuu8477 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8486  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
+  'uuuuuu8459 .
+    unit -> 'uuuuuu8459 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8468  -> FStar_Util.mk_ref FStar_Pervasives_Native.None 
 let (new_bv_set : unit -> bv FStar_Util.set) =
-  fun uu____8496  -> FStar_Util.new_set order_bv 
+  fun uu____8478  -> FStar_Util.new_set order_bv 
 let (new_id_set : unit -> FStar_Ident.ident FStar_Util.set) =
-  fun uu____8506  -> FStar_Util.new_set order_ident 
+  fun uu____8488  -> FStar_Util.new_set order_ident 
 let (new_fv_set : unit -> FStar_Ident.lident FStar_Util.set) =
-  fun uu____8516  -> FStar_Util.new_set order_fv 
+  fun uu____8498  -> FStar_Util.new_set order_fv 
 let (order_univ_name : univ_name -> univ_name -> Prims.int) =
   fun x  ->
     fun y  ->
-      let uu____8531 = FStar_Ident.text_of_id x  in
-      let uu____8533 = FStar_Ident.text_of_id y  in
-      FStar_String.compare uu____8531 uu____8533
+      let uu____8513 = FStar_Ident.text_of_id x  in
+      let uu____8515 = FStar_Ident.text_of_id y  in
+      FStar_String.compare uu____8513 uu____8515
   
 let (new_universe_names_set : unit -> univ_name FStar_Util.set) =
-  fun uu____8542  -> FStar_Util.new_set order_univ_name 
+  fun uu____8524  -> FStar_Util.new_set order_univ_name 
 let (eq_binding : binding -> binding -> Prims.bool) =
   fun b1  ->
     fun b2  ->
       match (b1, b2) with
       | (Binding_var bv1,Binding_var bv2) -> bv_eq bv1 bv2
-      | (Binding_lid (lid1,uu____8561),Binding_lid (lid2,uu____8563)) ->
+      | (Binding_lid (lid1,uu____8543),Binding_lid (lid2,uu____8545)) ->
           FStar_Ident.lid_equals lid1 lid2
       | (Binding_univ u1,Binding_univ u2) -> FStar_Ident.ident_equals u1 u2
-      | uu____8598 -> false
+      | uu____8580 -> false
   
 let (no_names : freenames) = new_bv_set () 
 let (no_fvars : FStar_Ident.lident FStar_Util.set) = new_fv_set () 
@@ -1836,80 +1833,70 @@ let (freenames_of_list : bv Prims.list -> freenames) =
   fun l  -> FStar_List.fold_right FStar_Util.set_add l no_names 
 let (list_of_freenames : freenames -> bv Prims.list) =
   fun fvs  -> FStar_Util.set_elements fvs 
-let mk : 'a . 'a -> 'a mk_t_a =
+let mk : 'a . 'a -> FStar_Range.range -> 'a syntax =
   fun t  ->
-    fun uu____8652  ->
-      fun r  ->
-        let uu____8656 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-        { n = t; pos = r; vars = uu____8656 }
+    fun r  ->
+      let uu____8633 = FStar_Util.mk_ref FStar_Pervasives_Native.None  in
+      { n = t; pos = r; vars = uu____8633 }
   
 let (bv_to_tm : bv -> term) =
   fun bv1  ->
-    let uu____8667 = range_of_bv bv1  in
-    mk (Tm_bvar bv1) FStar_Pervasives_Native.None uu____8667
+    let uu____8644 = range_of_bv bv1  in mk (Tm_bvar bv1) uu____8644
   
 let (bv_to_name : bv -> term) =
   fun bv1  ->
-    let uu____8674 = range_of_bv bv1  in
-    mk (Tm_name bv1) FStar_Pervasives_Native.None uu____8674
+    let uu____8651 = range_of_bv bv1  in mk (Tm_name bv1) uu____8651
   
 let (binders_to_names : binders -> term Prims.list) =
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.map
-         (fun uu____8704  ->
-            match uu____8704 with | (x,uu____8712) -> bv_to_name x))
+         (fun uu____8681  ->
+            match uu____8681 with | (x,uu____8689) -> bv_to_name x))
   
-let (mk_Tm_app : term -> args -> mk_t) =
+let (mk_Tm_app : term -> args -> FStar_Range.range -> term) =
   fun t1  ->
     fun args1  ->
-      fun k  ->
-        fun p  ->
-          match args1 with
-          | [] -> t1
-          | uu____8742 ->
-              mk (Tm_app (t1, args1)) FStar_Pervasives_Native.None p
+      fun p  ->
+        match args1 with | [] -> t1 | uu____8712 -> mk (Tm_app (t1, args1)) p
   
 let (mk_Tm_uinst : term -> universes -> term) =
   fun t  ->
     fun us  ->
       match t.n with
-      | Tm_fvar uu____8768 ->
-          (match us with
-           | [] -> t
-           | us1 -> mk (Tm_uinst (t, us1)) FStar_Pervasives_Native.None t.pos)
-      | uu____8772 -> failwith "Unexpected universe instantiation"
+      | Tm_fvar uu____8738 ->
+          (match us with | [] -> t | us1 -> mk (Tm_uinst (t, us1)) t.pos)
+      | uu____8742 -> failwith "Unexpected universe instantiation"
   
-let (extend_app_n : term -> args -> mk_t) =
+let (extend_app_n : term -> args -> FStar_Range.range -> term) =
   fun t  ->
     fun args'  ->
-      fun kopt  ->
-        fun r  ->
-          match t.n with
-          | Tm_app (head,args1) ->
-              mk_Tm_app head (FStar_List.append args1 args') kopt r
-          | uu____8831 -> mk_Tm_app t args' kopt r
+      fun r  ->
+        match t.n with
+        | Tm_app (head,args1) ->
+            mk_Tm_app head (FStar_List.append args1 args') r
+        | uu____8794 -> mk_Tm_app t args' r
   
-let (extend_app : term -> arg -> mk_t) =
-  fun t  -> fun arg1  -> fun kopt  -> fun r  -> extend_app_n t [arg1] kopt r 
+let (extend_app : term -> arg -> FStar_Range.range -> term) =
+  fun t  -> fun arg1  -> fun r  -> extend_app_n t [arg1] r 
 let (mk_Tm_delayed : (term * subst_ts) -> FStar_Range.range -> term) =
-  fun lr  -> fun pos  -> mk (Tm_delayed lr) FStar_Pervasives_Native.None pos 
+  fun lr  -> fun pos  -> mk (Tm_delayed lr) pos 
 let (mk_Total' : typ -> universe FStar_Pervasives_Native.option -> comp) =
-  fun t  -> fun u  -> mk (Total (t, u)) FStar_Pervasives_Native.None t.pos 
+  fun t  -> fun u  -> mk (Total (t, u)) t.pos 
 let (mk_GTotal' : typ -> universe FStar_Pervasives_Native.option -> comp) =
-  fun t  -> fun u  -> mk (GTotal (t, u)) FStar_Pervasives_Native.None t.pos 
+  fun t  -> fun u  -> mk (GTotal (t, u)) t.pos 
 let (mk_Total : typ -> comp) =
   fun t  -> mk_Total' t FStar_Pervasives_Native.None 
 let (mk_GTotal : typ -> comp) =
   fun t  -> mk_GTotal' t FStar_Pervasives_Native.None 
 let (mk_Comp : comp_typ -> comp) =
-  fun ct  -> mk (Comp ct) FStar_Pervasives_Native.None (ct.result_typ).pos 
+  fun ct  -> mk (Comp ct) (ct.result_typ).pos 
 let (mk_lb :
   (lbname * univ_name Prims.list * FStar_Ident.lident * typ * term *
     attribute Prims.list * FStar_Range.range) -> letbinding)
   =
-  fun uu____8967  ->
-    match uu____8967 with
+  fun uu____8925  ->
+    match uu____8925 with
     | (x,univs,eff,t,e,attrs,pos) ->
         {
           lbname = x;
@@ -1950,20 +1937,17 @@ let (extend_subst : subst_elt -> subst_elt Prims.list -> subst_t) =
   fun x  -> fun s  -> x :: s 
 let (argpos : arg -> FStar_Range.range) =
   fun x  -> (FStar_Pervasives_Native.fst x).pos 
-let (tun : term) =
-  mk Tm_unknown FStar_Pervasives_Native.None FStar_Range.dummyRange 
+let (tun : term) = mk Tm_unknown FStar_Range.dummyRange 
 let (teff : term) =
-  mk (Tm_constant FStar_Const.Const_effect) FStar_Pervasives_Native.None
-    FStar_Range.dummyRange
-  
+  mk (Tm_constant FStar_Const.Const_effect) FStar_Range.dummyRange 
 let (is_teff : term -> Prims.bool) =
   fun t  ->
     match t.n with
     | Tm_constant (FStar_Const.Const_effect ) -> true
-    | uu____9067 -> false
+    | uu____9025 -> false
   
 let (is_type : term -> Prims.bool) =
-  fun t  -> match t.n with | Tm_type uu____9077 -> true | uu____9079 -> false 
+  fun t  -> match t.n with | Tm_type uu____9035 -> true | uu____9037 -> false 
 let (null_id : FStar_Ident.ident) =
   FStar_Ident.mk_ident ("_", FStar_Range.dummyRange) 
 let (null_bv : term -> bv) =
@@ -1971,7 +1955,7 @@ let (null_bv : term -> bv) =
 let (mk_binder : bv -> binder) = fun a  -> (a, FStar_Pervasives_Native.None) 
 let (null_binder : term -> binder) =
   fun t  ->
-    let uu____9105 = null_bv t  in (uu____9105, FStar_Pervasives_Native.None)
+    let uu____9063 = null_bv t  in (uu____9063, FStar_Pervasives_Native.None)
   
 let (imp_tag : arg_qualifier) = Implicit false 
 let (iarg : term -> arg) =
@@ -1979,26 +1963,26 @@ let (iarg : term -> arg) =
 let (as_arg : term -> arg) = fun t  -> (t, FStar_Pervasives_Native.None) 
 let (is_null_bv : bv -> Prims.bool) =
   fun b  ->
-    let uu____9137 = FStar_Ident.text_of_id b.ppname  in
-    let uu____9139 = FStar_Ident.text_of_id null_id  in
-    uu____9137 = uu____9139
+    let uu____9095 = FStar_Ident.text_of_id b.ppname  in
+    let uu____9097 = FStar_Ident.text_of_id null_id  in
+    uu____9095 = uu____9097
   
 let (is_null_binder : binder -> Prims.bool) =
   fun b  -> is_null_bv (FStar_Pervasives_Native.fst b) 
 let (is_top_level : letbinding Prims.list -> Prims.bool) =
-  fun uu___1_9159  ->
-    match uu___1_9159 with
-    | { lbname = FStar_Util.Inr uu____9163; lbunivs = uu____9164;
-        lbtyp = uu____9165; lbeff = uu____9166; lbdef = uu____9167;
-        lbattrs = uu____9168; lbpos = uu____9169;_}::uu____9170 -> true
-    | uu____9184 -> false
+  fun uu___1_9117  ->
+    match uu___1_9117 with
+    | { lbname = FStar_Util.Inr uu____9121; lbunivs = uu____9122;
+        lbtyp = uu____9123; lbeff = uu____9124; lbdef = uu____9125;
+        lbattrs = uu____9126; lbpos = uu____9127;_}::uu____9128 -> true
+    | uu____9142 -> false
   
 let (freenames_of_binders : binders -> freenames) =
   fun bs  ->
     FStar_List.fold_right
-      (fun uu____9206  ->
+      (fun uu____9164  ->
          fun out  ->
-           match uu____9206 with | (x,uu____9219) -> FStar_Util.set_add x out)
+           match uu____9164 with | (x,uu____9177) -> FStar_Util.set_add x out)
       bs no_names
   
 let (binders_of_list : bv Prims.list -> binders) =
@@ -2008,25 +1992,25 @@ let (binders_of_list : bv Prims.list -> binders) =
   
 let (binders_of_freenames : freenames -> binders) =
   fun fvs  ->
-    let uu____9252 = FStar_Util.set_elements fvs  in
-    FStar_All.pipe_right uu____9252 binders_of_list
+    let uu____9210 = FStar_Util.set_elements fvs  in
+    FStar_All.pipe_right uu____9210 binders_of_list
   
 let (is_implicit : aqual -> Prims.bool) =
-  fun uu___2_9263  ->
-    match uu___2_9263 with
-    | FStar_Pervasives_Native.Some (Implicit uu____9265) -> true
-    | uu____9268 -> false
+  fun uu___2_9221  ->
+    match uu___2_9221 with
+    | FStar_Pervasives_Native.Some (Implicit uu____9223) -> true
+    | uu____9226 -> false
   
 let (is_implicit_or_meta : aqual -> Prims.bool) =
-  fun uu___3_9276  ->
-    match uu___3_9276 with
-    | FStar_Pervasives_Native.Some (Implicit uu____9278) -> true
-    | FStar_Pervasives_Native.Some (Meta uu____9281) -> true
-    | uu____9285 -> false
+  fun uu___3_9234  ->
+    match uu___3_9234 with
+    | FStar_Pervasives_Native.Some (Implicit uu____9236) -> true
+    | FStar_Pervasives_Native.Some (Meta uu____9239) -> true
+    | uu____9243 -> false
   
 let (as_implicit : Prims.bool -> aqual) =
-  fun uu___4_9293  ->
-    if uu___4_9293
+  fun uu___4_9251  ->
+    if uu___4_9251
     then FStar_Pervasives_Native.Some imp_tag
     else FStar_Pervasives_Native.None
   
@@ -2034,23 +2018,23 @@ let (pat_bvs : pat -> bv Prims.list) =
   fun p  ->
     let rec aux b p1 =
       match p1.v with
-      | Pat_dot_term uu____9331 -> b
-      | Pat_constant uu____9338 -> b
+      | Pat_dot_term uu____9289 -> b
+      | Pat_constant uu____9296 -> b
       | Pat_wild x -> x :: b
       | Pat_var x -> x :: b
-      | Pat_cons (uu____9341,pats) ->
+      | Pat_cons (uu____9299,pats) ->
           FStar_List.fold_left
             (fun b1  ->
-               fun uu____9375  ->
-                 match uu____9375 with | (p2,uu____9388) -> aux b1 p2) b pats
+               fun uu____9333  ->
+                 match uu____9333 with | (p2,uu____9346) -> aux b1 p2) b pats
        in
-    let uu____9395 = aux [] p  in
-    FStar_All.pipe_left FStar_List.rev uu____9395
+    let uu____9353 = aux [] p  in
+    FStar_All.pipe_left FStar_List.rev uu____9353
   
 let (range_of_ropt :
   FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range) =
-  fun uu___5_9409  ->
-    match uu___5_9409 with
+  fun uu___5_9367  ->
+    match uu___5_9367 with
     | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange
     | FStar_Pervasives_Native.Some r -> r
   
@@ -2062,45 +2046,45 @@ let (gen_bv :
     fun r  ->
       fun t  ->
         let id = FStar_Ident.mk_ident (s, (range_of_ropt r))  in
-        let uu____9449 = FStar_Ident.next_id ()  in
-        { ppname = id; index = uu____9449; sort = t }
+        let uu____9407 = FStar_Ident.next_id ()  in
+        { ppname = id; index = uu____9407; sort = t }
   
 let (new_bv : FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
   = fun ropt  -> fun t  -> gen_bv FStar_Ident.reserved_prefix ropt t 
 let (freshen_bv : bv -> bv) =
   fun bv1  ->
-    let uu____9472 = is_null_bv bv1  in
-    if uu____9472
+    let uu____9430 = is_null_bv bv1  in
+    if uu____9430
     then
-      let uu____9475 =
-        let uu____9478 = range_of_bv bv1  in
-        FStar_Pervasives_Native.Some uu____9478  in
-      new_bv uu____9475 bv1.sort
+      let uu____9433 =
+        let uu____9436 = range_of_bv bv1  in
+        FStar_Pervasives_Native.Some uu____9436  in
+      new_bv uu____9433 bv1.sort
     else
-      (let uu___614_9481 = bv1  in
-       let uu____9482 = FStar_Ident.next_id ()  in
+      (let uu___609_9439 = bv1  in
+       let uu____9440 = FStar_Ident.next_id ()  in
        {
-         ppname = (uu___614_9481.ppname);
-         index = uu____9482;
-         sort = (uu___614_9481.sort)
+         ppname = (uu___609_9439.ppname);
+         index = uu____9440;
+         sort = (uu___609_9439.sort)
        })
   
 let (freshen_binder : binder -> binder) =
   fun b  ->
-    let uu____9490 = b  in
-    match uu____9490 with
-    | (bv1,aq) -> let uu____9497 = freshen_bv bv1  in (uu____9497, aq)
+    let uu____9448 = b  in
+    match uu____9448 with
+    | (bv1,aq) -> let uu____9455 = freshen_bv bv1  in (uu____9455, aq)
   
 let (new_univ_name :
   FStar_Range.range FStar_Pervasives_Native.option -> univ_name) =
   fun ropt  ->
     let id = FStar_Ident.next_id ()  in
-    let uu____9512 =
-      let uu____9518 =
-        let uu____9520 = FStar_Util.string_of_int id  in
-        Prims.op_Hat FStar_Ident.reserved_prefix uu____9520  in
-      (uu____9518, (range_of_ropt ropt))  in
-    FStar_Ident.mk_ident uu____9512
+    let uu____9470 =
+      let uu____9476 =
+        let uu____9478 = FStar_Util.string_of_int id  in
+        Prims.op_Hat FStar_Ident.reserved_prefix uu____9478  in
+      (uu____9476, (range_of_ropt ropt))  in
+    FStar_Ident.mk_ident uu____9470
   
 let (lbname_eq :
   (bv,FStar_Ident.lident) FStar_Util.either ->
@@ -2111,7 +2095,7 @@ let (lbname_eq :
       match (l1, l2) with
       | (FStar_Util.Inl x,FStar_Util.Inl y) -> bv_eq x y
       | (FStar_Util.Inr l,FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
-      | uu____9580 -> false
+      | uu____9538 -> false
   
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun fv1  ->
@@ -2122,12 +2106,12 @@ let (fv_eq_lid : fv -> FStar_Ident.lident -> Prims.bool) =
 let (set_bv_range : bv -> FStar_Range.range -> bv) =
   fun bv1  ->
     fun r  ->
-      let uu___641_9629 = bv1  in
-      let uu____9630 = FStar_Ident.set_id_range r bv1.ppname  in
+      let uu___636_9587 = bv1  in
+      let uu____9588 = FStar_Ident.set_id_range r bv1.ppname  in
       {
-        ppname = uu____9630;
-        index = (uu___641_9629.index);
-        sort = (uu___641_9629.sort)
+        ppname = uu____9588;
+        index = (uu___636_9587.index);
+        sort = (uu___636_9587.sort)
       }
   
 let (lid_as_fv :
@@ -2137,15 +2121,15 @@ let (lid_as_fv :
   fun l  ->
     fun dd  ->
       fun dq  ->
-        let uu____9651 =
-          let uu____9652 = FStar_Ident.range_of_lid l  in
-          withinfo l uu____9652  in
-        { fv_name = uu____9651; fv_delta = dd; fv_qual = dq }
+        let uu____9609 =
+          let uu____9610 = FStar_Ident.range_of_lid l  in
+          withinfo l uu____9610  in
+        { fv_name = uu____9609; fv_delta = dd; fv_qual = dq }
   
 let (fv_to_tm : fv -> term) =
   fun fv1  ->
-    let uu____9659 = FStar_Ident.range_of_lid (fv1.fv_name).v  in
-    mk (Tm_fvar fv1) FStar_Pervasives_Native.None uu____9659
+    let uu____9617 = FStar_Ident.range_of_lid (fv1.fv_name).v  in
+    mk (Tm_fvar fv1) uu____9617
   
 let (fvar :
   FStar_Ident.lident ->
@@ -2153,38 +2137,38 @@ let (fvar :
   =
   fun l  ->
     fun dd  ->
-      fun dq  -> let uu____9680 = lid_as_fv l dd dq  in fv_to_tm uu____9680
+      fun dq  -> let uu____9638 = lid_as_fv l dd dq  in fv_to_tm uu____9638
   
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv1  -> (fv1.fv_name).v 
 let (range_of_fv : fv -> FStar_Range.range) =
   fun fv1  ->
-    let uu____9693 = lid_of_fv fv1  in FStar_Ident.range_of_lid uu____9693
+    let uu____9651 = lid_of_fv fv1  in FStar_Ident.range_of_lid uu____9651
   
 let (set_range_of_fv : fv -> FStar_Range.range -> fv) =
   fun fv1  ->
     fun r  ->
-      let uu___654_9705 = fv1  in
-      let uu____9706 =
-        let uu___656_9707 = fv1.fv_name  in
-        let uu____9708 =
-          let uu____9709 = lid_of_fv fv1  in
-          FStar_Ident.set_lid_range uu____9709 r  in
-        { v = uu____9708; p = (uu___656_9707.p) }  in
+      let uu___649_9663 = fv1  in
+      let uu____9664 =
+        let uu___651_9665 = fv1.fv_name  in
+        let uu____9666 =
+          let uu____9667 = lid_of_fv fv1  in
+          FStar_Ident.set_lid_range uu____9667 r  in
+        { v = uu____9666; p = (uu___651_9665.p) }  in
       {
-        fv_name = uu____9706;
-        fv_delta = (uu___654_9705.fv_delta);
-        fv_qual = (uu___654_9705.fv_qual)
+        fv_name = uu____9664;
+        fv_delta = (uu___649_9663.fv_delta);
+        fv_qual = (uu___649_9663.fv_qual)
       }
   
 let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
   fun l  ->
     fun s  ->
       FStar_List.existsb
-        (fun uu___6_9735  ->
-           match uu___6_9735 with
-           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9740));
-               pos = uu____9741; vars = uu____9742;_} when data = s -> true
-           | uu____9749 -> false) l
+        (fun uu___6_9693  ->
+           match uu___6_9693 with
+           | { n = Tm_constant (FStar_Const.Const_string (data,uu____9698));
+               pos = uu____9699; vars = uu____9700;_} when data = s -> true
+           | uu____9707 -> false) l
   
 let rec (eq_pat : pat -> pat -> Prims.bool) =
   fun p1  ->
@@ -2192,20 +2176,20 @@ let rec (eq_pat : pat -> pat -> Prims.bool) =
       match ((p1.v), (p2.v)) with
       | (Pat_constant c1,Pat_constant c2) -> FStar_Const.eq_const c1 c2
       | (Pat_cons (fv1,as1),Pat_cons (fv2,as2)) ->
-          let uu____9808 = fv_eq fv1 fv2  in
-          if uu____9808
+          let uu____9766 = fv_eq fv1 fv2  in
+          if uu____9766
           then
-            let uu____9813 = FStar_List.zip as1 as2  in
-            FStar_All.pipe_right uu____9813
+            let uu____9771 = FStar_List.zip as1 as2  in
+            FStar_All.pipe_right uu____9771
               (FStar_List.for_all
-                 (fun uu____9880  ->
-                    match uu____9880 with
+                 (fun uu____9838  ->
+                    match uu____9838 with
                     | ((p11,b1),(p21,b2)) -> (b1 = b2) && (eq_pat p11 p21)))
           else false
-      | (Pat_var uu____9918,Pat_var uu____9919) -> true
-      | (Pat_wild uu____9921,Pat_wild uu____9922) -> true
+      | (Pat_var uu____9876,Pat_var uu____9877) -> true
+      | (Pat_wild uu____9879,Pat_wild uu____9880) -> true
       | (Pat_dot_term (bv1,t1),Pat_dot_term (bv2,t2)) -> true
-      | (uu____9937,uu____9938) -> false
+      | (uu____9895,uu____9896) -> false
   
 let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero 
 let (delta_equational : delta_depth) =
@@ -2214,28 +2198,24 @@ let (fvconst : FStar_Ident.lident -> fv) =
   fun l  -> lid_as_fv l delta_constant FStar_Pervasives_Native.None 
 let (tconst : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9956 =
-      let uu____9963 = let uu____9964 = fvconst l  in Tm_fvar uu____9964  in
-      mk uu____9963  in
-    uu____9956 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____9914 = let uu____9915 = fvconst l  in Tm_fvar uu____9915  in
+    mk uu____9914 FStar_Range.dummyRange
   
 let (tabbrev : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9971 =
-      let uu____9978 =
-        let uu____9979 =
-          lid_as_fv l (Delta_constant_at_level Prims.int_one)
-            FStar_Pervasives_Native.None
-           in
-        Tm_fvar uu____9979  in
-      mk uu____9978  in
-    uu____9971 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____9922 =
+      let uu____9923 =
+        lid_as_fv l (Delta_constant_at_level Prims.int_one)
+          FStar_Pervasives_Native.None
+         in
+      Tm_fvar uu____9923  in
+    mk uu____9922 FStar_Range.dummyRange
   
 let (tdataconstr : FStar_Ident.lident -> term) =
   fun l  ->
-    let uu____9987 =
+    let uu____9931 =
       lid_as_fv l delta_constant (FStar_Pervasives_Native.Some Data_ctor)  in
-    fv_to_tm uu____9987
+    fv_to_tm uu____9931
   
 let (t_unit : term) = tconst FStar_Parser_Const.unit_lid 
 let (t_bool : term) = tconst FStar_Parser_Const.bool_lid 
@@ -2258,77 +2238,63 @@ let (t_norm_step : term) = tconst FStar_Parser_Const.norm_step_lid
 let (t_tac_of : term -> term -> term) =
   fun a  ->
     fun b  ->
-      let uu____10017 =
-        let uu____10022 =
-          let uu____10023 = tabbrev FStar_Parser_Const.tac_lid  in
-          mk_Tm_uinst uu____10023 [U_zero; U_zero]  in
-        let uu____10024 =
-          let uu____10025 = as_arg a  in
-          let uu____10034 = let uu____10045 = as_arg b  in [uu____10045]  in
-          uu____10025 :: uu____10034  in
-        mk_Tm_app uu____10022 uu____10024  in
-      uu____10017 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____9961 =
+        let uu____9962 = tabbrev FStar_Parser_Const.tac_lid  in
+        mk_Tm_uinst uu____9962 [U_zero; U_zero]  in
+      let uu____9963 =
+        let uu____9964 = as_arg a  in
+        let uu____9973 = let uu____9984 = as_arg b  in [uu____9984]  in
+        uu____9964 :: uu____9973  in
+      mk_Tm_app uu____9961 uu____9963 FStar_Range.dummyRange
   
 let (t_tactic_of : term -> term) =
   fun t  ->
-    let uu____10084 =
-      let uu____10089 =
-        let uu____10090 = tabbrev FStar_Parser_Const.tactic_lid  in
-        mk_Tm_uinst uu____10090 [U_zero]  in
-      let uu____10091 = let uu____10092 = as_arg t  in [uu____10092]  in
-      mk_Tm_app uu____10089 uu____10091  in
-    uu____10084 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10023 =
+      let uu____10024 = tabbrev FStar_Parser_Const.tactic_lid  in
+      mk_Tm_uinst uu____10024 [U_zero]  in
+    let uu____10025 = let uu____10026 = as_arg t  in [uu____10026]  in
+    mk_Tm_app uu____10023 uu____10025 FStar_Range.dummyRange
   
 let (t_tactic_unit : term) = t_tactic_of t_unit 
 let (t_list_of : term -> term) =
   fun t  ->
-    let uu____10124 =
-      let uu____10129 =
-        let uu____10130 = tabbrev FStar_Parser_Const.list_lid  in
-        mk_Tm_uinst uu____10130 [U_zero]  in
-      let uu____10131 = let uu____10132 = as_arg t  in [uu____10132]  in
-      mk_Tm_app uu____10129 uu____10131  in
-    uu____10124 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10058 =
+      let uu____10059 = tabbrev FStar_Parser_Const.list_lid  in
+      mk_Tm_uinst uu____10059 [U_zero]  in
+    let uu____10060 = let uu____10061 = as_arg t  in [uu____10061]  in
+    mk_Tm_app uu____10058 uu____10060 FStar_Range.dummyRange
   
 let (t_option_of : term -> term) =
   fun t  ->
-    let uu____10163 =
-      let uu____10168 =
-        let uu____10169 = tabbrev FStar_Parser_Const.option_lid  in
-        mk_Tm_uinst uu____10169 [U_zero]  in
-      let uu____10170 = let uu____10171 = as_arg t  in [uu____10171]  in
-      mk_Tm_app uu____10168 uu____10170  in
-    uu____10163 FStar_Pervasives_Native.None FStar_Range.dummyRange
+    let uu____10092 =
+      let uu____10093 = tabbrev FStar_Parser_Const.option_lid  in
+      mk_Tm_uinst uu____10093 [U_zero]  in
+    let uu____10094 = let uu____10095 = as_arg t  in [uu____10095]  in
+    mk_Tm_app uu____10092 uu____10094 FStar_Range.dummyRange
   
 let (t_tuple2_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____10207 =
-        let uu____10212 =
-          let uu____10213 = tabbrev FStar_Parser_Const.lid_tuple2  in
-          mk_Tm_uinst uu____10213 [U_zero; U_zero]  in
-        let uu____10214 =
-          let uu____10215 = as_arg t1  in
-          let uu____10224 = let uu____10235 = as_arg t2  in [uu____10235]  in
-          uu____10215 :: uu____10224  in
-        mk_Tm_app uu____10212 uu____10214  in
-      uu____10207 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10131 =
+        let uu____10132 = tabbrev FStar_Parser_Const.lid_tuple2  in
+        mk_Tm_uinst uu____10132 [U_zero; U_zero]  in
+      let uu____10133 =
+        let uu____10134 = as_arg t1  in
+        let uu____10143 = let uu____10154 = as_arg t2  in [uu____10154]  in
+        uu____10134 :: uu____10143  in
+      mk_Tm_app uu____10131 uu____10133 FStar_Range.dummyRange
   
 let (t_either_of : term -> term -> term) =
   fun t1  ->
     fun t2  ->
-      let uu____10279 =
-        let uu____10284 =
-          let uu____10285 = tabbrev FStar_Parser_Const.either_lid  in
-          mk_Tm_uinst uu____10285 [U_zero; U_zero]  in
-        let uu____10286 =
-          let uu____10287 = as_arg t1  in
-          let uu____10296 = let uu____10307 = as_arg t2  in [uu____10307]  in
-          uu____10287 :: uu____10296  in
-        mk_Tm_app uu____10284 uu____10286  in
-      uu____10279 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____10198 =
+        let uu____10199 = tabbrev FStar_Parser_Const.either_lid  in
+        mk_Tm_uinst uu____10199 [U_zero; U_zero]  in
+      let uu____10200 =
+        let uu____10201 = as_arg t1  in
+        let uu____10210 = let uu____10221 = as_arg t2  in [uu____10221]  in
+        uu____10201 :: uu____10210  in
+      mk_Tm_app uu____10198 uu____10200 FStar_Range.dummyRange
   
 let (unit_const : term) =
-  mk (Tm_constant FStar_Const.Const_unit) FStar_Pervasives_Native.None
-    FStar_Range.dummyRange
-  
+  mk (Tm_constant FStar_Const.Const_unit) FStar_Range.dummyRange 

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -128,13 +128,11 @@ let (name_function_binders :
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
         let uu____601 =
-          let uu____608 =
-            let uu____609 =
-              let uu____624 = name_binders binders  in (uu____624, comp)  in
-            FStar_Syntax_Syntax.Tm_arrow uu____609  in
-          FStar_Syntax_Syntax.mk uu____608  in
-        uu____601 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-    | uu____643 -> t
+          let uu____602 =
+            let uu____617 = name_binders binders  in (uu____617, comp)  in
+          FStar_Syntax_Syntax.Tm_arrow uu____602  in
+        FStar_Syntax_Syntax.mk uu____601 t.FStar_Syntax_Syntax.pos
+    | uu____636 -> t
   
 let (null_binders_of_tks :
   (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list ->
@@ -143,14 +141,14 @@ let (null_binders_of_tks :
   fun tks  ->
     FStar_All.pipe_right tks
       (FStar_List.map
-         (fun uu____680  ->
-            match uu____680 with
+         (fun uu____673  ->
+            match uu____673 with
             | (t,imp) ->
-                let uu____691 =
-                  let uu____692 = FStar_Syntax_Syntax.null_binder t  in
-                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu____692
+                let uu____684 =
+                  let uu____685 = FStar_Syntax_Syntax.null_binder t  in
+                  FStar_All.pipe_left FStar_Pervasives_Native.fst uu____685
                    in
-                (uu____691, imp)))
+                (uu____684, imp)))
   
 let (binders_of_tks :
   (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.aqual) Prims.list ->
@@ -159,26 +157,26 @@ let (binders_of_tks :
   fun tks  ->
     FStar_All.pipe_right tks
       (FStar_List.map
-         (fun uu____747  ->
-            match uu____747 with
+         (fun uu____740  ->
+            match uu____740 with
             | (t,imp) ->
-                let uu____764 =
+                let uu____757 =
                   FStar_Syntax_Syntax.new_bv
                     (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos))
                     t
                    in
-                (uu____764, imp)))
+                (uu____757, imp)))
   
 let (binders_of_freevars :
   FStar_Syntax_Syntax.bv FStar_Util.set ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun fvs  ->
-    let uu____777 = FStar_Util.set_elements fvs  in
-    FStar_All.pipe_right uu____777
+    let uu____770 = FStar_Util.set_elements fvs  in
+    FStar_All.pipe_right uu____770
       (FStar_List.map FStar_Syntax_Syntax.mk_binder)
   
-let mk_subst : 'uuuuuu789 . 'uuuuuu789 -> 'uuuuuu789 Prims.list =
+let mk_subst : 'uuuuuu782 . 'uuuuuu782 -> 'uuuuuu782 Prims.list =
   fun s  -> [s] 
 let (subst_of_list :
   FStar_Syntax_Syntax.binders ->
@@ -207,23 +205,23 @@ let (rename_binders :
       if (FStar_List.length replace_xs) = (FStar_List.length with_ys)
       then
         FStar_List.map2
-          (fun uu____915  ->
-             fun uu____916  ->
-               match (uu____915, uu____916) with
-               | ((x,uu____942),(y,uu____944)) ->
-                   let uu____965 =
-                     let uu____972 = FStar_Syntax_Syntax.bv_to_name y  in
-                     (x, uu____972)  in
-                   FStar_Syntax_Syntax.NT uu____965) replace_xs with_ys
+          (fun uu____908  ->
+             fun uu____909  ->
+               match (uu____908, uu____909) with
+               | ((x,uu____935),(y,uu____937)) ->
+                   let uu____958 =
+                     let uu____965 = FStar_Syntax_Syntax.bv_to_name y  in
+                     (x, uu____965)  in
+                   FStar_Syntax_Syntax.NT uu____958) replace_xs with_ys
       else failwith "Ill-formed substitution"
   
 let rec (unmeta : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun e  ->
     let e1 = FStar_Syntax_Subst.compress e  in
     match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_meta (e2,uu____988) -> unmeta e2
-    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____994,uu____995) -> unmeta e2
-    | uu____1036 -> e1
+    | FStar_Syntax_Syntax.Tm_meta (e2,uu____981) -> unmeta e2
+    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____987,uu____988) -> unmeta e2
+    | uu____1029 -> e1
   
 let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
@@ -232,22 +230,22 @@ let rec (unmeta_safe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
     match e1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta (e',m) ->
         (match m with
-         | FStar_Syntax_Syntax.Meta_monadic uu____1050 -> e1
-         | FStar_Syntax_Syntax.Meta_monadic_lift uu____1057 -> e1
-         | uu____1066 -> unmeta_safe e')
-    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____1068,uu____1069) ->
+         | FStar_Syntax_Syntax.Meta_monadic uu____1043 -> e1
+         | FStar_Syntax_Syntax.Meta_monadic_lift uu____1050 -> e1
+         | uu____1059 -> unmeta_safe e')
+    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____1061,uu____1062) ->
         unmeta_safe e2
-    | uu____1110 -> e1
+    | uu____1103 -> e1
   
 let (unmeta_lift : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____1117 =
-      let uu____1118 = FStar_Syntax_Subst.compress t  in
-      uu____1118.FStar_Syntax_Syntax.n  in
-    match uu____1117 with
+    let uu____1110 =
+      let uu____1111 = FStar_Syntax_Subst.compress t  in
+      uu____1111.FStar_Syntax_Syntax.n  in
+    match uu____1110 with
     | FStar_Syntax_Syntax.Tm_meta
-        (t1,FStar_Syntax_Syntax.Meta_monadic_lift uu____1122) -> t1
-    | uu____1135 -> t
+        (t1,FStar_Syntax_Syntax.Meta_monadic_lift uu____1115) -> t1
+    | uu____1128 -> t
   
 let rec (univ_kernel :
   FStar_Syntax_Syntax.universe -> (FStar_Syntax_Syntax.universe * Prims.int))
@@ -255,19 +253,19 @@ let rec (univ_kernel :
   fun u  ->
     match u with
     | FStar_Syntax_Syntax.U_unknown  -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_name uu____1154 -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_unif uu____1157 -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_max uu____1170 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_name uu____1147 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_unif uu____1150 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_max uu____1163 -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_zero  -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu____1178 = univ_kernel u1  in
-        (match uu____1178 with | (k,n) -> (k, (n + Prims.int_one)))
-    | FStar_Syntax_Syntax.U_bvar uu____1195 ->
+        let uu____1171 = univ_kernel u1  in
+        (match uu____1171 with | (k,n) -> (k, (n + Prims.int_one)))
+    | FStar_Syntax_Syntax.U_bvar uu____1188 ->
         failwith "Imposible: univ_kernel (U_bvar _)"
   
 let (constant_univ_as_nat : FStar_Syntax_Syntax.universe -> Prims.int) =
   fun u  ->
-    let uu____1210 = univ_kernel u  in FStar_Pervasives_Native.snd uu____1210
+    let uu____1203 = univ_kernel u  in FStar_Pervasives_Native.snd uu____1203
   
 let rec (compare_univs :
   FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe -> Prims.int)
@@ -276,36 +274,36 @@ let rec (compare_univs :
     fun u2  ->
       let rec compare_kernel uk1 uk2 =
         match (uk1, uk2) with
-        | (FStar_Syntax_Syntax.U_bvar uu____1243,uu____1244) ->
+        | (FStar_Syntax_Syntax.U_bvar uu____1236,uu____1237) ->
             failwith "Impossible: compare_kernel bvar"
-        | (uu____1248,FStar_Syntax_Syntax.U_bvar uu____1249) ->
+        | (uu____1241,FStar_Syntax_Syntax.U_bvar uu____1242) ->
             failwith "Impossible: compare_kernel bvar"
-        | (FStar_Syntax_Syntax.U_succ uu____1253,uu____1254) ->
+        | (FStar_Syntax_Syntax.U_succ uu____1246,uu____1247) ->
             failwith "Impossible: compare_kernel succ"
-        | (uu____1257,FStar_Syntax_Syntax.U_succ uu____1258) ->
+        | (uu____1250,FStar_Syntax_Syntax.U_succ uu____1251) ->
             failwith "Impossible: compare_kernel succ"
         | (FStar_Syntax_Syntax.U_unknown ,FStar_Syntax_Syntax.U_unknown ) ->
             Prims.int_zero
-        | (FStar_Syntax_Syntax.U_unknown ,uu____1262) -> ~- Prims.int_one
-        | (uu____1264,FStar_Syntax_Syntax.U_unknown ) -> Prims.int_one
+        | (FStar_Syntax_Syntax.U_unknown ,uu____1255) -> ~- Prims.int_one
+        | (uu____1257,FStar_Syntax_Syntax.U_unknown ) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_zero ) ->
             Prims.int_zero
-        | (FStar_Syntax_Syntax.U_zero ,uu____1267) -> ~- Prims.int_one
-        | (uu____1269,FStar_Syntax_Syntax.U_zero ) -> Prims.int_one
+        | (FStar_Syntax_Syntax.U_zero ,uu____1260) -> ~- Prims.int_one
+        | (uu____1262,FStar_Syntax_Syntax.U_zero ) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_name u11,FStar_Syntax_Syntax.U_name u21) ->
-            let uu____1273 = FStar_Ident.text_of_id u11  in
-            let uu____1275 = FStar_Ident.text_of_id u21  in
-            FStar_String.compare uu____1273 uu____1275
-        | (FStar_Syntax_Syntax.U_name uu____1277,uu____1278) ->
+            let uu____1266 = FStar_Ident.text_of_id u11  in
+            let uu____1268 = FStar_Ident.text_of_id u21  in
+            FStar_String.compare uu____1266 uu____1268
+        | (FStar_Syntax_Syntax.U_name uu____1270,uu____1271) ->
             ~- Prims.int_one
-        | (uu____1280,FStar_Syntax_Syntax.U_name uu____1281) -> Prims.int_one
+        | (uu____1273,FStar_Syntax_Syntax.U_name uu____1274) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_unif u11,FStar_Syntax_Syntax.U_unif u21) ->
-            let uu____1305 = FStar_Syntax_Unionfind.univ_uvar_id u11  in
-            let uu____1307 = FStar_Syntax_Unionfind.univ_uvar_id u21  in
-            uu____1305 - uu____1307
-        | (FStar_Syntax_Syntax.U_unif uu____1309,uu____1310) ->
+            let uu____1298 = FStar_Syntax_Unionfind.univ_uvar_id u11  in
+            let uu____1300 = FStar_Syntax_Unionfind.univ_uvar_id u21  in
+            uu____1298 - uu____1300
+        | (FStar_Syntax_Syntax.U_unif uu____1302,uu____1303) ->
             ~- Prims.int_one
-        | (uu____1322,FStar_Syntax_Syntax.U_unif uu____1323) -> Prims.int_one
+        | (uu____1315,FStar_Syntax_Syntax.U_unif uu____1316) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max us2) ->
             let n1 = FStar_List.length us1  in
             let n2 = FStar_List.length us2  in
@@ -313,10 +311,10 @@ let rec (compare_univs :
             then n1 - n2
             else
               (let copt =
-                 let uu____1351 = FStar_List.zip us1 us2  in
-                 FStar_Util.find_map uu____1351
-                   (fun uu____1367  ->
-                      match uu____1367 with
+                 let uu____1344 = FStar_List.zip us1 us2  in
+                 FStar_Util.find_map uu____1344
+                   (fun uu____1360  ->
+                      match uu____1360 with
                       | (u11,u21) ->
                           let c = compare_univs u11 u21  in
                           if c <> Prims.int_zero
@@ -327,15 +325,15 @@ let rec (compare_univs :
                | FStar_Pervasives_Native.None  -> Prims.int_zero
                | FStar_Pervasives_Native.Some c -> c)
          in
-      let uu____1395 = univ_kernel u1  in
-      match uu____1395 with
+      let uu____1388 = univ_kernel u1  in
+      match uu____1388 with
       | (uk1,n1) ->
-          let uu____1406 = univ_kernel u2  in
-          (match uu____1406 with
+          let uu____1399 = univ_kernel u2  in
+          (match uu____1399 with
            | (uk2,n2) ->
-               let uu____1417 = compare_kernel uk1 uk2  in
-               (match uu____1417 with
-                | uu____1420 when uu____1420 = Prims.int_zero -> n1 - n2
+               let uu____1410 = compare_kernel uk1 uk2  in
+               (match uu____1410 with
+                | uu____1413 when uu____1413 = Prims.int_zero -> n1 - n2
                 | n -> n))
   
 let (eq_univs :
@@ -343,7 +341,7 @@ let (eq_univs :
   =
   fun u1  ->
     fun u2  ->
-      let uu____1435 = compare_univs u1 u2  in uu____1435 = Prims.int_zero
+      let uu____1428 = compare_univs u1 u2  in uu____1428 = Prims.int_zero
   
 let (ml_comp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -351,17 +349,17 @@ let (ml_comp :
   =
   fun t  ->
     fun r  ->
-      let uu____1454 =
-        let uu____1455 =
+      let uu____1447 =
+        let uu____1448 =
           FStar_Ident.set_lid_range FStar_Parser_Const.effect_ML_lid r  in
         {
           FStar_Syntax_Syntax.comp_univs = [FStar_Syntax_Syntax.U_zero];
-          FStar_Syntax_Syntax.effect_name = uu____1455;
+          FStar_Syntax_Syntax.effect_name = uu____1448;
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = [FStar_Syntax_Syntax.MLEFFECT]
         }  in
-      FStar_Syntax_Syntax.mk_Comp uu____1454
+      FStar_Syntax_Syntax.mk_Comp uu____1447
   
 let (comp_effect_name :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> FStar_Ident.lident)
@@ -369,9 +367,9 @@ let (comp_effect_name :
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-    | FStar_Syntax_Syntax.Total uu____1475 ->
+    | FStar_Syntax_Syntax.Total uu____1468 ->
         FStar_Parser_Const.effect_Tot_lid
-    | FStar_Syntax_Syntax.GTotal uu____1484 ->
+    | FStar_Syntax_Syntax.GTotal uu____1477 ->
         FStar_Parser_Const.effect_GTot_lid
   
 let (comp_flags :
@@ -380,8 +378,8 @@ let (comp_flags :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____1507 -> [FStar_Syntax_Syntax.TOTAL]
-    | FStar_Syntax_Syntax.GTotal uu____1516 ->
+    | FStar_Syntax_Syntax.Total uu____1500 -> [FStar_Syntax_Syntax.TOTAL]
+    | FStar_Syntax_Syntax.GTotal uu____1509 ->
         [FStar_Syntax_Syntax.SOMETRIVIAL]
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.flags
   
@@ -391,22 +389,22 @@ let (comp_to_comp_typ_nouniv :
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp c1 -> c1
     | FStar_Syntax_Syntax.Total (t,u_opt) ->
-        let uu____1543 =
-          let uu____1544 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
-          FStar_Util.dflt [] uu____1544  in
+        let uu____1536 =
+          let uu____1537 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
+          FStar_Util.dflt [] uu____1537  in
         {
-          FStar_Syntax_Syntax.comp_univs = uu____1543;
+          FStar_Syntax_Syntax.comp_univs = uu____1536;
           FStar_Syntax_Syntax.effect_name = (comp_effect_name c);
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = (comp_flags c)
         }
     | FStar_Syntax_Syntax.GTotal (t,u_opt) ->
-        let uu____1573 =
-          let uu____1574 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
-          FStar_Util.dflt [] uu____1574  in
+        let uu____1566 =
+          let uu____1567 = FStar_Util.map_opt u_opt (fun x  -> [x])  in
+          FStar_Util.dflt [] uu____1567  in
         {
-          FStar_Syntax_Syntax.comp_univs = uu____1573;
+          FStar_Syntax_Syntax.comp_univs = uu____1566;
           FStar_Syntax_Syntax.effect_name = (comp_effect_name c);
           FStar_Syntax_Syntax.result_typ = t;
           FStar_Syntax_Syntax.effect_args = [];
@@ -420,26 +418,26 @@ let (comp_set_flags :
   =
   fun c  ->
     fun f  ->
-      let uu___238_1610 = c  in
-      let uu____1611 =
-        let uu____1612 =
-          let uu___240_1613 = comp_to_comp_typ_nouniv c  in
+      let uu___238_1603 = c  in
+      let uu____1604 =
+        let uu____1605 =
+          let uu___240_1606 = comp_to_comp_typ_nouniv c  in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___240_1613.FStar_Syntax_Syntax.comp_univs);
+              (uu___240_1606.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___240_1613.FStar_Syntax_Syntax.effect_name);
+              (uu___240_1606.FStar_Syntax_Syntax.effect_name);
             FStar_Syntax_Syntax.result_typ =
-              (uu___240_1613.FStar_Syntax_Syntax.result_typ);
+              (uu___240_1606.FStar_Syntax_Syntax.result_typ);
             FStar_Syntax_Syntax.effect_args =
-              (uu___240_1613.FStar_Syntax_Syntax.effect_args);
+              (uu___240_1606.FStar_Syntax_Syntax.effect_args);
             FStar_Syntax_Syntax.flags = f
           }  in
-        FStar_Syntax_Syntax.Comp uu____1612  in
+        FStar_Syntax_Syntax.Comp uu____1605  in
       {
-        FStar_Syntax_Syntax.n = uu____1611;
-        FStar_Syntax_Syntax.pos = (uu___238_1610.FStar_Syntax_Syntax.pos);
-        FStar_Syntax_Syntax.vars = (uu___238_1610.FStar_Syntax_Syntax.vars)
+        FStar_Syntax_Syntax.n = uu____1604;
+        FStar_Syntax_Syntax.pos = (uu___238_1603.FStar_Syntax_Syntax.pos);
+        FStar_Syntax_Syntax.vars = (uu___238_1603.FStar_Syntax_Syntax.vars)
       }
   
 let (comp_to_comp_typ :
@@ -463,7 +461,7 @@ let (comp_to_comp_typ :
           FStar_Syntax_Syntax.effect_args = [];
           FStar_Syntax_Syntax.flags = (comp_flags c)
         }
-    | uu____1653 ->
+    | uu____1646 ->
         failwith "Assertion failed: Computation type without universe"
   
 let (destruct_comp :
@@ -474,25 +472,25 @@ let (destruct_comp :
   fun c  ->
     let wp =
       match c.FStar_Syntax_Syntax.effect_args with
-      | (wp,uu____1675)::[] -> wp
-      | uu____1700 ->
-          let uu____1711 =
-            let uu____1713 =
+      | (wp,uu____1668)::[] -> wp
+      | uu____1693 ->
+          let uu____1704 =
+            let uu____1706 =
               FStar_Ident.string_of_lid c.FStar_Syntax_Syntax.effect_name  in
-            let uu____1715 =
-              let uu____1717 =
+            let uu____1708 =
+              let uu____1710 =
                 FStar_All.pipe_right c.FStar_Syntax_Syntax.effect_args
                   FStar_List.length
                  in
-              FStar_All.pipe_right uu____1717 FStar_Util.string_of_int  in
+              FStar_All.pipe_right uu____1710 FStar_Util.string_of_int  in
             FStar_Util.format2
               "Impossible: Got a computation %s with %s effect args"
-              uu____1713 uu____1715
+              uu____1706 uu____1708
              in
-          failwith uu____1711
+          failwith uu____1704
        in
-    let uu____1741 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs  in
-    (uu____1741, (c.FStar_Syntax_Syntax.result_typ), wp)
+    let uu____1734 = FStar_List.hd c.FStar_Syntax_Syntax.comp_univs  in
+    (uu____1734, (c.FStar_Syntax_Syntax.result_typ), wp)
   
 let (is_named_tot :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -501,8 +499,8 @@ let (is_named_tot :
     | FStar_Syntax_Syntax.Comp c1 ->
         FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name
           FStar_Parser_Const.effect_Tot_lid
-    | FStar_Syntax_Syntax.Total uu____1755 -> true
-    | FStar_Syntax_Syntax.GTotal uu____1765 -> false
+    | FStar_Syntax_Syntax.Total uu____1748 -> true
+    | FStar_Syntax_Syntax.GTotal uu____1758 -> false
   
 let (is_total_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -512,22 +510,22 @@ let (is_total_comp :
       ||
       (FStar_All.pipe_right (comp_flags c)
          (FStar_Util.for_some
-            (fun uu___0_1790  ->
-               match uu___0_1790 with
+            (fun uu___0_1783  ->
+               match uu___0_1783 with
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
-               | uu____1794 -> false)))
+               | uu____1787 -> false)))
   
 let (is_partial_return :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c  ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
-         (fun uu___1_1811  ->
-            match uu___1_1811 with
+         (fun uu___1_1804  ->
+            match uu___1_1804 with
             | FStar_Syntax_Syntax.RETURN  -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN  -> true
-            | uu____1815 -> false))
+            | uu____1808 -> false))
   
 let (is_tot_or_gtot_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -546,18 +544,18 @@ let (is_pure_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____1847 -> true
-    | FStar_Syntax_Syntax.GTotal uu____1857 -> false
+    | FStar_Syntax_Syntax.Total uu____1840 -> true
+    | FStar_Syntax_Syntax.GTotal uu____1850 -> false
     | FStar_Syntax_Syntax.Comp ct ->
         ((is_total_comp c) ||
            (is_pure_effect ct.FStar_Syntax_Syntax.effect_name))
           ||
           (FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
              (FStar_Util.for_some
-                (fun uu___2_1872  ->
-                   match uu___2_1872 with
+                (fun uu___2_1865  ->
+                   match uu___2_1865 with
                    | FStar_Syntax_Syntax.LEMMA  -> true
-                   | uu____1875 -> false)))
+                   | uu____1868 -> false)))
   
 let (is_ghost_effect : FStar_Ident.lident -> Prims.bool) =
   fun l  ->
@@ -578,12 +576,12 @@ let (is_pure_or_ghost_effect : FStar_Ident.lident -> Prims.bool) =
   fun l  -> (is_pure_effect l) || (is_ghost_effect l) 
 let (is_pure_or_ghost_function : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1916 =
-      let uu____1917 = FStar_Syntax_Subst.compress t  in
-      uu____1917.FStar_Syntax_Syntax.n  in
-    match uu____1916 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____1921,c) -> is_pure_or_ghost_comp c
-    | uu____1943 -> true
+    let uu____1909 =
+      let uu____1910 = FStar_Syntax_Subst.compress t  in
+      uu____1910.FStar_Syntax_Syntax.n  in
+    match uu____1909 with
+    | FStar_Syntax_Syntax.Tm_arrow (uu____1914,c) -> is_pure_or_ghost_comp c
+    | uu____1936 -> true
   
 let (is_lemma_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -592,30 +590,30 @@ let (is_lemma_comp :
     | FStar_Syntax_Syntax.Comp ct ->
         FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
           FStar_Parser_Const.effect_Lemma_lid
-    | uu____1958 -> false
+    | uu____1951 -> false
   
 let (is_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____1967 =
-      let uu____1968 = FStar_Syntax_Subst.compress t  in
-      uu____1968.FStar_Syntax_Syntax.n  in
-    match uu____1967 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____1972,c) -> is_lemma_comp c
-    | uu____1994 -> false
+    let uu____1960 =
+      let uu____1961 = FStar_Syntax_Subst.compress t  in
+      uu____1961.FStar_Syntax_Syntax.n  in
+    match uu____1960 with
+    | FStar_Syntax_Syntax.Tm_arrow (uu____1965,c) -> is_lemma_comp c
+    | uu____1987 -> false
   
 let rec (head_of : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____2002 =
-      let uu____2003 = FStar_Syntax_Subst.compress t  in
-      uu____2003.FStar_Syntax_Syntax.n  in
-    match uu____2002 with
-    | FStar_Syntax_Syntax.Tm_app (t1,uu____2007) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_match (t1,uu____2033) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_abs (uu____2070,t1,uu____2072) -> head_of t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____2098,uu____2099) ->
+    let uu____1995 =
+      let uu____1996 = FStar_Syntax_Subst.compress t  in
+      uu____1996.FStar_Syntax_Syntax.n  in
+    match uu____1995 with
+    | FStar_Syntax_Syntax.Tm_app (t1,uu____2000) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_match (t1,uu____2026) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_abs (uu____2063,t1,uu____2065) -> head_of t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____2091,uu____2092) ->
         head_of t1
-    | FStar_Syntax_Syntax.Tm_meta (t1,uu____2141) -> head_of t1
-    | uu____2146 -> t
+    | FStar_Syntax_Syntax.Tm_meta (t1,uu____2134) -> head_of t1
+    | uu____2139 -> t
   
 let (head_and_args :
   FStar_Syntax_Syntax.term ->
@@ -628,7 +626,7 @@ let (head_and_args :
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head,args) -> (head, args)
-    | uu____2224 -> (t1, [])
+    | uu____2217 -> (t1, [])
   
 let rec (head_and_args' :
   FStar_Syntax_Syntax.term ->
@@ -640,18 +638,18 @@ let rec (head_and_args' :
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head,args) ->
-        let uu____2306 = head_and_args' head  in
-        (match uu____2306 with
+        let uu____2299 = head_and_args' head  in
+        (match uu____2299 with
          | (head1,args') -> (head1, (FStar_List.append args' args)))
-    | uu____2375 -> (t1, [])
+    | uu____2368 -> (t1, [])
   
 let (un_uinst : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____2402) ->
+    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____2395) ->
         FStar_Syntax_Subst.compress t2
-    | uu____2407 -> t1
+    | uu____2400 -> t1
   
 let (is_ml_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
@@ -663,11 +661,11 @@ let (is_ml_comp :
           ||
           (FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
              (FStar_Util.for_some
-                (fun uu___3_2425  ->
-                   match uu___3_2425 with
+                (fun uu___3_2418  ->
+                   match uu___3_2418 with
                    | FStar_Syntax_Syntax.MLEFFECT  -> true
-                   | uu____2428 -> false)))
-    | uu____2430 -> false
+                   | uu____2421 -> false)))
+    | uu____2423 -> false
   
 let (comp_result :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -675,8 +673,8 @@ let (comp_result :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t,uu____2447) -> t
-    | FStar_Syntax_Syntax.GTotal (t,uu____2457) -> t
+    | FStar_Syntax_Syntax.Total (t,uu____2440) -> t
+    | FStar_Syntax_Syntax.GTotal (t,uu____2450) -> t
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.result_typ
   
 let (set_result_typ :
@@ -687,23 +685,23 @@ let (set_result_typ :
   fun c  ->
     fun t  ->
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____2486 ->
+      | FStar_Syntax_Syntax.Total uu____2479 ->
           FStar_Syntax_Syntax.mk_Total t
-      | FStar_Syntax_Syntax.GTotal uu____2495 ->
+      | FStar_Syntax_Syntax.GTotal uu____2488 ->
           FStar_Syntax_Syntax.mk_GTotal t
       | FStar_Syntax_Syntax.Comp ct ->
           FStar_Syntax_Syntax.mk_Comp
-            (let uu___379_2507 = ct  in
+            (let uu___379_2500 = ct  in
              {
                FStar_Syntax_Syntax.comp_univs =
-                 (uu___379_2507.FStar_Syntax_Syntax.comp_univs);
+                 (uu___379_2500.FStar_Syntax_Syntax.comp_univs);
                FStar_Syntax_Syntax.effect_name =
-                 (uu___379_2507.FStar_Syntax_Syntax.effect_name);
+                 (uu___379_2500.FStar_Syntax_Syntax.effect_name);
                FStar_Syntax_Syntax.result_typ = t;
                FStar_Syntax_Syntax.effect_args =
-                 (uu___379_2507.FStar_Syntax_Syntax.effect_args);
+                 (uu___379_2500.FStar_Syntax_Syntax.effect_args);
                FStar_Syntax_Syntax.flags =
-                 (uu___379_2507.FStar_Syntax_Syntax.flags)
+                 (uu___379_2500.FStar_Syntax_Syntax.flags)
              })
   
 let (is_trivial_wp :
@@ -711,18 +709,18 @@ let (is_trivial_wp :
   fun c  ->
     FStar_All.pipe_right (comp_flags c)
       (FStar_Util.for_some
-         (fun uu___4_2523  ->
-            match uu___4_2523 with
+         (fun uu___4_2516  ->
+            match uu___4_2516 with
             | FStar_Syntax_Syntax.TOTAL  -> true
             | FStar_Syntax_Syntax.RETURN  -> true
-            | uu____2527 -> false))
+            | uu____2520 -> false))
   
 let (comp_effect_args : FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.args)
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total uu____2535 -> []
-    | FStar_Syntax_Syntax.GTotal uu____2552 -> []
+    | FStar_Syntax_Syntax.Total uu____2528 -> []
+    | FStar_Syntax_Syntax.GTotal uu____2545 -> []
     | FStar_Syntax_Syntax.Comp ct -> ct.FStar_Syntax_Syntax.effect_args
   
 let (primops : FStar_Ident.lident Prims.list) =
@@ -752,15 +750,15 @@ let (is_primop :
     match f.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         is_primop_lid (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____2596 -> false
+    | uu____2589 -> false
   
 let rec (unascribe : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun e  ->
     let e1 = FStar_Syntax_Subst.compress e  in
     match e1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____2606,uu____2607) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (e2,uu____2599,uu____2600) ->
         unascribe e2
-    | uu____2648 -> e1
+    | uu____2641 -> e1
   
 let rec (ascribe :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -773,46 +771,46 @@ let rec (ascribe :
   fun t  ->
     fun k  ->
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_ascribed (t',uu____2701,uu____2702) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t',uu____2694,uu____2695) ->
           ascribe t' k
-      | uu____2743 ->
+      | uu____2736 ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (t, k, FStar_Pervasives_Native.None))
-            FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+            t.FStar_Syntax_Syntax.pos
   
 let (unfold_lazy : FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term)
   =
   fun i  ->
-    let uu____2770 =
-      let uu____2779 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
-      FStar_Util.must uu____2779  in
-    uu____2770 i.FStar_Syntax_Syntax.lkind i
+    let uu____2763 =
+      let uu____2772 = FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
+      FStar_Util.must uu____2772  in
+    uu____2763 i.FStar_Syntax_Syntax.lkind i
   
 let rec (unlazy : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____2835 =
-      let uu____2836 = FStar_Syntax_Subst.compress t  in
-      uu____2836.FStar_Syntax_Syntax.n  in
-    match uu____2835 with
+    let uu____2828 =
+      let uu____2829 = FStar_Syntax_Subst.compress t  in
+      uu____2829.FStar_Syntax_Syntax.n  in
+    match uu____2828 with
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu____2840 = unfold_lazy i  in
-        FStar_All.pipe_left unlazy uu____2840
-    | uu____2841 -> t
+        let uu____2833 = unfold_lazy i  in
+        FStar_All.pipe_left unlazy uu____2833
+    | uu____2834 -> t
   
 let (unlazy_emb : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____2848 =
-      let uu____2849 = FStar_Syntax_Subst.compress t  in
-      uu____2849.FStar_Syntax_Syntax.n  in
-    match uu____2848 with
+    let uu____2841 =
+      let uu____2842 = FStar_Syntax_Subst.compress t  in
+      uu____2842.FStar_Syntax_Syntax.n  in
+    match uu____2841 with
     | FStar_Syntax_Syntax.Tm_lazy i ->
         (match i.FStar_Syntax_Syntax.lkind with
-         | FStar_Syntax_Syntax.Lazy_embedding uu____2853 ->
-             let uu____2862 = unfold_lazy i  in
-             FStar_All.pipe_left unlazy uu____2862
-         | uu____2863 -> t)
-    | uu____2864 -> t
+         | FStar_Syntax_Syntax.Lazy_embedding uu____2846 ->
+             let uu____2855 = unfold_lazy i  in
+             FStar_All.pipe_left unlazy uu____2855
+         | uu____2856 -> t)
+    | uu____2857 -> t
   
 let (eq_lazy_kind :
   FStar_Syntax_Syntax.lazy_kind ->
@@ -840,24 +838,24 @@ let (eq_lazy_kind :
           -> true
       | (FStar_Syntax_Syntax.Lazy_uvar ,FStar_Syntax_Syntax.Lazy_uvar ) ->
           true
-      | uu____2889 -> false
+      | uu____2882 -> false
   
 let unlazy_as_t :
-  'uuuuuu2902 .
-    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'uuuuuu2902
+  'uuuuuu2895 .
+    FStar_Syntax_Syntax.lazy_kind -> FStar_Syntax_Syntax.term -> 'uuuuuu2895
   =
   fun k  ->
     fun t  ->
-      let uu____2913 =
-        let uu____2914 = FStar_Syntax_Subst.compress t  in
-        uu____2914.FStar_Syntax_Syntax.n  in
-      match uu____2913 with
+      let uu____2906 =
+        let uu____2907 = FStar_Syntax_Subst.compress t  in
+        uu____2907.FStar_Syntax_Syntax.n  in
+      match uu____2906 with
       | FStar_Syntax_Syntax.Tm_lazy
           { FStar_Syntax_Syntax.blob = v; FStar_Syntax_Syntax.lkind = k';
-            FStar_Syntax_Syntax.ltyp = uu____2919;
-            FStar_Syntax_Syntax.rng = uu____2920;_}
+            FStar_Syntax_Syntax.ltyp = uu____2912;
+            FStar_Syntax_Syntax.rng = uu____2913;_}
           when eq_lazy_kind k k' -> FStar_Dyn.undyn v
-      | uu____2923 -> failwith "Not a Tm_lazy of the expected kind"
+      | uu____2916 -> failwith "Not a Tm_lazy of the expected kind"
   
 let mk_lazy :
   'a .
@@ -876,27 +874,25 @@ let mk_lazy :
             | FStar_Pervasives_Native.Some r1 -> r1
             | FStar_Pervasives_Native.None  -> FStar_Range.dummyRange  in
           let i =
-            let uu____2964 = FStar_Dyn.mkdyn t  in
+            let uu____2957 = FStar_Dyn.mkdyn t  in
             {
-              FStar_Syntax_Syntax.blob = uu____2964;
+              FStar_Syntax_Syntax.blob = uu____2957;
               FStar_Syntax_Syntax.lkind = k;
               FStar_Syntax_Syntax.ltyp = typ;
               FStar_Syntax_Syntax.rng = rng
             }  in
-          FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_lazy i)
-            FStar_Pervasives_Native.None rng
+          FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_lazy i) rng
   
 let (canon_app :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+    FStar_Syntax_Syntax.term)
   =
   fun t  ->
-    let uu____2977 =
-      let uu____2992 = unascribe t  in head_and_args' uu____2992  in
-    match uu____2977 with
+    let uu____2968 =
+      let uu____2983 = unascribe t  in head_and_args' uu____2983  in
+    match uu____2968 with
     | (hd,args) ->
-        FStar_Syntax_Syntax.mk_Tm_app hd args FStar_Pervasives_Native.None
-          t.FStar_Syntax_Syntax.pos
+        FStar_Syntax_Syntax.mk_Tm_app hd args t.FStar_Syntax_Syntax.pos
   
 type eq_result =
   | Equal 
@@ -904,15 +900,15 @@ type eq_result =
   | Unknown 
 let (uu___is_Equal : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Equal  -> true | uu____3026 -> false
+    match projectee with | Equal  -> true | uu____3015 -> false
   
 let (uu___is_NotEqual : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | NotEqual  -> true | uu____3037 -> false
+    match projectee with | NotEqual  -> true | uu____3026 -> false
   
 let (uu___is_Unknown : eq_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Unknown  -> true | uu____3048 -> false
+    match projectee with | Unknown  -> true | uu____3037 -> false
   
 let (injectives : Prims.string Prims.list) =
   ["FStar.Int8.int_to_t";
@@ -936,10 +932,10 @@ let (eq_inj : eq_result -> eq_result -> eq_result) =
     fun g  ->
       match (f, g) with
       | (Equal ,Equal ) -> Equal
-      | (NotEqual ,uu____3098) -> NotEqual
-      | (uu____3099,NotEqual ) -> NotEqual
-      | (Unknown ,uu____3100) -> Unknown
-      | (uu____3101,Unknown ) -> Unknown
+      | (NotEqual ,uu____3087) -> NotEqual
+      | (uu____3088,NotEqual ) -> NotEqual
+      | (Unknown ,uu____3089) -> Unknown
+      | (uu____3090,Unknown ) -> Unknown
   
 let rec (eq_tm :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result) =
@@ -947,44 +943,44 @@ let rec (eq_tm :
     fun t2  ->
       let t11 = canon_app t1  in
       let t21 = canon_app t2  in
-      let equal_if uu___5_3210 = if uu___5_3210 then Equal else Unknown  in
-      let equal_iff uu___6_3221 = if uu___6_3221 then Equal else NotEqual  in
-      let eq_and f g = match f with | Equal  -> g () | uu____3242 -> Unknown
+      let equal_if uu___5_3195 = if uu___5_3195 then Equal else Unknown  in
+      let equal_iff uu___6_3206 = if uu___6_3206 then Equal else NotEqual  in
+      let eq_and f g = match f with | Equal  -> g () | uu____3227 -> Unknown
          in
       let equal_data f1 args1 f2 args2 =
-        let uu____3264 = FStar_Syntax_Syntax.fv_eq f1 f2  in
-        if uu____3264
+        let uu____3249 = FStar_Syntax_Syntax.fv_eq f1 f2  in
+        if uu____3249
         then
-          let uu____3268 = FStar_List.zip args1 args2  in
+          let uu____3253 = FStar_List.zip args1 args2  in
           FStar_All.pipe_left
             (FStar_List.fold_left
                (fun acc  ->
-                  fun uu____3345  ->
-                    match uu____3345 with
+                  fun uu____3330  ->
+                    match uu____3330 with
                     | ((a1,q1),(a2,q2)) ->
-                        let uu____3386 = eq_tm a1 a2  in
-                        eq_inj acc uu____3386) Equal) uu____3268
+                        let uu____3371 = eq_tm a1 a2  in
+                        eq_inj acc uu____3371) Equal) uu____3253
         else NotEqual  in
       let heads_and_args_in_case_both_data =
-        let uu____3400 =
-          let uu____3417 = FStar_All.pipe_right t11 unmeta  in
-          FStar_All.pipe_right uu____3417 head_and_args  in
-        match uu____3400 with
+        let uu____3385 =
+          let uu____3402 = FStar_All.pipe_right t11 unmeta  in
+          FStar_All.pipe_right uu____3402 head_and_args  in
+        match uu____3385 with
         | (head1,args1) ->
-            let uu____3470 =
-              let uu____3487 = FStar_All.pipe_right t21 unmeta  in
-              FStar_All.pipe_right uu____3487 head_and_args  in
-            (match uu____3470 with
+            let uu____3455 =
+              let uu____3472 = FStar_All.pipe_right t21 unmeta  in
+              FStar_All.pipe_right uu____3472 head_and_args  in
+            (match uu____3455 with
              | (head2,args2) ->
-                 let uu____3540 =
-                   let uu____3545 =
-                     let uu____3546 = un_uinst head1  in
-                     uu____3546.FStar_Syntax_Syntax.n  in
-                   let uu____3549 =
-                     let uu____3550 = un_uinst head2  in
-                     uu____3550.FStar_Syntax_Syntax.n  in
-                   (uu____3545, uu____3549)  in
-                 (match uu____3540 with
+                 let uu____3525 =
+                   let uu____3530 =
+                     let uu____3531 = un_uinst head1  in
+                     uu____3531.FStar_Syntax_Syntax.n  in
+                   let uu____3534 =
+                     let uu____3535 = un_uinst head2  in
+                     uu____3535.FStar_Syntax_Syntax.n  in
+                   (uu____3530, uu____3534)  in
+                 (match uu____3525 with
                   | (FStar_Syntax_Syntax.Tm_fvar
                      f,FStar_Syntax_Syntax.Tm_fvar g) when
                       (f.FStar_Syntax_Syntax.fv_qual =
@@ -995,7 +991,7 @@ let rec (eq_tm :
                            (FStar_Pervasives_Native.Some
                               FStar_Syntax_Syntax.Data_ctor))
                       -> FStar_Pervasives_Native.Some (f, args1, g, args2)
-                  | uu____3577 -> FStar_Pervasives_Native.None))
+                  | uu____3562 -> FStar_Pervasives_Native.None))
          in
       let t12 = unmeta t11  in
       let t22 = unmeta t21  in
@@ -1003,98 +999,98 @@ let rec (eq_tm :
       | (FStar_Syntax_Syntax.Tm_bvar bv1,FStar_Syntax_Syntax.Tm_bvar bv2) ->
           equal_if
             (bv1.FStar_Syntax_Syntax.index = bv2.FStar_Syntax_Syntax.index)
-      | (FStar_Syntax_Syntax.Tm_lazy uu____3595,uu____3596) ->
-          let uu____3597 = unlazy t12  in eq_tm uu____3597 t22
-      | (uu____3598,FStar_Syntax_Syntax.Tm_lazy uu____3599) ->
-          let uu____3600 = unlazy t22  in eq_tm t12 uu____3600
+      | (FStar_Syntax_Syntax.Tm_lazy uu____3580,uu____3581) ->
+          let uu____3582 = unlazy t12  in eq_tm uu____3582 t22
+      | (uu____3583,FStar_Syntax_Syntax.Tm_lazy uu____3584) ->
+          let uu____3585 = unlazy t22  in eq_tm t12 uu____3585
       | (FStar_Syntax_Syntax.Tm_name a,FStar_Syntax_Syntax.Tm_name b) ->
-          let uu____3603 = FStar_Syntax_Syntax.bv_eq a b  in
-          equal_if uu____3603
-      | uu____3605 when
+          let uu____3588 = FStar_Syntax_Syntax.bv_eq a b  in
+          equal_if uu____3588
+      | uu____3590 when
           FStar_All.pipe_right heads_and_args_in_case_both_data
             FStar_Util.is_some
           ->
-          let uu____3629 =
+          let uu____3614 =
             FStar_All.pipe_right heads_and_args_in_case_both_data
               FStar_Util.must
              in
-          FStar_All.pipe_right uu____3629
-            (fun uu____3677  ->
-               match uu____3677 with
+          FStar_All.pipe_right uu____3614
+            (fun uu____3662  ->
+               match uu____3662 with
                | (f,args1,g,args2) -> equal_data f args1 g args2)
       | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-          let uu____3692 = FStar_Syntax_Syntax.fv_eq f g  in
-          equal_if uu____3692
+          let uu____3677 = FStar_Syntax_Syntax.fv_eq f g  in
+          equal_if uu____3677
       | (FStar_Syntax_Syntax.Tm_uinst (f,us),FStar_Syntax_Syntax.Tm_uinst
          (g,vs)) ->
-          let uu____3706 = eq_tm f g  in
-          eq_and uu____3706
-            (fun uu____3709  ->
-               let uu____3710 = eq_univs_list us vs  in equal_if uu____3710)
+          let uu____3691 = eq_tm f g  in
+          eq_and uu____3691
+            (fun uu____3694  ->
+               let uu____3695 = eq_univs_list us vs  in equal_if uu____3695)
       | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3712),uu____3713) -> Unknown
-      | (uu____3714,FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu____3715)) -> Unknown
+         uu____3697),uu____3698) -> Unknown
+      | (uu____3699,FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
+         uu____3700)) -> Unknown
       | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant d)
           ->
-          let uu____3718 = FStar_Const.eq_const c d  in equal_iff uu____3718
+          let uu____3703 = FStar_Const.eq_const c d  in equal_iff uu____3703
       | (FStar_Syntax_Syntax.Tm_uvar
-         (u1,([],uu____3721)),FStar_Syntax_Syntax.Tm_uvar
-         (u2,([],uu____3723))) ->
-          let uu____3752 =
+         (u1,([],uu____3706)),FStar_Syntax_Syntax.Tm_uvar
+         (u2,([],uu____3708))) ->
+          let uu____3737 =
             FStar_Syntax_Unionfind.equiv u1.FStar_Syntax_Syntax.ctx_uvar_head
               u2.FStar_Syntax_Syntax.ctx_uvar_head
              in
-          equal_if uu____3752
+          equal_if uu____3737
       | (FStar_Syntax_Syntax.Tm_app (h1,args1),FStar_Syntax_Syntax.Tm_app
          (h2,args2)) ->
-          let uu____3806 =
-            let uu____3811 =
-              let uu____3812 = un_uinst h1  in
-              uu____3812.FStar_Syntax_Syntax.n  in
-            let uu____3815 =
-              let uu____3816 = un_uinst h2  in
-              uu____3816.FStar_Syntax_Syntax.n  in
-            (uu____3811, uu____3815)  in
-          (match uu____3806 with
+          let uu____3791 =
+            let uu____3796 =
+              let uu____3797 = un_uinst h1  in
+              uu____3797.FStar_Syntax_Syntax.n  in
+            let uu____3800 =
+              let uu____3801 = un_uinst h2  in
+              uu____3801.FStar_Syntax_Syntax.n  in
+            (uu____3796, uu____3800)  in
+          (match uu____3791 with
            | (FStar_Syntax_Syntax.Tm_fvar f1,FStar_Syntax_Syntax.Tm_fvar f2)
                when
                (FStar_Syntax_Syntax.fv_eq f1 f2) &&
-                 (let uu____3822 =
-                    let uu____3824 = FStar_Syntax_Syntax.lid_of_fv f1  in
-                    FStar_Ident.string_of_lid uu____3824  in
-                  FStar_List.mem uu____3822 injectives)
+                 (let uu____3807 =
+                    let uu____3809 = FStar_Syntax_Syntax.lid_of_fv f1  in
+                    FStar_Ident.string_of_lid uu____3809  in
+                  FStar_List.mem uu____3807 injectives)
                -> equal_data f1 args1 f2 args2
-           | uu____3826 ->
-               let uu____3831 = eq_tm h1 h2  in
-               eq_and uu____3831 (fun uu____3833  -> eq_args args1 args2))
+           | uu____3811 ->
+               let uu____3816 = eq_tm h1 h2  in
+               eq_and uu____3816 (fun uu____3818  -> eq_args args1 args2))
       | (FStar_Syntax_Syntax.Tm_match (t13,bs1),FStar_Syntax_Syntax.Tm_match
          (t23,bs2)) ->
           if (FStar_List.length bs1) = (FStar_List.length bs2)
           then
-            let uu____3939 = FStar_List.zip bs1 bs2  in
-            let uu____4002 = eq_tm t13 t23  in
+            let uu____3924 = FStar_List.zip bs1 bs2  in
+            let uu____3987 = eq_tm t13 t23  in
             FStar_List.fold_right
-              (fun uu____4039  ->
+              (fun uu____4024  ->
                  fun a  ->
-                   match uu____4039 with
+                   match uu____4024 with
                    | (b1,b2) ->
-                       eq_and a (fun uu____4132  -> branch_matches b1 b2))
-              uu____3939 uu____4002
+                       eq_and a (fun uu____4117  -> branch_matches b1 b2))
+              uu____3924 uu____3987
           else Unknown
       | (FStar_Syntax_Syntax.Tm_type u,FStar_Syntax_Syntax.Tm_type v) ->
-          let uu____4137 = eq_univs u v  in equal_if uu____4137
+          let uu____4122 = eq_univs u v  in equal_if uu____4122
       | (FStar_Syntax_Syntax.Tm_quoted (t13,q1),FStar_Syntax_Syntax.Tm_quoted
          (t23,q2)) ->
-          let uu____4151 = eq_quoteinfo q1 q2  in
-          eq_and uu____4151 (fun uu____4153  -> eq_tm t13 t23)
+          let uu____4136 = eq_quoteinfo q1 q2  in
+          eq_and uu____4136 (fun uu____4138  -> eq_tm t13 t23)
       | (FStar_Syntax_Syntax.Tm_refine
          (t13,phi1),FStar_Syntax_Syntax.Tm_refine (t23,phi2)) ->
-          let uu____4166 =
+          let uu____4151 =
             eq_tm t13.FStar_Syntax_Syntax.sort t23.FStar_Syntax_Syntax.sort
              in
-          eq_and uu____4166 (fun uu____4168  -> eq_tm phi1 phi2)
-      | uu____4169 -> Unknown
+          eq_and uu____4151 (fun uu____4153  -> eq_tm phi1 phi2)
+      | uu____4154 -> Unknown
 
 and (eq_quoteinfo :
   FStar_Syntax_Syntax.quoteinfo -> FStar_Syntax_Syntax.quoteinfo -> eq_result)
@@ -1117,23 +1113,23 @@ and (eq_antiquotes :
     fun a2  ->
       match (a1, a2) with
       | ([],[]) -> Equal
-      | ([],uu____4241) -> NotEqual
-      | (uu____4272,[]) -> NotEqual
+      | ([],uu____4226) -> NotEqual
+      | (uu____4257,[]) -> NotEqual
       | ((x1,t1)::a11,(x2,t2)::a21) ->
-          let uu____4361 =
-            let uu____4363 = FStar_Syntax_Syntax.bv_eq x1 x2  in
-            Prims.op_Negation uu____4363  in
-          if uu____4361
+          let uu____4346 =
+            let uu____4348 = FStar_Syntax_Syntax.bv_eq x1 x2  in
+            Prims.op_Negation uu____4348  in
+          if uu____4346
           then NotEqual
           else
-            (let uu____4368 = eq_tm t1 t2  in
-             match uu____4368 with
+            (let uu____4353 = eq_tm t1 t2  in
+             match uu____4353 with
              | NotEqual  -> NotEqual
              | Unknown  ->
-                 let uu____4369 = eq_antiquotes a11 a21  in
-                 (match uu____4369 with
+                 let uu____4354 = eq_antiquotes a11 a21  in
+                 (match uu____4354 with
                   | NotEqual  -> NotEqual
-                  | uu____4370 -> Unknown)
+                  | uu____4355 -> Unknown)
              | Equal  -> eq_antiquotes a11 a21)
 
 and (branch_matches :
@@ -1154,25 +1150,25 @@ and (branch_matches :
             true
         | (FStar_Pervasives_Native.Some x,FStar_Pervasives_Native.Some y) ->
             f x y
-        | (uu____4454,uu____4455) -> false  in
-      let uu____4465 = b1  in
-      match uu____4465 with
+        | (uu____4439,uu____4440) -> false  in
+      let uu____4450 = b1  in
+      match uu____4450 with
       | (p1,w1,t1) ->
-          let uu____4499 = b2  in
-          (match uu____4499 with
+          let uu____4484 = b2  in
+          (match uu____4484 with
            | (p2,w2,t2) ->
-               let uu____4533 = FStar_Syntax_Syntax.eq_pat p1 p2  in
-               if uu____4533
+               let uu____4518 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+               if uu____4518
                then
-                 let uu____4536 =
-                   (let uu____4540 = eq_tm t1 t2  in uu____4540 = Equal) &&
+                 let uu____4521 =
+                   (let uu____4525 = eq_tm t1 t2  in uu____4525 = Equal) &&
                      (related_by
                         (fun t11  ->
                            fun t21  ->
-                             let uu____4549 = eq_tm t11 t21  in
-                             uu____4549 = Equal) w1 w2)
+                             let uu____4534 = eq_tm t11 t21  in
+                             uu____4534 = Equal) w1 w2)
                     in
-                 (if uu____4536 then Equal else Unknown)
+                 (if uu____4521 then Equal else Unknown)
                else Unknown)
 
 and (eq_args :
@@ -1181,12 +1177,12 @@ and (eq_args :
     fun a2  ->
       match (a1, a2) with
       | ([],[]) -> Equal
-      | ((a,uu____4614)::a11,(b,uu____4617)::b1) ->
-          let uu____4691 = eq_tm a b  in
-          (match uu____4691 with
+      | ((a,uu____4599)::a11,(b,uu____4602)::b1) ->
+          let uu____4676 = eq_tm a b  in
+          (match uu____4676 with
            | Equal  -> eq_args a11 b1
-           | uu____4692 -> Unknown)
-      | uu____4693 -> Unknown
+           | uu____4677 -> Unknown)
+      | uu____4678 -> Unknown
 
 and (eq_univs_list :
   FStar_Syntax_Syntax.universes ->
@@ -1207,8 +1203,8 @@ let (eq_aqual :
       match (a1, a2) with
       | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.None ) ->
           Equal
-      | (FStar_Pervasives_Native.None ,uu____4748) -> NotEqual
-      | (uu____4755,FStar_Pervasives_Native.None ) -> NotEqual
+      | (FStar_Pervasives_Native.None ,uu____4733) -> NotEqual
+      | (uu____4740,FStar_Pervasives_Native.None ) -> NotEqual
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
          b1),FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit b2))
           when b1 = b2 -> Equal
@@ -1218,87 +1214,87 @@ let (eq_aqual :
       | (FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality
          ),FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality )) ->
           Equal
-      | uu____4785 -> NotEqual
+      | uu____4770 -> NotEqual
   
 let rec (unrefine : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____4802) ->
+    | FStar_Syntax_Syntax.Tm_refine (x,uu____4787) ->
         unrefine x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____4808,uu____4809) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____4793,uu____4794) ->
         unrefine t2
-    | uu____4850 -> t1
+    | uu____4835 -> t1
   
 let rec (is_uvar : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____4858 =
-      let uu____4859 = FStar_Syntax_Subst.compress t  in
-      uu____4859.FStar_Syntax_Syntax.n  in
-    match uu____4858 with
-    | FStar_Syntax_Syntax.Tm_uvar uu____4863 -> true
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4878) -> is_uvar t1
-    | FStar_Syntax_Syntax.Tm_app uu____4883 ->
-        let uu____4900 =
-          let uu____4901 = FStar_All.pipe_right t head_and_args  in
-          FStar_All.pipe_right uu____4901 FStar_Pervasives_Native.fst  in
-        FStar_All.pipe_right uu____4900 is_uvar
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____4964,uu____4965) ->
+    let uu____4843 =
+      let uu____4844 = FStar_Syntax_Subst.compress t  in
+      uu____4844.FStar_Syntax_Syntax.n  in
+    match uu____4843 with
+    | FStar_Syntax_Syntax.Tm_uvar uu____4848 -> true
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____4863) -> is_uvar t1
+    | FStar_Syntax_Syntax.Tm_app uu____4868 ->
+        let uu____4885 =
+          let uu____4886 = FStar_All.pipe_right t head_and_args  in
+          FStar_All.pipe_right uu____4886 FStar_Pervasives_Native.fst  in
+        FStar_All.pipe_right uu____4885 is_uvar
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____4949,uu____4950) ->
         is_uvar t1
-    | uu____5006 -> false
+    | uu____4991 -> false
   
 let rec (is_unit : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5015 =
-      let uu____5016 = unrefine t  in uu____5016.FStar_Syntax_Syntax.n  in
-    match uu____5015 with
+    let uu____5000 =
+      let uu____5001 = unrefine t  in uu____5001.FStar_Syntax_Syntax.n  in
+    match uu____5000 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         ((FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.unit_lid) ||
            (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid))
           ||
           (FStar_Syntax_Syntax.fv_eq_lid fv
              FStar_Parser_Const.auto_squash_lid)
-    | FStar_Syntax_Syntax.Tm_app (head,uu____5022) -> is_unit head
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5048) -> is_unit t1
-    | uu____5053 -> false
+    | FStar_Syntax_Syntax.Tm_app (head,uu____5007) -> is_unit head
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____5033) -> is_unit t1
+    | uu____5038 -> false
   
 let (is_eqtype_no_unrefine : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5062 =
-      let uu____5063 = FStar_Syntax_Subst.compress t  in
-      uu____5063.FStar_Syntax_Syntax.n  in
-    match uu____5062 with
+    let uu____5047 =
+      let uu____5048 = FStar_Syntax_Subst.compress t  in
+      uu____5048.FStar_Syntax_Syntax.n  in
+    match uu____5047 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.eqtype_lid
-    | uu____5068 -> false
+    | uu____5053 -> false
   
 let (is_fun : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
-    let uu____5077 =
-      let uu____5078 = FStar_Syntax_Subst.compress e  in
-      uu____5078.FStar_Syntax_Syntax.n  in
-    match uu____5077 with
-    | FStar_Syntax_Syntax.Tm_abs uu____5082 -> true
-    | uu____5102 -> false
+    let uu____5062 =
+      let uu____5063 = FStar_Syntax_Subst.compress e  in
+      uu____5063.FStar_Syntax_Syntax.n  in
+    match uu____5062 with
+    | FStar_Syntax_Syntax.Tm_abs uu____5067 -> true
+    | uu____5087 -> false
   
 let (is_function_typ : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____5111 =
-      let uu____5112 = FStar_Syntax_Subst.compress t  in
-      uu____5112.FStar_Syntax_Syntax.n  in
-    match uu____5111 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____5116 -> true
-    | uu____5132 -> false
+    let uu____5096 =
+      let uu____5097 = FStar_Syntax_Subst.compress t  in
+      uu____5097.FStar_Syntax_Syntax.n  in
+    match uu____5096 with
+    | FStar_Syntax_Syntax.Tm_arrow uu____5101 -> true
+    | uu____5117 -> false
   
 let rec (pre_typ : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_refine (x,uu____5142) ->
+    | FStar_Syntax_Syntax.Tm_refine (x,uu____5127) ->
         pre_typ x.FStar_Syntax_Syntax.sort
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____5148,uu____5149) ->
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____5133,uu____5134) ->
         pre_typ t2
-    | uu____5190 -> t1
+    | uu____5175 -> t1
   
 let (destruct :
   FStar_Syntax_Syntax.term ->
@@ -1310,45 +1306,45 @@ let (destruct :
   fun typ  ->
     fun lid  ->
       let typ1 = FStar_Syntax_Subst.compress typ  in
-      let uu____5215 =
-        let uu____5216 = un_uinst typ1  in uu____5216.FStar_Syntax_Syntax.n
+      let uu____5200 =
+        let uu____5201 = un_uinst typ1  in uu____5201.FStar_Syntax_Syntax.n
          in
-      match uu____5215 with
+      match uu____5200 with
       | FStar_Syntax_Syntax.Tm_app (head,args) ->
           let head1 = un_uinst head  in
           (match head1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_fvar tc when
                FStar_Syntax_Syntax.fv_eq_lid tc lid ->
                FStar_Pervasives_Native.Some args
-           | uu____5281 -> FStar_Pervasives_Native.None)
+           | uu____5266 -> FStar_Pervasives_Native.None)
       | FStar_Syntax_Syntax.Tm_fvar tc when
           FStar_Syntax_Syntax.fv_eq_lid tc lid ->
           FStar_Pervasives_Native.Some []
-      | uu____5311 -> FStar_Pervasives_Native.None
+      | uu____5296 -> FStar_Pervasives_Native.None
   
 let (lids_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Ident.lident Prims.list) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_let (uu____5332,lids) -> lids
-    | FStar_Syntax_Syntax.Sig_splice (lids,uu____5339) -> lids
-    | FStar_Syntax_Syntax.Sig_bundle (uu____5344,lids) -> lids
+    | FStar_Syntax_Syntax.Sig_let (uu____5317,lids) -> lids
+    | FStar_Syntax_Syntax.Sig_splice (lids,uu____5324) -> lids
+    | FStar_Syntax_Syntax.Sig_bundle (uu____5329,lids) -> lids
     | FStar_Syntax_Syntax.Sig_inductive_typ
-        (lid,uu____5355,uu____5356,uu____5357,uu____5358,uu____5359) -> 
+        (lid,uu____5340,uu____5341,uu____5342,uu____5343,uu____5344) -> 
         [lid]
     | FStar_Syntax_Syntax.Sig_effect_abbrev
-        (lid,uu____5369,uu____5370,uu____5371,uu____5372) -> [lid]
+        (lid,uu____5354,uu____5355,uu____5356,uu____5357) -> [lid]
     | FStar_Syntax_Syntax.Sig_datacon
-        (lid,uu____5378,uu____5379,uu____5380,uu____5381,uu____5382) -> 
+        (lid,uu____5363,uu____5364,uu____5365,uu____5366,uu____5367) -> 
         [lid]
-    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5390,uu____5391) ->
+    | FStar_Syntax_Syntax.Sig_declare_typ (lid,uu____5375,uu____5376) ->
         [lid]
-    | FStar_Syntax_Syntax.Sig_assume (lid,uu____5393,uu____5394) -> [lid]
+    | FStar_Syntax_Syntax.Sig_assume (lid,uu____5378,uu____5379) -> [lid]
     | FStar_Syntax_Syntax.Sig_new_effect n -> [n.FStar_Syntax_Syntax.mname]
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____5396 -> []
-    | FStar_Syntax_Syntax.Sig_pragma uu____5397 -> []
-    | FStar_Syntax_Syntax.Sig_fail uu____5398 -> []
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5411 -> []
+    | FStar_Syntax_Syntax.Sig_sub_effect uu____5381 -> []
+    | FStar_Syntax_Syntax.Sig_pragma uu____5382 -> []
+    | FStar_Syntax_Syntax.Sig_fail uu____5383 -> []
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5396 -> []
   
 let (lid_of_sigelt :
   FStar_Syntax_Syntax.sigelt ->
@@ -1357,7 +1353,7 @@ let (lid_of_sigelt :
   fun se  ->
     match lids_of_sigelt se with
     | l::[] -> FStar_Pervasives_Native.Some l
-    | uu____5435 -> FStar_Pervasives_Native.None
+    | uu____5420 -> FStar_Pervasives_Native.None
   
 let (quals_of_sigelt :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.qualifier Prims.list) =
@@ -1368,24 +1364,24 @@ let (range_of_lbname :
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
     FStar_Range.range)
   =
-  fun uu___7_5461  ->
-    match uu___7_5461 with
+  fun uu___7_5446  ->
+    match uu___7_5446 with
     | FStar_Util.Inl x -> FStar_Syntax_Syntax.range_of_bv x
     | FStar_Util.Inr fv ->
         FStar_Ident.range_of_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
   
 let range_of_arg :
-  'uuuuuu5475 'uuuuuu5476 .
-    ('uuuuuu5475 FStar_Syntax_Syntax.syntax * 'uuuuuu5476) ->
+  'uuuuuu5460 'uuuuuu5461 .
+    ('uuuuuu5460 FStar_Syntax_Syntax.syntax * 'uuuuuu5461) ->
       FStar_Range.range
   =
-  fun uu____5487  ->
-    match uu____5487 with | (hd,uu____5495) -> hd.FStar_Syntax_Syntax.pos
+  fun uu____5472  ->
+    match uu____5472 with | (hd,uu____5480) -> hd.FStar_Syntax_Syntax.pos
   
 let range_of_args :
-  'uuuuuu5509 'uuuuuu5510 .
-    ('uuuuuu5509 FStar_Syntax_Syntax.syntax * 'uuuuuu5510) Prims.list ->
+  'uuuuuu5494 'uuuuuu5495 .
+    ('uuuuuu5494 FStar_Syntax_Syntax.syntax * 'uuuuuu5495) Prims.list ->
       FStar_Range.range -> FStar_Range.range
   =
   fun args  ->
@@ -1405,10 +1401,9 @@ let (mk_app :
     fun args  ->
       match args with
       | [] -> f
-      | uu____5608 ->
+      | uu____5593 ->
           let r = range_of_args args f.FStar_Syntax_Syntax.pos  in
-          FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (f, args))
-            FStar_Pervasives_Native.None r
+          FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (f, args)) r
   
 let (mk_app_binders :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -1418,15 +1413,15 @@ let (mk_app_binders :
   =
   fun f  ->
     fun bs  ->
-      let uu____5667 =
+      let uu____5652 =
         FStar_List.map
-          (fun uu____5694  ->
-             match uu____5694 with
+          (fun uu____5679  ->
+             match uu____5679 with
              | (bv,aq) ->
-                 let uu____5713 = FStar_Syntax_Syntax.bv_to_name bv  in
-                 (uu____5713, aq)) bs
+                 let uu____5698 = FStar_Syntax_Syntax.bv_to_name bv  in
+                 (uu____5698, aq)) bs
          in
-      mk_app f uu____5667
+      mk_app f uu____5652
   
 let (field_projector_prefix : Prims.string) = "__proj__" 
 let (field_projector_sep : Prims.string) = "__item__" 
@@ -1448,20 +1443,20 @@ let (mk_field_projector_name_from_ident :
         if field_projector_contains_constructor itext
         then i
         else
-          (let uu____5764 =
-             let uu____5770 =
-               let uu____5772 =
-                 let uu____5774 = FStar_Ident.ident_of_lid lid  in
-                 FStar_Ident.text_of_id uu____5774  in
-               mk_field_projector_name_from_string uu____5772 itext  in
-             let uu____5775 = FStar_Ident.range_of_id i  in
-             (uu____5770, uu____5775)  in
-           FStar_Ident.mk_ident uu____5764)
+          (let uu____5749 =
+             let uu____5755 =
+               let uu____5757 =
+                 let uu____5759 = FStar_Ident.ident_of_lid lid  in
+                 FStar_Ident.text_of_id uu____5759  in
+               mk_field_projector_name_from_string uu____5757 itext  in
+             let uu____5760 = FStar_Ident.range_of_id i  in
+             (uu____5755, uu____5760)  in
+           FStar_Ident.mk_ident uu____5749)
          in
-      let uu____5777 =
-        let uu____5778 = FStar_Ident.ns_of_lid lid  in
-        FStar_List.append uu____5778 [newi]  in
-      FStar_Ident.lid_of_ids uu____5777
+      let uu____5762 =
+        let uu____5763 = FStar_Ident.ns_of_lid lid  in
+        FStar_List.append uu____5763 [newi]  in
+      FStar_Ident.lid_of_ids uu____5762
   
 let (mk_field_projector_name :
   FStar_Ident.lident ->
@@ -1471,16 +1466,16 @@ let (mk_field_projector_name :
     fun x  ->
       fun i  ->
         let nm =
-          let uu____5800 = FStar_Syntax_Syntax.is_null_bv x  in
-          if uu____5800
+          let uu____5785 = FStar_Syntax_Syntax.is_null_bv x  in
+          if uu____5785
           then
-            let uu____5803 =
-              let uu____5809 =
-                let uu____5811 = FStar_Util.string_of_int i  in
-                Prims.op_Hat "_" uu____5811  in
-              let uu____5814 = FStar_Syntax_Syntax.range_of_bv x  in
-              (uu____5809, uu____5814)  in
-            FStar_Ident.mk_ident uu____5803
+            let uu____5788 =
+              let uu____5794 =
+                let uu____5796 = FStar_Util.string_of_int i  in
+                Prims.op_Hat "_" uu____5796  in
+              let uu____5799 = FStar_Syntax_Syntax.range_of_bv x  in
+              (uu____5794, uu____5799)  in
+            FStar_Ident.mk_ident uu____5788
           else x.FStar_Syntax_Syntax.ppname  in
         mk_field_projector_name_from_ident lid nm
   
@@ -1488,23 +1483,23 @@ let (ses_of_sigbundle :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt Prims.list) =
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_bundle (ses,uu____5829) -> ses
-    | uu____5838 -> failwith "ses_of_sigbundle: not a Sig_bundle"
+    | FStar_Syntax_Syntax.Sig_bundle (ses,uu____5814) -> ses
+    | uu____5823 -> failwith "ses_of_sigbundle: not a Sig_bundle"
   
 let (set_uvar : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit)
   =
   fun uv  ->
     fun t  ->
-      let uu____5853 = FStar_Syntax_Unionfind.find uv  in
-      match uu____5853 with
-      | FStar_Pervasives_Native.Some uu____5856 ->
-          let uu____5857 =
-            let uu____5859 =
-              let uu____5861 = FStar_Syntax_Unionfind.uvar_id uv  in
-              FStar_All.pipe_left FStar_Util.string_of_int uu____5861  in
-            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____5859  in
-          failwith uu____5857
-      | uu____5866 -> FStar_Syntax_Unionfind.change uv t
+      let uu____5838 = FStar_Syntax_Unionfind.find uv  in
+      match uu____5838 with
+      | FStar_Pervasives_Native.Some uu____5841 ->
+          let uu____5842 =
+            let uu____5844 =
+              let uu____5846 = FStar_Syntax_Unionfind.uvar_id uv  in
+              FStar_All.pipe_left FStar_Util.string_of_int uu____5846  in
+            FStar_Util.format1 "Changing a fixed uvar! ?%s\n" uu____5844  in
+          failwith uu____5842
+      | uu____5851 -> FStar_Syntax_Unionfind.change uv t
   
 let (qualifier_equal :
   FStar_Syntax_Syntax.qualifier ->
@@ -1519,44 +1514,44 @@ let (qualifier_equal :
       | (FStar_Syntax_Syntax.Projector
          (l1a,l1b),FStar_Syntax_Syntax.Projector (l2a,l2b)) ->
           (FStar_Ident.lid_equals l1a l2a) &&
-            (let uu____5890 = FStar_Ident.text_of_id l1b  in
-             let uu____5892 = FStar_Ident.text_of_id l2b  in
-             uu____5890 = uu____5892)
+            (let uu____5875 = FStar_Ident.text_of_id l1b  in
+             let uu____5877 = FStar_Ident.text_of_id l2b  in
+             uu____5875 = uu____5877)
       | (FStar_Syntax_Syntax.RecordType
          (ns1,f1),FStar_Syntax_Syntax.RecordType (ns2,f2)) ->
           ((((FStar_List.length ns1) = (FStar_List.length ns2)) &&
               (FStar_List.forall2
                  (fun x1  ->
                     fun x2  ->
-                      let uu____5921 = FStar_Ident.text_of_id x1  in
-                      let uu____5923 = FStar_Ident.text_of_id x2  in
-                      uu____5921 = uu____5923) f1 f2))
+                      let uu____5906 = FStar_Ident.text_of_id x1  in
+                      let uu____5908 = FStar_Ident.text_of_id x2  in
+                      uu____5906 = uu____5908) f1 f2))
              && ((FStar_List.length f1) = (FStar_List.length f2)))
             &&
             (FStar_List.forall2
                (fun x1  ->
                   fun x2  ->
-                    let uu____5932 = FStar_Ident.text_of_id x1  in
-                    let uu____5934 = FStar_Ident.text_of_id x2  in
-                    uu____5932 = uu____5934) f1 f2)
+                    let uu____5917 = FStar_Ident.text_of_id x1  in
+                    let uu____5919 = FStar_Ident.text_of_id x2  in
+                    uu____5917 = uu____5919) f1 f2)
       | (FStar_Syntax_Syntax.RecordConstructor
          (ns1,f1),FStar_Syntax_Syntax.RecordConstructor (ns2,f2)) ->
           ((((FStar_List.length ns1) = (FStar_List.length ns2)) &&
               (FStar_List.forall2
                  (fun x1  ->
                     fun x2  ->
-                      let uu____5963 = FStar_Ident.text_of_id x1  in
-                      let uu____5965 = FStar_Ident.text_of_id x2  in
-                      uu____5963 = uu____5965) f1 f2))
+                      let uu____5948 = FStar_Ident.text_of_id x1  in
+                      let uu____5950 = FStar_Ident.text_of_id x2  in
+                      uu____5948 = uu____5950) f1 f2))
              && ((FStar_List.length f1) = (FStar_List.length f2)))
             &&
             (FStar_List.forall2
                (fun x1  ->
                   fun x2  ->
-                    let uu____5974 = FStar_Ident.text_of_id x1  in
-                    let uu____5976 = FStar_Ident.text_of_id x2  in
-                    uu____5974 = uu____5976) f1 f2)
-      | uu____5979 -> q1 = q2
+                    let uu____5959 = FStar_Ident.text_of_id x1  in
+                    let uu____5961 = FStar_Ident.text_of_id x2  in
+                    uu____5959 = uu____5961) f1 f2)
+      | uu____5964 -> q1 = q2
   
 let (abs :
   FStar_Syntax_Syntax.binders ->
@@ -1571,54 +1566,47 @@ let (abs :
           match lopt1 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some rc ->
-              let uu____6025 =
-                let uu___1007_6026 = rc  in
-                let uu____6027 =
+              let uu____6010 =
+                let uu___1007_6011 = rc  in
+                let uu____6012 =
                   FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                     (FStar_Syntax_Subst.close bs)
                    in
                 {
                   FStar_Syntax_Syntax.residual_effect =
-                    (uu___1007_6026.FStar_Syntax_Syntax.residual_effect);
-                  FStar_Syntax_Syntax.residual_typ = uu____6027;
+                    (uu___1007_6011.FStar_Syntax_Syntax.residual_effect);
+                  FStar_Syntax_Syntax.residual_typ = uu____6012;
                   FStar_Syntax_Syntax.residual_flags =
-                    (uu___1007_6026.FStar_Syntax_Syntax.residual_flags)
+                    (uu___1007_6011.FStar_Syntax_Syntax.residual_flags)
                 }  in
-              FStar_Pervasives_Native.Some uu____6025
+              FStar_Pervasives_Native.Some uu____6010
            in
         match bs with
         | [] -> t
-        | uu____6044 ->
+        | uu____6029 ->
             let body =
-              let uu____6046 = FStar_Syntax_Subst.close bs t  in
-              FStar_Syntax_Subst.compress uu____6046  in
+              let uu____6031 = FStar_Syntax_Subst.close bs t  in
+              FStar_Syntax_Subst.compress uu____6031  in
             (match body.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Tm_abs (bs',t1,lopt') ->
-                 let uu____6076 =
-                   let uu____6083 =
-                     let uu____6084 =
-                       let uu____6103 =
-                         let uu____6112 = FStar_Syntax_Subst.close_binders bs
-                            in
-                         FStar_List.append uu____6112 bs'  in
-                       let uu____6127 = close_lopt lopt'  in
-                       (uu____6103, t1, uu____6127)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____6084  in
-                   FStar_Syntax_Syntax.mk uu____6083  in
-                 uu____6076 FStar_Pervasives_Native.None
-                   t1.FStar_Syntax_Syntax.pos
-             | uu____6142 ->
-                 let uu____6143 =
-                   let uu____6150 =
-                     let uu____6151 =
-                       let uu____6170 = FStar_Syntax_Subst.close_binders bs
+                 let uu____6061 =
+                   let uu____6062 =
+                     let uu____6081 =
+                       let uu____6090 = FStar_Syntax_Subst.close_binders bs
                           in
-                       let uu____6179 = close_lopt lopt  in
-                       (uu____6170, body, uu____6179)  in
-                     FStar_Syntax_Syntax.Tm_abs uu____6151  in
-                   FStar_Syntax_Syntax.mk uu____6150  in
-                 uu____6143 FStar_Pervasives_Native.None
-                   t.FStar_Syntax_Syntax.pos)
+                       FStar_List.append uu____6090 bs'  in
+                     let uu____6105 = close_lopt lopt'  in
+                     (uu____6081, t1, uu____6105)  in
+                   FStar_Syntax_Syntax.Tm_abs uu____6062  in
+                 FStar_Syntax_Syntax.mk uu____6061 t1.FStar_Syntax_Syntax.pos
+             | uu____6120 ->
+                 let uu____6121 =
+                   let uu____6122 =
+                     let uu____6141 = FStar_Syntax_Subst.close_binders bs  in
+                     let uu____6150 = close_lopt lopt  in
+                     (uu____6141, body, uu____6150)  in
+                   FStar_Syntax_Syntax.Tm_abs uu____6122  in
+                 FStar_Syntax_Syntax.mk uu____6121 t.FStar_Syntax_Syntax.pos)
   
 let (arrow :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -1630,16 +1618,14 @@ let (arrow :
     fun c  ->
       match bs with
       | [] -> comp_result c
-      | uu____6235 ->
-          let uu____6244 =
-            let uu____6251 =
-              let uu____6252 =
-                let uu____6267 = FStar_Syntax_Subst.close_binders bs  in
-                let uu____6276 = FStar_Syntax_Subst.close_comp bs c  in
-                (uu____6267, uu____6276)  in
-              FStar_Syntax_Syntax.Tm_arrow uu____6252  in
-            FStar_Syntax_Syntax.mk uu____6251  in
-          uu____6244 FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
+      | uu____6206 ->
+          let uu____6215 =
+            let uu____6216 =
+              let uu____6231 = FStar_Syntax_Subst.close_binders bs  in
+              let uu____6240 = FStar_Syntax_Subst.close_comp bs c  in
+              (uu____6231, uu____6240)  in
+            FStar_Syntax_Syntax.Tm_arrow uu____6216  in
+          FStar_Syntax_Syntax.mk uu____6215 c.FStar_Syntax_Syntax.pos
   
 let (flat_arrow :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -1650,54 +1636,54 @@ let (flat_arrow :
   fun bs  ->
     fun c  ->
       let t = arrow bs c  in
-      let uu____6325 =
-        let uu____6326 = FStar_Syntax_Subst.compress t  in
-        uu____6326.FStar_Syntax_Syntax.n  in
-      match uu____6325 with
+      let uu____6289 =
+        let uu____6290 = FStar_Syntax_Subst.compress t  in
+        uu____6290.FStar_Syntax_Syntax.n  in
+      match uu____6289 with
       | FStar_Syntax_Syntax.Tm_arrow (bs1,c1) ->
           (match c1.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Total (tres,uu____6356) ->
-               let uu____6365 =
-                 let uu____6366 = FStar_Syntax_Subst.compress tres  in
-                 uu____6366.FStar_Syntax_Syntax.n  in
-               (match uu____6365 with
+           | FStar_Syntax_Syntax.Total (tres,uu____6320) ->
+               let uu____6329 =
+                 let uu____6330 = FStar_Syntax_Subst.compress tres  in
+                 uu____6330.FStar_Syntax_Syntax.n  in
+               (match uu____6329 with
                 | FStar_Syntax_Syntax.Tm_arrow (bs',c') ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_arrow
                          ((FStar_List.append bs1 bs'), c'))
-                      FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
-                | uu____6409 -> t)
-           | uu____6410 -> t)
-      | uu____6411 -> t
+                      t.FStar_Syntax_Syntax.pos
+                | uu____6373 -> t)
+           | uu____6374 -> t)
+      | uu____6375 -> t
   
 let rec (canon_arrow :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun t  ->
-    let uu____6424 =
-      let uu____6425 = FStar_Syntax_Subst.compress t  in
-      uu____6425.FStar_Syntax_Syntax.n  in
-    match uu____6424 with
+    let uu____6388 =
+      let uu____6389 = FStar_Syntax_Subst.compress t  in
+      uu____6389.FStar_Syntax_Syntax.n  in
+    match uu____6388 with
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
         let cn =
           match c.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Total (t1,u) ->
-              let uu____6463 =
-                let uu____6472 = canon_arrow t1  in (uu____6472, u)  in
-              FStar_Syntax_Syntax.Total uu____6463
-          | uu____6479 -> c.FStar_Syntax_Syntax.n  in
+              let uu____6427 =
+                let uu____6436 = canon_arrow t1  in (uu____6436, u)  in
+              FStar_Syntax_Syntax.Total uu____6427
+          | uu____6443 -> c.FStar_Syntax_Syntax.n  in
         let c1 =
-          let uu___1051_6483 = c  in
+          let uu___1051_6447 = c  in
           {
             FStar_Syntax_Syntax.n = cn;
             FStar_Syntax_Syntax.pos =
-              (uu___1051_6483.FStar_Syntax_Syntax.pos);
+              (uu___1051_6447.FStar_Syntax_Syntax.pos);
             FStar_Syntax_Syntax.vars =
-              (uu___1051_6483.FStar_Syntax_Syntax.vars)
+              (uu___1051_6447.FStar_Syntax_Syntax.vars)
           }  in
         flat_arrow bs c1
-    | uu____6486 -> t
+    | uu____6450 -> t
   
 let (refine :
   FStar_Syntax_Syntax.bv ->
@@ -1706,21 +1692,19 @@ let (refine :
   =
   fun b  ->
     fun t  ->
-      let uu____6504 =
-        let uu____6505 = FStar_Syntax_Syntax.range_of_bv b  in
-        FStar_Range.union_ranges uu____6505 t.FStar_Syntax_Syntax.pos  in
-      let uu____6506 =
-        let uu____6513 =
-          let uu____6514 =
-            let uu____6521 =
-              let uu____6524 =
-                let uu____6525 = FStar_Syntax_Syntax.mk_binder b  in
-                [uu____6525]  in
-              FStar_Syntax_Subst.close uu____6524 t  in
-            (b, uu____6521)  in
-          FStar_Syntax_Syntax.Tm_refine uu____6514  in
-        FStar_Syntax_Syntax.mk uu____6513  in
-      uu____6506 FStar_Pervasives_Native.None uu____6504
+      let uu____6468 =
+        let uu____6469 =
+          let uu____6476 =
+            let uu____6479 =
+              let uu____6480 = FStar_Syntax_Syntax.mk_binder b  in
+              [uu____6480]  in
+            FStar_Syntax_Subst.close uu____6479 t  in
+          (b, uu____6476)  in
+        FStar_Syntax_Syntax.Tm_refine uu____6469  in
+      let uu____6501 =
+        let uu____6502 = FStar_Syntax_Syntax.range_of_bv b  in
+        FStar_Range.union_ranges uu____6502 t.FStar_Syntax_Syntax.pos  in
+      FStar_Syntax_Syntax.mk uu____6468 uu____6501
   
 let (branch : FStar_Syntax_Syntax.branch -> FStar_Syntax_Syntax.branch) =
   fun b  -> FStar_Syntax_Subst.close_branch b 
@@ -1733,45 +1717,45 @@ let rec (arrow_formals_comp_ln :
     let k1 = FStar_Syntax_Subst.compress k  in
     match k1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____6605 = is_total_comp c  in
-        if uu____6605
+        let uu____6562 = is_total_comp c  in
+        if uu____6562
         then
-          let uu____6620 = arrow_formals_comp_ln (comp_result c)  in
-          (match uu____6620 with
+          let uu____6577 = arrow_formals_comp_ln (comp_result c)  in
+          (match uu____6577 with
            | (bs',k2) -> ((FStar_List.append bs bs'), k2))
         else (bs, c)
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____6687;
-           FStar_Syntax_Syntax.index = uu____6688;
-           FStar_Syntax_Syntax.sort = s;_},uu____6690)
+        ({ FStar_Syntax_Syntax.ppname = uu____6644;
+           FStar_Syntax_Syntax.index = uu____6645;
+           FStar_Syntax_Syntax.sort = s;_},uu____6647)
         ->
         let rec aux s1 k2 =
-          let uu____6721 =
-            let uu____6722 = FStar_Syntax_Subst.compress s1  in
-            uu____6722.FStar_Syntax_Syntax.n  in
-          match uu____6721 with
-          | FStar_Syntax_Syntax.Tm_arrow uu____6737 ->
+          let uu____6678 =
+            let uu____6679 = FStar_Syntax_Subst.compress s1  in
+            uu____6679.FStar_Syntax_Syntax.n  in
+          match uu____6678 with
+          | FStar_Syntax_Syntax.Tm_arrow uu____6694 ->
               arrow_formals_comp_ln s1
           | FStar_Syntax_Syntax.Tm_refine
-              ({ FStar_Syntax_Syntax.ppname = uu____6752;
-                 FStar_Syntax_Syntax.index = uu____6753;
-                 FStar_Syntax_Syntax.sort = s2;_},uu____6755)
+              ({ FStar_Syntax_Syntax.ppname = uu____6709;
+                 FStar_Syntax_Syntax.index = uu____6710;
+                 FStar_Syntax_Syntax.sort = s2;_},uu____6712)
               -> aux s2 k2
-          | uu____6763 ->
-              let uu____6764 = FStar_Syntax_Syntax.mk_Total k2  in
-              ([], uu____6764)
+          | uu____6720 ->
+              let uu____6721 = FStar_Syntax_Syntax.mk_Total k2  in
+              ([], uu____6721)
            in
         aux s k1
-    | uu____6779 ->
-        let uu____6780 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____6780)
+    | uu____6736 ->
+        let uu____6737 = FStar_Syntax_Syntax.mk_Total k1  in ([], uu____6737)
   
 let (arrow_formals_comp :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun k  ->
-    let uu____6805 = arrow_formals_comp_ln k  in
-    match uu____6805 with | (bs,c) -> FStar_Syntax_Subst.open_comp bs c
+    let uu____6762 = arrow_formals_comp_ln k  in
+    match uu____6762 with | (bs,c) -> FStar_Syntax_Subst.open_comp bs c
   
 let (arrow_formals_ln :
   FStar_Syntax_Syntax.term ->
@@ -1780,8 +1764,8 @@ let (arrow_formals_ln :
       FStar_Syntax_Syntax.syntax))
   =
   fun k  ->
-    let uu____6860 = arrow_formals_comp_ln k  in
-    match uu____6860 with | (bs,c) -> (bs, (comp_result c))
+    let uu____6817 = arrow_formals_comp_ln k  in
+    match uu____6817 with | (bs,c) -> (bs, (comp_result c))
   
 let (arrow_formals :
   FStar_Syntax_Syntax.term ->
@@ -1789,8 +1773,8 @@ let (arrow_formals :
       FStar_Syntax_Syntax.syntax))
   =
   fun k  ->
-    let uu____6927 = arrow_formals_comp k  in
-    match uu____6927 with | (bs,c) -> (bs, (comp_result c))
+    let uu____6884 = arrow_formals_comp k  in
+    match uu____6884 with | (bs,c) -> (bs, (comp_result c))
   
 let (let_rec_arity :
   FStar_Syntax_Syntax.letbinding ->
@@ -1801,56 +1785,56 @@ let (let_rec_arity :
       let k1 = FStar_Syntax_Subst.compress k  in
       match k1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____7029 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____7029 with
+          let uu____6986 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____6986 with
            | (bs1,c1) ->
                let ct = comp_to_comp_typ c1  in
-               let uu____7053 =
+               let uu____7010 =
                  FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                    (FStar_Util.find_opt
-                      (fun uu___8_7062  ->
-                         match uu___8_7062 with
-                         | FStar_Syntax_Syntax.DECREASES uu____7064 -> true
-                         | uu____7068 -> false))
+                      (fun uu___8_7019  ->
+                         match uu___8_7019 with
+                         | FStar_Syntax_Syntax.DECREASES uu____7021 -> true
+                         | uu____7025 -> false))
                   in
-               (match uu____7053 with
+               (match uu____7010 with
                 | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                     d) -> (bs1, (FStar_Pervasives_Native.Some d))
-                | uu____7103 ->
-                    let uu____7106 = is_total_comp c1  in
-                    if uu____7106
+                | uu____7060 ->
+                    let uu____7063 = is_total_comp c1  in
+                    if uu____7063
                     then
-                      let uu____7125 = arrow_until_decreases (comp_result c1)
+                      let uu____7082 = arrow_until_decreases (comp_result c1)
                          in
-                      (match uu____7125 with
+                      (match uu____7082 with
                        | (bs',d) -> ((FStar_List.append bs1 bs'), d))
                     else (bs1, FStar_Pervasives_Native.None)))
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____7218;
-             FStar_Syntax_Syntax.index = uu____7219;
-             FStar_Syntax_Syntax.sort = k2;_},uu____7221)
+          ({ FStar_Syntax_Syntax.ppname = uu____7175;
+             FStar_Syntax_Syntax.index = uu____7176;
+             FStar_Syntax_Syntax.sort = k2;_},uu____7178)
           -> arrow_until_decreases k2
-      | uu____7229 -> ([], FStar_Pervasives_Native.None)  in
-    let uu____7250 = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp  in
-    match uu____7250 with
+      | uu____7186 -> ([], FStar_Pervasives_Native.None)  in
+    let uu____7207 = arrow_until_decreases lb.FStar_Syntax_Syntax.lbtyp  in
+    match uu____7207 with
     | (bs,dopt) ->
         let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs  in
-        let uu____7304 =
+        let uu____7261 =
           FStar_Util.map_opt dopt
             (fun d  ->
                let d_bvs = FStar_Syntax_Free.names d  in
-               let uu____7325 =
-                 FStar_Common.tabulate n_univs (fun uu____7331  -> false)  in
-               let uu____7334 =
+               let uu____7282 =
+                 FStar_Common.tabulate n_univs (fun uu____7288  -> false)  in
+               let uu____7291 =
                  FStar_All.pipe_right bs
                    (FStar_List.map
-                      (fun uu____7359  ->
-                         match uu____7359 with
-                         | (x,uu____7368) -> FStar_Util.set_mem x d_bvs))
+                      (fun uu____7316  ->
+                         match uu____7316 with
+                         | (x,uu____7325) -> FStar_Util.set_mem x d_bvs))
                   in
-               FStar_List.append uu____7325 uu____7334)
+               FStar_List.append uu____7282 uu____7291)
            in
-        ((n_univs + (FStar_List.length bs)), uu____7304)
+        ((n_univs + (FStar_List.length bs)), uu____7261)
   
 let (abs_formals :
   FStar_Syntax_Syntax.term ->
@@ -1861,46 +1845,46 @@ let (abs_formals :
     let subst_lcomp_opt s l =
       match l with
       | FStar_Pervasives_Native.Some rc ->
-          let uu____7424 =
-            let uu___1149_7425 = rc  in
-            let uu____7426 =
+          let uu____7381 =
+            let uu___1149_7382 = rc  in
+            let uu____7383 =
               FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                 (FStar_Syntax_Subst.subst s)
                in
             {
               FStar_Syntax_Syntax.residual_effect =
-                (uu___1149_7425.FStar_Syntax_Syntax.residual_effect);
-              FStar_Syntax_Syntax.residual_typ = uu____7426;
+                (uu___1149_7382.FStar_Syntax_Syntax.residual_effect);
+              FStar_Syntax_Syntax.residual_typ = uu____7383;
               FStar_Syntax_Syntax.residual_flags =
-                (uu___1149_7425.FStar_Syntax_Syntax.residual_flags)
+                (uu___1149_7382.FStar_Syntax_Syntax.residual_flags)
             }  in
-          FStar_Pervasives_Native.Some uu____7424
-      | uu____7435 -> l  in
+          FStar_Pervasives_Native.Some uu____7381
+      | uu____7392 -> l  in
     let rec aux t1 abs_body_lcomp =
-      let uu____7469 =
-        let uu____7470 =
-          let uu____7473 = FStar_Syntax_Subst.compress t1  in
-          FStar_All.pipe_left unascribe uu____7473  in
-        uu____7470.FStar_Syntax_Syntax.n  in
-      match uu____7469 with
+      let uu____7426 =
+        let uu____7427 =
+          let uu____7430 = FStar_Syntax_Subst.compress t1  in
+          FStar_All.pipe_left unascribe uu____7430  in
+        uu____7427.FStar_Syntax_Syntax.n  in
+      match uu____7426 with
       | FStar_Syntax_Syntax.Tm_abs (bs,t2,what) ->
-          let uu____7519 = aux t2 what  in
-          (match uu____7519 with
+          let uu____7476 = aux t2 what  in
+          (match uu____7476 with
            | (bs',t3,what1) -> ((FStar_List.append bs bs'), t3, what1))
-      | uu____7591 -> ([], t1, abs_body_lcomp)  in
-    let uu____7608 = aux t FStar_Pervasives_Native.None  in
-    match uu____7608 with
+      | uu____7548 -> ([], t1, abs_body_lcomp)  in
+    let uu____7565 = aux t FStar_Pervasives_Native.None  in
+    match uu____7565 with
     | (bs,t1,abs_body_lcomp) ->
-        let uu____7656 = FStar_Syntax_Subst.open_term' bs t1  in
-        (match uu____7656 with
+        let uu____7613 = FStar_Syntax_Subst.open_term' bs t1  in
+        (match uu____7613 with
          | (bs1,t2,opening) ->
              let abs_body_lcomp1 = subst_lcomp_opt opening abs_body_lcomp  in
              (bs1, t2, abs_body_lcomp1))
   
 let (remove_inacc : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let no_acc uu____7690 =
-      match uu____7690 with
+    let no_acc uu____7647 =
+      match uu____7647 with
       | (b,aq) ->
           let aq1 =
             match aq with
@@ -1908,24 +1892,21 @@ let (remove_inacc : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
                 (true )) ->
                 FStar_Pervasives_Native.Some
                   (FStar_Syntax_Syntax.Implicit false)
-            | uu____7704 -> aq  in
+            | uu____7661 -> aq  in
           (b, aq1)
        in
-    let uu____7709 = arrow_formals_comp_ln t  in
-    match uu____7709 with
+    let uu____7666 = arrow_formals_comp_ln t  in
+    match uu____7666 with
     | (bs,c) ->
         (match bs with
          | [] -> t
-         | uu____7746 ->
-             let uu____7755 =
-               let uu____7762 =
-                 let uu____7763 =
-                   let uu____7778 = FStar_List.map no_acc bs  in
-                   (uu____7778, c)  in
-                 FStar_Syntax_Syntax.Tm_arrow uu____7763  in
-               FStar_Syntax_Syntax.mk uu____7762  in
-             uu____7755 FStar_Pervasives_Native.None
-               t.FStar_Syntax_Syntax.pos)
+         | uu____7703 ->
+             let uu____7712 =
+               let uu____7713 =
+                 let uu____7728 = FStar_List.map no_acc bs  in
+                 (uu____7728, c)  in
+               FStar_Syntax_Syntax.Tm_arrow uu____7713  in
+             FStar_Syntax_Syntax.mk uu____7712 t.FStar_Syntax_Syntax.pos)
   
 let (mk_letbinding :
   (FStar_Syntax_Syntax.bv,FStar_Syntax_Syntax.fv) FStar_Util.either ->
@@ -1973,14 +1954,14 @@ let (close_univs_and_mk_letbinding :
                 fun pos  ->
                   let def1 =
                     match (recs, univ_vars) with
-                    | (FStar_Pervasives_Native.None ,uu____7949) -> def
-                    | (uu____7960,[]) -> def
-                    | (FStar_Pervasives_Native.Some fvs,uu____7972) ->
+                    | (FStar_Pervasives_Native.None ,uu____7899) -> def
+                    | (uu____7910,[]) -> def
+                    | (FStar_Pervasives_Native.Some fvs,uu____7922) ->
                         let universes =
                           FStar_All.pipe_right univ_vars
                             (FStar_List.map
-                               (fun uu____7988  ->
-                                  FStar_Syntax_Syntax.U_name uu____7988))
+                               (fun uu____7938  ->
+                                  FStar_Syntax_Syntax.U_name uu____7938))
                            in
                         let inst =
                           FStar_All.pipe_right fvs
@@ -2011,31 +1992,31 @@ let (open_univ_vars_binders_and_comp :
       fun c  ->
         match binders with
         | [] ->
-            let uu____8070 = FStar_Syntax_Subst.open_univ_vars_comp uvs c  in
-            (match uu____8070 with | (uvs1,c1) -> (uvs1, [], c1))
-        | uu____8105 ->
+            let uu____8020 = FStar_Syntax_Subst.open_univ_vars_comp uvs c  in
+            (match uu____8020 with | (uvs1,c1) -> (uvs1, [], c1))
+        | uu____8055 ->
             let t' = arrow binders c  in
-            let uu____8117 = FStar_Syntax_Subst.open_univ_vars uvs t'  in
-            (match uu____8117 with
+            let uu____8067 = FStar_Syntax_Subst.open_univ_vars uvs t'  in
+            (match uu____8067 with
              | (uvs1,t'1) ->
-                 let uu____8138 =
-                   let uu____8139 = FStar_Syntax_Subst.compress t'1  in
-                   uu____8139.FStar_Syntax_Syntax.n  in
-                 (match uu____8138 with
+                 let uu____8088 =
+                   let uu____8089 = FStar_Syntax_Subst.compress t'1  in
+                   uu____8089.FStar_Syntax_Syntax.n  in
+                 (match uu____8088 with
                   | FStar_Syntax_Syntax.Tm_arrow (binders1,c1) ->
                       (uvs1, binders1, c1)
-                  | uu____8188 -> failwith "Impossible"))
+                  | uu____8138 -> failwith "Impossible"))
   
 let (is_tuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
-        let uu____8213 =
+        let uu____8163 =
           FStar_Ident.string_of_lid
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
            in
-        FStar_Parser_Const.is_tuple_constructor_string uu____8213
-    | uu____8215 -> false
+        FStar_Parser_Const.is_tuple_constructor_string uu____8163
+    | uu____8165 -> false
   
 let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t  ->
@@ -2043,7 +2024,7 @@ let (is_dtuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Parser_Const.is_dtuple_constructor_lid
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-    | uu____8226 -> false
+    | uu____8176 -> false
   
 let (is_lid_equality : FStar_Ident.lident -> Prims.bool) =
   fun x  -> FStar_Ident.lid_equals x FStar_Parser_Const.eq2_lid 
@@ -2068,27 +2049,27 @@ let (is_constructor :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t  ->
     fun lid  ->
-      let uu____8289 =
-        let uu____8290 = pre_typ t  in uu____8290.FStar_Syntax_Syntax.n  in
-      match uu____8289 with
+      let uu____8239 =
+        let uu____8240 = pre_typ t  in uu____8240.FStar_Syntax_Syntax.n  in
+      match uu____8239 with
       | FStar_Syntax_Syntax.Tm_fvar tc ->
           FStar_Ident.lid_equals
             (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v lid
-      | uu____8295 -> false
+      | uu____8245 -> false
   
 let rec (is_constructed_typ :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident -> Prims.bool) =
   fun t  ->
     fun lid  ->
-      let uu____8309 =
-        let uu____8310 = pre_typ t  in uu____8310.FStar_Syntax_Syntax.n  in
-      match uu____8309 with
-      | FStar_Syntax_Syntax.Tm_fvar uu____8314 -> is_constructor t lid
-      | FStar_Syntax_Syntax.Tm_app (t1,uu____8316) ->
+      let uu____8259 =
+        let uu____8260 = pre_typ t  in uu____8260.FStar_Syntax_Syntax.n  in
+      match uu____8259 with
+      | FStar_Syntax_Syntax.Tm_fvar uu____8264 -> is_constructor t lid
+      | FStar_Syntax_Syntax.Tm_app (t1,uu____8266) ->
           is_constructed_typ t1 lid
-      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____8342) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t1,uu____8292) ->
           is_constructed_typ t1 lid
-      | uu____8347 -> false
+      | uu____8297 -> false
   
 let rec (get_tycon :
   FStar_Syntax_Syntax.term ->
@@ -2097,119 +2078,117 @@ let rec (get_tycon :
   fun t  ->
     let t1 = pre_typ t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_bvar uu____8360 ->
+    | FStar_Syntax_Syntax.Tm_bvar uu____8310 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_name uu____8361 ->
+    | FStar_Syntax_Syntax.Tm_name uu____8311 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____8362 ->
+    | FStar_Syntax_Syntax.Tm_fvar uu____8312 ->
         FStar_Pervasives_Native.Some t1
-    | FStar_Syntax_Syntax.Tm_app (t2,uu____8364) -> get_tycon t2
-    | uu____8389 -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Tm_app (t2,uu____8314) -> get_tycon t2
+    | uu____8339 -> FStar_Pervasives_Native.None
   
 let (is_fstar_tactics_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____8397 =
-      let uu____8398 = un_uinst t  in uu____8398.FStar_Syntax_Syntax.n  in
-    match uu____8397 with
+    let uu____8347 =
+      let uu____8348 = un_uinst t  in uu____8348.FStar_Syntax_Syntax.n  in
+    match uu____8347 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.by_tactic_lid
-    | uu____8403 -> false
+    | uu____8353 -> false
   
 let (is_builtin_tactic : FStar_Ident.lident -> Prims.bool) =
   fun md  ->
     let path = FStar_Ident.path_of_lid md  in
     if (FStar_List.length path) > (Prims.of_int (2))
     then
-      let uu____8417 =
-        let uu____8421 = FStar_List.splitAt (Prims.of_int (2)) path  in
-        FStar_Pervasives_Native.fst uu____8421  in
-      match uu____8417 with
+      let uu____8367 =
+        let uu____8371 = FStar_List.splitAt (Prims.of_int (2)) path  in
+        FStar_Pervasives_Native.fst uu____8371  in
+      match uu____8367 with
       | "FStar"::"Tactics"::[] -> true
       | "FStar"::"Reflection"::[] -> true
-      | uu____8453 -> false
+      | uu____8403 -> false
     else false
   
 let (ktype : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
-    FStar_Pervasives_Native.None FStar_Range.dummyRange
+    FStar_Range.dummyRange
   
 let (ktype0 : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_zero)
-    FStar_Pervasives_Native.None FStar_Range.dummyRange
+    FStar_Range.dummyRange
   
 let (type_u :
   unit -> (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.universe)) =
-  fun uu____8472  ->
+  fun uu____8422  ->
     let u =
-      let uu____8478 =
+      let uu____8428 =
         FStar_Syntax_Unionfind.univ_fresh FStar_Range.dummyRange  in
       FStar_All.pipe_left
-        (fun uu____8499  -> FStar_Syntax_Syntax.U_unif uu____8499) uu____8478
+        (fun uu____8449  -> FStar_Syntax_Syntax.U_unif uu____8449) uu____8428
        in
-    let uu____8500 =
+    let uu____8450 =
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
-        FStar_Pervasives_Native.None FStar_Range.dummyRange
+        FStar_Range.dummyRange
        in
-    (uu____8500, u)
+    (uu____8450, u)
   
 let (attr_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun a  ->
     fun a'  ->
-      let uu____8513 = eq_tm a a'  in
-      match uu____8513 with | Equal  -> true | uu____8516 -> false
+      let uu____8463 = eq_tm a a'  in
+      match uu____8463 with | Equal  -> true | uu____8466 -> false
   
 let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
-  let uu____8521 =
-    let uu____8528 =
-      let uu____8529 =
-        let uu____8530 =
-          FStar_Ident.lid_of_path ["FStar"; "Pervasives"; "Substitute"]
-            FStar_Range.dummyRange
-           in
-        FStar_Syntax_Syntax.lid_as_fv uu____8530
-          FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
+  let uu____8471 =
+    let uu____8472 =
+      let uu____8473 =
+        FStar_Ident.lid_of_path ["FStar"; "Pervasives"; "Substitute"]
+          FStar_Range.dummyRange
          in
-      FStar_Syntax_Syntax.Tm_fvar uu____8529  in
-    FStar_Syntax_Syntax.mk uu____8528  in
-  uu____8521 FStar_Pervasives_Native.None FStar_Range.dummyRange 
+      FStar_Syntax_Syntax.lid_as_fv uu____8473
+        FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
+       in
+    FStar_Syntax_Syntax.Tm_fvar uu____8472  in
+  FStar_Syntax_Syntax.mk uu____8471 FStar_Range.dummyRange 
 let (exp_true_bool : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true))
-    FStar_Pervasives_Native.None FStar_Range.dummyRange
+    FStar_Range.dummyRange
   
 let (exp_false_bool : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false))
-    FStar_Pervasives_Native.None FStar_Range.dummyRange
+    FStar_Range.dummyRange
   
 let (exp_unit : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_unit)
-    FStar_Pervasives_Native.None FStar_Range.dummyRange
+    FStar_Range.dummyRange
   
 let (exp_int : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant
          (FStar_Const.Const_int (s, FStar_Pervasives_Native.None)))
-      FStar_Pervasives_Native.None FStar_Range.dummyRange
+      FStar_Range.dummyRange
   
 let (exp_char : FStar_BaseTypes.char -> FStar_Syntax_Syntax.term) =
   fun c  ->
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c))
-      FStar_Pervasives_Native.None FStar_Range.dummyRange
+      FStar_Range.dummyRange
   
 let (exp_string : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s  ->
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_constant
          (FStar_Const.Const_string (s, FStar_Range.dummyRange)))
-      FStar_Pervasives_Native.None FStar_Range.dummyRange
+      FStar_Range.dummyRange
   
 let (fvar_const : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l  ->
@@ -2261,25 +2240,23 @@ let (mk_conj_opt :
       match phi1 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.Some phi2
       | FStar_Pervasives_Native.Some phi11 ->
-          let uu____8643 =
-            let uu____8646 =
+          let uu____8586 =
+            let uu____8589 =
+              let uu____8590 =
+                let uu____8607 =
+                  let uu____8618 = FStar_Syntax_Syntax.as_arg phi11  in
+                  let uu____8627 =
+                    let uu____8638 = FStar_Syntax_Syntax.as_arg phi2  in
+                    [uu____8638]  in
+                  uu____8618 :: uu____8627  in
+                (tand, uu____8607)  in
+              FStar_Syntax_Syntax.Tm_app uu____8590  in
+            let uu____8683 =
               FStar_Range.union_ranges phi11.FStar_Syntax_Syntax.pos
                 phi2.FStar_Syntax_Syntax.pos
                in
-            let uu____8647 =
-              let uu____8654 =
-                let uu____8655 =
-                  let uu____8672 =
-                    let uu____8683 = FStar_Syntax_Syntax.as_arg phi11  in
-                    let uu____8692 =
-                      let uu____8703 = FStar_Syntax_Syntax.as_arg phi2  in
-                      [uu____8703]  in
-                    uu____8683 :: uu____8692  in
-                  (tand, uu____8672)  in
-                FStar_Syntax_Syntax.Tm_app uu____8655  in
-              FStar_Syntax_Syntax.mk uu____8654  in
-            uu____8647 FStar_Pervasives_Native.None uu____8646  in
-          FStar_Pervasives_Native.Some uu____8643
+            FStar_Syntax_Syntax.mk uu____8589 uu____8683  in
+          FStar_Pervasives_Native.Some uu____8586
   
 let (mk_binop :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2290,39 +2267,35 @@ let (mk_binop :
   fun op_t  ->
     fun phi1  ->
       fun phi2  ->
-        let uu____8780 =
+        let uu____8716 =
+          let uu____8717 =
+            let uu____8734 =
+              let uu____8745 = FStar_Syntax_Syntax.as_arg phi1  in
+              let uu____8754 =
+                let uu____8765 = FStar_Syntax_Syntax.as_arg phi2  in
+                [uu____8765]  in
+              uu____8745 :: uu____8754  in
+            (op_t, uu____8734)  in
+          FStar_Syntax_Syntax.Tm_app uu____8717  in
+        let uu____8810 =
           FStar_Range.union_ranges phi1.FStar_Syntax_Syntax.pos
             phi2.FStar_Syntax_Syntax.pos
            in
-        let uu____8781 =
-          let uu____8788 =
-            let uu____8789 =
-              let uu____8806 =
-                let uu____8817 = FStar_Syntax_Syntax.as_arg phi1  in
-                let uu____8826 =
-                  let uu____8837 = FStar_Syntax_Syntax.as_arg phi2  in
-                  [uu____8837]  in
-                uu____8817 :: uu____8826  in
-              (op_t, uu____8806)  in
-            FStar_Syntax_Syntax.Tm_app uu____8789  in
-          FStar_Syntax_Syntax.mk uu____8788  in
-        uu____8781 FStar_Pervasives_Native.None uu____8780
+        FStar_Syntax_Syntax.mk uu____8716 uu____8810
   
 let (mk_neg :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun phi  ->
-    let uu____8894 =
-      let uu____8901 =
-        let uu____8902 =
-          let uu____8919 =
-            let uu____8930 = FStar_Syntax_Syntax.as_arg phi  in [uu____8930]
-             in
-          (t_not, uu____8919)  in
-        FStar_Syntax_Syntax.Tm_app uu____8902  in
-      FStar_Syntax_Syntax.mk uu____8901  in
-    uu____8894 FStar_Pervasives_Native.None phi.FStar_Syntax_Syntax.pos
+    let uu____8823 =
+      let uu____8824 =
+        let uu____8841 =
+          let uu____8852 = FStar_Syntax_Syntax.as_arg phi  in [uu____8852]
+           in
+        (t_not, uu____8841)  in
+      FStar_Syntax_Syntax.Tm_app uu____8824  in
+    FStar_Syntax_Syntax.mk uu____8823 phi.FStar_Syntax_Syntax.pos
   
 let (mk_conj :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2369,44 +2342,41 @@ let (b2t :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   fun e  ->
-    let uu____9127 =
-      let uu____9134 =
-        let uu____9135 =
-          let uu____9152 =
-            let uu____9163 = FStar_Syntax_Syntax.as_arg e  in [uu____9163]
-             in
-          (b2t_v, uu____9152)  in
-        FStar_Syntax_Syntax.Tm_app uu____9135  in
-      FStar_Syntax_Syntax.mk uu____9134  in
-    uu____9127 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+    let uu____9049 =
+      let uu____9050 =
+        let uu____9067 =
+          let uu____9078 = FStar_Syntax_Syntax.as_arg e  in [uu____9078]  in
+        (b2t_v, uu____9067)  in
+      FStar_Syntax_Syntax.Tm_app uu____9050  in
+    FStar_Syntax_Syntax.mk uu____9049 e.FStar_Syntax_Syntax.pos
   
 let (unb2t :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
   =
   fun e  ->
-    let uu____9210 = head_and_args e  in
-    match uu____9210 with
+    let uu____9125 = head_and_args e  in
+    match uu____9125 with
     | (hd,args) ->
-        let uu____9255 =
-          let uu____9270 =
-            let uu____9271 = FStar_Syntax_Subst.compress hd  in
-            uu____9271.FStar_Syntax_Syntax.n  in
-          (uu____9270, args)  in
-        (match uu____9255 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(e1,uu____9288)::[]) when
+        let uu____9170 =
+          let uu____9185 =
+            let uu____9186 = FStar_Syntax_Subst.compress hd  in
+            uu____9186.FStar_Syntax_Syntax.n  in
+          (uu____9185, args)  in
+        (match uu____9170 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(e1,uu____9203)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid ->
              FStar_Pervasives_Native.Some e1
-         | uu____9323 -> FStar_Pervasives_Native.None)
+         | uu____9238 -> FStar_Pervasives_Native.None)
   
 let (is_t_true : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____9345 =
-      let uu____9346 = unmeta t  in uu____9346.FStar_Syntax_Syntax.n  in
-    match uu____9345 with
+    let uu____9260 =
+      let uu____9261 = unmeta t  in uu____9261.FStar_Syntax_Syntax.n  in
+    match uu____9260 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
-    | uu____9351 -> false
+    | uu____9266 -> false
   
 let (mk_conj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2415,12 +2385,12 @@ let (mk_conj_simp :
   =
   fun t1  ->
     fun t2  ->
-      let uu____9374 = is_t_true t1  in
-      if uu____9374
+      let uu____9289 = is_t_true t1  in
+      if uu____9289
       then t2
       else
-        (let uu____9381 = is_t_true t2  in
-         if uu____9381 then t1 else mk_conj t1 t2)
+        (let uu____9296 = is_t_true t2  in
+         if uu____9296 then t1 else mk_conj t1 t2)
   
 let (mk_disj_simp :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2429,12 +2399,12 @@ let (mk_disj_simp :
   =
   fun t1  ->
     fun t2  ->
-      let uu____9409 = is_t_true t1  in
-      if uu____9409
+      let uu____9324 = is_t_true t1  in
+      if uu____9324
       then t_true
       else
-        (let uu____9416 = is_t_true t2  in
-         if uu____9416 then t_true else mk_disj t1 t2)
+        (let uu____9331 = is_t_true t2  in
+         if uu____9331 then t_true else mk_disj t1 t2)
   
 let (teq : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.eq2_lid 
 let (mk_untyped_eq2 :
@@ -2444,23 +2414,21 @@ let (mk_untyped_eq2 :
   =
   fun e1  ->
     fun e2  ->
-      let uu____9445 =
+      let uu____9360 =
+        let uu____9361 =
+          let uu____9378 =
+            let uu____9389 = FStar_Syntax_Syntax.as_arg e1  in
+            let uu____9398 =
+              let uu____9409 = FStar_Syntax_Syntax.as_arg e2  in [uu____9409]
+               in
+            uu____9389 :: uu____9398  in
+          (teq, uu____9378)  in
+        FStar_Syntax_Syntax.Tm_app uu____9361  in
+      let uu____9454 =
         FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
           e2.FStar_Syntax_Syntax.pos
          in
-      let uu____9446 =
-        let uu____9453 =
-          let uu____9454 =
-            let uu____9471 =
-              let uu____9482 = FStar_Syntax_Syntax.as_arg e1  in
-              let uu____9491 =
-                let uu____9502 = FStar_Syntax_Syntax.as_arg e2  in
-                [uu____9502]  in
-              uu____9482 :: uu____9491  in
-            (teq, uu____9471)  in
-          FStar_Syntax_Syntax.Tm_app uu____9454  in
-        FStar_Syntax_Syntax.mk uu____9453  in
-      uu____9446 FStar_Pervasives_Native.None uu____9445
+      FStar_Syntax_Syntax.mk uu____9360 uu____9454
   
 let (mk_eq2 :
   FStar_Syntax_Syntax.universe ->
@@ -2473,26 +2441,24 @@ let (mk_eq2 :
       fun e1  ->
         fun e2  ->
           let eq_inst = FStar_Syntax_Syntax.mk_Tm_uinst teq [u]  in
-          let uu____9569 =
+          let uu____9477 =
+            let uu____9478 =
+              let uu____9495 =
+                let uu____9506 = FStar_Syntax_Syntax.iarg t  in
+                let uu____9515 =
+                  let uu____9526 = FStar_Syntax_Syntax.as_arg e1  in
+                  let uu____9535 =
+                    let uu____9546 = FStar_Syntax_Syntax.as_arg e2  in
+                    [uu____9546]  in
+                  uu____9526 :: uu____9535  in
+                uu____9506 :: uu____9515  in
+              (eq_inst, uu____9495)  in
+            FStar_Syntax_Syntax.Tm_app uu____9478  in
+          let uu____9599 =
             FStar_Range.union_ranges e1.FStar_Syntax_Syntax.pos
               e2.FStar_Syntax_Syntax.pos
              in
-          let uu____9570 =
-            let uu____9577 =
-              let uu____9578 =
-                let uu____9595 =
-                  let uu____9606 = FStar_Syntax_Syntax.iarg t  in
-                  let uu____9615 =
-                    let uu____9626 = FStar_Syntax_Syntax.as_arg e1  in
-                    let uu____9635 =
-                      let uu____9646 = FStar_Syntax_Syntax.as_arg e2  in
-                      [uu____9646]  in
-                    uu____9626 :: uu____9635  in
-                  uu____9606 :: uu____9615  in
-                (eq_inst, uu____9595)  in
-              FStar_Syntax_Syntax.Tm_app uu____9578  in
-            FStar_Syntax_Syntax.mk uu____9577  in
-          uu____9570 FStar_Pervasives_Native.None uu____9569
+          FStar_Syntax_Syntax.mk uu____9477 uu____9599
   
 let (mk_has_type :
   FStar_Syntax_Syntax.term ->
@@ -2509,24 +2475,22 @@ let (mk_has_type :
             (FStar_Syntax_Syntax.Tm_uinst
                (t_has_type,
                  [FStar_Syntax_Syntax.U_zero; FStar_Syntax_Syntax.U_zero]))
-            FStar_Pervasives_Native.None FStar_Range.dummyRange
+            FStar_Range.dummyRange
            in
-        let uu____9723 =
-          let uu____9730 =
-            let uu____9731 =
-              let uu____9748 =
-                let uu____9759 = FStar_Syntax_Syntax.iarg t  in
-                let uu____9768 =
-                  let uu____9779 = FStar_Syntax_Syntax.as_arg x  in
-                  let uu____9788 =
-                    let uu____9799 = FStar_Syntax_Syntax.as_arg t'  in
-                    [uu____9799]  in
-                  uu____9779 :: uu____9788  in
-                uu____9759 :: uu____9768  in
-              (t_has_type1, uu____9748)  in
-            FStar_Syntax_Syntax.Tm_app uu____9731  in
-          FStar_Syntax_Syntax.mk uu____9730  in
-        uu____9723 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____9624 =
+          let uu____9625 =
+            let uu____9642 =
+              let uu____9653 = FStar_Syntax_Syntax.iarg t  in
+              let uu____9662 =
+                let uu____9673 = FStar_Syntax_Syntax.as_arg x  in
+                let uu____9682 =
+                  let uu____9693 = FStar_Syntax_Syntax.as_arg t'  in
+                  [uu____9693]  in
+                uu____9673 :: uu____9682  in
+              uu____9653 :: uu____9662  in
+            (t_has_type1, uu____9642)  in
+          FStar_Syntax_Syntax.Tm_app uu____9625  in
+        FStar_Syntax_Syntax.mk uu____9624 FStar_Range.dummyRange
   
 let (mk_with_type :
   FStar_Syntax_Syntax.universe ->
@@ -2544,37 +2508,33 @@ let (mk_with_type :
         let t_with_type1 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_uinst (t_with_type, [u]))
-            FStar_Pervasives_Native.None FStar_Range.dummyRange
+            FStar_Range.dummyRange
            in
-        let uu____9876 =
-          let uu____9883 =
-            let uu____9884 =
-              let uu____9901 =
-                let uu____9912 = FStar_Syntax_Syntax.iarg t  in
-                let uu____9921 =
-                  let uu____9932 = FStar_Syntax_Syntax.as_arg e  in
-                  [uu____9932]  in
-                uu____9912 :: uu____9921  in
-              (t_with_type1, uu____9901)  in
-            FStar_Syntax_Syntax.Tm_app uu____9884  in
-          FStar_Syntax_Syntax.mk uu____9883  in
-        uu____9876 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____9770 =
+          let uu____9771 =
+            let uu____9788 =
+              let uu____9799 = FStar_Syntax_Syntax.iarg t  in
+              let uu____9808 =
+                let uu____9819 = FStar_Syntax_Syntax.as_arg e  in
+                [uu____9819]  in
+              uu____9799 :: uu____9808  in
+            (t_with_type1, uu____9788)  in
+          FStar_Syntax_Syntax.Tm_app uu____9771  in
+        FStar_Syntax_Syntax.mk uu____9770 FStar_Range.dummyRange
   
 let (lex_t : FStar_Syntax_Syntax.term) =
   fvar_const FStar_Parser_Const.lex_t_lid 
 let (lex_top : FStar_Syntax_Syntax.term) =
-  let uu____9979 =
-    let uu____9986 =
-      let uu____9987 =
-        let uu____9994 =
-          FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
-            FStar_Syntax_Syntax.delta_constant
-            (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-           in
-        (uu____9994, [FStar_Syntax_Syntax.U_zero])  in
-      FStar_Syntax_Syntax.Tm_uinst uu____9987  in
-    FStar_Syntax_Syntax.mk uu____9986  in
-  uu____9979 FStar_Pervasives_Native.None FStar_Range.dummyRange 
+  let uu____9866 =
+    let uu____9867 =
+      let uu____9874 =
+        FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
+          FStar_Syntax_Syntax.delta_constant
+          (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
+         in
+      (uu____9874, [FStar_Syntax_Syntax.U_zero])  in
+    FStar_Syntax_Syntax.Tm_uinst uu____9867  in
+  FStar_Syntax_Syntax.mk uu____9866 FStar_Range.dummyRange 
 let (lex_pair : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.lexcons_lid
     FStar_Syntax_Syntax.delta_constant
@@ -2635,28 +2595,26 @@ let (mk_forall_aux :
   fun fa  ->
     fun x  ->
       fun body  ->
-        let uu____10077 =
-          let uu____10084 =
-            let uu____10085 =
-              let uu____10102 =
-                let uu____10113 =
-                  FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort  in
-                let uu____10122 =
-                  let uu____10133 =
-                    let uu____10142 =
-                      let uu____10143 =
-                        let uu____10144 = FStar_Syntax_Syntax.mk_binder x  in
-                        [uu____10144]  in
-                      abs uu____10143 body
-                        (FStar_Pervasives_Native.Some (residual_tot ktype0))
-                       in
-                    FStar_Syntax_Syntax.as_arg uu____10142  in
-                  [uu____10133]  in
-                uu____10113 :: uu____10122  in
-              (fa, uu____10102)  in
-            FStar_Syntax_Syntax.Tm_app uu____10085  in
-          FStar_Syntax_Syntax.mk uu____10084  in
-        uu____10077 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____9957 =
+          let uu____9958 =
+            let uu____9975 =
+              let uu____9986 =
+                FStar_Syntax_Syntax.iarg x.FStar_Syntax_Syntax.sort  in
+              let uu____9995 =
+                let uu____10006 =
+                  let uu____10015 =
+                    let uu____10016 =
+                      let uu____10017 = FStar_Syntax_Syntax.mk_binder x  in
+                      [uu____10017]  in
+                    abs uu____10016 body
+                      (FStar_Pervasives_Native.Some (residual_tot ktype0))
+                     in
+                  FStar_Syntax_Syntax.as_arg uu____10015  in
+                [uu____10006]  in
+              uu____9986 :: uu____9995  in
+            (fa, uu____9975)  in
+          FStar_Syntax_Syntax.Tm_app uu____9958  in
+        FStar_Syntax_Syntax.mk uu____9957 FStar_Range.dummyRange
   
 let (mk_forall_no_univ :
   FStar_Syntax_Syntax.bv ->
@@ -2683,8 +2641,8 @@ let (close_forall_no_univs :
       FStar_List.fold_right
         (fun b  ->
            fun f1  ->
-             let uu____10271 = FStar_Syntax_Syntax.is_null_binder b  in
-             if uu____10271
+             let uu____10144 = FStar_Syntax_Syntax.is_null_binder b  in
+             if uu____10144
              then f1
              else mk_forall_no_univ (FStar_Pervasives_Native.fst b) f1) bs f
   
@@ -2692,8 +2650,8 @@ let (is_wild_pat :
   FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t -> Prims.bool) =
   fun p  ->
     match p.FStar_Syntax_Syntax.v with
-    | FStar_Syntax_Syntax.Pat_wild uu____10290 -> true
-    | uu____10292 -> false
+    | FStar_Syntax_Syntax.Pat_wild uu____10163 -> true
+    | uu____10165 -> false
   
 let (if_then_else :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -2705,28 +2663,28 @@ let (if_then_else :
     fun t1  ->
       fun t2  ->
         let then_branch =
-          let uu____10339 =
+          let uu____10212 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant (FStar_Const.Const_bool true))
               t1.FStar_Syntax_Syntax.pos
              in
-          (uu____10339, FStar_Pervasives_Native.None, t1)  in
+          (uu____10212, FStar_Pervasives_Native.None, t1)  in
         let else_branch =
-          let uu____10368 =
+          let uu____10241 =
             FStar_Syntax_Syntax.withinfo
               (FStar_Syntax_Syntax.Pat_constant
                  (FStar_Const.Const_bool false)) t2.FStar_Syntax_Syntax.pos
              in
-          (uu____10368, FStar_Pervasives_Native.None, t2)  in
-        let uu____10382 =
-          let uu____10383 =
+          (uu____10241, FStar_Pervasives_Native.None, t2)  in
+        let uu____10255 =
+          let uu____10256 =
             FStar_Range.union_ranges t1.FStar_Syntax_Syntax.pos
               t2.FStar_Syntax_Syntax.pos
              in
-          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____10383  in
+          FStar_Range.union_ranges b.FStar_Syntax_Syntax.pos uu____10256  in
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_match (b, [then_branch; else_branch]))
-          FStar_Pervasives_Native.None uu____10382
+          uu____10255
   
 let (mk_squash :
   FStar_Syntax_Syntax.universe ->
@@ -2740,10 +2698,10 @@ let (mk_squash :
           (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None
          in
-      let uu____10459 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
-      let uu____10462 =
-        let uu____10473 = FStar_Syntax_Syntax.as_arg p  in [uu____10473]  in
-      mk_app uu____10459 uu____10462
+      let uu____10332 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+      let uu____10335 =
+        let uu____10346 = FStar_Syntax_Syntax.as_arg p  in [uu____10346]  in
+      mk_app uu____10332 uu____10335
   
 let (mk_auto_squash :
   FStar_Syntax_Syntax.universe ->
@@ -2757,10 +2715,10 @@ let (mk_auto_squash :
           (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)))
           FStar_Pervasives_Native.None
          in
-      let uu____10513 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
-      let uu____10516 =
-        let uu____10527 = FStar_Syntax_Syntax.as_arg p  in [uu____10527]  in
-      mk_app uu____10513 uu____10516
+      let uu____10386 = FStar_Syntax_Syntax.mk_Tm_uinst sq [u]  in
+      let uu____10389 =
+        let uu____10400 = FStar_Syntax_Syntax.as_arg p  in [uu____10400]  in
+      mk_app uu____10386 uu____10389
   
 let (un_squash :
   FStar_Syntax_Syntax.term ->
@@ -2768,18 +2726,18 @@ let (un_squash :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10562 = head_and_args t  in
-    match uu____10562 with
+    let uu____10435 = head_and_args t  in
+    match uu____10435 with
     | (head,args) ->
         let head1 = unascribe head  in
         let head2 = un_uinst head1  in
-        let uu____10611 =
-          let uu____10626 =
-            let uu____10627 = FStar_Syntax_Subst.compress head2  in
-            uu____10627.FStar_Syntax_Syntax.n  in
-          (uu____10626, args)  in
-        (match uu____10611 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____10646)::[]) when
+        let uu____10484 =
+          let uu____10499 =
+            let uu____10500 = FStar_Syntax_Subst.compress head2  in
+            uu____10500.FStar_Syntax_Syntax.n  in
+          (uu____10499, args)  in
+        (match uu____10484 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,(p,uu____10519)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some p
          | (FStar_Syntax_Syntax.Tm_refine (b,p),[]) ->
@@ -2788,27 +2746,27 @@ let (un_squash :
                   FStar_Syntax_Syntax.fv_eq_lid fv
                     FStar_Parser_Const.unit_lid
                   ->
-                  let uu____10712 =
-                    let uu____10717 =
-                      let uu____10718 = FStar_Syntax_Syntax.mk_binder b  in
-                      [uu____10718]  in
-                    FStar_Syntax_Subst.open_term uu____10717 p  in
-                  (match uu____10712 with
+                  let uu____10585 =
+                    let uu____10590 =
+                      let uu____10591 = FStar_Syntax_Syntax.mk_binder b  in
+                      [uu____10591]  in
+                    FStar_Syntax_Subst.open_term uu____10590 p  in
+                  (match uu____10585 with
                    | (bs,p1) ->
                        let b1 =
                          match bs with
                          | b1::[] -> b1
-                         | uu____10775 -> failwith "impossible"  in
-                       let uu____10783 =
-                         let uu____10785 = FStar_Syntax_Free.names p1  in
+                         | uu____10648 -> failwith "impossible"  in
+                       let uu____10656 =
+                         let uu____10658 = FStar_Syntax_Free.names p1  in
                          FStar_Util.set_mem (FStar_Pervasives_Native.fst b1)
-                           uu____10785
+                           uu____10658
                           in
-                       if uu____10783
+                       if uu____10656
                        then FStar_Pervasives_Native.None
                        else FStar_Pervasives_Native.Some p1)
-              | uu____10801 -> FStar_Pervasives_Native.None)
-         | uu____10804 -> FStar_Pervasives_Native.None)
+              | uu____10674 -> FStar_Pervasives_Native.None)
+         | uu____10677 -> FStar_Pervasives_Native.None)
   
 let (is_squash :
   FStar_Syntax_Syntax.term ->
@@ -2816,23 +2774,23 @@ let (is_squash :
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____10835 = head_and_args t  in
-    match uu____10835 with
+    let uu____10708 = head_and_args t  in
+    match uu____10708 with
     | (head,args) ->
-        let uu____10886 =
-          let uu____10901 =
-            let uu____10902 = FStar_Syntax_Subst.compress head  in
-            uu____10902.FStar_Syntax_Syntax.n  in
-          (uu____10901, args)  in
-        (match uu____10886 with
+        let uu____10759 =
+          let uu____10774 =
+            let uu____10775 = FStar_Syntax_Subst.compress head  in
+            uu____10775.FStar_Syntax_Syntax.n  in
+          (uu____10774, args)  in
+        (match uu____10759 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____10924;
-               FStar_Syntax_Syntax.vars = uu____10925;_},u::[]),(t1,uu____10928)::[])
+               FStar_Syntax_Syntax.pos = uu____10797;
+               FStar_Syntax_Syntax.vars = uu____10798;_},u::[]),(t1,uu____10801)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____10975 -> FStar_Pervasives_Native.None)
+         | uu____10848 -> FStar_Pervasives_Native.None)
   
 let (is_auto_squash :
   FStar_Syntax_Syntax.term ->
@@ -2840,35 +2798,35 @@ let (is_auto_squash :
       FStar_Syntax_Syntax.syntax) FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____11010 = head_and_args t  in
-    match uu____11010 with
+    let uu____10883 = head_and_args t  in
+    match uu____10883 with
     | (head,args) ->
-        let uu____11061 =
-          let uu____11076 =
-            let uu____11077 = FStar_Syntax_Subst.compress head  in
-            uu____11077.FStar_Syntax_Syntax.n  in
-          (uu____11076, args)  in
-        (match uu____11061 with
+        let uu____10934 =
+          let uu____10949 =
+            let uu____10950 = FStar_Syntax_Subst.compress head  in
+            uu____10950.FStar_Syntax_Syntax.n  in
+          (uu____10949, args)  in
+        (match uu____10934 with
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-               FStar_Syntax_Syntax.pos = uu____11099;
-               FStar_Syntax_Syntax.vars = uu____11100;_},u::[]),(t1,uu____11103)::[])
+               FStar_Syntax_Syntax.pos = uu____10972;
+               FStar_Syntax_Syntax.vars = uu____10973;_},u::[]),(t1,uu____10976)::[])
              when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.auto_squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
-         | uu____11150 -> FStar_Pervasives_Native.None)
+         | uu____11023 -> FStar_Pervasives_Native.None)
   
 let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____11178 =
-      let uu____11195 = unmeta t  in head_and_args uu____11195  in
-    match uu____11178 with
-    | (head,uu____11198) ->
-        let uu____11223 =
-          let uu____11224 = un_uinst head  in
-          uu____11224.FStar_Syntax_Syntax.n  in
-        (match uu____11223 with
+    let uu____11051 =
+      let uu____11068 = unmeta t  in head_and_args uu____11068  in
+    match uu____11051 with
+    | (head,uu____11071) ->
+        let uu____11096 =
+          let uu____11097 = un_uinst head  in
+          uu____11097.FStar_Syntax_Syntax.n  in
+        (match uu____11096 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              (((((((((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.squash_lid)
@@ -2923,7 +2881,7 @@ let (is_sub_singleton : FStar_Syntax_Syntax.term -> Prims.bool) =
                ||
                (FStar_Syntax_Syntax.fv_eq_lid fv
                   FStar_Parser_Const.precedes_lid)
-         | uu____11229 -> false)
+         | uu____11102 -> false)
   
 let (arrow_one_ln :
   FStar_Syntax_Syntax.typ ->
@@ -2931,22 +2889,22 @@ let (arrow_one_ln :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____11249 =
-      let uu____11250 = FStar_Syntax_Subst.compress t  in
-      uu____11250.FStar_Syntax_Syntax.n  in
-    match uu____11249 with
+    let uu____11122 =
+      let uu____11123 = FStar_Syntax_Subst.compress t  in
+      uu____11123.FStar_Syntax_Syntax.n  in
+    match uu____11122 with
     | FStar_Syntax_Syntax.Tm_arrow ([],c) ->
         failwith "fatal: empty binders on arrow?"
     | FStar_Syntax_Syntax.Tm_arrow (b::[],c) ->
         FStar_Pervasives_Native.Some (b, c)
     | FStar_Syntax_Syntax.Tm_arrow (b::bs,c) ->
-        let uu____11356 =
-          let uu____11361 =
-            let uu____11362 = arrow bs c  in
-            FStar_Syntax_Syntax.mk_Total uu____11362  in
-          (b, uu____11361)  in
-        FStar_Pervasives_Native.Some uu____11356
-    | uu____11367 -> FStar_Pervasives_Native.None
+        let uu____11229 =
+          let uu____11234 =
+            let uu____11235 = arrow bs c  in
+            FStar_Syntax_Syntax.mk_Total uu____11235  in
+          (b, uu____11234)  in
+        FStar_Pervasives_Native.Some uu____11229
+    | uu____11240 -> FStar_Pervasives_Native.None
   
 let (arrow_one :
   FStar_Syntax_Syntax.typ ->
@@ -2954,18 +2912,18 @@ let (arrow_one :
       FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____11390 = arrow_one_ln t  in
-    FStar_Util.bind_opt uu____11390
-      (fun uu____11418  ->
-         match uu____11418 with
+    let uu____11263 = arrow_one_ln t  in
+    FStar_Util.bind_opt uu____11263
+      (fun uu____11291  ->
+         match uu____11291 with
          | (b,c) ->
-             let uu____11437 = FStar_Syntax_Subst.open_comp [b] c  in
-             (match uu____11437 with
+             let uu____11310 = FStar_Syntax_Subst.open_comp [b] c  in
+             (match uu____11310 with
               | (bs,c1) ->
                   let b1 =
                     match bs with
                     | b1::[] -> b1
-                    | uu____11500 ->
+                    | uu____11373 ->
                         failwith
                           "impossible: open_comp returned different amount of binders"
                      in
@@ -2975,8 +2933,8 @@ let (is_free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv  ->
     fun t  ->
-      let uu____11537 = FStar_Syntax_Free.names t  in
-      FStar_Util.set_mem bv uu____11537
+      let uu____11410 = FStar_Syntax_Free.names t  in
+      FStar_Util.set_mem bv uu____11410
   
 type qpats = FStar_Syntax_Syntax.args Prims.list
 type connective =
@@ -2985,7 +2943,7 @@ type connective =
   | BaseConn of (FStar_Ident.lident * FStar_Syntax_Syntax.args) 
 let (uu___is_QAll : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QAll _0 -> true | uu____11589 -> false
+    match projectee with | QAll _0 -> true | uu____11462 -> false
   
 let (__proj__QAll__item___0 :
   connective ->
@@ -2993,7 +2951,7 @@ let (__proj__QAll__item___0 :
   = fun projectee  -> match projectee with | QAll _0 -> _0 
 let (uu___is_QEx : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | QEx _0 -> true | uu____11632 -> false
+    match projectee with | QEx _0 -> true | uu____11505 -> false
   
 let (__proj__QEx__item___0 :
   connective ->
@@ -3001,7 +2959,7 @@ let (__proj__QEx__item___0 :
   = fun projectee  -> match projectee with | QEx _0 -> _0 
 let (uu___is_BaseConn : connective -> Prims.bool) =
   fun projectee  ->
-    match projectee with | BaseConn _0 -> true | uu____11673 -> false
+    match projectee with | BaseConn _0 -> true | uu____11546 -> false
   
 let (__proj__BaseConn__item___0 :
   connective -> (FStar_Ident.lident * FStar_Syntax_Syntax.args)) =
@@ -3048,26 +3006,26 @@ let (destruct_typ_as_formula :
       let f2 = FStar_Syntax_Subst.compress f1  in
       match f2.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t,FStar_Syntax_Syntax.Meta_monadic uu____12059) ->
+          (t,FStar_Syntax_Syntax.Meta_monadic uu____11932) ->
           unmeta_monadic t
       | FStar_Syntax_Syntax.Tm_meta
-          (t,FStar_Syntax_Syntax.Meta_monadic_lift uu____12071) ->
+          (t,FStar_Syntax_Syntax.Meta_monadic_lift uu____11944) ->
           unmeta_monadic t
-      | uu____12084 -> f2  in
+      | uu____11957 -> f2  in
     let lookup_arity_lid table target_lid args =
       let arg_len = FStar_List.length args  in
-      let aux uu____12153 =
-        match uu____12153 with
+      let aux uu____12026 =
+        match uu____12026 with
         | (arity,lids) ->
             if arg_len = arity
             then
               FStar_Util.find_map lids
-                (fun uu____12191  ->
-                   match uu____12191 with
+                (fun uu____12064  ->
+                   match uu____12064 with
                    | (lid,out_lid) ->
-                       let uu____12200 =
+                       let uu____12073 =
                          FStar_Ident.lid_equals target_lid lid  in
-                       if uu____12200
+                       if uu____12073
                        then
                          FStar_Pervasives_Native.Some
                            (BaseConn (out_lid, args))
@@ -3076,43 +3034,43 @@ let (destruct_typ_as_formula :
          in
       FStar_Util.find_map table aux  in
     let destruct_base_conn t =
-      let uu____12227 = head_and_args t  in
-      match uu____12227 with
+      let uu____12100 = head_and_args t  in
+      match uu____12100 with
       | (hd,args) ->
-          let uu____12272 =
-            let uu____12273 = un_uinst hd  in
-            uu____12273.FStar_Syntax_Syntax.n  in
-          (match uu____12272 with
+          let uu____12145 =
+            let uu____12146 = un_uinst hd  in
+            uu____12146.FStar_Syntax_Syntax.n  in
+          (match uu____12145 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                lookup_arity_lid destruct_base_table
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v args
-           | uu____12279 -> FStar_Pervasives_Native.None)
+           | uu____12152 -> FStar_Pervasives_Native.None)
        in
     let destruct_sq_base_conn t =
-      let uu____12288 = un_squash t  in
-      FStar_Util.bind_opt uu____12288
+      let uu____12161 = un_squash t  in
+      FStar_Util.bind_opt uu____12161
         (fun t1  ->
-           let uu____12304 = head_and_args' t1  in
-           match uu____12304 with
+           let uu____12177 = head_and_args' t1  in
+           match uu____12177 with
            | (hd,args) ->
-               let uu____12343 =
-                 let uu____12344 = un_uinst hd  in
-                 uu____12344.FStar_Syntax_Syntax.n  in
-               (match uu____12343 with
+               let uu____12216 =
+                 let uu____12217 = un_uinst hd  in
+                 uu____12217.FStar_Syntax_Syntax.n  in
+               (match uu____12216 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     lookup_arity_lid destruct_sq_base_table
                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       args
-                | uu____12350 -> FStar_Pervasives_Native.None))
+                | uu____12223 -> FStar_Pervasives_Native.None))
        in
     let patterns t =
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta
-          (t2,FStar_Syntax_Syntax.Meta_pattern (uu____12391,pats)) ->
-          let uu____12429 = FStar_Syntax_Subst.compress t2  in
-          (pats, uu____12429)
-      | uu____12442 -> ([], t1)  in
+          (t2,FStar_Syntax_Syntax.Meta_pattern (uu____12264,pats)) ->
+          let uu____12302 = FStar_Syntax_Subst.compress t2  in
+          (pats, uu____12302)
+      | uu____12315 -> ([], t1)  in
     let destruct_q_conn t =
       let is_q fa fv =
         if fa
@@ -3120,228 +3078,228 @@ let (destruct_typ_as_formula :
         else is_exists (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
          in
       let flat t1 =
-        let uu____12509 = head_and_args t1  in
-        match uu____12509 with
+        let uu____12382 = head_and_args t1  in
+        match uu____12382 with
         | (t2,args) ->
-            let uu____12564 = un_uinst t2  in
-            let uu____12565 =
+            let uu____12437 = un_uinst t2  in
+            let uu____12438 =
               FStar_All.pipe_right args
                 (FStar_List.map
-                   (fun uu____12606  ->
-                      match uu____12606 with
+                   (fun uu____12479  ->
+                      match uu____12479 with
                       | (t3,imp) ->
-                          let uu____12625 = unascribe t3  in
-                          (uu____12625, imp)))
+                          let uu____12498 = unascribe t3  in
+                          (uu____12498, imp)))
                in
-            (uu____12564, uu____12565)
+            (uu____12437, uu____12438)
          in
       let rec aux qopt out t1 =
-        let uu____12676 = let uu____12700 = flat t1  in (qopt, uu____12700)
+        let uu____12549 = let uu____12573 = flat t1  in (qopt, uu____12573)
            in
-        match uu____12676 with
+        match uu____12549 with
         | (FStar_Pervasives_Native.Some
            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                 FStar_Syntax_Syntax.pos = uu____12740;
-                 FStar_Syntax_Syntax.vars = uu____12741;_},({
+                 FStar_Syntax_Syntax.pos = uu____12613;
+                 FStar_Syntax_Syntax.vars = uu____12614;_},({
                                                               FStar_Syntax_Syntax.n
                                                                 =
                                                                 FStar_Syntax_Syntax.Tm_abs
-                                                                (b::[],t2,uu____12744);
+                                                                (b::[],t2,uu____12617);
                                                               FStar_Syntax_Syntax.pos
-                                                                = uu____12745;
+                                                                = uu____12618;
                                                               FStar_Syntax_Syntax.vars
-                                                                = uu____12746;_},uu____12747)::[]))
+                                                                = uu____12619;_},uu____12620)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.Some
            fa,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-                 FStar_Syntax_Syntax.pos = uu____12849;
-                 FStar_Syntax_Syntax.vars = uu____12850;_},uu____12851::
+                 FStar_Syntax_Syntax.pos = uu____12722;
+                 FStar_Syntax_Syntax.vars = uu____12723;_},uu____12724::
                ({
                   FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                    (b::[],t2,uu____12854);
-                  FStar_Syntax_Syntax.pos = uu____12855;
-                  FStar_Syntax_Syntax.vars = uu____12856;_},uu____12857)::[]))
+                    (b::[],t2,uu____12727);
+                  FStar_Syntax_Syntax.pos = uu____12728;
+                  FStar_Syntax_Syntax.vars = uu____12729;_},uu____12730)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.None
            ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-               FStar_Syntax_Syntax.pos = uu____12974;
-               FStar_Syntax_Syntax.vars = uu____12975;_},({
+               FStar_Syntax_Syntax.pos = uu____12847;
+               FStar_Syntax_Syntax.vars = uu____12848;_},({
                                                             FStar_Syntax_Syntax.n
                                                               =
                                                               FStar_Syntax_Syntax.Tm_abs
-                                                              (b::[],t2,uu____12978);
+                                                              (b::[],t2,uu____12851);
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu____12979;
+                                                              = uu____12852;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu____12980;_},uu____12981)::[]))
+                                                              = uu____12853;_},uu____12854)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____13074 =
-              let uu____13078 =
+            let uu____12947 =
+              let uu____12951 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                  in
-              FStar_Pervasives_Native.Some uu____13078  in
-            aux uu____13074 (b :: out) t2
+              FStar_Pervasives_Native.Some uu____12951  in
+            aux uu____12947 (b :: out) t2
         | (FStar_Pervasives_Native.None
            ,({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
-               FStar_Syntax_Syntax.pos = uu____13088;
-               FStar_Syntax_Syntax.vars = uu____13089;_},uu____13090::
+               FStar_Syntax_Syntax.pos = uu____12961;
+               FStar_Syntax_Syntax.vars = uu____12962;_},uu____12963::
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                  (b::[],t2,uu____13093);
-                FStar_Syntax_Syntax.pos = uu____13094;
-                FStar_Syntax_Syntax.vars = uu____13095;_},uu____13096)::[]))
+                  (b::[],t2,uu____12966);
+                FStar_Syntax_Syntax.pos = uu____12967;
+                FStar_Syntax_Syntax.vars = uu____12968;_},uu____12969)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu____13205 =
-              let uu____13209 =
+            let uu____13078 =
+              let uu____13082 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                  in
-              FStar_Pervasives_Native.Some uu____13209  in
-            aux uu____13205 (b :: out) t2
-        | (FStar_Pervasives_Native.Some b,uu____13219) ->
+              FStar_Pervasives_Native.Some uu____13082  in
+            aux uu____13078 (b :: out) t2
+        | (FStar_Pervasives_Native.Some b,uu____13092) ->
             let bs = FStar_List.rev out  in
-            let uu____13272 = FStar_Syntax_Subst.open_term bs t1  in
-            (match uu____13272 with
+            let uu____13145 = FStar_Syntax_Subst.open_term bs t1  in
+            (match uu____13145 with
              | (bs1,t2) ->
-                 let uu____13281 = patterns t2  in
-                 (match uu____13281 with
+                 let uu____13154 = patterns t2  in
+                 (match uu____13154 with
                   | (pats,body) ->
                       if b
                       then
                         FStar_Pervasives_Native.Some (QAll (bs1, pats, body))
                       else
                         FStar_Pervasives_Native.Some (QEx (bs1, pats, body))))
-        | uu____13331 -> FStar_Pervasives_Native.None  in
+        | uu____13204 -> FStar_Pervasives_Native.None  in
       aux FStar_Pervasives_Native.None [] t  in
     let rec destruct_sq_forall t =
-      let uu____13386 = un_squash t  in
-      FStar_Util.bind_opt uu____13386
+      let uu____13259 = un_squash t  in
+      FStar_Util.bind_opt uu____13259
         (fun t1  ->
-           let uu____13401 = arrow_one t1  in
-           match uu____13401 with
+           let uu____13274 = arrow_one t1  in
+           match uu____13274 with
            | FStar_Pervasives_Native.Some (b,c) ->
-               let uu____13416 =
-                 let uu____13418 = is_tot_or_gtot_comp c  in
-                 Prims.op_Negation uu____13418  in
-               if uu____13416
+               let uu____13289 =
+                 let uu____13291 = is_tot_or_gtot_comp c  in
+                 Prims.op_Negation uu____13291  in
+               if uu____13289
                then FStar_Pervasives_Native.None
                else
                  (let q =
-                    let uu____13428 = comp_to_comp_typ_nouniv c  in
-                    uu____13428.FStar_Syntax_Syntax.result_typ  in
-                  let uu____13429 =
+                    let uu____13301 = comp_to_comp_typ_nouniv c  in
+                    uu____13301.FStar_Syntax_Syntax.result_typ  in
+                  let uu____13302 =
                     is_free_in (FStar_Pervasives_Native.fst b) q  in
-                  if uu____13429
+                  if uu____13302
                   then
-                    let uu____13436 = patterns q  in
-                    match uu____13436 with
+                    let uu____13309 = patterns q  in
+                    match uu____13309 with
                     | (pats,q1) ->
                         FStar_All.pipe_left maybe_collect
                           (FStar_Pervasives_Native.Some
                              (QAll ([b], pats, q1)))
                   else
-                    (let uu____13499 =
-                       let uu____13500 =
-                         let uu____13505 =
-                           let uu____13506 =
+                    (let uu____13372 =
+                       let uu____13373 =
+                         let uu____13378 =
+                           let uu____13379 =
                              FStar_Syntax_Syntax.as_arg
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                               in
-                           let uu____13517 =
-                             let uu____13528 = FStar_Syntax_Syntax.as_arg q
+                           let uu____13390 =
+                             let uu____13401 = FStar_Syntax_Syntax.as_arg q
                                 in
-                             [uu____13528]  in
-                           uu____13506 :: uu____13517  in
-                         (FStar_Parser_Const.imp_lid, uu____13505)  in
-                       BaseConn uu____13500  in
-                     FStar_Pervasives_Native.Some uu____13499))
-           | uu____13561 -> FStar_Pervasives_Native.None)
+                             [uu____13401]  in
+                           uu____13379 :: uu____13390  in
+                         (FStar_Parser_Const.imp_lid, uu____13378)  in
+                       BaseConn uu____13373  in
+                     FStar_Pervasives_Native.Some uu____13372))
+           | uu____13434 -> FStar_Pervasives_Native.None)
     
     and destruct_sq_exists t =
-      let uu____13569 = un_squash t  in
-      FStar_Util.bind_opt uu____13569
+      let uu____13442 = un_squash t  in
+      FStar_Util.bind_opt uu____13442
         (fun t1  ->
-           let uu____13600 = head_and_args' t1  in
-           match uu____13600 with
+           let uu____13473 = head_and_args' t1  in
+           match uu____13473 with
            | (hd,args) ->
-               let uu____13639 =
-                 let uu____13654 =
-                   let uu____13655 = un_uinst hd  in
-                   uu____13655.FStar_Syntax_Syntax.n  in
-                 (uu____13654, args)  in
-               (match uu____13639 with
+               let uu____13512 =
+                 let uu____13527 =
+                   let uu____13528 = un_uinst hd  in
+                   uu____13528.FStar_Syntax_Syntax.n  in
+                 (uu____13527, args)  in
+               (match uu____13512 with
                 | (FStar_Syntax_Syntax.Tm_fvar
-                   fv,(a1,uu____13672)::(a2,uu____13674)::[]) when
+                   fv,(a1,uu____13545)::(a2,uu____13547)::[]) when
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.dtuple2_lid
                     ->
-                    let uu____13725 =
-                      let uu____13726 = FStar_Syntax_Subst.compress a2  in
-                      uu____13726.FStar_Syntax_Syntax.n  in
-                    (match uu____13725 with
-                     | FStar_Syntax_Syntax.Tm_abs (b::[],q,uu____13733) ->
-                         let uu____13768 = FStar_Syntax_Subst.open_term [b] q
+                    let uu____13598 =
+                      let uu____13599 = FStar_Syntax_Subst.compress a2  in
+                      uu____13599.FStar_Syntax_Syntax.n  in
+                    (match uu____13598 with
+                     | FStar_Syntax_Syntax.Tm_abs (b::[],q,uu____13606) ->
+                         let uu____13641 = FStar_Syntax_Subst.open_term [b] q
                             in
-                         (match uu____13768 with
+                         (match uu____13641 with
                           | (bs,q1) ->
                               let b1 =
                                 match bs with
                                 | b1::[] -> b1
-                                | uu____13821 -> failwith "impossible"  in
-                              let uu____13829 = patterns q1  in
-                              (match uu____13829 with
+                                | uu____13694 -> failwith "impossible"  in
+                              let uu____13702 = patterns q1  in
+                              (match uu____13702 with
                                | (pats,q2) ->
                                    FStar_All.pipe_left maybe_collect
                                      (FStar_Pervasives_Native.Some
                                         (QEx ([b1], pats, q2)))))
-                     | uu____13890 -> FStar_Pervasives_Native.None)
-                | uu____13891 -> FStar_Pervasives_Native.None))
+                     | uu____13763 -> FStar_Pervasives_Native.None)
+                | uu____13764 -> FStar_Pervasives_Native.None))
     
     and maybe_collect f1 =
       match f1 with
       | FStar_Pervasives_Native.Some (QAll (bs,pats,phi)) ->
-          let uu____13914 = destruct_sq_forall phi  in
-          (match uu____13914 with
+          let uu____13787 = destruct_sq_forall phi  in
+          (match uu____13787 with
            | FStar_Pervasives_Native.Some (QAll (bs',pats',psi)) ->
                FStar_All.pipe_left
-                 (fun uu____13924  ->
-                    FStar_Pervasives_Native.Some uu____13924)
+                 (fun uu____13797  ->
+                    FStar_Pervasives_Native.Some uu____13797)
                  (QAll
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13931 -> f1)
+           | uu____13804 -> f1)
       | FStar_Pervasives_Native.Some (QEx (bs,pats,phi)) ->
-          let uu____13937 = destruct_sq_exists phi  in
-          (match uu____13937 with
+          let uu____13810 = destruct_sq_exists phi  in
+          (match uu____13810 with
            | FStar_Pervasives_Native.Some (QEx (bs',pats',psi)) ->
                FStar_All.pipe_left
-                 (fun uu____13947  ->
-                    FStar_Pervasives_Native.Some uu____13947)
+                 (fun uu____13820  ->
+                    FStar_Pervasives_Native.Some uu____13820)
                  (QEx
                     ((FStar_List.append bs bs'),
                       (FStar_List.append pats pats'), psi))
-           | uu____13954 -> f1)
-      | uu____13957 -> f1
+           | uu____13827 -> f1)
+      | uu____13830 -> f1
      in
     let phi = unmeta_monadic f  in
-    let uu____13961 = destruct_base_conn phi  in
-    FStar_Util.catch_opt uu____13961
-      (fun uu____13966  ->
-         let uu____13967 = destruct_q_conn phi  in
-         FStar_Util.catch_opt uu____13967
-           (fun uu____13972  ->
-              let uu____13973 = destruct_sq_base_conn phi  in
-              FStar_Util.catch_opt uu____13973
-                (fun uu____13978  ->
-                   let uu____13979 = destruct_sq_forall phi  in
-                   FStar_Util.catch_opt uu____13979
-                     (fun uu____13984  ->
-                        let uu____13985 = destruct_sq_exists phi  in
-                        FStar_Util.catch_opt uu____13985
-                          (fun uu____13989  -> FStar_Pervasives_Native.None)))))
+    let uu____13834 = destruct_base_conn phi  in
+    FStar_Util.catch_opt uu____13834
+      (fun uu____13839  ->
+         let uu____13840 = destruct_q_conn phi  in
+         FStar_Util.catch_opt uu____13840
+           (fun uu____13845  ->
+              let uu____13846 = destruct_sq_base_conn phi  in
+              FStar_Util.catch_opt uu____13846
+                (fun uu____13851  ->
+                   let uu____13852 = destruct_sq_forall phi  in
+                   FStar_Util.catch_opt uu____13852
+                     (fun uu____13857  ->
+                        let uu____13858 = destruct_sq_exists phi  in
+                        FStar_Util.catch_opt uu____13858
+                          (fun uu____13862  -> FStar_Pervasives_Native.None)))))
   
 let (action_as_lb :
   FStar_Ident.lident ->
@@ -3352,25 +3310,25 @@ let (action_as_lb :
     fun a  ->
       fun pos  ->
         let lb =
-          let uu____14007 =
-            let uu____14012 =
+          let uu____13880 =
+            let uu____13885 =
               FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name
                 FStar_Syntax_Syntax.delta_equational
                 FStar_Pervasives_Native.None
                in
-            FStar_Util.Inr uu____14012  in
-          let uu____14013 =
-            let uu____14014 =
+            FStar_Util.Inr uu____13885  in
+          let uu____13886 =
+            let uu____13887 =
               FStar_Syntax_Syntax.mk_Total a.FStar_Syntax_Syntax.action_typ
                in
-            arrow a.FStar_Syntax_Syntax.action_params uu____14014  in
-          let uu____14017 =
+            arrow a.FStar_Syntax_Syntax.action_params uu____13887  in
+          let uu____13890 =
             abs a.FStar_Syntax_Syntax.action_params
               a.FStar_Syntax_Syntax.action_defn FStar_Pervasives_Native.None
              in
           close_univs_and_mk_letbinding FStar_Pervasives_Native.None
-            uu____14007 a.FStar_Syntax_Syntax.action_univs uu____14013
-            FStar_Parser_Const.effect_Tot_lid uu____14017 [] pos
+            uu____13880 a.FStar_Syntax_Syntax.action_univs uu____13886
+            FStar_Parser_Const.effect_Tot_lid uu____13890 [] pos
            in
         {
           FStar_Syntax_Syntax.sigel =
@@ -3394,18 +3352,16 @@ let (mk_reify :
     let reify_ =
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_reify)
-        FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+        t.FStar_Syntax_Syntax.pos
        in
-    let uu____14043 =
-      let uu____14050 =
-        let uu____14051 =
-          let uu____14068 =
-            let uu____14079 = FStar_Syntax_Syntax.as_arg t  in [uu____14079]
-             in
-          (reify_, uu____14068)  in
-        FStar_Syntax_Syntax.Tm_app uu____14051  in
-      FStar_Syntax_Syntax.mk uu____14050  in
-    uu____14043 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+    let uu____13916 =
+      let uu____13917 =
+        let uu____13934 =
+          let uu____13945 = FStar_Syntax_Syntax.as_arg t  in [uu____13945]
+           in
+        (reify_, uu____13934)  in
+      FStar_Syntax_Syntax.Tm_app uu____13917  in
+    FStar_Syntax_Syntax.mk uu____13916 t.FStar_Syntax_Syntax.pos
   
 let (mk_reflect :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -3413,64 +3369,60 @@ let (mk_reflect :
   =
   fun t  ->
     let reflect_ =
-      let uu____14131 =
-        let uu____14138 =
-          let uu____14139 =
-            let uu____14140 = FStar_Ident.lid_of_str "Bogus.Effect"  in
-            FStar_Const.Const_reflect uu____14140  in
-          FStar_Syntax_Syntax.Tm_constant uu____14139  in
-        FStar_Syntax_Syntax.mk uu____14138  in
-      uu____14131 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos  in
-    let uu____14142 =
-      let uu____14149 =
-        let uu____14150 =
-          let uu____14167 =
-            let uu____14178 = FStar_Syntax_Syntax.as_arg t  in [uu____14178]
-             in
-          (reflect_, uu____14167)  in
-        FStar_Syntax_Syntax.Tm_app uu____14150  in
-      FStar_Syntax_Syntax.mk uu____14149  in
-    uu____14142 FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+      let uu____13997 =
+        let uu____13998 =
+          let uu____13999 = FStar_Ident.lid_of_str "Bogus.Effect"  in
+          FStar_Const.Const_reflect uu____13999  in
+        FStar_Syntax_Syntax.Tm_constant uu____13998  in
+      FStar_Syntax_Syntax.mk uu____13997 t.FStar_Syntax_Syntax.pos  in
+    let uu____14001 =
+      let uu____14002 =
+        let uu____14019 =
+          let uu____14030 = FStar_Syntax_Syntax.as_arg t  in [uu____14030]
+           in
+        (reflect_, uu____14019)  in
+      FStar_Syntax_Syntax.Tm_app uu____14002  in
+    FStar_Syntax_Syntax.mk uu____14001 t.FStar_Syntax_Syntax.pos
   
 let rec (delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
   fun t  ->
     let t1 = FStar_Syntax_Subst.compress t  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____14222 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu____14074 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu____14239 = unfold_lazy i  in delta_qualifier uu____14239
+        let uu____14091 = unfold_lazy i  in delta_qualifier uu____14091
     | FStar_Syntax_Syntax.Tm_fvar fv -> fv.FStar_Syntax_Syntax.fv_delta
-    | FStar_Syntax_Syntax.Tm_bvar uu____14241 ->
+    | FStar_Syntax_Syntax.Tm_bvar uu____14093 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_name uu____14242 ->
+    | FStar_Syntax_Syntax.Tm_name uu____14094 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_match uu____14243 ->
+    | FStar_Syntax_Syntax.Tm_match uu____14095 ->
         FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_uvar uu____14266 ->
+    | FStar_Syntax_Syntax.Tm_uvar uu____14118 ->
         FStar_Syntax_Syntax.delta_equational
     | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Syntax_Syntax.delta_equational
-    | FStar_Syntax_Syntax.Tm_type uu____14279 ->
+    | FStar_Syntax_Syntax.Tm_type uu____14131 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_quoted uu____14280 ->
+    | FStar_Syntax_Syntax.Tm_quoted uu____14132 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_constant uu____14287 ->
+    | FStar_Syntax_Syntax.Tm_constant uu____14139 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_arrow uu____14288 ->
+    | FStar_Syntax_Syntax.Tm_arrow uu____14140 ->
         FStar_Syntax_Syntax.delta_constant
-    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____14304) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_uinst (t2,uu____14156) -> delta_qualifier t2
     | FStar_Syntax_Syntax.Tm_refine
-        ({ FStar_Syntax_Syntax.ppname = uu____14309;
-           FStar_Syntax_Syntax.index = uu____14310;
-           FStar_Syntax_Syntax.sort = t2;_},uu____14312)
+        ({ FStar_Syntax_Syntax.ppname = uu____14161;
+           FStar_Syntax_Syntax.index = uu____14162;
+           FStar_Syntax_Syntax.sort = t2;_},uu____14164)
         -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_meta (t2,uu____14321) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____14327,uu____14328) ->
+    | FStar_Syntax_Syntax.Tm_meta (t2,uu____14173) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____14179,uu____14180) ->
         delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_app (t2,uu____14370) -> delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_abs (uu____14395,t2,uu____14397) ->
+    | FStar_Syntax_Syntax.Tm_app (t2,uu____14222) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_abs (uu____14247,t2,uu____14249) ->
         delta_qualifier t2
-    | FStar_Syntax_Syntax.Tm_let (uu____14422,t2) -> delta_qualifier t2
+    | FStar_Syntax_Syntax.Tm_let (uu____14274,t2) -> delta_qualifier t2
   
 let rec (incr_delta_depth :
   FStar_Syntax_Syntax.delta_depth -> FStar_Syntax_Syntax.delta_depth) =
@@ -3485,28 +3437,28 @@ let rec (incr_delta_depth :
 let (incr_delta_qualifier :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.delta_depth) =
   fun t  ->
-    let uu____14461 = delta_qualifier t  in incr_delta_depth uu____14461
+    let uu____14313 = delta_qualifier t  in incr_delta_depth uu____14313
   
 let (is_unknown : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____14469 =
-      let uu____14470 = FStar_Syntax_Subst.compress t  in
-      uu____14470.FStar_Syntax_Syntax.n  in
-    match uu____14469 with
+    let uu____14321 =
+      let uu____14322 = FStar_Syntax_Subst.compress t  in
+      uu____14322.FStar_Syntax_Syntax.n  in
+    match uu____14321 with
     | FStar_Syntax_Syntax.Tm_unknown  -> true
-    | uu____14475 -> false
+    | uu____14327 -> false
   
 let rec apply_last :
-  'uuuuuu14484 .
-    ('uuuuuu14484 -> 'uuuuuu14484) ->
-      'uuuuuu14484 Prims.list -> 'uuuuuu14484 Prims.list
+  'uuuuuu14336 .
+    ('uuuuuu14336 -> 'uuuuuu14336) ->
+      'uuuuuu14336 Prims.list -> 'uuuuuu14336 Prims.list
   =
   fun f  ->
     fun l  ->
       match l with
       | [] -> failwith "apply_last: got empty list"
-      | a::[] -> let uu____14510 = f a  in [uu____14510]
-      | x::xs -> let uu____14515 = apply_last f xs  in x :: uu____14515
+      | a::[] -> let uu____14362 = f a  in [uu____14362]
+      | x::xs -> let uu____14367 = apply_last f xs  in x :: uu____14367
   
 let (dm4f_lid :
   FStar_Syntax_Syntax.eff_decl -> Prims.string -> FStar_Ident.lident) =
@@ -3530,52 +3482,46 @@ let (mk_list :
     fun rng  ->
       fun l  ->
         let ctor l1 =
-          let uu____14570 =
-            let uu____14577 =
-              let uu____14578 =
-                FStar_Syntax_Syntax.lid_as_fv l1
-                  FStar_Syntax_Syntax.delta_constant
-                  (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
-                 in
-              FStar_Syntax_Syntax.Tm_fvar uu____14578  in
-            FStar_Syntax_Syntax.mk uu____14577  in
-          uu____14570 FStar_Pervasives_Native.None rng  in
+          let uu____14422 =
+            let uu____14423 =
+              FStar_Syntax_Syntax.lid_as_fv l1
+                FStar_Syntax_Syntax.delta_constant
+                (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
+               in
+            FStar_Syntax_Syntax.Tm_fvar uu____14423  in
+          FStar_Syntax_Syntax.mk uu____14422 rng  in
         let cons args pos =
-          let uu____14592 =
-            let uu____14597 =
-              let uu____14598 = ctor FStar_Parser_Const.cons_lid  in
-              FStar_Syntax_Syntax.mk_Tm_uinst uu____14598
-                [FStar_Syntax_Syntax.U_zero]
-               in
-            FStar_Syntax_Syntax.mk_Tm_app uu____14597 args  in
-          uu____14592 FStar_Pervasives_Native.None pos  in
-        let nil args pos =
-          let uu____14612 =
-            let uu____14617 =
-              let uu____14618 = ctor FStar_Parser_Const.nil_lid  in
-              FStar_Syntax_Syntax.mk_Tm_uinst uu____14618
-                [FStar_Syntax_Syntax.U_zero]
-               in
-            FStar_Syntax_Syntax.mk_Tm_app uu____14617 args  in
-          uu____14612 FStar_Pervasives_Native.None pos  in
-        let uu____14619 =
-          let uu____14620 =
-            let uu____14621 = FStar_Syntax_Syntax.iarg typ  in [uu____14621]
+          let uu____14435 =
+            let uu____14436 = ctor FStar_Parser_Const.cons_lid  in
+            FStar_Syntax_Syntax.mk_Tm_uinst uu____14436
+              [FStar_Syntax_Syntax.U_zero]
              in
-          nil uu____14620 rng  in
+          FStar_Syntax_Syntax.mk_Tm_app uu____14435 args pos  in
+        let nil args pos =
+          let uu____14448 =
+            let uu____14449 = ctor FStar_Parser_Const.nil_lid  in
+            FStar_Syntax_Syntax.mk_Tm_uinst uu____14449
+              [FStar_Syntax_Syntax.U_zero]
+             in
+          FStar_Syntax_Syntax.mk_Tm_app uu____14448 args pos  in
+        let uu____14450 =
+          let uu____14451 =
+            let uu____14452 = FStar_Syntax_Syntax.iarg typ  in [uu____14452]
+             in
+          nil uu____14451 rng  in
         FStar_List.fold_right
           (fun t  ->
              fun a  ->
-               let uu____14655 =
-                 let uu____14656 = FStar_Syntax_Syntax.iarg typ  in
-                 let uu____14665 =
-                   let uu____14676 = FStar_Syntax_Syntax.as_arg t  in
-                   let uu____14685 =
-                     let uu____14696 = FStar_Syntax_Syntax.as_arg a  in
-                     [uu____14696]  in
-                   uu____14676 :: uu____14685  in
-                 uu____14656 :: uu____14665  in
-               cons uu____14655 t.FStar_Syntax_Syntax.pos) l uu____14619
+               let uu____14486 =
+                 let uu____14487 = FStar_Syntax_Syntax.iarg typ  in
+                 let uu____14496 =
+                   let uu____14507 = FStar_Syntax_Syntax.as_arg t  in
+                   let uu____14516 =
+                     let uu____14527 = FStar_Syntax_Syntax.as_arg a  in
+                     [uu____14527]  in
+                   uu____14507 :: uu____14516  in
+                 uu____14487 :: uu____14496  in
+               cons uu____14486 t.FStar_Syntax_Syntax.pos) l uu____14450
   
 let rec eqlist :
   'a .
@@ -3587,7 +3533,7 @@ let rec eqlist :
         match (xs, ys) with
         | ([],[]) -> true
         | (x::xs1,y::ys1) -> (eq x y) && (eqlist eq xs1 ys1)
-        | uu____14805 -> false
+        | uu____14636 -> false
   
 let eqsum :
   'a 'b .
@@ -3602,7 +3548,7 @@ let eqsum :
           match (x, y) with
           | (FStar_Util.Inl x1,FStar_Util.Inl y1) -> e1 x1 y1
           | (FStar_Util.Inr x1,FStar_Util.Inr y1) -> e2 x1 y1
-          | uu____14919 -> false
+          | uu____14750 -> false
   
 let eqprod :
   'a 'b .
@@ -3627,7 +3573,7 @@ let eqopt :
         match (x, y) with
         | (FStar_Pervasives_Native.Some x1,FStar_Pervasives_Native.Some y1)
             -> e x1 y1
-        | uu____15085 -> false
+        | uu____14916 -> false
   
 let (debug_term_eq : Prims.bool FStar_ST.ref) = FStar_Util.mk_ref false 
 let (check : Prims.string -> Prims.bool -> Prims.bool) =
@@ -3636,8 +3582,8 @@ let (check : Prims.string -> Prims.bool -> Prims.bool) =
       if cond
       then true
       else
-        ((let uu____15123 = FStar_ST.op_Bang debug_term_eq  in
-          if uu____15123
+        ((let uu____14954 = FStar_ST.op_Bang debug_term_eq  in
+          if uu____14954
           then FStar_Util.print1 ">>> term_eq failing: %s\n" msg
           else ());
          false)
@@ -3650,34 +3596,34 @@ let rec (term_eq_dbg :
   fun dbg  ->
     fun t1  ->
       fun t2  ->
-        let t11 = let uu____15327 = unmeta_safe t1  in canon_app uu____15327
+        let t11 = let uu____15156 = unmeta_safe t1  in canon_app uu____15156
            in
-        let t21 = let uu____15333 = unmeta_safe t2  in canon_app uu____15333
+        let t21 = let uu____15160 = unmeta_safe t2  in canon_app uu____15160
            in
-        let uu____15336 =
-          let uu____15341 =
-            let uu____15342 =
-              let uu____15345 = un_uinst t11  in
-              FStar_Syntax_Subst.compress uu____15345  in
-            uu____15342.FStar_Syntax_Syntax.n  in
-          let uu____15346 =
-            let uu____15347 =
-              let uu____15350 = un_uinst t21  in
-              FStar_Syntax_Subst.compress uu____15350  in
-            uu____15347.FStar_Syntax_Syntax.n  in
-          (uu____15341, uu____15346)  in
-        match uu____15336 with
-        | (FStar_Syntax_Syntax.Tm_uinst uu____15352,uu____15353) ->
+        let uu____15163 =
+          let uu____15168 =
+            let uu____15169 =
+              let uu____15172 = un_uinst t11  in
+              FStar_Syntax_Subst.compress uu____15172  in
+            uu____15169.FStar_Syntax_Syntax.n  in
+          let uu____15173 =
+            let uu____15174 =
+              let uu____15177 = un_uinst t21  in
+              FStar_Syntax_Subst.compress uu____15177  in
+            uu____15174.FStar_Syntax_Syntax.n  in
+          (uu____15168, uu____15173)  in
+        match uu____15163 with
+        | (FStar_Syntax_Syntax.Tm_uinst uu____15179,uu____15180) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15362,FStar_Syntax_Syntax.Tm_uinst uu____15363) ->
+        | (uu____15189,FStar_Syntax_Syntax.Tm_uinst uu____15190) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_delayed uu____15372,uu____15373) ->
+        | (FStar_Syntax_Syntax.Tm_delayed uu____15199,uu____15200) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15390,FStar_Syntax_Syntax.Tm_delayed uu____15391) ->
+        | (uu____15217,FStar_Syntax_Syntax.Tm_delayed uu____15218) ->
             failwith "term_eq: impossible, should have been removed"
-        | (FStar_Syntax_Syntax.Tm_ascribed uu____15408,uu____15409) ->
+        | (FStar_Syntax_Syntax.Tm_ascribed uu____15235,uu____15236) ->
             failwith "term_eq: impossible, should have been removed"
-        | (uu____15438,FStar_Syntax_Syntax.Tm_ascribed uu____15439) ->
+        | (uu____15265,FStar_Syntax_Syntax.Tm_ascribed uu____15266) ->
             failwith "term_eq: impossible, should have been removed"
         | (FStar_Syntax_Syntax.Tm_bvar x,FStar_Syntax_Syntax.Tm_bvar y) ->
             check "bvar"
@@ -3686,152 +3632,152 @@ let rec (term_eq_dbg :
             check "name"
               (x.FStar_Syntax_Syntax.index = y.FStar_Syntax_Syntax.index)
         | (FStar_Syntax_Syntax.Tm_fvar x,FStar_Syntax_Syntax.Tm_fvar y) ->
-            let uu____15478 = FStar_Syntax_Syntax.fv_eq x y  in
-            check "fvar" uu____15478
+            let uu____15305 = FStar_Syntax_Syntax.fv_eq x y  in
+            check "fvar" uu____15305
         | (FStar_Syntax_Syntax.Tm_constant c1,FStar_Syntax_Syntax.Tm_constant
            c2) ->
-            let uu____15483 = FStar_Const.eq_const c1 c2  in
-            check "const" uu____15483
+            let uu____15310 = FStar_Const.eq_const c1 c2  in
+            check "const" uu____15310
         | (FStar_Syntax_Syntax.Tm_type
-           uu____15486,FStar_Syntax_Syntax.Tm_type uu____15487) -> true
+           uu____15313,FStar_Syntax_Syntax.Tm_type uu____15314) -> true
         | (FStar_Syntax_Syntax.Tm_abs (b1,t12,k1),FStar_Syntax_Syntax.Tm_abs
            (b2,t22,k2)) ->
-            (let uu____15545 = eqlist (binder_eq_dbg dbg) b1 b2  in
-             check "abs binders" uu____15545) &&
-              (let uu____15555 = term_eq_dbg dbg t12 t22  in
-               check "abs bodies" uu____15555)
+            (let uu____15372 = eqlist (binder_eq_dbg dbg) b1 b2  in
+             check "abs binders" uu____15372) &&
+              (let uu____15382 = term_eq_dbg dbg t12 t22  in
+               check "abs bodies" uu____15382)
         | (FStar_Syntax_Syntax.Tm_arrow (b1,c1),FStar_Syntax_Syntax.Tm_arrow
            (b2,c2)) ->
-            (let uu____15604 = eqlist (binder_eq_dbg dbg) b1 b2  in
-             check "arrow binders" uu____15604) &&
-              (let uu____15614 = comp_eq_dbg dbg c1 c2  in
-               check "arrow comp" uu____15614)
+            (let uu____15431 = eqlist (binder_eq_dbg dbg) b1 b2  in
+             check "arrow binders" uu____15431) &&
+              (let uu____15441 = comp_eq_dbg dbg c1 c2  in
+               check "arrow comp" uu____15441)
         | (FStar_Syntax_Syntax.Tm_refine
            (b1,t12),FStar_Syntax_Syntax.Tm_refine (b2,t22)) ->
-            (let uu____15631 =
+            (let uu____15458 =
                term_eq_dbg dbg b1.FStar_Syntax_Syntax.sort
                  b2.FStar_Syntax_Syntax.sort
                 in
-             check "refine bv sort" uu____15631) &&
-              (let uu____15635 = term_eq_dbg dbg t12 t22  in
-               check "refine formula" uu____15635)
+             check "refine bv sort" uu____15458) &&
+              (let uu____15462 = term_eq_dbg dbg t12 t22  in
+               check "refine formula" uu____15462)
         | (FStar_Syntax_Syntax.Tm_app (f1,a1),FStar_Syntax_Syntax.Tm_app
            (f2,a2)) ->
-            (let uu____15692 = term_eq_dbg dbg f1 f2  in
-             check "app head" uu____15692) &&
-              (let uu____15696 = eqlist (arg_eq_dbg dbg) a1 a2  in
-               check "app args" uu____15696)
+            (let uu____15519 = term_eq_dbg dbg f1 f2  in
+             check "app head" uu____15519) &&
+              (let uu____15523 = eqlist (arg_eq_dbg dbg) a1 a2  in
+               check "app args" uu____15523)
         | (FStar_Syntax_Syntax.Tm_match
            (t12,bs1),FStar_Syntax_Syntax.Tm_match (t22,bs2)) ->
-            (let uu____15785 = term_eq_dbg dbg t12 t22  in
-             check "match head" uu____15785) &&
-              (let uu____15789 = eqlist (branch_eq_dbg dbg) bs1 bs2  in
-               check "match branches" uu____15789)
-        | (FStar_Syntax_Syntax.Tm_lazy uu____15806,uu____15807) ->
-            let uu____15808 =
-              let uu____15810 = unlazy t11  in
-              term_eq_dbg dbg uu____15810 t21  in
-            check "lazy_l" uu____15808
-        | (uu____15812,FStar_Syntax_Syntax.Tm_lazy uu____15813) ->
-            let uu____15814 =
-              let uu____15816 = unlazy t21  in
-              term_eq_dbg dbg t11 uu____15816  in
-            check "lazy_r" uu____15814
+            (let uu____15612 = term_eq_dbg dbg t12 t22  in
+             check "match head" uu____15612) &&
+              (let uu____15616 = eqlist (branch_eq_dbg dbg) bs1 bs2  in
+               check "match branches" uu____15616)
+        | (FStar_Syntax_Syntax.Tm_lazy uu____15633,uu____15634) ->
+            let uu____15635 =
+              let uu____15637 = unlazy t11  in
+              term_eq_dbg dbg uu____15637 t21  in
+            check "lazy_l" uu____15635
+        | (uu____15639,FStar_Syntax_Syntax.Tm_lazy uu____15640) ->
+            let uu____15641 =
+              let uu____15643 = unlazy t21  in
+              term_eq_dbg dbg t11 uu____15643  in
+            check "lazy_r" uu____15641
         | (FStar_Syntax_Syntax.Tm_let
            ((b1,lbs1),t12),FStar_Syntax_Syntax.Tm_let ((b2,lbs2),t22)) ->
             ((check "let flag" (b1 = b2)) &&
-               (let uu____15861 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2
+               (let uu____15688 = eqlist (letbinding_eq_dbg dbg) lbs1 lbs2
                    in
-                check "let lbs" uu____15861))
+                check "let lbs" uu____15688))
               &&
-              (let uu____15865 = term_eq_dbg dbg t12 t22  in
-               check "let body" uu____15865)
+              (let uu____15692 = term_eq_dbg dbg t12 t22  in
+               check "let body" uu____15692)
         | (FStar_Syntax_Syntax.Tm_uvar
-           (u1,uu____15869),FStar_Syntax_Syntax.Tm_uvar (u2,uu____15871)) ->
+           (u1,uu____15696),FStar_Syntax_Syntax.Tm_uvar (u2,uu____15698)) ->
             check "uvar"
               (u1.FStar_Syntax_Syntax.ctx_uvar_head =
                  u2.FStar_Syntax_Syntax.ctx_uvar_head)
         | (FStar_Syntax_Syntax.Tm_quoted
            (qt1,qi1),FStar_Syntax_Syntax.Tm_quoted (qt2,qi2)) ->
-            (let uu____15931 =
-               let uu____15933 = eq_quoteinfo qi1 qi2  in uu____15933 = Equal
+            (let uu____15758 =
+               let uu____15760 = eq_quoteinfo qi1 qi2  in uu____15760 = Equal
                 in
-             check "tm_quoted qi" uu____15931) &&
-              (let uu____15936 = term_eq_dbg dbg qt1 qt2  in
-               check "tm_quoted payload" uu____15936)
+             check "tm_quoted qi" uu____15758) &&
+              (let uu____15763 = term_eq_dbg dbg qt1 qt2  in
+               check "tm_quoted payload" uu____15763)
         | (FStar_Syntax_Syntax.Tm_meta (t12,m1),FStar_Syntax_Syntax.Tm_meta
            (t22,m2)) ->
             (match (m1, m2) with
              | (FStar_Syntax_Syntax.Meta_monadic
                 (n1,ty1),FStar_Syntax_Syntax.Meta_monadic (n2,ty2)) ->
-                 (let uu____15966 = FStar_Ident.lid_equals n1 n2  in
-                  check "meta_monadic lid" uu____15966) &&
-                   (let uu____15970 = term_eq_dbg dbg ty1 ty2  in
-                    check "meta_monadic type" uu____15970)
+                 (let uu____15793 = FStar_Ident.lid_equals n1 n2  in
+                  check "meta_monadic lid" uu____15793) &&
+                   (let uu____15797 = term_eq_dbg dbg ty1 ty2  in
+                    check "meta_monadic type" uu____15797)
              | (FStar_Syntax_Syntax.Meta_monadic_lift
                 (s1,t13,ty1),FStar_Syntax_Syntax.Meta_monadic_lift
                 (s2,t23,ty2)) ->
-                 ((let uu____15989 = FStar_Ident.lid_equals s1 s2  in
-                   check "meta_monadic_lift src" uu____15989) &&
-                    (let uu____15993 = FStar_Ident.lid_equals t13 t23  in
-                     check "meta_monadic_lift tgt" uu____15993))
+                 ((let uu____15816 = FStar_Ident.lid_equals s1 s2  in
+                   check "meta_monadic_lift src" uu____15816) &&
+                    (let uu____15820 = FStar_Ident.lid_equals t13 t23  in
+                     check "meta_monadic_lift tgt" uu____15820))
                    &&
-                   (let uu____15997 = term_eq_dbg dbg ty1 ty2  in
-                    check "meta_monadic_lift type" uu____15997)
-             | uu____16000 -> fail "metas")
-        | (FStar_Syntax_Syntax.Tm_unknown ,uu____16006) -> fail "unk"
-        | (uu____16008,FStar_Syntax_Syntax.Tm_unknown ) -> fail "unk"
-        | (FStar_Syntax_Syntax.Tm_bvar uu____16010,uu____16011) ->
+                   (let uu____15824 = term_eq_dbg dbg ty1 ty2  in
+                    check "meta_monadic_lift type" uu____15824)
+             | uu____15827 -> fail "metas")
+        | (FStar_Syntax_Syntax.Tm_unknown ,uu____15833) -> fail "unk"
+        | (uu____15835,FStar_Syntax_Syntax.Tm_unknown ) -> fail "unk"
+        | (FStar_Syntax_Syntax.Tm_bvar uu____15837,uu____15838) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_name uu____16013,uu____16014) ->
+        | (FStar_Syntax_Syntax.Tm_name uu____15840,uu____15841) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_fvar uu____16016,uu____16017) ->
+        | (FStar_Syntax_Syntax.Tm_fvar uu____15843,uu____15844) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_constant uu____16019,uu____16020) ->
+        | (FStar_Syntax_Syntax.Tm_constant uu____15846,uu____15847) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_type uu____16022,uu____16023) ->
+        | (FStar_Syntax_Syntax.Tm_type uu____15849,uu____15850) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_abs uu____16025,uu____16026) ->
+        | (FStar_Syntax_Syntax.Tm_abs uu____15852,uu____15853) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_arrow uu____16046,uu____16047) ->
+        | (FStar_Syntax_Syntax.Tm_arrow uu____15873,uu____15874) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_refine uu____16063,uu____16064) ->
+        | (FStar_Syntax_Syntax.Tm_refine uu____15890,uu____15891) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_app uu____16072,uu____16073) ->
+        | (FStar_Syntax_Syntax.Tm_app uu____15899,uu____15900) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_match uu____16091,uu____16092) ->
+        | (FStar_Syntax_Syntax.Tm_match uu____15918,uu____15919) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_let uu____16116,uu____16117) ->
+        | (FStar_Syntax_Syntax.Tm_let uu____15943,uu____15944) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_uvar uu____16132,uu____16133) ->
+        | (FStar_Syntax_Syntax.Tm_uvar uu____15959,uu____15960) ->
             fail "bottom"
-        | (FStar_Syntax_Syntax.Tm_meta uu____16147,uu____16148) ->
+        | (FStar_Syntax_Syntax.Tm_meta uu____15974,uu____15975) ->
             fail "bottom"
-        | (uu____16156,FStar_Syntax_Syntax.Tm_bvar uu____16157) ->
+        | (uu____15983,FStar_Syntax_Syntax.Tm_bvar uu____15984) ->
             fail "bottom"
-        | (uu____16159,FStar_Syntax_Syntax.Tm_name uu____16160) ->
+        | (uu____15986,FStar_Syntax_Syntax.Tm_name uu____15987) ->
             fail "bottom"
-        | (uu____16162,FStar_Syntax_Syntax.Tm_fvar uu____16163) ->
+        | (uu____15989,FStar_Syntax_Syntax.Tm_fvar uu____15990) ->
             fail "bottom"
-        | (uu____16165,FStar_Syntax_Syntax.Tm_constant uu____16166) ->
+        | (uu____15992,FStar_Syntax_Syntax.Tm_constant uu____15993) ->
             fail "bottom"
-        | (uu____16168,FStar_Syntax_Syntax.Tm_type uu____16169) ->
+        | (uu____15995,FStar_Syntax_Syntax.Tm_type uu____15996) ->
             fail "bottom"
-        | (uu____16171,FStar_Syntax_Syntax.Tm_abs uu____16172) ->
+        | (uu____15998,FStar_Syntax_Syntax.Tm_abs uu____15999) ->
             fail "bottom"
-        | (uu____16192,FStar_Syntax_Syntax.Tm_arrow uu____16193) ->
+        | (uu____16019,FStar_Syntax_Syntax.Tm_arrow uu____16020) ->
             fail "bottom"
-        | (uu____16209,FStar_Syntax_Syntax.Tm_refine uu____16210) ->
+        | (uu____16036,FStar_Syntax_Syntax.Tm_refine uu____16037) ->
             fail "bottom"
-        | (uu____16218,FStar_Syntax_Syntax.Tm_app uu____16219) ->
+        | (uu____16045,FStar_Syntax_Syntax.Tm_app uu____16046) ->
             fail "bottom"
-        | (uu____16237,FStar_Syntax_Syntax.Tm_match uu____16238) ->
+        | (uu____16064,FStar_Syntax_Syntax.Tm_match uu____16065) ->
             fail "bottom"
-        | (uu____16262,FStar_Syntax_Syntax.Tm_let uu____16263) ->
+        | (uu____16089,FStar_Syntax_Syntax.Tm_let uu____16090) ->
             fail "bottom"
-        | (uu____16278,FStar_Syntax_Syntax.Tm_uvar uu____16279) ->
+        | (uu____16105,FStar_Syntax_Syntax.Tm_uvar uu____16106) ->
             fail "bottom"
-        | (uu____16293,FStar_Syntax_Syntax.Tm_meta uu____16294) ->
+        | (uu____16120,FStar_Syntax_Syntax.Tm_meta uu____16121) ->
             fail "bottom"
 
 and (arg_eq_dbg :
@@ -3848,13 +3794,13 @@ and (arg_eq_dbg :
         eqprod
           (fun t1  ->
              fun t2  ->
-               let uu____16329 = term_eq_dbg dbg t1 t2  in
-               check "arg tm" uu____16329)
+               let uu____16156 = term_eq_dbg dbg t1 t2  in
+               check "arg tm" uu____16156)
           (fun q1  ->
              fun q2  ->
-               let uu____16341 =
-                 let uu____16343 = eq_aqual q1 q2  in uu____16343 = Equal  in
-               check "arg qual" uu____16341) a1 a2
+               let uu____16168 =
+                 let uu____16170 = eq_aqual q1 q2  in uu____16170 = Equal  in
+               check "arg qual" uu____16168) a1 a2
 
 and (binder_eq_dbg :
   Prims.bool ->
@@ -3869,16 +3815,16 @@ and (binder_eq_dbg :
         eqprod
           (fun b11  ->
              fun b21  ->
-               let uu____16368 =
+               let uu____16195 =
                  term_eq_dbg dbg b11.FStar_Syntax_Syntax.sort
                    b21.FStar_Syntax_Syntax.sort
                   in
-               check "binder sort" uu____16368)
+               check "binder sort" uu____16195)
           (fun q1  ->
              fun q2  ->
-               let uu____16380 =
-                 let uu____16382 = eq_aqual q1 q2  in uu____16382 = Equal  in
-               check "binder qual" uu____16380) b1 b2
+               let uu____16207 =
+                 let uu____16209 = eq_aqual q1 q2  in uu____16209 = Equal  in
+               check "binder qual" uu____16207) b1 b2
 
 and (comp_eq_dbg :
   Prims.bool ->
@@ -3890,16 +3836,16 @@ and (comp_eq_dbg :
       fun c2  ->
         let c11 = comp_to_comp_typ_nouniv c1  in
         let c21 = comp_to_comp_typ_nouniv c2  in
-        ((let uu____16396 =
+        ((let uu____16223 =
             FStar_Ident.lid_equals c11.FStar_Syntax_Syntax.effect_name
               c21.FStar_Syntax_Syntax.effect_name
              in
-          check "comp eff" uu____16396) &&
-           (let uu____16400 =
+          check "comp eff" uu____16223) &&
+           (let uu____16227 =
               term_eq_dbg dbg c11.FStar_Syntax_Syntax.result_typ
                 c21.FStar_Syntax_Syntax.result_typ
                in
-            check "comp result typ" uu____16400))
+            check "comp result typ" uu____16227))
           && true
 
 and (eq_flags_dbg :
@@ -3919,23 +3865,23 @@ and (branch_eq_dbg :
         FStar_Syntax_Syntax.syntax) -> Prims.bool)
   =
   fun dbg  ->
-    fun uu____16410  ->
-      fun uu____16411  ->
-        match (uu____16410, uu____16411) with
+    fun uu____16237  ->
+      fun uu____16238  ->
+        match (uu____16237, uu____16238) with
         | ((p1,w1,t1),(p2,w2,t2)) ->
-            ((let uu____16538 = FStar_Syntax_Syntax.eq_pat p1 p2  in
-              check "branch pat" uu____16538) &&
-               (let uu____16542 = term_eq_dbg dbg t1 t2  in
-                check "branch body" uu____16542))
+            ((let uu____16365 = FStar_Syntax_Syntax.eq_pat p1 p2  in
+              check "branch pat" uu____16365) &&
+               (let uu____16369 = term_eq_dbg dbg t1 t2  in
+                check "branch body" uu____16369))
               &&
-              (let uu____16546 =
+              (let uu____16373 =
                  match (w1, w2) with
                  | (FStar_Pervasives_Native.Some
                     x,FStar_Pervasives_Native.Some y) -> term_eq_dbg dbg x y
                  | (FStar_Pervasives_Native.None
                     ,FStar_Pervasives_Native.None ) -> true
-                 | uu____16588 -> false  in
-               check "branch when" uu____16546)
+                 | uu____16415 -> false  in
+               check "branch when" uu____16373)
 
 and (letbinding_eq_dbg :
   Prims.bool ->
@@ -3945,85 +3891,85 @@ and (letbinding_eq_dbg :
   fun dbg  ->
     fun lb1  ->
       fun lb2  ->
-        ((let uu____16609 =
+        ((let uu____16436 =
             eqsum (fun bv1  -> fun bv2  -> true) FStar_Syntax_Syntax.fv_eq
               lb1.FStar_Syntax_Syntax.lbname lb2.FStar_Syntax_Syntax.lbname
              in
-          check "lb bv" uu____16609) &&
-           (let uu____16618 =
+          check "lb bv" uu____16436) &&
+           (let uu____16445 =
               term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbtyp
                 lb2.FStar_Syntax_Syntax.lbtyp
                in
-            check "lb typ" uu____16618))
+            check "lb typ" uu____16445))
           &&
-          (let uu____16622 =
+          (let uu____16449 =
              term_eq_dbg dbg lb1.FStar_Syntax_Syntax.lbdef
                lb2.FStar_Syntax_Syntax.lbdef
               in
-           check "lb def" uu____16622)
+           check "lb def" uu____16449)
 
 let (term_eq :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t1  ->
     fun t2  ->
       let r =
-        let uu____16639 = FStar_ST.op_Bang debug_term_eq  in
-        term_eq_dbg uu____16639 t1 t2  in
+        let uu____16466 = FStar_ST.op_Bang debug_term_eq  in
+        term_eq_dbg uu____16466 t1 t2  in
       FStar_ST.op_Colon_Equals debug_term_eq false; r
   
 let rec (sizeof : FStar_Syntax_Syntax.term -> Prims.int) =
   fun t  ->
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____16693 ->
-        let uu____16708 =
-          let uu____16710 = FStar_Syntax_Subst.compress t  in
-          sizeof uu____16710  in
-        Prims.int_one + uu____16708
+    | FStar_Syntax_Syntax.Tm_delayed uu____16520 ->
+        let uu____16535 =
+          let uu____16537 = FStar_Syntax_Subst.compress t  in
+          sizeof uu____16537  in
+        Prims.int_one + uu____16535
     | FStar_Syntax_Syntax.Tm_bvar bv ->
-        let uu____16713 = sizeof bv.FStar_Syntax_Syntax.sort  in
-        Prims.int_one + uu____16713
+        let uu____16540 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        Prims.int_one + uu____16540
     | FStar_Syntax_Syntax.Tm_name bv ->
-        let uu____16717 = sizeof bv.FStar_Syntax_Syntax.sort  in
-        Prims.int_one + uu____16717
+        let uu____16544 = sizeof bv.FStar_Syntax_Syntax.sort  in
+        Prims.int_one + uu____16544
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) ->
-        let uu____16726 = sizeof t1  in (FStar_List.length us) + uu____16726
-    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____16730) ->
-        let uu____16755 = sizeof t1  in
-        let uu____16757 =
+        let uu____16553 = sizeof t1  in (FStar_List.length us) + uu____16553
+    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____16557) ->
+        let uu____16582 = sizeof t1  in
+        let uu____16584 =
           FStar_List.fold_left
             (fun acc  ->
-               fun uu____16772  ->
-                 match uu____16772 with
-                 | (bv,uu____16782) ->
-                     let uu____16787 = sizeof bv.FStar_Syntax_Syntax.sort  in
-                     acc + uu____16787) Prims.int_zero bs
+               fun uu____16599  ->
+                 match uu____16599 with
+                 | (bv,uu____16609) ->
+                     let uu____16614 = sizeof bv.FStar_Syntax_Syntax.sort  in
+                     acc + uu____16614) Prims.int_zero bs
            in
-        uu____16755 + uu____16757
+        uu____16582 + uu____16584
     | FStar_Syntax_Syntax.Tm_app (hd,args) ->
-        let uu____16816 = sizeof hd  in
-        let uu____16818 =
+        let uu____16643 = sizeof hd  in
+        let uu____16645 =
           FStar_List.fold_left
             (fun acc  ->
-               fun uu____16833  ->
-                 match uu____16833 with
-                 | (arg,uu____16843) ->
-                     let uu____16848 = sizeof arg  in acc + uu____16848)
+               fun uu____16660  ->
+                 match uu____16660 with
+                 | (arg,uu____16670) ->
+                     let uu____16675 = sizeof arg  in acc + uu____16675)
             Prims.int_zero args
            in
-        uu____16816 + uu____16818
-    | uu____16851 -> Prims.int_one
+        uu____16643 + uu____16645
+    | uu____16678 -> Prims.int_one
   
 let (is_fvar : FStar_Ident.lident -> FStar_Syntax_Syntax.term -> Prims.bool)
   =
   fun lid  ->
     fun t  ->
-      let uu____16865 =
-        let uu____16866 = un_uinst t  in uu____16866.FStar_Syntax_Syntax.n
+      let uu____16692 =
+        let uu____16693 = un_uinst t  in uu____16693.FStar_Syntax_Syntax.n
          in
-      match uu____16865 with
+      match uu____16692 with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Syntax_Syntax.fv_eq_lid fv lid
-      | uu____16871 -> false
+      | uu____16698 -> false
   
 let (is_synth_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  -> is_fvar FStar_Parser_Const.synth_lid t 
@@ -4040,17 +3986,17 @@ let (get_attribute :
     fun attrs  ->
       FStar_List.tryPick
         (fun t  ->
-           let uu____16932 = head_and_args t  in
-           match uu____16932 with
+           let uu____16759 = head_and_args t  in
+           match uu____16759 with
            | (head,args) ->
-               let uu____16987 =
-                 let uu____16988 = FStar_Syntax_Subst.compress head  in
-                 uu____16988.FStar_Syntax_Syntax.n  in
-               (match uu____16987 with
+               let uu____16814 =
+                 let uu____16815 = FStar_Syntax_Subst.compress head  in
+                 uu____16815.FStar_Syntax_Syntax.n  in
+               (match uu____16814 with
                 | FStar_Syntax_Syntax.Tm_fvar fv when
                     FStar_Syntax_Syntax.fv_eq_lid fv attr ->
                     FStar_Pervasives_Native.Some args
-                | uu____17014 -> FStar_Pervasives_Native.None)) attrs
+                | uu____16841 -> FStar_Pervasives_Native.None)) attrs
   
 let (remove_attr :
   FStar_Ident.lident ->
@@ -4061,7 +4007,7 @@ let (remove_attr :
     fun attrs  ->
       FStar_List.filter
         (fun a  ->
-           let uu____17047 = is_fvar attr a  in Prims.op_Negation uu____17047)
+           let uu____16874 = is_fvar attr a  in Prims.op_Negation uu____16874)
         attrs
   
 let (process_pragma :
@@ -4071,8 +4017,8 @@ let (process_pragma :
       FStar_Errors.set_option_warning_callback_range
         (FStar_Pervasives_Native.Some r);
       (let set_options s =
-         let uu____17069 = FStar_Options.set_options s  in
-         match uu____17069 with
+         let uu____16896 = FStar_Options.set_options s  in
+         match uu____16896 with
          | FStar_Getopt.Success  -> ()
          | FStar_Getopt.Help  ->
              FStar_Errors.raise_error
@@ -4088,9 +4034,9 @@ let (process_pragma :
        | FStar_Syntax_Syntax.LightOff  -> FStar_Options.set_ml_ish ()
        | FStar_Syntax_Syntax.SetOptions o -> set_options o
        | FStar_Syntax_Syntax.ResetOptions sopt ->
-           ((let uu____17083 = FStar_Options.restore_cmd_line_options false
+           ((let uu____16910 = FStar_Options.restore_cmd_line_options false
                 in
-             FStar_All.pipe_right uu____17083 (fun uu____17085  -> ()));
+             FStar_All.pipe_right uu____16910 (fun uu____16912  -> ()));
             (match sopt with
              | FStar_Pervasives_Native.None  -> ()
              | FStar_Pervasives_Native.Some s -> set_options s))
@@ -4101,8 +4047,8 @@ let (process_pragma :
              | FStar_Pervasives_Native.Some s -> set_options s))
        | FStar_Syntax_Syntax.RestartSolver  -> ()
        | FStar_Syntax_Syntax.PopOptions  ->
-           let uu____17099 = FStar_Options.internal_pop ()  in
-           if uu____17099
+           let uu____16926 = FStar_Options.internal_pop ()  in
+           if uu____16926
            then ()
            else
              FStar_Errors.raise_error
@@ -4116,153 +4062,153 @@ let rec (unbound_variables :
   fun tm  ->
     let t = FStar_Syntax_Subst.compress tm  in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____17131 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu____16958 -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_name x -> []
-    | FStar_Syntax_Syntax.Tm_uvar uu____17150 -> []
+    | FStar_Syntax_Syntax.Tm_uvar uu____16977 -> []
     | FStar_Syntax_Syntax.Tm_type u -> []
     | FStar_Syntax_Syntax.Tm_bvar x -> [x]
-    | FStar_Syntax_Syntax.Tm_fvar uu____17165 -> []
-    | FStar_Syntax_Syntax.Tm_constant uu____17166 -> []
-    | FStar_Syntax_Syntax.Tm_lazy uu____17167 -> []
+    | FStar_Syntax_Syntax.Tm_fvar uu____16992 -> []
+    | FStar_Syntax_Syntax.Tm_constant uu____16993 -> []
+    | FStar_Syntax_Syntax.Tm_lazy uu____16994 -> []
     | FStar_Syntax_Syntax.Tm_unknown  -> []
     | FStar_Syntax_Syntax.Tm_uinst (t1,us) -> unbound_variables t1
-    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____17176) ->
-        let uu____17201 = FStar_Syntax_Subst.open_term bs t1  in
-        (match uu____17201 with
+    | FStar_Syntax_Syntax.Tm_abs (bs,t1,uu____17003) ->
+        let uu____17028 = FStar_Syntax_Subst.open_term bs t1  in
+        (match uu____17028 with
          | (bs1,t2) ->
-             let uu____17210 =
+             let uu____17037 =
                FStar_List.collect
-                 (fun uu____17222  ->
-                    match uu____17222 with
-                    | (b,uu____17232) ->
+                 (fun uu____17049  ->
+                    match uu____17049 with
+                    | (b,uu____17059) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1
                 in
-             let uu____17237 = unbound_variables t2  in
-             FStar_List.append uu____17210 uu____17237)
+             let uu____17064 = unbound_variables t2  in
+             FStar_List.append uu____17037 uu____17064)
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____17262 = FStar_Syntax_Subst.open_comp bs c  in
-        (match uu____17262 with
+        let uu____17089 = FStar_Syntax_Subst.open_comp bs c  in
+        (match uu____17089 with
          | (bs1,c1) ->
-             let uu____17271 =
+             let uu____17098 =
                FStar_List.collect
-                 (fun uu____17283  ->
-                    match uu____17283 with
-                    | (b,uu____17293) ->
+                 (fun uu____17110  ->
+                    match uu____17110 with
+                    | (b,uu____17120) ->
                         unbound_variables b.FStar_Syntax_Syntax.sort) bs1
                 in
-             let uu____17298 = unbound_variables_comp c1  in
-             FStar_List.append uu____17271 uu____17298)
+             let uu____17125 = unbound_variables_comp c1  in
+             FStar_List.append uu____17098 uu____17125)
     | FStar_Syntax_Syntax.Tm_refine (b,t1) ->
-        let uu____17307 =
+        let uu____17134 =
           FStar_Syntax_Subst.open_term [(b, FStar_Pervasives_Native.None)] t1
            in
-        (match uu____17307 with
+        (match uu____17134 with
          | (bs,t2) ->
-             let uu____17330 =
+             let uu____17157 =
                FStar_List.collect
-                 (fun uu____17342  ->
-                    match uu____17342 with
-                    | (b1,uu____17352) ->
+                 (fun uu____17169  ->
+                    match uu____17169 with
+                    | (b1,uu____17179) ->
                         unbound_variables b1.FStar_Syntax_Syntax.sort) bs
                 in
-             let uu____17357 = unbound_variables t2  in
-             FStar_List.append uu____17330 uu____17357)
+             let uu____17184 = unbound_variables t2  in
+             FStar_List.append uu____17157 uu____17184)
     | FStar_Syntax_Syntax.Tm_app (t1,args) ->
-        let uu____17386 =
+        let uu____17213 =
           FStar_List.collect
-            (fun uu____17400  ->
-               match uu____17400 with
-               | (x,uu____17412) -> unbound_variables x) args
+            (fun uu____17227  ->
+               match uu____17227 with
+               | (x,uu____17239) -> unbound_variables x) args
            in
-        let uu____17421 = unbound_variables t1  in
-        FStar_List.append uu____17386 uu____17421
+        let uu____17248 = unbound_variables t1  in
+        FStar_List.append uu____17213 uu____17248
     | FStar_Syntax_Syntax.Tm_match (t1,pats) ->
-        let uu____17462 = unbound_variables t1  in
-        let uu____17465 =
+        let uu____17289 = unbound_variables t1  in
+        let uu____17292 =
           FStar_All.pipe_right pats
             (FStar_List.collect
                (fun br  ->
-                  let uu____17480 = FStar_Syntax_Subst.open_branch br  in
-                  match uu____17480 with
+                  let uu____17307 = FStar_Syntax_Subst.open_branch br  in
+                  match uu____17307 with
                   | (p,wopt,t2) ->
-                      let uu____17502 = unbound_variables t2  in
-                      let uu____17505 =
+                      let uu____17329 = unbound_variables t2  in
+                      let uu____17332 =
                         match wopt with
                         | FStar_Pervasives_Native.None  -> []
                         | FStar_Pervasives_Native.Some t3 ->
                             unbound_variables t3
                          in
-                      FStar_List.append uu____17502 uu____17505))
+                      FStar_List.append uu____17329 uu____17332))
            in
-        FStar_List.append uu____17462 uu____17465
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____17519) ->
-        let uu____17560 = unbound_variables t1  in
-        let uu____17563 =
-          let uu____17566 =
+        FStar_List.append uu____17289 uu____17292
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____17346) ->
+        let uu____17387 = unbound_variables t1  in
+        let uu____17390 =
+          let uu____17393 =
             match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> unbound_variables t2
             | FStar_Util.Inr c2 -> unbound_variables_comp c2  in
-          let uu____17597 =
+          let uu____17424 =
             match FStar_Pervasives_Native.snd asc with
             | FStar_Pervasives_Native.None  -> []
             | FStar_Pervasives_Native.Some tac -> unbound_variables tac  in
-          FStar_List.append uu____17566 uu____17597  in
-        FStar_List.append uu____17560 uu____17563
+          FStar_List.append uu____17393 uu____17424  in
+        FStar_List.append uu____17387 uu____17390
     | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t1) ->
-        let uu____17638 = unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
-        let uu____17641 =
-          let uu____17644 = unbound_variables lb.FStar_Syntax_Syntax.lbdef
+        let uu____17465 = unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
+        let uu____17468 =
+          let uu____17471 = unbound_variables lb.FStar_Syntax_Syntax.lbdef
              in
-          let uu____17647 =
+          let uu____17474 =
             match lb.FStar_Syntax_Syntax.lbname with
-            | FStar_Util.Inr uu____17652 -> unbound_variables t1
+            | FStar_Util.Inr uu____17479 -> unbound_variables t1
             | FStar_Util.Inl bv ->
-                let uu____17654 =
+                let uu____17481 =
                   FStar_Syntax_Subst.open_term
                     [(bv, FStar_Pervasives_Native.None)] t1
                    in
-                (match uu____17654 with
-                 | (uu____17675,t2) -> unbound_variables t2)
+                (match uu____17481 with
+                 | (uu____17502,t2) -> unbound_variables t2)
              in
-          FStar_List.append uu____17644 uu____17647  in
-        FStar_List.append uu____17638 uu____17641
-    | FStar_Syntax_Syntax.Tm_let ((uu____17677,lbs),t1) ->
-        let uu____17697 = FStar_Syntax_Subst.open_let_rec lbs t1  in
-        (match uu____17697 with
+          FStar_List.append uu____17471 uu____17474  in
+        FStar_List.append uu____17465 uu____17468
+    | FStar_Syntax_Syntax.Tm_let ((uu____17504,lbs),t1) ->
+        let uu____17524 = FStar_Syntax_Subst.open_let_rec lbs t1  in
+        (match uu____17524 with
          | (lbs1,t2) ->
-             let uu____17712 = unbound_variables t2  in
-             let uu____17715 =
+             let uu____17539 = unbound_variables t2  in
+             let uu____17542 =
                FStar_List.collect
                  (fun lb  ->
-                    let uu____17722 =
+                    let uu____17549 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbtyp  in
-                    let uu____17725 =
+                    let uu____17552 =
                       unbound_variables lb.FStar_Syntax_Syntax.lbdef  in
-                    FStar_List.append uu____17722 uu____17725) lbs1
+                    FStar_List.append uu____17549 uu____17552) lbs1
                 in
-             FStar_List.append uu____17712 uu____17715)
+             FStar_List.append uu____17539 uu____17542)
     | FStar_Syntax_Syntax.Tm_quoted (tm1,qi) ->
         (match qi.FStar_Syntax_Syntax.qkind with
          | FStar_Syntax_Syntax.Quote_static  -> []
          | FStar_Syntax_Syntax.Quote_dynamic  -> unbound_variables tm1)
     | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
-        let uu____17742 = unbound_variables t1  in
-        let uu____17745 =
+        let uu____17569 = unbound_variables t1  in
+        let uu____17572 =
           match m with
-          | FStar_Syntax_Syntax.Meta_pattern (uu____17750,args) ->
+          | FStar_Syntax_Syntax.Meta_pattern (uu____17577,args) ->
               FStar_List.collect
                 (FStar_List.collect
-                   (fun uu____17805  ->
-                      match uu____17805 with
-                      | (a,uu____17817) -> unbound_variables a)) args
+                   (fun uu____17632  ->
+                      match uu____17632 with
+                      | (a,uu____17644) -> unbound_variables a)) args
           | FStar_Syntax_Syntax.Meta_monadic_lift
-              (uu____17826,uu____17827,t') -> unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_monadic (uu____17833,t') ->
+              (uu____17653,uu____17654,t') -> unbound_variables t'
+          | FStar_Syntax_Syntax.Meta_monadic (uu____17660,t') ->
               unbound_variables t'
-          | FStar_Syntax_Syntax.Meta_labeled uu____17839 -> []
-          | FStar_Syntax_Syntax.Meta_desugared uu____17848 -> []
-          | FStar_Syntax_Syntax.Meta_named uu____17849 -> []  in
-        FStar_List.append uu____17742 uu____17745
+          | FStar_Syntax_Syntax.Meta_labeled uu____17666 -> []
+          | FStar_Syntax_Syntax.Meta_desugared uu____17675 -> []
+          | FStar_Syntax_Syntax.Meta_named uu____17676 -> []  in
+        FStar_List.append uu____17569 uu____17572
 
 and (unbound_variables_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -4270,19 +4216,19 @@ and (unbound_variables_comp :
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.GTotal (t,uu____17856) -> unbound_variables t
-    | FStar_Syntax_Syntax.Total (t,uu____17866) -> unbound_variables t
+    | FStar_Syntax_Syntax.GTotal (t,uu____17683) -> unbound_variables t
+    | FStar_Syntax_Syntax.Total (t,uu____17693) -> unbound_variables t
     | FStar_Syntax_Syntax.Comp ct ->
-        let uu____17876 = unbound_variables ct.FStar_Syntax_Syntax.result_typ
+        let uu____17703 = unbound_variables ct.FStar_Syntax_Syntax.result_typ
            in
-        let uu____17879 =
+        let uu____17706 =
           FStar_List.collect
-            (fun uu____17893  ->
-               match uu____17893 with
-               | (a,uu____17905) -> unbound_variables a)
+            (fun uu____17720  ->
+               match uu____17720 with
+               | (a,uu____17732) -> unbound_variables a)
             ct.FStar_Syntax_Syntax.effect_args
            in
-        FStar_List.append uu____17876 uu____17879
+        FStar_List.append uu____17703 uu____17706
 
 let (extract_attr' :
   FStar_Ident.lid ->
@@ -4296,18 +4242,18 @@ let (extract_attr' :
         match attrs1 with
         | [] -> FStar_Pervasives_Native.None
         | h::t ->
-            let uu____18020 = head_and_args h  in
-            (match uu____18020 with
+            let uu____17847 = head_and_args h  in
+            (match uu____17847 with
              | (head,args) ->
-                 let uu____18081 =
-                   let uu____18082 = FStar_Syntax_Subst.compress head  in
-                   uu____18082.FStar_Syntax_Syntax.n  in
-                 (match uu____18081 with
+                 let uu____17908 =
+                   let uu____17909 = FStar_Syntax_Subst.compress head  in
+                   uu____17909.FStar_Syntax_Syntax.n  in
+                 (match uu____17908 with
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv attr_lid ->
                       let attrs' = FStar_List.rev_acc acc t  in
                       FStar_Pervasives_Native.Some (attrs', args)
-                  | uu____18135 -> aux (h :: acc) t))
+                  | uu____17962 -> aux (h :: acc) t))
          in
       aux [] attrs
   
@@ -4319,111 +4265,111 @@ let (extract_attr :
   =
   fun attr_lid  ->
     fun se  ->
-      let uu____18159 =
+      let uu____17986 =
         extract_attr' attr_lid se.FStar_Syntax_Syntax.sigattrs  in
-      match uu____18159 with
+      match uu____17986 with
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (attrs',t) ->
           FStar_Pervasives_Native.Some
-            ((let uu___2505_18201 = se  in
+            ((let uu___2505_18028 = se  in
               {
                 FStar_Syntax_Syntax.sigel =
-                  (uu___2505_18201.FStar_Syntax_Syntax.sigel);
+                  (uu___2505_18028.FStar_Syntax_Syntax.sigel);
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___2505_18201.FStar_Syntax_Syntax.sigrng);
+                  (uu___2505_18028.FStar_Syntax_Syntax.sigrng);
                 FStar_Syntax_Syntax.sigquals =
-                  (uu___2505_18201.FStar_Syntax_Syntax.sigquals);
+                  (uu___2505_18028.FStar_Syntax_Syntax.sigquals);
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___2505_18201.FStar_Syntax_Syntax.sigmeta);
+                  (uu___2505_18028.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs = attrs';
                 FStar_Syntax_Syntax.sigopts =
-                  (uu___2505_18201.FStar_Syntax_Syntax.sigopts)
+                  (uu___2505_18028.FStar_Syntax_Syntax.sigopts)
               }), t)
   
 let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____18209 =
-      let uu____18210 = FStar_Syntax_Subst.compress t  in
-      uu____18210.FStar_Syntax_Syntax.n  in
-    match uu____18209 with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____18214,c) ->
+    let uu____18036 =
+      let uu____18037 = FStar_Syntax_Subst.compress t  in
+      uu____18037.FStar_Syntax_Syntax.n  in
+    match uu____18036 with
+    | FStar_Syntax_Syntax.Tm_arrow (uu____18041,c) ->
         (match c.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Comp ct when
              FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                FStar_Parser_Const.effect_Lemma_lid
              ->
              (match ct.FStar_Syntax_Syntax.effect_args with
-              | _req::_ens::(pats,uu____18242)::uu____18243 ->
+              | _req::_ens::(pats,uu____18069)::uu____18070 ->
                   let pats' = unmeta pats  in
-                  let uu____18303 = head_and_args pats'  in
-                  (match uu____18303 with
-                   | (head,uu____18322) ->
-                       let uu____18347 =
-                         let uu____18348 = un_uinst head  in
-                         uu____18348.FStar_Syntax_Syntax.n  in
-                       (match uu____18347 with
+                  let uu____18130 = head_and_args pats'  in
+                  (match uu____18130 with
+                   | (head,uu____18149) ->
+                       let uu____18174 =
+                         let uu____18175 = un_uinst head  in
+                         uu____18175.FStar_Syntax_Syntax.n  in
+                       (match uu____18174 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.cons_lid
-                        | uu____18353 -> false))
-              | uu____18355 -> false)
-         | uu____18367 -> false)
-    | uu____18369 -> false
+                        | uu____18180 -> false))
+              | uu____18182 -> false)
+         | uu____18194 -> false)
+    | uu____18196 -> false
   
 let rec (list_elements :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
   =
   fun e  ->
-    let uu____18385 =
-      let uu____18402 = unmeta e  in head_and_args uu____18402  in
-    match uu____18385 with
+    let uu____18212 =
+      let uu____18229 = unmeta e  in head_and_args uu____18229  in
+    match uu____18212 with
     | (head,args) ->
-        let uu____18433 =
-          let uu____18448 =
-            let uu____18449 = un_uinst head  in
-            uu____18449.FStar_Syntax_Syntax.n  in
-          (uu____18448, args)  in
-        (match uu____18433 with
-         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____18467) when
+        let uu____18260 =
+          let uu____18275 =
+            let uu____18276 = un_uinst head  in
+            uu____18276.FStar_Syntax_Syntax.n  in
+          (uu____18275, args)  in
+        (match uu____18260 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,uu____18294) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid ->
              FStar_Pervasives_Native.Some []
          | (FStar_Syntax_Syntax.Tm_fvar
-            fv,uu____18491::(hd,uu____18493)::(tl,uu____18495)::[]) when
+            fv,uu____18318::(hd,uu____18320)::(tl,uu____18322)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid ->
-             let uu____18562 =
-               let uu____18565 =
-                 let uu____18568 = list_elements tl  in
-                 FStar_Util.must uu____18568  in
-               hd :: uu____18565  in
-             FStar_Pervasives_Native.Some uu____18562
-         | uu____18577 -> FStar_Pervasives_Native.None)
+             let uu____18389 =
+               let uu____18392 =
+                 let uu____18395 = list_elements tl  in
+                 FStar_Util.must uu____18395  in
+               hd :: uu____18392  in
+             FStar_Pervasives_Native.Some uu____18389
+         | uu____18404 -> FStar_Pervasives_Native.None)
   
 let (unthunk : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____18600 =
-      let uu____18601 = FStar_Syntax_Subst.compress t  in
-      uu____18601.FStar_Syntax_Syntax.n  in
-    match uu____18600 with
-    | FStar_Syntax_Syntax.Tm_abs (b::[],e,uu____18606) ->
-        let uu____18641 = FStar_Syntax_Subst.open_term [b] e  in
-        (match uu____18641 with
+    let uu____18427 =
+      let uu____18428 = FStar_Syntax_Subst.compress t  in
+      uu____18428.FStar_Syntax_Syntax.n  in
+    match uu____18427 with
+    | FStar_Syntax_Syntax.Tm_abs (b::[],e,uu____18433) ->
+        let uu____18468 = FStar_Syntax_Subst.open_term [b] e  in
+        (match uu____18468 with
          | (bs,e1) ->
              let b1 = FStar_List.hd bs  in
-             let uu____18673 = is_free_in (FStar_Pervasives_Native.fst b1) e1
+             let uu____18500 = is_free_in (FStar_Pervasives_Native.fst b1) e1
                 in
-             if uu____18673
+             if uu____18500
              then
-               let uu____18678 =
-                 let uu____18689 = FStar_Syntax_Syntax.as_arg exp_unit  in
-                 [uu____18689]  in
-               mk_app t uu____18678
+               let uu____18505 =
+                 let uu____18516 = FStar_Syntax_Syntax.as_arg exp_unit  in
+                 [uu____18516]  in
+               mk_app t uu____18505
              else e1)
-    | uu____18716 ->
-        let uu____18717 =
-          let uu____18728 = FStar_Syntax_Syntax.as_arg exp_unit  in
-          [uu____18728]  in
-        mk_app t uu____18717
+    | uu____18543 ->
+        let uu____18544 =
+          let uu____18555 = FStar_Syntax_Syntax.as_arg exp_unit  in
+          [uu____18555]  in
+        mk_app t uu____18544
   
 let (unthunk_lemma_post :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) = fun t  -> unthunk t 
@@ -4435,8 +4381,8 @@ let (smt_lemma_as_forall :
   fun t  ->
     fun universe_of_binders  ->
       let list_elements1 e =
-        let uu____18789 = list_elements e  in
-        match uu____18789 with
+        let uu____18616 = list_elements e  in
+        match uu____18616 with
         | FStar_Pervasives_Native.Some l -> l
         | FStar_Pervasives_Native.None  ->
             (FStar_Errors.log_issue e.FStar_Syntax_Syntax.pos
@@ -4445,125 +4391,121 @@ let (smt_lemma_as_forall :
              [])
          in
       let one_pat p =
-        let uu____18824 =
-          let uu____18841 = unmeta p  in
-          FStar_All.pipe_right uu____18841 head_and_args  in
-        match uu____18824 with
+        let uu____18651 =
+          let uu____18668 = unmeta p  in
+          FStar_All.pipe_right uu____18668 head_and_args  in
+        match uu____18651 with
         | (head,args) ->
-            let uu____18892 =
-              let uu____18907 =
-                let uu____18908 = un_uinst head  in
-                uu____18908.FStar_Syntax_Syntax.n  in
-              (uu____18907, args)  in
-            (match uu____18892 with
+            let uu____18719 =
+              let uu____18734 =
+                let uu____18735 = un_uinst head  in
+                uu____18735.FStar_Syntax_Syntax.n  in
+              (uu____18734, args)  in
+            (match uu____18719 with
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,(uu____18930,uu____18931)::arg::[]) when
+                fv,(uu____18757,uu____18758)::arg::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
                  -> arg
-             | uu____18983 ->
-                 let uu____18998 =
-                   let uu____19004 =
-                     let uu____19006 = tts p  in
+             | uu____18810 ->
+                 let uu____18825 =
+                   let uu____18831 =
+                     let uu____18833 = tts p  in
                      FStar_Util.format1
                        "Not an atomic SMT pattern: %s; patterns on lemmas must be a list of simple SMTPat's or a single SMTPatOr containing a list of lists of patterns"
-                       uu____19006
+                       uu____18833
                       in
-                   (FStar_Errors.Error_IllSMTPat, uu____19004)  in
-                 FStar_Errors.raise_error uu____18998
+                   (FStar_Errors.Error_IllSMTPat, uu____18831)  in
+                 FStar_Errors.raise_error uu____18825
                    p.FStar_Syntax_Syntax.pos)
          in
       let lemma_pats p =
         let elts = list_elements1 p  in
         let smt_pat_or t1 =
-          let uu____19049 =
-            let uu____19066 = unmeta t1  in
-            FStar_All.pipe_right uu____19066 head_and_args  in
-          match uu____19049 with
+          let uu____18876 =
+            let uu____18893 = unmeta t1  in
+            FStar_All.pipe_right uu____18893 head_and_args  in
+          match uu____18876 with
           | (head,args) ->
-              let uu____19113 =
-                let uu____19128 =
-                  let uu____19129 = un_uinst head  in
-                  uu____19129.FStar_Syntax_Syntax.n  in
-                (uu____19128, args)  in
-              (match uu____19113 with
-               | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____19148)::[]) when
+              let uu____18940 =
+                let uu____18955 =
+                  let uu____18956 = un_uinst head  in
+                  uu____18956.FStar_Syntax_Syntax.n  in
+                (uu____18955, args)  in
+              (match uu____18940 with
+               | (FStar_Syntax_Syntax.Tm_fvar fv,(e,uu____18975)::[]) when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.smtpatOr_lid
                    -> FStar_Pervasives_Native.Some e
-               | uu____19185 -> FStar_Pervasives_Native.None)
+               | uu____19012 -> FStar_Pervasives_Native.None)
            in
         match elts with
         | t1::[] ->
-            let uu____19215 = smt_pat_or t1  in
-            (match uu____19215 with
+            let uu____19042 = smt_pat_or t1  in
+            (match uu____19042 with
              | FStar_Pervasives_Native.Some e ->
-                 let uu____19237 = list_elements1 e  in
-                 FStar_All.pipe_right uu____19237
+                 let uu____19064 = list_elements1 e  in
+                 FStar_All.pipe_right uu____19064
                    (FStar_List.map
                       (fun branch1  ->
-                         let uu____19267 = list_elements1 branch1  in
-                         FStar_All.pipe_right uu____19267
+                         let uu____19094 = list_elements1 branch1  in
+                         FStar_All.pipe_right uu____19094
                            (FStar_List.map one_pat)))
-             | uu____19296 ->
-                 let uu____19301 =
+             | uu____19123 ->
+                 let uu____19128 =
                    FStar_All.pipe_right elts (FStar_List.map one_pat)  in
-                 [uu____19301])
-        | uu____19356 ->
-            let uu____19359 =
+                 [uu____19128])
+        | uu____19183 ->
+            let uu____19186 =
               FStar_All.pipe_right elts (FStar_List.map one_pat)  in
-            [uu____19359]
+            [uu____19186]
          in
-      let uu____19414 =
-        let uu____19445 =
-          let uu____19446 = FStar_Syntax_Subst.compress t  in
-          uu____19446.FStar_Syntax_Syntax.n  in
-        match uu____19445 with
+      let uu____19241 =
+        let uu____19272 =
+          let uu____19273 = FStar_Syntax_Subst.compress t  in
+          uu____19273.FStar_Syntax_Syntax.n  in
+        match uu____19272 with
         | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-            let uu____19501 = FStar_Syntax_Subst.open_comp binders c  in
-            (match uu____19501 with
+            let uu____19328 = FStar_Syntax_Subst.open_comp binders c  in
+            (match uu____19328 with
              | (binders1,c1) ->
                  (match c1.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Comp
-                      { FStar_Syntax_Syntax.comp_univs = uu____19568;
-                        FStar_Syntax_Syntax.effect_name = uu____19569;
-                        FStar_Syntax_Syntax.result_typ = uu____19570;
+                      { FStar_Syntax_Syntax.comp_univs = uu____19395;
+                        FStar_Syntax_Syntax.effect_name = uu____19396;
+                        FStar_Syntax_Syntax.result_typ = uu____19397;
                         FStar_Syntax_Syntax.effect_args =
-                          (pre,uu____19572)::(post,uu____19574)::(pats,uu____19576)::[];
-                        FStar_Syntax_Syntax.flags = uu____19577;_}
+                          (pre,uu____19399)::(post,uu____19401)::(pats,uu____19403)::[];
+                        FStar_Syntax_Syntax.flags = uu____19404;_}
                       ->
-                      let uu____19638 = lemma_pats pats  in
-                      (binders1, pre, post, uu____19638)
-                  | uu____19673 -> failwith "impos"))
-        | uu____19705 -> failwith "Impos"  in
-      match uu____19414 with
+                      let uu____19465 = lemma_pats pats  in
+                      (binders1, pre, post, uu____19465)
+                  | uu____19500 -> failwith "impos"))
+        | uu____19532 -> failwith "Impos"  in
+      match uu____19241 with
       | (binders,pre,post,patterns) ->
           let post1 = unthunk_lemma_post post  in
           let body =
-            let uu____19789 =
-              let uu____19796 =
-                let uu____19797 =
-                  let uu____19804 = mk_imp pre post1  in
-                  let uu____19807 =
-                    let uu____19808 =
-                      let uu____19829 =
-                        FStar_Syntax_Syntax.binders_to_names binders  in
-                      (uu____19829, patterns)  in
-                    FStar_Syntax_Syntax.Meta_pattern uu____19808  in
-                  (uu____19804, uu____19807)  in
-                FStar_Syntax_Syntax.Tm_meta uu____19797  in
-              FStar_Syntax_Syntax.mk uu____19796  in
-            uu____19789 FStar_Pervasives_Native.None
-              t.FStar_Syntax_Syntax.pos
-             in
+            let uu____19616 =
+              let uu____19617 =
+                let uu____19624 = mk_imp pre post1  in
+                let uu____19627 =
+                  let uu____19628 =
+                    let uu____19649 =
+                      FStar_Syntax_Syntax.binders_to_names binders  in
+                    (uu____19649, patterns)  in
+                  FStar_Syntax_Syntax.Meta_pattern uu____19628  in
+                (uu____19624, uu____19627)  in
+              FStar_Syntax_Syntax.Tm_meta uu____19617  in
+            FStar_Syntax_Syntax.mk uu____19616 t.FStar_Syntax_Syntax.pos  in
           let quant =
-            let uu____19853 = universe_of_binders binders  in
+            let uu____19673 = universe_of_binders binders  in
             FStar_List.fold_right2
               (fun b  ->
                  fun u  ->
                    fun out  ->
                      mk_forall u (FStar_Pervasives_Native.fst b) out) binders
-              uu____19853 body
+              uu____19673 body
              in
           quant
   
@@ -4572,19 +4514,19 @@ let (eff_decl_of_new_effect :
   fun se  ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_new_effect ne -> ne
-    | uu____19883 -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
+    | uu____19703 -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
   
 let (is_layered : FStar_Syntax_Syntax.eff_decl -> Prims.bool) =
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.Layered_eff uu____19894 -> true
-    | uu____19896 -> false
+    | FStar_Syntax_Syntax.Layered_eff uu____19714 -> true
+    | uu____19716 -> false
   
 let (is_dm4f : FStar_Syntax_Syntax.eff_decl -> Prims.bool) =
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.DM4F_eff uu____19907 -> true
-    | uu____19909 -> false
+    | FStar_Syntax_Syntax.DM4F_eff uu____19727 -> true
+    | uu____19729 -> false
   
 let (apply_wp_eff_combinators :
   (FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme) ->
@@ -4593,30 +4535,30 @@ let (apply_wp_eff_combinators :
   =
   fun f  ->
     fun combs  ->
-      let uu____19927 = f combs.FStar_Syntax_Syntax.ret_wp  in
-      let uu____19928 = f combs.FStar_Syntax_Syntax.bind_wp  in
-      let uu____19929 = f combs.FStar_Syntax_Syntax.stronger  in
-      let uu____19930 = f combs.FStar_Syntax_Syntax.if_then_else  in
-      let uu____19931 = f combs.FStar_Syntax_Syntax.ite_wp  in
-      let uu____19932 = f combs.FStar_Syntax_Syntax.close_wp  in
-      let uu____19933 = f combs.FStar_Syntax_Syntax.trivial  in
-      let uu____19934 =
+      let uu____19747 = f combs.FStar_Syntax_Syntax.ret_wp  in
+      let uu____19748 = f combs.FStar_Syntax_Syntax.bind_wp  in
+      let uu____19749 = f combs.FStar_Syntax_Syntax.stronger  in
+      let uu____19750 = f combs.FStar_Syntax_Syntax.if_then_else  in
+      let uu____19751 = f combs.FStar_Syntax_Syntax.ite_wp  in
+      let uu____19752 = f combs.FStar_Syntax_Syntax.close_wp  in
+      let uu____19753 = f combs.FStar_Syntax_Syntax.trivial  in
+      let uu____19754 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.repr  in
-      let uu____19937 =
+      let uu____19757 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.return_repr  in
-      let uu____19940 =
+      let uu____19760 =
         FStar_Util.map_option f combs.FStar_Syntax_Syntax.bind_repr  in
       {
-        FStar_Syntax_Syntax.ret_wp = uu____19927;
-        FStar_Syntax_Syntax.bind_wp = uu____19928;
-        FStar_Syntax_Syntax.stronger = uu____19929;
-        FStar_Syntax_Syntax.if_then_else = uu____19930;
-        FStar_Syntax_Syntax.ite_wp = uu____19931;
-        FStar_Syntax_Syntax.close_wp = uu____19932;
-        FStar_Syntax_Syntax.trivial = uu____19933;
-        FStar_Syntax_Syntax.repr = uu____19934;
-        FStar_Syntax_Syntax.return_repr = uu____19937;
-        FStar_Syntax_Syntax.bind_repr = uu____19940
+        FStar_Syntax_Syntax.ret_wp = uu____19747;
+        FStar_Syntax_Syntax.bind_wp = uu____19748;
+        FStar_Syntax_Syntax.stronger = uu____19749;
+        FStar_Syntax_Syntax.if_then_else = uu____19750;
+        FStar_Syntax_Syntax.ite_wp = uu____19751;
+        FStar_Syntax_Syntax.close_wp = uu____19752;
+        FStar_Syntax_Syntax.trivial = uu____19753;
+        FStar_Syntax_Syntax.repr = uu____19754;
+        FStar_Syntax_Syntax.return_repr = uu____19757;
+        FStar_Syntax_Syntax.bind_repr = uu____19760
       }
   
 let (apply_layered_eff_combinators :
@@ -4626,26 +4568,26 @@ let (apply_layered_eff_combinators :
   =
   fun f  ->
     fun combs  ->
-      let map_tuple uu____19972 =
-        match uu____19972 with
+      let map_tuple uu____19792 =
+        match uu____19792 with
         | (ts1,ts2) ->
-            let uu____19983 = f ts1  in
-            let uu____19984 = f ts2  in (uu____19983, uu____19984)
+            let uu____19803 = f ts1  in
+            let uu____19804 = f ts2  in (uu____19803, uu____19804)
          in
-      let uu____19985 = map_tuple combs.FStar_Syntax_Syntax.l_repr  in
-      let uu____19990 = map_tuple combs.FStar_Syntax_Syntax.l_return  in
-      let uu____19995 = map_tuple combs.FStar_Syntax_Syntax.l_bind  in
-      let uu____20000 = map_tuple combs.FStar_Syntax_Syntax.l_subcomp  in
-      let uu____20005 = map_tuple combs.FStar_Syntax_Syntax.l_if_then_else
+      let uu____19805 = map_tuple combs.FStar_Syntax_Syntax.l_repr  in
+      let uu____19810 = map_tuple combs.FStar_Syntax_Syntax.l_return  in
+      let uu____19815 = map_tuple combs.FStar_Syntax_Syntax.l_bind  in
+      let uu____19820 = map_tuple combs.FStar_Syntax_Syntax.l_subcomp  in
+      let uu____19825 = map_tuple combs.FStar_Syntax_Syntax.l_if_then_else
          in
       {
         FStar_Syntax_Syntax.l_base_effect =
           (combs.FStar_Syntax_Syntax.l_base_effect);
-        FStar_Syntax_Syntax.l_repr = uu____19985;
-        FStar_Syntax_Syntax.l_return = uu____19990;
-        FStar_Syntax_Syntax.l_bind = uu____19995;
-        FStar_Syntax_Syntax.l_subcomp = uu____20000;
-        FStar_Syntax_Syntax.l_if_then_else = uu____20005
+        FStar_Syntax_Syntax.l_repr = uu____19805;
+        FStar_Syntax_Syntax.l_return = uu____19810;
+        FStar_Syntax_Syntax.l_bind = uu____19815;
+        FStar_Syntax_Syntax.l_subcomp = uu____19820;
+        FStar_Syntax_Syntax.l_if_then_else = uu____19825
       }
   
 let (apply_eff_combinators :
@@ -4657,14 +4599,14 @@ let (apply_eff_combinators :
     fun combs  ->
       match combs with
       | FStar_Syntax_Syntax.Primitive_eff combs1 ->
-          let uu____20027 = apply_wp_eff_combinators f combs1  in
-          FStar_Syntax_Syntax.Primitive_eff uu____20027
+          let uu____19847 = apply_wp_eff_combinators f combs1  in
+          FStar_Syntax_Syntax.Primitive_eff uu____19847
       | FStar_Syntax_Syntax.DM4F_eff combs1 ->
-          let uu____20029 = apply_wp_eff_combinators f combs1  in
-          FStar_Syntax_Syntax.DM4F_eff uu____20029
+          let uu____19849 = apply_wp_eff_combinators f combs1  in
+          FStar_Syntax_Syntax.DM4F_eff uu____19849
       | FStar_Syntax_Syntax.Layered_eff combs1 ->
-          let uu____20031 = apply_layered_eff_combinators f combs1  in
-          FStar_Syntax_Syntax.Layered_eff uu____20031
+          let uu____19851 = apply_layered_eff_combinators f combs1  in
+          FStar_Syntax_Syntax.Layered_eff uu____19851
   
 let (get_wp_close_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4676,7 +4618,7 @@ let (get_wp_close_combinator :
         FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.close_wp)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.close_wp)
-    | uu____20046 -> FStar_Pervasives_Native.None
+    | uu____19866 -> FStar_Pervasives_Native.None
   
 let (get_eff_repr :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4688,12 +4630,12 @@ let (get_eff_repr :
         combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.DM4F_eff combs -> combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____20060 =
+        let uu____19880 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_repr
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____20060
-          (fun uu____20067  -> FStar_Pervasives_Native.Some uu____20067)
+        FStar_All.pipe_right uu____19880
+          (fun uu____19887  -> FStar_Pervasives_Native.Some uu____19887)
   
 let (get_bind_vc_combinator :
   FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.tscheme) =
@@ -4728,12 +4670,12 @@ let (get_bind_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.bind_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____20107 =
+        let uu____19927 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_bind
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____20107
-          (fun uu____20114  -> FStar_Pervasives_Native.Some uu____20114)
+        FStar_All.pipe_right uu____19927
+          (fun uu____19934  -> FStar_Pervasives_Native.Some uu____19934)
   
 let (get_return_repr :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4746,12 +4688,12 @@ let (get_return_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.return_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____20128 =
+        let uu____19948 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_return
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____20128
-          (fun uu____20135  -> FStar_Pervasives_Native.Some uu____20135)
+        FStar_All.pipe_right uu____19948
+          (fun uu____19955  -> FStar_Pervasives_Native.Some uu____19955)
   
 let (get_wp_trivial_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4761,11 +4703,11 @@ let (get_wp_trivial_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.trivial
-          (fun uu____20149  -> FStar_Pervasives_Native.Some uu____20149)
+          (fun uu____19969  -> FStar_Pervasives_Native.Some uu____19969)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.trivial
-          (fun uu____20153  -> FStar_Pervasives_Native.Some uu____20153)
-    | uu____20154 -> FStar_Pervasives_Native.None
+          (fun uu____19973  -> FStar_Pervasives_Native.Some uu____19973)
+    | uu____19974 -> FStar_Pervasives_Native.None
   
 let (get_layered_if_then_else_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4774,13 +4716,13 @@ let (get_layered_if_then_else_combinator :
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____20166 =
+        let uu____19986 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_if_then_else
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____20166
-          (fun uu____20173  -> FStar_Pervasives_Native.Some uu____20173)
-    | uu____20174 -> FStar_Pervasives_Native.None
+        FStar_All.pipe_right uu____19986
+          (fun uu____19993  -> FStar_Pervasives_Native.Some uu____19993)
+    | uu____19994 -> FStar_Pervasives_Native.None
   
 let (get_wp_if_then_else_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4790,11 +4732,11 @@ let (get_wp_if_then_else_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu____20188  -> FStar_Pervasives_Native.Some uu____20188)
+          (fun uu____20008  -> FStar_Pervasives_Native.Some uu____20008)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu____20192  -> FStar_Pervasives_Native.Some uu____20192)
-    | uu____20193 -> FStar_Pervasives_Native.None
+          (fun uu____20012  -> FStar_Pervasives_Native.Some uu____20012)
+    | uu____20013 -> FStar_Pervasives_Native.None
   
 let (get_wp_ite_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4804,11 +4746,11 @@ let (get_wp_ite_combinator :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu____20207  -> FStar_Pervasives_Native.Some uu____20207)
+          (fun uu____20027  -> FStar_Pervasives_Native.Some uu____20027)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu____20211  -> FStar_Pervasives_Native.Some uu____20211)
-    | uu____20212 -> FStar_Pervasives_Native.None
+          (fun uu____20031  -> FStar_Pervasives_Native.Some uu____20031)
+    | uu____20032 -> FStar_Pervasives_Native.None
   
 let (get_stronger_vc_combinator :
   FStar_Syntax_Syntax.eff_decl -> FStar_Syntax_Syntax.tscheme) =
@@ -4828,17 +4770,17 @@ let (get_stronger_repr :
   =
   fun ed  ->
     match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.Primitive_eff uu____20236 ->
+    | FStar_Syntax_Syntax.Primitive_eff uu____20056 ->
         FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.DM4F_eff uu____20237 ->
+    | FStar_Syntax_Syntax.DM4F_eff uu____20057 ->
         FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        let uu____20239 =
+        let uu____20059 =
           FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_subcomp
             FStar_Pervasives_Native.fst
            in
-        FStar_All.pipe_right uu____20239
-          (fun uu____20246  -> FStar_Pervasives_Native.Some uu____20246)
+        FStar_All.pipe_right uu____20059
+          (fun uu____20066  -> FStar_Pervasives_Native.Some uu____20066)
   
 let (get_layered_effect_base :
   FStar_Syntax_Syntax.eff_decl ->
@@ -4848,6 +4790,6 @@ let (get_layered_effect_base :
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Layered_eff combs ->
         FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_base_effect
-          (fun uu____20260  -> FStar_Pervasives_Native.Some uu____20260)
-    | uu____20261 -> FStar_Pervasives_Native.None
+          (fun uu____20080  -> FStar_Pervasives_Native.Some uu____20080)
+    | uu____20081 -> FStar_Pervasives_Native.None
   

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -1721,8 +1721,7 @@ let (intro_rec :
                                    uu____2667.FStar_Syntax_Syntax.pos  in
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_let
-                                      ((true, lbs), body1))
-                                   FStar_Pervasives_Native.None uu____2666
+                                      ((true, lbs), body1)) uu____2666
                                   in
                                let uu____2683 = set_solution goal tm  in
                                FStar_Tactics_Monad.bind uu____2683
@@ -3348,21 +3347,20 @@ let (revert : unit -> unit FStar_Tactics_Monad.tac) =
                         let uu____7170 =
                           let uu____7171 =
                             let uu____7172 =
-                              FStar_Tactics_Types.goal_type goal  in
-                            uu____7172.FStar_Syntax_Syntax.pos  in
-                          let uu____7175 =
-                            let uu____7180 =
                               let uu____7181 =
-                                let uu____7190 =
-                                  FStar_Syntax_Syntax.bv_to_name x  in
-                                FStar_Syntax_Syntax.as_arg uu____7190  in
-                              [uu____7181]  in
-                            FStar_Syntax_Syntax.mk_Tm_app r uu____7180  in
-                          uu____7175 FStar_Pervasives_Native.None uu____7171
+                                FStar_Syntax_Syntax.bv_to_name x  in
+                              FStar_Syntax_Syntax.as_arg uu____7181  in
+                            [uu____7172]  in
+                          let uu____7198 =
+                            let uu____7199 =
+                              FStar_Tactics_Types.goal_type goal  in
+                            uu____7199.FStar_Syntax_Syntax.pos  in
+                          FStar_Syntax_Syntax.mk_Tm_app r uu____7171
+                            uu____7198
                            in
                         set_solution goal uu____7170  in
                       FStar_Tactics_Monad.bind uu____7167
-                        (fun uu____7209  ->
+                        (fun uu____7204  ->
                            let g =
                              FStar_Tactics_Types.mk_goal env' u_r
                                goal.FStar_Tactics_Types.opts
@@ -3375,8 +3373,8 @@ let (free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv  ->
     fun t  ->
-      let uu____7223 = FStar_Syntax_Free.names t  in
-      FStar_Util.set_mem bv uu____7223
+      let uu____7218 = FStar_Syntax_Free.names t  in
+      FStar_Util.set_mem bv uu____7218
   
 let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b  ->
@@ -3384,22 +3382,22 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal  ->
          FStar_Tactics_Monad.mlog
-           (fun uu____7244  ->
-              let uu____7245 = FStar_Syntax_Print.binder_to_string b  in
-              let uu____7247 =
-                let uu____7249 =
-                  let uu____7251 =
-                    let uu____7260 = FStar_Tactics_Types.goal_env goal  in
-                    FStar_TypeChecker_Env.all_binders uu____7260  in
-                  FStar_All.pipe_right uu____7251 FStar_List.length  in
-                FStar_All.pipe_right uu____7249 FStar_Util.string_of_int  in
+           (fun uu____7239  ->
+              let uu____7240 = FStar_Syntax_Print.binder_to_string b  in
+              let uu____7242 =
+                let uu____7244 =
+                  let uu____7246 =
+                    let uu____7255 = FStar_Tactics_Types.goal_env goal  in
+                    FStar_TypeChecker_Env.all_binders uu____7255  in
+                  FStar_All.pipe_right uu____7246 FStar_List.length  in
+                FStar_All.pipe_right uu____7244 FStar_Util.string_of_int  in
               FStar_Util.print2 "Clear of (%s), env has %s binders\n"
-                uu____7245 uu____7247)
-           (fun uu____7281  ->
-              let uu____7282 =
-                let uu____7293 = FStar_Tactics_Types.goal_env goal  in
-                split_env bv uu____7293  in
-              match uu____7282 with
+                uu____7240 uu____7242)
+           (fun uu____7276  ->
+              let uu____7277 =
+                let uu____7288 = FStar_Tactics_Types.goal_env goal  in
+                split_env bv uu____7288  in
+              match uu____7277 with
               | FStar_Pervasives_Native.None  ->
                   FStar_Tactics_Monad.fail
                     "Cannot clear; binder not in environment"
@@ -3408,46 +3406,46 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                     match bvs1 with
                     | [] -> FStar_Tactics_Monad.ret ()
                     | bv'::bvs2 ->
-                        let uu____7338 =
+                        let uu____7333 =
                           free_in bv1 bv'.FStar_Syntax_Syntax.sort  in
-                        if uu____7338
+                        if uu____7333
                         then
-                          let uu____7343 =
-                            let uu____7345 =
+                          let uu____7338 =
+                            let uu____7340 =
                               FStar_Syntax_Print.bv_to_string bv'  in
                             FStar_Util.format1
                               "Cannot clear; binder present in the type of %s"
-                              uu____7345
+                              uu____7340
                              in
-                          FStar_Tactics_Monad.fail uu____7343
+                          FStar_Tactics_Monad.fail uu____7338
                         else check bvs2
                      in
-                  let uu____7350 =
-                    let uu____7352 = FStar_Tactics_Types.goal_type goal  in
-                    free_in bv1 uu____7352  in
-                  if uu____7350
+                  let uu____7345 =
+                    let uu____7347 = FStar_Tactics_Types.goal_type goal  in
+                    free_in bv1 uu____7347  in
+                  if uu____7345
                   then
                     FStar_Tactics_Monad.fail
                       "Cannot clear; binder present in goal"
                   else
-                    (let uu____7359 = check bvs  in
-                     FStar_Tactics_Monad.bind uu____7359
-                       (fun uu____7365  ->
+                    (let uu____7354 = check bvs  in
+                     FStar_Tactics_Monad.bind uu____7354
+                       (fun uu____7360  ->
                           let env' = push_bvs e' bvs  in
-                          let uu____7367 =
-                            let uu____7374 =
+                          let uu____7362 =
+                            let uu____7369 =
                               FStar_Tactics_Types.goal_type goal  in
                             FStar_Tactics_Monad.new_uvar "clear.witness" env'
-                              uu____7374
+                              uu____7369
                              in
-                          FStar_Tactics_Monad.bind uu____7367
-                            (fun uu____7384  ->
-                               match uu____7384 with
+                          FStar_Tactics_Monad.bind uu____7362
+                            (fun uu____7379  ->
+                               match uu____7379 with
                                | (ut,uvar_ut) ->
-                                   let uu____7393 = set_solution goal ut  in
-                                   FStar_Tactics_Monad.bind uu____7393
-                                     (fun uu____7398  ->
-                                        let uu____7399 =
+                                   let uu____7388 = set_solution goal ut  in
+                                   FStar_Tactics_Monad.bind uu____7388
+                                     (fun uu____7393  ->
+                                        let uu____7394 =
                                           FStar_Tactics_Types.mk_goal env'
                                             uvar_ut
                                             goal.FStar_Tactics_Types.opts
@@ -3455,21 +3453,21 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                             goal.FStar_Tactics_Types.label
                                            in
                                         FStar_Tactics_Monad.replace_cur
-                                          uu____7399))))))
+                                          uu____7394))))))
   
 let (clear_top : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7407  ->
+  fun uu____7402  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal  ->
-         let uu____7413 =
-           let uu____7420 = FStar_Tactics_Types.goal_env goal  in
-           FStar_TypeChecker_Env.pop_bv uu____7420  in
-         match uu____7413 with
+         let uu____7408 =
+           let uu____7415 = FStar_Tactics_Types.goal_env goal  in
+           FStar_TypeChecker_Env.pop_bv uu____7415  in
+         match uu____7408 with
          | FStar_Pervasives_Native.None  ->
              FStar_Tactics_Monad.fail "Cannot clear; empty context"
-         | FStar_Pervasives_Native.Some (x,uu____7429) ->
-             let uu____7434 = FStar_Syntax_Syntax.mk_binder x  in
-             clear uu____7434)
+         | FStar_Pervasives_Native.Some (x,uu____7424) ->
+             let uu____7429 = FStar_Syntax_Syntax.mk_binder x  in
+             clear uu____7429)
   
 let (prune : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s  ->
@@ -3477,8 +3475,8 @@ let (prune : Prims.string -> unit FStar_Tactics_Monad.tac) =
       (fun g  ->
          let ctx = FStar_Tactics_Types.goal_env g  in
          let ctx' =
-           let uu____7454 = FStar_Ident.path_of_text s  in
-           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7454  in
+           let uu____7449 = FStar_Ident.path_of_text s  in
+           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7449  in
          let g' = FStar_Tactics_Types.goal_with_env g ctx'  in
          FStar_Tactics_Monad.replace_cur g')
   
@@ -3488,8 +3486,8 @@ let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
       (fun g  ->
          let ctx = FStar_Tactics_Types.goal_env g  in
          let ctx' =
-           let uu____7475 = FStar_Ident.path_of_text s  in
-           FStar_TypeChecker_Env.add_proof_ns ctx uu____7475  in
+           let uu____7470 = FStar_Ident.path_of_text s  in
+           FStar_TypeChecker_Env.add_proof_ns ctx uu____7470  in
          let g' = FStar_Tactics_Types.goal_with_env g ctx'  in
          FStar_Tactics_Monad.replace_cur g')
   
@@ -3501,123 +3499,123 @@ let (_trefl :
     fun r  ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
-           let uu____7495 =
-             let uu____7499 = FStar_Tactics_Types.goal_env g  in
-             do_unify uu____7499 l r  in
-           FStar_Tactics_Monad.bind uu____7495
+           let uu____7490 =
+             let uu____7494 = FStar_Tactics_Types.goal_env g  in
+             do_unify uu____7494 l r  in
+           FStar_Tactics_Monad.bind uu____7490
              (fun b  ->
                 if b
                 then solve' g FStar_Syntax_Util.exp_unit
                 else
                   (let l1 =
-                     let uu____7510 = FStar_Tactics_Types.goal_env g  in
+                     let uu____7505 = FStar_Tactics_Types.goal_env g  in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7510 l
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7505 l
                       in
                    let r1 =
-                     let uu____7512 = FStar_Tactics_Types.goal_env g  in
+                     let uu____7507 = FStar_Tactics_Types.goal_env g  in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7512 r
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7507 r
                       in
-                   let uu____7513 =
-                     let uu____7517 = FStar_Tactics_Types.goal_env g  in
-                     do_unify uu____7517 l1 r1  in
-                   FStar_Tactics_Monad.bind uu____7513
+                   let uu____7508 =
+                     let uu____7512 = FStar_Tactics_Types.goal_env g  in
+                     do_unify uu____7512 l1 r1  in
+                   FStar_Tactics_Monad.bind uu____7508
                      (fun b1  ->
                         if b1
                         then solve' g FStar_Syntax_Util.exp_unit
                         else
-                          (let uu____7527 =
-                             let uu____7534 =
-                               let uu____7540 =
+                          (let uu____7522 =
+                             let uu____7529 =
+                               let uu____7535 =
                                  FStar_Tactics_Types.goal_env g  in
-                               tts uu____7540  in
+                               tts uu____7535  in
                              FStar_TypeChecker_Err.print_discrepancy
-                               uu____7534 l1 r1
+                               uu____7529 l1 r1
                               in
-                           match uu____7527 with
+                           match uu____7522 with
                            | (ls,rs) ->
                                fail2 "not a trivial equality ((%s) vs (%s))"
                                  ls rs)))))
   
 let (trefl : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7557  ->
-    let uu____7560 =
+  fun uu____7552  ->
+    let uu____7555 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
-           let uu____7568 =
-             let uu____7575 =
-               let uu____7576 = FStar_Tactics_Types.goal_env g  in
-               let uu____7577 = FStar_Tactics_Types.goal_type g  in
-               whnf uu____7576 uu____7577  in
-             destruct_eq uu____7575  in
-           match uu____7568 with
+           let uu____7563 =
+             let uu____7570 =
+               let uu____7571 = FStar_Tactics_Types.goal_env g  in
+               let uu____7572 = FStar_Tactics_Types.goal_type g  in
+               whnf uu____7571 uu____7572  in
+             destruct_eq uu____7570  in
+           match uu____7563 with
            | FStar_Pervasives_Native.Some (l,r) -> _trefl l r
            | FStar_Pervasives_Native.None  ->
-               let uu____7590 =
-                 let uu____7592 = FStar_Tactics_Types.goal_env g  in
-                 let uu____7593 = FStar_Tactics_Types.goal_type g  in
-                 tts uu____7592 uu____7593  in
-               fail1 "not an equality (%s)" uu____7590)
+               let uu____7585 =
+                 let uu____7587 = FStar_Tactics_Types.goal_env g  in
+                 let uu____7588 = FStar_Tactics_Types.goal_type g  in
+                 tts uu____7587 uu____7588  in
+               fail1 "not an equality (%s)" uu____7585)
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7560
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7555
   
 let (dup : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7607  ->
+  fun uu____7602  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g  ->
          let env1 = FStar_Tactics_Types.goal_env g  in
-         let uu____7615 =
-           let uu____7622 = FStar_Tactics_Types.goal_type g  in
-           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7622  in
-         FStar_Tactics_Monad.bind uu____7615
-           (fun uu____7632  ->
-              match uu____7632 with
+         let uu____7610 =
+           let uu____7617 = FStar_Tactics_Types.goal_type g  in
+           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7617  in
+         FStar_Tactics_Monad.bind uu____7610
+           (fun uu____7627  ->
+              match uu____7627 with
               | (u,u_uvar) ->
                   let g' =
-                    let uu___1039_7642 = g  in
+                    let uu___1039_7637 = g  in
                     {
                       FStar_Tactics_Types.goal_main_env =
-                        (uu___1039_7642.FStar_Tactics_Types.goal_main_env);
+                        (uu___1039_7637.FStar_Tactics_Types.goal_main_env);
                       FStar_Tactics_Types.goal_ctx_uvar = u_uvar;
                       FStar_Tactics_Types.opts =
-                        (uu___1039_7642.FStar_Tactics_Types.opts);
+                        (uu___1039_7637.FStar_Tactics_Types.opts);
                       FStar_Tactics_Types.is_guard =
-                        (uu___1039_7642.FStar_Tactics_Types.is_guard);
+                        (uu___1039_7637.FStar_Tactics_Types.is_guard);
                       FStar_Tactics_Types.label =
-                        (uu___1039_7642.FStar_Tactics_Types.label)
+                        (uu___1039_7637.FStar_Tactics_Types.label)
                     }  in
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____7646  ->
+                    (fun uu____7641  ->
                        let t_eq =
-                         let uu____7648 =
-                           let uu____7649 = FStar_Tactics_Types.goal_type g
+                         let uu____7643 =
+                           let uu____7644 = FStar_Tactics_Types.goal_type g
                               in
                            env1.FStar_TypeChecker_Env.universe_of env1
-                             uu____7649
+                             uu____7644
                             in
-                         let uu____7650 = FStar_Tactics_Types.goal_type g  in
-                         let uu____7651 = FStar_Tactics_Types.goal_witness g
+                         let uu____7645 = FStar_Tactics_Types.goal_type g  in
+                         let uu____7646 = FStar_Tactics_Types.goal_witness g
                             in
-                         FStar_Syntax_Util.mk_eq2 uu____7648 uu____7650 u
-                           uu____7651
+                         FStar_Syntax_Util.mk_eq2 uu____7643 uu____7645 u
+                           uu____7646
                           in
-                       let uu____7652 =
+                       let uu____7647 =
                          FStar_Tactics_Monad.add_irrelevant_goal g
                            "dup equation" env1 t_eq
                           in
-                       FStar_Tactics_Monad.bind uu____7652
-                         (fun uu____7658  ->
-                            let uu____7659 =
+                       FStar_Tactics_Monad.bind uu____7647
+                         (fun uu____7653  ->
+                            let uu____7654 =
                               FStar_Tactics_Monad.add_goals [g']  in
-                            FStar_Tactics_Monad.bind uu____7659
-                              (fun uu____7663  -> FStar_Tactics_Monad.ret ())))))
+                            FStar_Tactics_Monad.bind uu____7654
+                              (fun uu____7658  -> FStar_Tactics_Monad.ret ())))))
   
 let longest_prefix :
   'a .
@@ -3631,11 +3629,11 @@ let longest_prefix :
         let rec aux acc l11 l21 =
           match (l11, l21) with
           | (x::xs,y::ys) ->
-              let uu____7789 = f x y  in
-              if uu____7789 then aux (x :: acc) xs ys else (acc, xs, ys)
-          | uu____7812 -> (acc, l11, l21)  in
-        let uu____7827 = aux [] l1 l2  in
-        match uu____7827 with | (pr,t1,t2) -> ((FStar_List.rev pr), t1, t2)
+              let uu____7784 = f x y  in
+              if uu____7784 then aux (x :: acc) xs ys else (acc, xs, ys)
+          | uu____7807 -> (acc, l11, l21)  in
+        let uu____7822 = aux [] l1 l2  in
+        match uu____7822 with | (pr,t1,t2) -> ((FStar_List.rev pr), t1, t2)
   
 let (join_goals :
   FStar_Tactics_Types.goal ->
@@ -3651,13 +3649,13 @@ let (join_goals :
                FStar_Syntax_Util.mk_forall_no_univ
                  (FStar_Pervasives_Native.fst b) f1) bs f
          in
-      let uu____7933 = FStar_Tactics_Types.get_phi g1  in
-      match uu____7933 with
+      let uu____7928 = FStar_Tactics_Types.get_phi g1  in
+      match uu____7928 with
       | FStar_Pervasives_Native.None  ->
           FStar_Tactics_Monad.fail "goal 1 is not irrelevant"
       | FStar_Pervasives_Native.Some phi1 ->
-          let uu____7940 = FStar_Tactics_Types.get_phi g2  in
-          (match uu____7940 with
+          let uu____7935 = FStar_Tactics_Types.get_phi g2  in
+          (match uu____7935 with
            | FStar_Pervasives_Native.None  ->
                FStar_Tactics_Monad.fail "goal 2 is not irrelevant"
            | FStar_Pervasives_Native.Some phi2 ->
@@ -3667,231 +3665,231 @@ let (join_goals :
                let gamma2 =
                  (g2.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma
                   in
-               let uu____7953 =
+               let uu____7948 =
                  longest_prefix FStar_Syntax_Syntax.eq_binding
                    (FStar_List.rev gamma1) (FStar_List.rev gamma2)
                   in
-               (match uu____7953 with
+               (match uu____7948 with
                 | (gamma,r1,r2) ->
                     let t1 =
-                      let uu____7984 =
+                      let uu____7979 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r1)
                          in
-                      close_forall_no_univs uu____7984 phi1  in
+                      close_forall_no_univs uu____7979 phi1  in
                     let t2 =
-                      let uu____7994 =
+                      let uu____7989 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r2)
                          in
-                      close_forall_no_univs uu____7994 phi2  in
-                    let uu____8003 =
+                      close_forall_no_univs uu____7989 phi2  in
+                    let uu____7998 =
                       set_solution g1 FStar_Syntax_Util.exp_unit  in
-                    FStar_Tactics_Monad.bind uu____8003
-                      (fun uu____8008  ->
-                         let uu____8009 =
+                    FStar_Tactics_Monad.bind uu____7998
+                      (fun uu____8003  ->
+                         let uu____8004 =
                            set_solution g2 FStar_Syntax_Util.exp_unit  in
-                         FStar_Tactics_Monad.bind uu____8009
-                           (fun uu____8016  ->
+                         FStar_Tactics_Monad.bind uu____8004
+                           (fun uu____8011  ->
                               let ng = FStar_Syntax_Util.mk_conj t1 t2  in
                               let nenv =
-                                let uu___1091_8021 =
+                                let uu___1091_8016 =
                                   FStar_Tactics_Types.goal_env g1  in
-                                let uu____8022 =
+                                let uu____8017 =
                                   FStar_Util.smap_create (Prims.of_int (100))
                                    in
                                 {
                                   FStar_TypeChecker_Env.solver =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.solver);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.solver);
                                   FStar_TypeChecker_Env.range =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.range);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.range);
                                   FStar_TypeChecker_Env.curmodule =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.curmodule);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.curmodule);
                                   FStar_TypeChecker_Env.gamma =
                                     (FStar_List.rev gamma);
                                   FStar_TypeChecker_Env.gamma_sig =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.gamma_sig);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.gamma_sig);
                                   FStar_TypeChecker_Env.gamma_cache =
-                                    uu____8022;
+                                    uu____8017;
                                   FStar_TypeChecker_Env.modules =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.modules);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.modules);
                                   FStar_TypeChecker_Env.expected_typ =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.expected_typ);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.expected_typ);
                                   FStar_TypeChecker_Env.sigtab =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.sigtab);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.sigtab);
                                   FStar_TypeChecker_Env.attrtab =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.attrtab);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.attrtab);
                                   FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.instantiate_imp);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.instantiate_imp);
                                   FStar_TypeChecker_Env.effects =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.effects);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.effects);
                                   FStar_TypeChecker_Env.generalize =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.generalize);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.generalize);
                                   FStar_TypeChecker_Env.letrecs =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.letrecs);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.letrecs);
                                   FStar_TypeChecker_Env.top_level =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.top_level);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.top_level);
                                   FStar_TypeChecker_Env.check_uvars =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.check_uvars);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.check_uvars);
                                   FStar_TypeChecker_Env.use_eq =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.use_eq);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.use_eq);
                                   FStar_TypeChecker_Env.use_eq_strict =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.use_eq_strict);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.is_iface);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.admit);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.admit);
                                   FStar_TypeChecker_Env.lax =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.lax);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.lax_universes);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.phase1);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.phase1);
                                   FStar_TypeChecker_Env.failhard =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.failhard);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.failhard);
                                   FStar_TypeChecker_Env.nosynth =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.nosynth);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.nosynth);
                                   FStar_TypeChecker_Env.uvar_subtyping =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.uvar_subtyping);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.tc_term =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.tc_term);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.type_of =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.type_of);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.type_of);
                                   FStar_TypeChecker_Env.universe_of =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.universe_of);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.universe_of);
                                   FStar_TypeChecker_Env.check_type_of =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.check_type_of);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.check_type_of);
                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.use_bv_sorts);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.qtbl_name_and_index);
                                   FStar_TypeChecker_Env.normalized_eff_names
                                     =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.normalized_eff_names);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.normalized_eff_names);
                                   FStar_TypeChecker_Env.fv_delta_depths =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.fv_delta_depths);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.fv_delta_depths);
                                   FStar_TypeChecker_Env.proof_ns =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.proof_ns);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.proof_ns);
                                   FStar_TypeChecker_Env.synth_hook =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.synth_hook);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.synth_hook);
                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                     =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                   FStar_TypeChecker_Env.splice =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.splice);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.splice);
                                   FStar_TypeChecker_Env.mpreprocess =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.mpreprocess);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.mpreprocess);
                                   FStar_TypeChecker_Env.postprocess =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.postprocess);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.postprocess);
                                   FStar_TypeChecker_Env.identifier_info =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.identifier_info);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.identifier_info);
                                   FStar_TypeChecker_Env.tc_hooks =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.tc_hooks);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.tc_hooks);
                                   FStar_TypeChecker_Env.dsenv =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.dsenv);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.dsenv);
                                   FStar_TypeChecker_Env.nbe =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.nbe);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.strict_args_tab);
+                                    (uu___1091_8016.FStar_TypeChecker_Env.strict_args_tab);
                                   FStar_TypeChecker_Env.erasable_types_tab =
-                                    (uu___1091_8021.FStar_TypeChecker_Env.erasable_types_tab)
+                                    (uu___1091_8016.FStar_TypeChecker_Env.erasable_types_tab)
                                 }  in
-                              let uu____8026 =
+                              let uu____8021 =
                                 FStar_Tactics_Monad.mk_irrelevant_goal
                                   "joined" nenv ng
                                   g1.FStar_Tactics_Types.opts
                                   g1.FStar_Tactics_Types.label
                                  in
-                              FStar_Tactics_Monad.bind uu____8026
+                              FStar_Tactics_Monad.bind uu____8021
                                 (fun goal  ->
                                    FStar_Tactics_Monad.mlog
-                                     (fun uu____8036  ->
-                                        let uu____8037 =
+                                     (fun uu____8031  ->
+                                        let uu____8032 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g1
                                            in
-                                        let uu____8039 =
+                                        let uu____8034 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g2
                                            in
-                                        let uu____8041 =
+                                        let uu____8036 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             goal
                                            in
                                         FStar_Util.print3
                                           "join_goals of\n(%s)\nand\n(%s)\n= (%s)\n"
-                                          uu____8037 uu____8039 uu____8041)
-                                     (fun uu____8045  ->
+                                          uu____8032 uu____8034 uu____8036)
+                                     (fun uu____8040  ->
                                         FStar_Tactics_Monad.ret goal))))))
   
 let (join : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____8053  ->
+  fun uu____8048  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps  ->
          match ps.FStar_Tactics_Types.goals with
          | g1::g2::gs ->
-             let uu____8069 =
+             let uu____8064 =
                FStar_Tactics_Monad.set
-                 (let uu___1106_8074 = ps  in
+                 (let uu___1106_8069 = ps  in
                   {
                     FStar_Tactics_Types.main_context =
-                      (uu___1106_8074.FStar_Tactics_Types.main_context);
+                      (uu___1106_8069.FStar_Tactics_Types.main_context);
                     FStar_Tactics_Types.all_implicits =
-                      (uu___1106_8074.FStar_Tactics_Types.all_implicits);
+                      (uu___1106_8069.FStar_Tactics_Types.all_implicits);
                     FStar_Tactics_Types.goals = gs;
                     FStar_Tactics_Types.smt_goals =
-                      (uu___1106_8074.FStar_Tactics_Types.smt_goals);
+                      (uu___1106_8069.FStar_Tactics_Types.smt_goals);
                     FStar_Tactics_Types.depth =
-                      (uu___1106_8074.FStar_Tactics_Types.depth);
+                      (uu___1106_8069.FStar_Tactics_Types.depth);
                     FStar_Tactics_Types.__dump =
-                      (uu___1106_8074.FStar_Tactics_Types.__dump);
+                      (uu___1106_8069.FStar_Tactics_Types.__dump);
                     FStar_Tactics_Types.psc =
-                      (uu___1106_8074.FStar_Tactics_Types.psc);
+                      (uu___1106_8069.FStar_Tactics_Types.psc);
                     FStar_Tactics_Types.entry_range =
-                      (uu___1106_8074.FStar_Tactics_Types.entry_range);
+                      (uu___1106_8069.FStar_Tactics_Types.entry_range);
                     FStar_Tactics_Types.guard_policy =
-                      (uu___1106_8074.FStar_Tactics_Types.guard_policy);
+                      (uu___1106_8069.FStar_Tactics_Types.guard_policy);
                     FStar_Tactics_Types.freshness =
-                      (uu___1106_8074.FStar_Tactics_Types.freshness);
+                      (uu___1106_8069.FStar_Tactics_Types.freshness);
                     FStar_Tactics_Types.tac_verb_dbg =
-                      (uu___1106_8074.FStar_Tactics_Types.tac_verb_dbg);
+                      (uu___1106_8069.FStar_Tactics_Types.tac_verb_dbg);
                     FStar_Tactics_Types.local_state =
-                      (uu___1106_8074.FStar_Tactics_Types.local_state)
+                      (uu___1106_8069.FStar_Tactics_Types.local_state)
                   })
                 in
-             FStar_Tactics_Monad.bind uu____8069
-               (fun uu____8077  ->
-                  let uu____8078 = join_goals g1 g2  in
-                  FStar_Tactics_Monad.bind uu____8078
+             FStar_Tactics_Monad.bind uu____8064
+               (fun uu____8072  ->
+                  let uu____8073 = join_goals g1 g2  in
+                  FStar_Tactics_Monad.bind uu____8073
                     (fun g12  -> FStar_Tactics_Monad.add_goals [g12]))
-         | uu____8083 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
+         | uu____8078 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
   
 let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s  ->
-    let uu____8099 =
+    let uu____8094 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
            FStar_Options.push ();
-           (let uu____8112 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts
+           (let uu____8107 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts
                in
-            FStar_Options.set uu____8112);
+            FStar_Options.set uu____8107);
            (let res = FStar_Options.set_options s  in
             let opts' = FStar_Options.peek ()  in
             FStar_Options.pop ();
             (match res with
              | FStar_Getopt.Success  ->
                  let g' =
-                   let uu___1117_8119 = g  in
+                   let uu___1117_8114 = g  in
                    {
                      FStar_Tactics_Types.goal_main_env =
-                       (uu___1117_8119.FStar_Tactics_Types.goal_main_env);
+                       (uu___1117_8114.FStar_Tactics_Types.goal_main_env);
                      FStar_Tactics_Types.goal_ctx_uvar =
-                       (uu___1117_8119.FStar_Tactics_Types.goal_ctx_uvar);
+                       (uu___1117_8114.FStar_Tactics_Types.goal_ctx_uvar);
                      FStar_Tactics_Types.opts = opts';
                      FStar_Tactics_Types.is_guard =
-                       (uu___1117_8119.FStar_Tactics_Types.is_guard);
+                       (uu___1117_8114.FStar_Tactics_Types.is_guard);
                      FStar_Tactics_Types.label =
-                       (uu___1117_8119.FStar_Tactics_Types.label)
+                       (uu___1117_8114.FStar_Tactics_Types.label)
                    }  in
                  FStar_Tactics_Monad.replace_cur g'
              | FStar_Getopt.Error err ->
@@ -3900,25 +3898,25 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
                  fail1 "Setting options `%s` failed (got `Help`?)" s)))
        in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "set_options")
-      uu____8099
+      uu____8094
   
 let (top_env : unit -> env FStar_Tactics_Monad.tac) =
-  fun uu____8136  ->
+  fun uu____8131  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps  ->
          FStar_All.pipe_left FStar_Tactics_Monad.ret
            ps.FStar_Tactics_Types.main_context)
   
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
-  fun uu____8151  ->
+  fun uu____8146  ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g  ->
-         let uu____8159 =
+         let uu____8154 =
            (FStar_Options.lax ()) ||
-             (let uu____8162 = FStar_Tactics_Types.goal_env g  in
-              uu____8162.FStar_TypeChecker_Env.lax)
+             (let uu____8157 = FStar_Tactics_Types.goal_env g  in
+              uu____8157.FStar_TypeChecker_Env.lax)
             in
-         FStar_Tactics_Monad.ret uu____8159)
+         FStar_Tactics_Monad.ret uu____8154)
   
 let (unquote :
   FStar_Reflection_Data.typ ->
@@ -3927,44 +3925,44 @@ let (unquote :
   =
   fun ty  ->
     fun tm  ->
-      let uu____8179 =
+      let uu____8174 =
         FStar_Tactics_Monad.mlog
+          (fun uu____8179  ->
+             let uu____8180 = FStar_Syntax_Print.term_to_string tm  in
+             FStar_Util.print1 "unquote: tm = %s\n" uu____8180)
           (fun uu____8184  ->
-             let uu____8185 = FStar_Syntax_Print.term_to_string tm  in
-             FStar_Util.print1 "unquote: tm = %s\n" uu____8185)
-          (fun uu____8189  ->
              FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                (fun goal  ->
                   let env1 =
-                    let uu____8195 = FStar_Tactics_Types.goal_env goal  in
-                    FStar_TypeChecker_Env.set_expected_typ uu____8195 ty  in
-                  let uu____8196 = __tc_ghost env1 tm  in
-                  FStar_Tactics_Monad.bind uu____8196
-                    (fun uu____8215  ->
-                       match uu____8215 with
+                    let uu____8190 = FStar_Tactics_Types.goal_env goal  in
+                    FStar_TypeChecker_Env.set_expected_typ uu____8190 ty  in
+                  let uu____8191 = __tc_ghost env1 tm  in
+                  FStar_Tactics_Monad.bind uu____8191
+                    (fun uu____8210  ->
+                       match uu____8210 with
                        | (tm1,typ,guard) ->
                            FStar_Tactics_Monad.mlog
-                             (fun uu____8229  ->
-                                let uu____8230 =
+                             (fun uu____8224  ->
+                                let uu____8225 =
                                   FStar_Syntax_Print.term_to_string tm1  in
                                 FStar_Util.print1 "unquote: tm' = %s\n"
-                                  uu____8230)
-                             (fun uu____8234  ->
+                                  uu____8225)
+                             (fun uu____8229  ->
                                 FStar_Tactics_Monad.mlog
-                                  (fun uu____8237  ->
-                                     let uu____8238 =
+                                  (fun uu____8232  ->
+                                     let uu____8233 =
                                        FStar_Syntax_Print.term_to_string typ
                                         in
                                      FStar_Util.print1 "unquote: typ = %s\n"
-                                       uu____8238)
-                                  (fun uu____8243  ->
-                                     let uu____8244 =
+                                       uu____8233)
+                                  (fun uu____8238  ->
+                                     let uu____8239 =
                                        proc_guard "unquote" env1 guard  in
-                                     FStar_Tactics_Monad.bind uu____8244
-                                       (fun uu____8249  ->
+                                     FStar_Tactics_Monad.bind uu____8239
+                                       (fun uu____8244  ->
                                           FStar_Tactics_Monad.ret tm1))))))
          in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____8179
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____8174
   
 let (uvar_env :
   env ->
@@ -3973,152 +3971,152 @@ let (uvar_env :
   =
   fun env1  ->
     fun ty  ->
-      let uu____8274 =
+      let uu____8269 =
         match ty with
         | FStar_Pervasives_Native.Some ty1 -> FStar_Tactics_Monad.ret ty1
         | FStar_Pervasives_Native.None  ->
-            let uu____8280 =
-              let uu____8287 =
-                let uu____8288 = FStar_Syntax_Util.type_u ()  in
-                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____8288
+            let uu____8275 =
+              let uu____8282 =
+                let uu____8283 = FStar_Syntax_Util.type_u ()  in
+                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____8283
                  in
-              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____8287  in
-            FStar_Tactics_Monad.bind uu____8280
-              (fun uu____8305  ->
-                 match uu____8305 with
+              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____8282  in
+            FStar_Tactics_Monad.bind uu____8275
+              (fun uu____8300  ->
+                 match uu____8300 with
                  | (typ,uvar_typ) -> FStar_Tactics_Monad.ret typ)
          in
-      FStar_Tactics_Monad.bind uu____8274
+      FStar_Tactics_Monad.bind uu____8269
         (fun typ  ->
-           let uu____8317 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ
+           let uu____8312 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ
               in
-           FStar_Tactics_Monad.bind uu____8317
-             (fun uu____8332  ->
-                match uu____8332 with
+           FStar_Tactics_Monad.bind uu____8312
+             (fun uu____8327  ->
+                match uu____8327 with
                 | (t,uvar_t) -> FStar_Tactics_Monad.ret t))
   
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t  ->
-    let uu____8351 =
+    let uu____8346 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps  ->
            let env1 = ps.FStar_Tactics_Types.main_context  in
            let opts =
              match ps.FStar_Tactics_Types.goals with
-             | g::uu____8370 -> g.FStar_Tactics_Types.opts
-             | uu____8373 -> FStar_Options.peek ()  in
-           let uu____8376 = FStar_Syntax_Util.head_and_args t  in
-           match uu____8376 with
+             | g::uu____8365 -> g.FStar_Tactics_Types.opts
+             | uu____8368 -> FStar_Options.peek ()  in
+           let uu____8371 = FStar_Syntax_Util.head_and_args t  in
+           match uu____8371 with
            | ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                  (ctx_uvar,uu____8396);
-                FStar_Syntax_Syntax.pos = uu____8397;
-                FStar_Syntax_Syntax.vars = uu____8398;_},uu____8399)
+                  (ctx_uvar,uu____8391);
+                FStar_Syntax_Syntax.pos = uu____8392;
+                FStar_Syntax_Syntax.vars = uu____8393;_},uu____8394)
                ->
                let env2 =
-                 let uu___1171_8441 = env1  in
+                 let uu___1171_8436 = env1  in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___1171_8441.FStar_TypeChecker_Env.solver);
+                     (uu___1171_8436.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___1171_8441.FStar_TypeChecker_Env.range);
+                     (uu___1171_8436.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___1171_8441.FStar_TypeChecker_Env.curmodule);
+                     (uu___1171_8436.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
                      (ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___1171_8441.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___1171_8436.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___1171_8441.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___1171_8436.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___1171_8441.FStar_TypeChecker_Env.modules);
+                     (uu___1171_8436.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___1171_8441.FStar_TypeChecker_Env.expected_typ);
+                     (uu___1171_8436.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___1171_8441.FStar_TypeChecker_Env.sigtab);
+                     (uu___1171_8436.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___1171_8441.FStar_TypeChecker_Env.attrtab);
+                     (uu___1171_8436.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___1171_8441.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___1171_8436.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___1171_8441.FStar_TypeChecker_Env.effects);
+                     (uu___1171_8436.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___1171_8441.FStar_TypeChecker_Env.generalize);
+                     (uu___1171_8436.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___1171_8441.FStar_TypeChecker_Env.letrecs);
+                     (uu___1171_8436.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level =
-                     (uu___1171_8441.FStar_TypeChecker_Env.top_level);
+                     (uu___1171_8436.FStar_TypeChecker_Env.top_level);
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___1171_8441.FStar_TypeChecker_Env.check_uvars);
+                     (uu___1171_8436.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___1171_8441.FStar_TypeChecker_Env.use_eq);
+                     (uu___1171_8436.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.use_eq_strict =
-                     (uu___1171_8441.FStar_TypeChecker_Env.use_eq_strict);
+                     (uu___1171_8436.FStar_TypeChecker_Env.use_eq_strict);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___1171_8441.FStar_TypeChecker_Env.is_iface);
+                     (uu___1171_8436.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___1171_8441.FStar_TypeChecker_Env.admit);
+                     (uu___1171_8436.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___1171_8441.FStar_TypeChecker_Env.lax);
+                     (uu___1171_8436.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___1171_8441.FStar_TypeChecker_Env.lax_universes);
+                     (uu___1171_8436.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___1171_8441.FStar_TypeChecker_Env.phase1);
+                     (uu___1171_8436.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___1171_8441.FStar_TypeChecker_Env.failhard);
+                     (uu___1171_8436.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___1171_8441.FStar_TypeChecker_Env.nosynth);
+                     (uu___1171_8436.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___1171_8441.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___1171_8436.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___1171_8441.FStar_TypeChecker_Env.tc_term);
+                     (uu___1171_8436.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___1171_8441.FStar_TypeChecker_Env.type_of);
+                     (uu___1171_8436.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___1171_8441.FStar_TypeChecker_Env.universe_of);
+                     (uu___1171_8436.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___1171_8441.FStar_TypeChecker_Env.check_type_of);
+                     (uu___1171_8436.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___1171_8441.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___1171_8436.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___1171_8441.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___1171_8436.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___1171_8441.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___1171_8436.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___1171_8441.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___1171_8436.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___1171_8441.FStar_TypeChecker_Env.proof_ns);
+                     (uu___1171_8436.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___1171_8441.FStar_TypeChecker_Env.synth_hook);
+                     (uu___1171_8436.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.try_solve_implicits_hook =
-                     (uu___1171_8441.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     (uu___1171_8436.FStar_TypeChecker_Env.try_solve_implicits_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___1171_8441.FStar_TypeChecker_Env.splice);
+                     (uu___1171_8436.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.mpreprocess =
-                     (uu___1171_8441.FStar_TypeChecker_Env.mpreprocess);
+                     (uu___1171_8436.FStar_TypeChecker_Env.mpreprocess);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___1171_8441.FStar_TypeChecker_Env.postprocess);
+                     (uu___1171_8436.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___1171_8441.FStar_TypeChecker_Env.identifier_info);
+                     (uu___1171_8436.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___1171_8441.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___1171_8436.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___1171_8441.FStar_TypeChecker_Env.dsenv);
+                     (uu___1171_8436.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___1171_8441.FStar_TypeChecker_Env.nbe);
+                     (uu___1171_8436.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___1171_8441.FStar_TypeChecker_Env.strict_args_tab);
+                     (uu___1171_8436.FStar_TypeChecker_Env.strict_args_tab);
                    FStar_TypeChecker_Env.erasable_types_tab =
-                     (uu___1171_8441.FStar_TypeChecker_Env.erasable_types_tab)
+                     (uu___1171_8436.FStar_TypeChecker_Env.erasable_types_tab)
                  }  in
                let g =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false ""  in
-               let uu____8445 =
-                 let uu____8448 = bnorm_goal g  in [uu____8448]  in
-               FStar_Tactics_Monad.add_goals uu____8445
-           | uu____8449 -> FStar_Tactics_Monad.fail "not a uvar")
+               let uu____8440 =
+                 let uu____8443 = bnorm_goal g  in [uu____8443]  in
+               FStar_Tactics_Monad.add_goals uu____8440
+           | uu____8444 -> FStar_Tactics_Monad.fail "not a uvar")
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____8351
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____8346
   
 let (tac_and :
   Prims.bool FStar_Tactics_Monad.tac ->
@@ -4129,18 +4127,18 @@ let (tac_and :
       let comp =
         FStar_Tactics_Monad.bind t1
           (fun b  ->
-             let uu____8511 = if b then t2 else FStar_Tactics_Monad.ret false
+             let uu____8506 = if b then t2 else FStar_Tactics_Monad.ret false
                 in
-             FStar_Tactics_Monad.bind uu____8511
+             FStar_Tactics_Monad.bind uu____8506
                (fun b'  ->
                   if b'
                   then FStar_Tactics_Monad.ret b'
                   else FStar_Tactics_Monad.fail ""))
          in
-      let uu____8537 = trytac comp  in
-      FStar_Tactics_Monad.bind uu____8537
-        (fun uu___5_8549  ->
-           match uu___5_8549 with
+      let uu____8532 = trytac comp  in
+      FStar_Tactics_Monad.bind uu____8532
+        (fun uu___5_8544  ->
+           match uu___5_8544 with
            | FStar_Pervasives_Native.Some (true ) ->
                FStar_Tactics_Monad.ret true
            | FStar_Pervasives_Native.Some (false ) -> failwith "impossible"
@@ -4154,35 +4152,35 @@ let (unify_env :
   fun e  ->
     fun t1  ->
       fun t2  ->
-        let uu____8591 =
+        let uu____8586 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps  ->
-               let uu____8599 = __tc e t1  in
-               FStar_Tactics_Monad.bind uu____8599
-                 (fun uu____8620  ->
-                    match uu____8620 with
+               let uu____8594 = __tc e t1  in
+               FStar_Tactics_Monad.bind uu____8594
+                 (fun uu____8615  ->
+                    match uu____8615 with
                     | (t11,ty1,g1) ->
-                        let uu____8633 = __tc e t2  in
-                        FStar_Tactics_Monad.bind uu____8633
-                          (fun uu____8654  ->
-                             match uu____8654 with
+                        let uu____8628 = __tc e t2  in
+                        FStar_Tactics_Monad.bind uu____8628
+                          (fun uu____8649  ->
+                             match uu____8649 with
                              | (t21,ty2,g2) ->
-                                 let uu____8667 =
+                                 let uu____8662 =
                                    proc_guard "unify_env g1" e g1  in
-                                 FStar_Tactics_Monad.bind uu____8667
-                                   (fun uu____8674  ->
-                                      let uu____8675 =
+                                 FStar_Tactics_Monad.bind uu____8662
+                                   (fun uu____8669  ->
+                                      let uu____8670 =
                                         proc_guard "unify_env g2" e g2  in
-                                      FStar_Tactics_Monad.bind uu____8675
-                                        (fun uu____8683  ->
-                                           let uu____8684 =
+                                      FStar_Tactics_Monad.bind uu____8670
+                                        (fun uu____8678  ->
+                                           let uu____8679 =
                                              do_unify e ty1 ty2  in
-                                           let uu____8688 =
+                                           let uu____8683 =
                                              do_unify e t11 t21  in
-                                           tac_and uu____8684 uu____8688)))))
+                                           tac_and uu____8679 uu____8683)))))
            in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unify_env")
-          uu____8591
+          uu____8586
   
 let (launch_process :
   Prims.string ->
@@ -4193,9 +4191,9 @@ let (launch_process :
     fun args  ->
       fun input  ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-          (fun uu____8736  ->
-             let uu____8737 = FStar_Options.unsafe_tactic_exec ()  in
-             if uu____8737
+          (fun uu____8731  ->
+             let uu____8732 = FStar_Options.unsafe_tactic_exec ()  in
+             if uu____8732
              then
                let s =
                  FStar_Util.run_process "tactic_launch" prog args
@@ -4214,50 +4212,50 @@ let (fresh_bv_named :
   fun nm  ->
     fun t  ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-        (fun uu____8771  ->
-           let uu____8772 =
+        (fun uu____8766  ->
+           let uu____8767 =
              FStar_Syntax_Syntax.gen_bv nm FStar_Pervasives_Native.None t  in
-           FStar_Tactics_Monad.ret uu____8772)
+           FStar_Tactics_Monad.ret uu____8767)
   
 let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
   fun ty  ->
-    let uu____8783 =
+    let uu____8778 =
       FStar_Tactics_Monad.mlog
+        (fun uu____8783  ->
+           let uu____8784 = FStar_Syntax_Print.term_to_string ty  in
+           FStar_Util.print1 "change: ty = %s\n" uu____8784)
         (fun uu____8788  ->
-           let uu____8789 = FStar_Syntax_Print.term_to_string ty  in
-           FStar_Util.print1 "change: ty = %s\n" uu____8789)
-        (fun uu____8793  ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g  ->
-                let uu____8797 =
-                  let uu____8806 = FStar_Tactics_Types.goal_env g  in
-                  __tc uu____8806 ty  in
-                FStar_Tactics_Monad.bind uu____8797
-                  (fun uu____8818  ->
-                     match uu____8818 with
-                     | (ty1,uu____8828,guard) ->
-                         let uu____8830 =
-                           let uu____8833 = FStar_Tactics_Types.goal_env g
+                let uu____8792 =
+                  let uu____8801 = FStar_Tactics_Types.goal_env g  in
+                  __tc uu____8801 ty  in
+                FStar_Tactics_Monad.bind uu____8792
+                  (fun uu____8813  ->
+                     match uu____8813 with
+                     | (ty1,uu____8823,guard) ->
+                         let uu____8825 =
+                           let uu____8828 = FStar_Tactics_Types.goal_env g
                               in
-                           proc_guard "change" uu____8833 guard  in
-                         FStar_Tactics_Monad.bind uu____8830
-                           (fun uu____8837  ->
-                              let uu____8838 =
-                                let uu____8842 =
+                           proc_guard "change" uu____8828 guard  in
+                         FStar_Tactics_Monad.bind uu____8825
+                           (fun uu____8832  ->
+                              let uu____8833 =
+                                let uu____8837 =
                                   FStar_Tactics_Types.goal_env g  in
-                                let uu____8843 =
+                                let uu____8838 =
                                   FStar_Tactics_Types.goal_type g  in
-                                do_unify uu____8842 uu____8843 ty1  in
-                              FStar_Tactics_Monad.bind uu____8838
+                                do_unify uu____8837 uu____8838 ty1  in
+                              FStar_Tactics_Monad.bind uu____8833
                                 (fun bb  ->
                                    if bb
                                    then
-                                     let uu____8852 =
+                                     let uu____8847 =
                                        FStar_Tactics_Types.goal_with_type g
                                          ty1
                                         in
                                      FStar_Tactics_Monad.replace_cur
-                                       uu____8852
+                                       uu____8847
                                    else
                                      (let steps =
                                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -4265,35 +4263,35 @@ let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
                                           FStar_Syntax_Syntax.delta_constant;
                                         FStar_TypeChecker_Env.Primops]  in
                                       let ng =
-                                        let uu____8859 =
+                                        let uu____8854 =
                                           FStar_Tactics_Types.goal_env g  in
-                                        let uu____8860 =
+                                        let uu____8855 =
                                           FStar_Tactics_Types.goal_type g  in
-                                        normalize steps uu____8859 uu____8860
+                                        normalize steps uu____8854 uu____8855
                                          in
                                       let nty =
+                                        let uu____8857 =
+                                          FStar_Tactics_Types.goal_env g  in
+                                        normalize steps uu____8857 ty1  in
+                                      let uu____8858 =
                                         let uu____8862 =
                                           FStar_Tactics_Types.goal_env g  in
-                                        normalize steps uu____8862 ty1  in
-                                      let uu____8863 =
-                                        let uu____8867 =
-                                          FStar_Tactics_Types.goal_env g  in
-                                        do_unify uu____8867 ng nty  in
-                                      FStar_Tactics_Monad.bind uu____8863
+                                        do_unify uu____8862 ng nty  in
+                                      FStar_Tactics_Monad.bind uu____8858
                                         (fun b  ->
                                            if b
                                            then
-                                             let uu____8876 =
+                                             let uu____8871 =
                                                FStar_Tactics_Types.goal_with_type
                                                  g ty1
                                                 in
                                              FStar_Tactics_Monad.replace_cur
-                                               uu____8876
+                                               uu____8871
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible")))))))
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8783
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8778
   
 let failwhen :
   'a .
@@ -4310,70 +4308,70 @@ let (t_destruct :
       FStar_Tactics_Monad.tac)
   =
   fun s_tm  ->
-    let uu____8950 =
+    let uu____8945 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g  ->
-           let uu____8968 =
-             let uu____8977 = FStar_Tactics_Types.goal_env g  in
-             __tc uu____8977 s_tm  in
-           FStar_Tactics_Monad.bind uu____8968
-             (fun uu____8995  ->
-                match uu____8995 with
+           let uu____8963 =
+             let uu____8972 = FStar_Tactics_Types.goal_env g  in
+             __tc uu____8972 s_tm  in
+           FStar_Tactics_Monad.bind uu____8963
+             (fun uu____8990  ->
+                match uu____8990 with
                 | (s_tm1,s_ty,guard) ->
-                    let uu____9013 =
-                      let uu____9016 = FStar_Tactics_Types.goal_env g  in
-                      proc_guard "destruct" uu____9016 guard  in
-                    FStar_Tactics_Monad.bind uu____9013
-                      (fun uu____9030  ->
+                    let uu____9008 =
+                      let uu____9011 = FStar_Tactics_Types.goal_env g  in
+                      proc_guard "destruct" uu____9011 guard  in
+                    FStar_Tactics_Monad.bind uu____9008
+                      (fun uu____9025  ->
                          let s_ty1 =
-                           let uu____9032 = FStar_Tactics_Types.goal_env g
+                           let uu____9027 = FStar_Tactics_Types.goal_env g
                               in
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.UnfoldTac;
                              FStar_TypeChecker_Env.Weak;
                              FStar_TypeChecker_Env.HNF;
                              FStar_TypeChecker_Env.UnfoldUntil
-                               FStar_Syntax_Syntax.delta_constant] uu____9032
+                               FStar_Syntax_Syntax.delta_constant] uu____9027
                              s_ty
                             in
-                         let uu____9033 =
-                           let uu____9048 = FStar_Syntax_Util.unrefine s_ty1
+                         let uu____9028 =
+                           let uu____9043 = FStar_Syntax_Util.unrefine s_ty1
                               in
-                           FStar_Syntax_Util.head_and_args' uu____9048  in
-                         match uu____9033 with
+                           FStar_Syntax_Util.head_and_args' uu____9043  in
+                         match uu____9028 with
                          | (h,args) ->
-                             let uu____9079 =
-                               let uu____9086 =
-                                 let uu____9087 =
+                             let uu____9074 =
+                               let uu____9081 =
+                                 let uu____9082 =
                                    FStar_Syntax_Subst.compress h  in
-                                 uu____9087.FStar_Syntax_Syntax.n  in
-                               match uu____9086 with
+                                 uu____9082.FStar_Syntax_Syntax.n  in
+                               match uu____9081 with
                                | FStar_Syntax_Syntax.Tm_fvar fv ->
                                    FStar_Tactics_Monad.ret (fv, [])
                                | FStar_Syntax_Syntax.Tm_uinst
                                    ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_fvar fv;
-                                      FStar_Syntax_Syntax.pos = uu____9102;
-                                      FStar_Syntax_Syntax.vars = uu____9103;_},us)
+                                      FStar_Syntax_Syntax.pos = uu____9097;
+                                      FStar_Syntax_Syntax.vars = uu____9098;_},us)
                                    -> FStar_Tactics_Monad.ret (fv, us)
-                               | uu____9113 ->
+                               | uu____9108 ->
                                    FStar_Tactics_Monad.fail
                                      "type is not an fv"
                                 in
-                             FStar_Tactics_Monad.bind uu____9079
-                               (fun uu____9134  ->
-                                  match uu____9134 with
+                             FStar_Tactics_Monad.bind uu____9074
+                               (fun uu____9129  ->
+                                  match uu____9129 with
                                   | (fv,a_us) ->
                                       let t_lid =
                                         FStar_Syntax_Syntax.lid_of_fv fv  in
-                                      let uu____9150 =
-                                        let uu____9153 =
+                                      let uu____9145 =
+                                        let uu____9148 =
                                           FStar_Tactics_Types.goal_env g  in
                                         FStar_TypeChecker_Env.lookup_sigelt
-                                          uu____9153 t_lid
+                                          uu____9148 t_lid
                                          in
-                                      (match uu____9150 with
+                                      (match uu____9145 with
                                        | FStar_Pervasives_Native.None  ->
                                            FStar_Tactics_Monad.fail
                                              "type not found in environment"
@@ -4388,18 +4386,18 @@ let (t_destruct :
                                                     se.FStar_Syntax_Syntax.sigattrs
                                                     FStar_Parser_Const.erasable_attr
                                                    in
-                                                let uu____9194 =
+                                                let uu____9189 =
                                                   erasable &&
-                                                    (let uu____9197 =
+                                                    (let uu____9192 =
                                                        FStar_Tactics_Types.is_irrelevant
                                                          g
                                                         in
                                                      Prims.op_Negation
-                                                       uu____9197)
+                                                       uu____9192)
                                                    in
-                                                failwhen uu____9194
+                                                failwhen uu____9189
                                                   "cannot destruct erasable type to solve proof-relevant goal"
-                                                  (fun uu____9207  ->
+                                                  (fun uu____9202  ->
                                                      failwhen
                                                        ((FStar_List.length
                                                            a_us)
@@ -4407,29 +4405,29 @@ let (t_destruct :
                                                           (FStar_List.length
                                                              t_us))
                                                        "t_us don't match?"
-                                                       (fun uu____9220  ->
-                                                          let uu____9221 =
+                                                       (fun uu____9215  ->
+                                                          let uu____9216 =
                                                             FStar_Syntax_Subst.open_term
                                                               t_ps t_ty
                                                              in
-                                                          match uu____9221
+                                                          match uu____9216
                                                           with
                                                           | (t_ps1,t_ty1) ->
-                                                              let uu____9236
+                                                              let uu____9231
                                                                 =
                                                                 FStar_Tactics_Monad.mapM
                                                                   (fun c_lid 
                                                                     ->
-                                                                    let uu____9264
+                                                                    let uu____9259
                                                                     =
-                                                                    let uu____9267
+                                                                    let uu____9262
                                                                     =
                                                                     FStar_Tactics_Types.goal_env
                                                                     g  in
                                                                     FStar_TypeChecker_Env.lookup_sigelt
-                                                                    uu____9267
+                                                                    uu____9262
                                                                     c_lid  in
-                                                                    match uu____9264
+                                                                    match uu____9259
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
@@ -4460,7 +4458,7 @@ let (t_destruct :
                                                                     c_us))
                                                                     "t_us don't match?"
                                                                     (fun
-                                                                    uu____9344
+                                                                    uu____9339
                                                                      ->
                                                                     let s =
                                                                     FStar_TypeChecker_Env.mk_univ_subst
@@ -4471,27 +4469,27 @@ let (t_destruct :
                                                                     FStar_Syntax_Subst.subst
                                                                     s c_ty
                                                                      in
-                                                                    let uu____9349
+                                                                    let uu____9344
                                                                     =
                                                                     FStar_TypeChecker_Env.inst_tscheme
                                                                     (c_us,
                                                                     c_ty1)
                                                                      in
-                                                                    match uu____9349
+                                                                    match uu____9344
                                                                     with
                                                                     | 
                                                                     (c_us1,c_ty2)
                                                                     ->
-                                                                    let uu____9372
+                                                                    let uu____9367
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     c_ty2  in
-                                                                    (match uu____9372
+                                                                    (match uu____9367
                                                                     with
                                                                     | 
                                                                     (bs,comp)
                                                                     ->
-                                                                    let uu____9391
+                                                                    let uu____9386
                                                                     =
                                                                     let rename_bv
                                                                     bv =
@@ -4501,132 +4499,132 @@ let (t_destruct :
                                                                      in
                                                                     let ppname1
                                                                     =
-                                                                    let uu____9414
+                                                                    let uu____9409
                                                                     =
-                                                                    let uu____9420
+                                                                    let uu____9415
                                                                     =
-                                                                    let uu____9422
+                                                                    let uu____9417
                                                                     =
                                                                     FStar_Ident.text_of_id
                                                                     ppname
                                                                      in
                                                                     Prims.op_Hat
                                                                     "a"
-                                                                    uu____9422
+                                                                    uu____9417
                                                                      in
-                                                                    let uu____9425
+                                                                    let uu____9420
                                                                     =
                                                                     FStar_Ident.range_of_id
                                                                     ppname
                                                                      in
-                                                                    (uu____9420,
-                                                                    uu____9425)
+                                                                    (uu____9415,
+                                                                    uu____9420)
                                                                      in
                                                                     FStar_Ident.mk_ident
-                                                                    uu____9414
+                                                                    uu____9409
                                                                      in
                                                                     FStar_Syntax_Syntax.freshen_bv
-                                                                    (let uu___1299_9429
+                                                                    (let uu___1299_9424
                                                                     = bv  in
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     = ppname1;
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1299_9429.FStar_Syntax_Syntax.index);
+                                                                    (uu___1299_9424.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
-                                                                    (uu___1299_9429.FStar_Syntax_Syntax.sort)
+                                                                    (uu___1299_9424.FStar_Syntax_Syntax.sort)
                                                                     })  in
                                                                     let bs' =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9455
+                                                                    uu____9450
                                                                      ->
-                                                                    match uu____9455
+                                                                    match uu____9450
                                                                     with
                                                                     | 
                                                                     (bv,aq)
                                                                     ->
-                                                                    let uu____9474
+                                                                    let uu____9469
                                                                     =
                                                                     rename_bv
                                                                     bv  in
-                                                                    (uu____9474,
+                                                                    (uu____9469,
                                                                     aq)) bs
                                                                      in
                                                                     let subst
                                                                     =
                                                                     FStar_List.map2
                                                                     (fun
-                                                                    uu____9499
+                                                                    uu____9494
                                                                      ->
                                                                     fun
-                                                                    uu____9500
+                                                                    uu____9495
                                                                      ->
                                                                     match 
-                                                                    (uu____9499,
-                                                                    uu____9500)
+                                                                    (uu____9494,
+                                                                    uu____9495)
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____9526),
-                                                                    (bv',uu____9528))
+                                                                    ((bv,uu____9521),
+                                                                    (bv',uu____9523))
                                                                     ->
-                                                                    let uu____9549
+                                                                    let uu____9544
                                                                     =
-                                                                    let uu____9556
+                                                                    let uu____9551
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv'  in
                                                                     (bv,
-                                                                    uu____9556)
+                                                                    uu____9551)
                                                                      in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____9549)
+                                                                    uu____9544)
                                                                     bs bs'
                                                                      in
-                                                                    let uu____9561
+                                                                    let uu____9556
                                                                     =
                                                                     FStar_Syntax_Subst.subst_binders
                                                                     subst bs'
                                                                      in
-                                                                    let uu____9570
+                                                                    let uu____9565
                                                                     =
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subst
                                                                     comp  in
-                                                                    (uu____9561,
-                                                                    uu____9570)
+                                                                    (uu____9556,
+                                                                    uu____9565)
                                                                      in
-                                                                    (match uu____9391
+                                                                    (match uu____9386
                                                                     with
                                                                     | 
                                                                     (bs1,comp1)
                                                                     ->
-                                                                    let uu____9617
+                                                                    let uu____9612
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     bs1  in
-                                                                    (match uu____9617
+                                                                    (match uu____9612
                                                                     with
                                                                     | 
                                                                     (d_ps,bs2)
                                                                     ->
-                                                                    let uu____9690
+                                                                    let uu____9685
                                                                     =
-                                                                    let uu____9692
+                                                                    let uu____9687
                                                                     =
                                                                     FStar_Syntax_Util.is_total_comp
                                                                     comp1  in
                                                                     Prims.op_Negation
-                                                                    uu____9692
+                                                                    uu____9687
                                                                      in
                                                                     failwhen
-                                                                    uu____9690
+                                                                    uu____9685
                                                                     "not total?"
                                                                     (fun
-                                                                    uu____9711
+                                                                    uu____9706
                                                                      ->
                                                                     let mk_pat
                                                                     p =
@@ -4638,25 +4636,25 @@ let (t_destruct :
                                                                     (s_tm1.FStar_Syntax_Syntax.pos)
                                                                     }  in
                                                                     let is_imp
-                                                                    uu___6_9728
+                                                                    uu___6_9723
                                                                     =
-                                                                    match uu___6_9728
+                                                                    match uu___6_9723
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
-                                                                    uu____9732)
+                                                                    uu____9727)
                                                                     -> true
                                                                     | 
-                                                                    uu____9735
+                                                                    uu____9730
                                                                     -> false
                                                                      in
-                                                                    let uu____9739
+                                                                    let uu____9734
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     args  in
-                                                                    match uu____9739
+                                                                    match uu____9734
                                                                     with
                                                                     | 
                                                                     (a_ps,a_is)
@@ -4668,7 +4666,7 @@ let (t_destruct :
                                                                     d_ps))
                                                                     "params not match?"
                                                                     (fun
-                                                                    uu____9875
+                                                                    uu____9870
                                                                      ->
                                                                     let d_ps_a_ps
                                                                     =
@@ -4679,13 +4677,13 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9937
+                                                                    uu____9932
                                                                      ->
-                                                                    match uu____9937
+                                                                    match uu____9932
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____9957),
-                                                                    (t,uu____9959))
+                                                                    ((bv,uu____9952),
+                                                                    (t,uu____9954))
                                                                     ->
                                                                     FStar_Syntax_Syntax.NT
                                                                     (bv, t))
@@ -4699,13 +4697,13 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____10029
+                                                                    uu____10024
                                                                      ->
-                                                                    match uu____10029
+                                                                    match uu____10024
                                                                     with
                                                                     | 
-                                                                    ((bv,uu____10056),
-                                                                    (t,uu____10058))
+                                                                    ((bv,uu____10051),
+                                                                    (t,uu____10053))
                                                                     ->
                                                                     ((mk_pat
                                                                     (FStar_Syntax_Syntax.Pat_dot_term
@@ -4717,9 +4715,9 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____10117
+                                                                    uu____10112
                                                                      ->
-                                                                    match uu____10117
+                                                                    match uu____10112
                                                                     with
                                                                     | 
                                                                     (bv,aq)
@@ -4753,162 +4751,162 @@ let (t_destruct :
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1
                                                                     s_ty1  in
-                                                                    let uu____10172
+                                                                    let uu____10167
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_pat
-                                                                    (let uu___1358_10196
+                                                                    (let uu___1358_10191
                                                                     = env1
                                                                      in
                                                                     {
                                                                     FStar_TypeChecker_Env.solver
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.solver);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.solver);
                                                                     FStar_TypeChecker_Env.range
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.range);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.range);
                                                                     FStar_TypeChecker_Env.curmodule
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.curmodule);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.curmodule);
                                                                     FStar_TypeChecker_Env.gamma
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.gamma);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.gamma);
                                                                     FStar_TypeChecker_Env.gamma_sig
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.gamma_sig);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.gamma_sig);
                                                                     FStar_TypeChecker_Env.gamma_cache
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.gamma_cache);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.gamma_cache);
                                                                     FStar_TypeChecker_Env.modules
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.modules);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.modules);
                                                                     FStar_TypeChecker_Env.expected_typ
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.expected_typ);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.expected_typ);
                                                                     FStar_TypeChecker_Env.sigtab
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.sigtab);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.sigtab);
                                                                     FStar_TypeChecker_Env.attrtab
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.attrtab);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.attrtab);
                                                                     FStar_TypeChecker_Env.instantiate_imp
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.instantiate_imp);
                                                                     FStar_TypeChecker_Env.effects
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.effects);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.effects);
                                                                     FStar_TypeChecker_Env.generalize
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.generalize);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.generalize);
                                                                     FStar_TypeChecker_Env.letrecs
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.letrecs);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.letrecs);
                                                                     FStar_TypeChecker_Env.top_level
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.top_level);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.top_level);
                                                                     FStar_TypeChecker_Env.check_uvars
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.check_uvars);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.check_uvars);
                                                                     FStar_TypeChecker_Env.use_eq
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.use_eq);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.use_eq);
                                                                     FStar_TypeChecker_Env.use_eq_strict
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.use_eq_strict);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.use_eq_strict);
                                                                     FStar_TypeChecker_Env.is_iface
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.is_iface);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.admit);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.admit);
                                                                     FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.lax_universes);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.lax_universes);
                                                                     FStar_TypeChecker_Env.phase1
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.phase1);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.phase1);
                                                                     FStar_TypeChecker_Env.failhard
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.failhard);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.failhard);
                                                                     FStar_TypeChecker_Env.nosynth
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.nosynth);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.nosynth);
                                                                     FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.uvar_subtyping);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.tc_term);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.tc_term);
                                                                     FStar_TypeChecker_Env.type_of
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.type_of);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.type_of);
                                                                     FStar_TypeChecker_Env.universe_of
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.universe_of);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.universe_of);
                                                                     FStar_TypeChecker_Env.check_type_of
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.check_type_of);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.check_type_of);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.use_bv_sorts);
                                                                     FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                     FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.normalized_eff_names);
                                                                     FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.fv_delta_depths);
                                                                     FStar_TypeChecker_Env.proof_ns
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.proof_ns);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.proof_ns);
                                                                     FStar_TypeChecker_Env.synth_hook
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.synth_hook);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.synth_hook);
                                                                     FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                     FStar_TypeChecker_Env.splice
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.splice);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.splice);
                                                                     FStar_TypeChecker_Env.mpreprocess
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.mpreprocess);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.mpreprocess);
                                                                     FStar_TypeChecker_Env.postprocess
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.postprocess);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.postprocess);
                                                                     FStar_TypeChecker_Env.identifier_info
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.identifier_info);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.identifier_info);
                                                                     FStar_TypeChecker_Env.tc_hooks
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.tc_hooks);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.tc_hooks);
                                                                     FStar_TypeChecker_Env.dsenv
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.dsenv);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.dsenv);
                                                                     FStar_TypeChecker_Env.nbe
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.nbe);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.nbe);
                                                                     FStar_TypeChecker_Env.strict_args_tab
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.strict_args_tab);
                                                                     FStar_TypeChecker_Env.erasable_types_tab
                                                                     =
-                                                                    (uu___1358_10196.FStar_TypeChecker_Env.erasable_types_tab)
+                                                                    (uu___1358_10191.FStar_TypeChecker_Env.erasable_types_tab)
                                                                     }) s_ty1
                                                                     pat  in
-                                                                    match uu____10172
+                                                                    match uu____10167
                                                                     with
                                                                     | 
-                                                                    (uu____10210,uu____10211,uu____10212,uu____10213,pat_t,uu____10215,_guard_pat,_erasable)
+                                                                    (uu____10205,uu____10206,uu____10207,uu____10208,pat_t,uu____10210,_guard_pat,_erasable)
                                                                     ->
                                                                     let eq_b
                                                                     =
-                                                                    let uu____10229
+                                                                    let uu____10224
                                                                     =
-                                                                    let uu____10230
+                                                                    let uu____10225
                                                                     =
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     equ s_ty1
@@ -4916,52 +4914,52 @@ let (t_destruct :
                                                                     pat_t  in
                                                                     FStar_Syntax_Util.mk_squash
                                                                     equ
-                                                                    uu____10230
+                                                                    uu____10225
                                                                      in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "breq"
                                                                     FStar_Pervasives_Native.None
-                                                                    uu____10229
+                                                                    uu____10224
                                                                      in
                                                                     let cod1
                                                                     =
-                                                                    let uu____10235
+                                                                    let uu____10230
                                                                     =
-                                                                    let uu____10244
+                                                                    let uu____10239
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     eq_b  in
-                                                                    [uu____10244]
+                                                                    [uu____10239]
                                                                      in
-                                                                    let uu____10263
+                                                                    let uu____10258
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod  in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____10235
-                                                                    uu____10263
+                                                                    uu____10230
+                                                                    uu____10258
                                                                      in
                                                                     let nty =
-                                                                    let uu____10269
+                                                                    let uu____10264
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod1  in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs3
-                                                                    uu____10269
+                                                                    uu____10264
                                                                      in
-                                                                    let uu____10272
+                                                                    let uu____10267
                                                                     =
                                                                     FStar_Tactics_Monad.new_uvar
                                                                     "destruct branch"
                                                                     env1 nty
                                                                      in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____10272
+                                                                    uu____10267
                                                                     (fun
-                                                                    uu____10302
+                                                                    uu____10297
                                                                      ->
-                                                                    match uu____10302
+                                                                    match uu____10297
                                                                     with
                                                                     | 
                                                                     (uvt,uv)
@@ -4979,58 +4977,58 @@ let (t_destruct :
                                                                      in
                                                                     let brt1
                                                                     =
-                                                                    let uu____10329
+                                                                    let uu____10324
                                                                     =
-                                                                    let uu____10340
+                                                                    let uu____10335
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Util.exp_unit
                                                                      in
-                                                                    [uu____10340]
+                                                                    [uu____10335]
                                                                      in
                                                                     FStar_Syntax_Util.mk_app
                                                                     brt
-                                                                    uu____10329
+                                                                    uu____10324
                                                                      in
                                                                     let br =
                                                                     FStar_Syntax_Subst.close_branch
                                                                     (pat,
                                                                     FStar_Pervasives_Native.None,
                                                                     brt1)  in
-                                                                    let uu____10376
+                                                                    let uu____10371
+                                                                    =
+                                                                    let uu____10382
                                                                     =
                                                                     let uu____10387
-                                                                    =
-                                                                    let uu____10392
                                                                     =
                                                                     FStar_BigInt.of_int_fs
                                                                     (FStar_List.length
                                                                     bs3)  in
                                                                     (fv1,
-                                                                    uu____10392)
-                                                                     in
-                                                                    (g', br,
                                                                     uu____10387)
                                                                      in
+                                                                    (g', br,
+                                                                    uu____10382)
+                                                                     in
                                                                     FStar_Tactics_Monad.ret
-                                                                    uu____10376)))))))
+                                                                    uu____10371)))))))
                                                                     | 
-                                                                    uu____10413
+                                                                    uu____10408
                                                                     ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "impossible: not a ctor"))
                                                                   c_lids
                                                                  in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____9236
+                                                                uu____9231
                                                                 (fun goal_brs
                                                                     ->
-                                                                   let uu____10463
+                                                                   let uu____10458
                                                                     =
                                                                     FStar_List.unzip3
                                                                     goal_brs
                                                                      in
-                                                                   match uu____10463
+                                                                   match uu____10458
                                                                    with
                                                                    | 
                                                                    (goals,brs,infos)
@@ -5040,63 +5038,62 @@ let (t_destruct :
                                                                     (FStar_Syntax_Syntax.Tm_match
                                                                     (s_tm1,
                                                                     brs))
-                                                                    FStar_Pervasives_Native.None
                                                                     s_tm1.FStar_Syntax_Syntax.pos
                                                                      in
-                                                                    let uu____10536
+                                                                    let uu____10531
                                                                     =
                                                                     solve' g
                                                                     w  in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____10536
+                                                                    uu____10531
                                                                     (fun
-                                                                    uu____10547
+                                                                    uu____10542
                                                                      ->
-                                                                    let uu____10548
+                                                                    let uu____10543
                                                                     =
                                                                     FStar_Tactics_Monad.add_goals
                                                                     goals  in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____10548
+                                                                    uu____10543
                                                                     (fun
-                                                                    uu____10558
+                                                                    uu____10553
                                                                      ->
                                                                     FStar_Tactics_Monad.ret
                                                                     infos)))))
-                                            | uu____10565 ->
+                                            | uu____10560 ->
                                                 FStar_Tactics_Monad.fail
                                                   "not an inductive type"))))))
        in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8950
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8945
   
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l  ->
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
-    | uu____10614::xs -> last xs
+    | uu____10609::xs -> last xs
   
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l  ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____10644 = init xs  in x :: uu____10644
+    | x::xs -> let uu____10639 = init xs  in x :: uu____10639
   
 let rec (inspect :
   FStar_Syntax_Syntax.term ->
     FStar_Reflection_Data.term_view FStar_Tactics_Monad.tac)
   =
   fun t  ->
-    let uu____10657 =
-      let uu____10660 = top_env ()  in
-      FStar_Tactics_Monad.bind uu____10660
+    let uu____10652 =
+      let uu____10655 = top_env ()  in
+      FStar_Tactics_Monad.bind uu____10655
         (fun e  ->
            let t1 = FStar_Syntax_Util.unascribe t  in
            let t2 = FStar_Syntax_Util.un_uinst t1  in
            let t3 = FStar_Syntax_Util.unlazy_emb t2  in
            match t3.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_meta (t4,uu____10676) -> inspect t4
+           | FStar_Syntax_Syntax.Tm_meta (t4,uu____10671) -> inspect t4
            | FStar_Syntax_Syntax.Tm_name bv ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Var bv)
@@ -5109,80 +5106,78 @@ let rec (inspect :
            | FStar_Syntax_Syntax.Tm_app (hd,[]) ->
                failwith "empty arguments on Tm_app"
            | FStar_Syntax_Syntax.Tm_app (hd,args) ->
-               let uu____10742 = last args  in
-               (match uu____10742 with
+               let uu____10737 = last args  in
+               (match uu____10737 with
                 | (a,q) ->
                     let q' = FStar_Reflection_Basic.inspect_aqual q  in
-                    let uu____10772 =
-                      let uu____10773 =
-                        let uu____10778 =
-                          let uu____10779 =
-                            let uu____10784 = init args  in
-                            FStar_Syntax_Syntax.mk_Tm_app hd uu____10784  in
-                          uu____10779 FStar_Pervasives_Native.None
+                    let uu____10767 =
+                      let uu____10768 =
+                        let uu____10773 =
+                          let uu____10774 = init args  in
+                          FStar_Syntax_Syntax.mk_Tm_app hd uu____10774
                             t3.FStar_Syntax_Syntax.pos
                            in
-                        (uu____10778, (a, q'))  in
-                      FStar_Reflection_Data.Tv_App uu____10773  in
-                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10772)
-           | FStar_Syntax_Syntax.Tm_abs ([],uu____10795,uu____10796) ->
+                        (uu____10773, (a, q'))  in
+                      FStar_Reflection_Data.Tv_App uu____10768  in
+                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10767)
+           | FStar_Syntax_Syntax.Tm_abs ([],uu____10785,uu____10786) ->
                failwith "empty arguments on Tm_abs"
            | FStar_Syntax_Syntax.Tm_abs (bs,t4,k) ->
-               let uu____10849 = FStar_Syntax_Subst.open_term bs t4  in
-               (match uu____10849 with
+               let uu____10839 = FStar_Syntax_Subst.open_term bs t4  in
+               (match uu____10839 with
                 | (bs1,t5) ->
                     (match bs1 with
                      | [] -> failwith "impossible"
                      | b::bs2 ->
-                         let uu____10891 =
-                           let uu____10892 =
-                             let uu____10897 = FStar_Syntax_Util.abs bs2 t5 k
+                         let uu____10881 =
+                           let uu____10882 =
+                             let uu____10887 = FStar_Syntax_Util.abs bs2 t5 k
                                 in
-                             (b, uu____10897)  in
-                           FStar_Reflection_Data.Tv_Abs uu____10892  in
+                             (b, uu____10887)  in
+                           FStar_Reflection_Data.Tv_Abs uu____10882  in
                          FStar_All.pipe_left FStar_Tactics_Monad.ret
-                           uu____10891))
-           | FStar_Syntax_Syntax.Tm_type uu____10900 ->
+                           uu____10881))
+           | FStar_Syntax_Syntax.Tm_type uu____10890 ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Type ())
            | FStar_Syntax_Syntax.Tm_arrow ([],k) ->
                failwith "empty binders on arrow"
-           | FStar_Syntax_Syntax.Tm_arrow uu____10925 ->
-               let uu____10940 = FStar_Syntax_Util.arrow_one t3  in
-               (match uu____10940 with
+           | FStar_Syntax_Syntax.Tm_arrow uu____10915 ->
+               let uu____10930 = FStar_Syntax_Util.arrow_one t3  in
+               (match uu____10930 with
                 | FStar_Pervasives_Native.Some (b,c) ->
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Arrow (b, c))
                 | FStar_Pervasives_Native.None  -> failwith "impossible")
            | FStar_Syntax_Syntax.Tm_refine (bv,t4) ->
                let b = FStar_Syntax_Syntax.mk_binder bv  in
-               let uu____10971 = FStar_Syntax_Subst.open_term [b] t4  in
-               (match uu____10971 with
+               let uu____10961 = FStar_Syntax_Subst.open_term [b] t4  in
+               (match uu____10961 with
                 | (b',t5) ->
                     let b1 =
                       match b' with
                       | b'1::[] -> b'1
-                      | uu____11024 -> failwith "impossible"  in
+                      | uu____11014 -> failwith "impossible"  in
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Refine
                          ((FStar_Pervasives_Native.fst b1), t5)))
            | FStar_Syntax_Syntax.Tm_constant c ->
-               let uu____11037 =
-                 let uu____11038 = FStar_Reflection_Basic.inspect_const c  in
-                 FStar_Reflection_Data.Tv_Const uu____11038  in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11037
+               let uu____11027 =
+                 let uu____11028 = FStar_Reflection_Basic.inspect_const c  in
+                 FStar_Reflection_Data.Tv_Const uu____11028  in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11027
            | FStar_Syntax_Syntax.Tm_uvar (ctx_u,s) ->
-               let uu____11059 =
-                 let uu____11060 =
-                   let uu____11065 =
-                     let uu____11066 =
+               let uu____11049 =
+                 let uu____11050 =
+                   let uu____11055 =
+                     let uu____11056 =
                        FStar_Syntax_Unionfind.uvar_id
                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                         in
-                     FStar_BigInt.of_int_fs uu____11066  in
-                   (uu____11065, (ctx_u, s))  in
-                 FStar_Reflection_Data.Tv_Uvar uu____11060  in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11059
+                     FStar_BigInt.of_int_fs uu____11056  in
+                   (uu____11055, (ctx_u, s))  in
+                 FStar_Reflection_Data.Tv_Uvar uu____11050  in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11049
            | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),t21) ->
                if lb.FStar_Syntax_Syntax.lbunivs <> []
                then
@@ -5190,19 +5185,19 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____11106 ->
+                  | FStar_Util.Inr uu____11096 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
                       let b = FStar_Syntax_Syntax.mk_binder bv  in
-                      let uu____11111 = FStar_Syntax_Subst.open_term [b] t21
+                      let uu____11101 = FStar_Syntax_Subst.open_term [b] t21
                          in
-                      (match uu____11111 with
+                      (match uu____11101 with
                        | (bs,t22) ->
                            let b1 =
                              match bs with
                              | b1::[] -> b1
-                             | uu____11164 ->
+                             | uu____11154 ->
                                  failwith
                                    "impossible: open_term returned different amount of binders"
                               in
@@ -5218,18 +5213,18 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____11208 ->
+                  | FStar_Util.Inr uu____11198 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
-                      let uu____11212 =
+                      let uu____11202 =
                         FStar_Syntax_Subst.open_let_rec [lb] t21  in
-                      (match uu____11212 with
+                      (match uu____11202 with
                        | (lbs,t22) ->
                            (match lbs with
                             | lb1::[] ->
                                 (match lb1.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____11232 ->
+                                 | FStar_Util.Inr uu____11222 ->
                                      FStar_Tactics_Monad.ret
                                        FStar_Reflection_Data.Tv_Unknown
                                  | FStar_Util.Inl bv1 ->
@@ -5241,28 +5236,28 @@ let rec (inspect :
                                             bv1,
                                             (lb1.FStar_Syntax_Syntax.lbdef),
                                             t22)))
-                            | uu____11240 ->
+                            | uu____11230 ->
                                 failwith
                                   "impossible: open_term returned different amount of binders")))
            | FStar_Syntax_Syntax.Tm_match (t4,brs) ->
                let rec inspect_pat p =
                  match p.FStar_Syntax_Syntax.v with
                  | FStar_Syntax_Syntax.Pat_constant c ->
-                     let uu____11295 = FStar_Reflection_Basic.inspect_const c
+                     let uu____11285 = FStar_Reflection_Basic.inspect_const c
                         in
-                     FStar_Reflection_Data.Pat_Constant uu____11295
+                     FStar_Reflection_Data.Pat_Constant uu____11285
                  | FStar_Syntax_Syntax.Pat_cons (fv,ps) ->
-                     let uu____11316 =
-                       let uu____11328 =
+                     let uu____11306 =
+                       let uu____11318 =
                          FStar_List.map
-                           (fun uu____11352  ->
-                              match uu____11352 with
+                           (fun uu____11342  ->
+                              match uu____11342 with
                               | (p1,b) ->
-                                  let uu____11373 = inspect_pat p1  in
-                                  (uu____11373, b)) ps
+                                  let uu____11363 = inspect_pat p1  in
+                                  (uu____11363, b)) ps
                           in
-                       (fv, uu____11328)  in
-                     FStar_Reflection_Data.Pat_Cons uu____11316
+                       (fv, uu____11318)  in
+                     FStar_Reflection_Data.Pat_Cons uu____11306
                  | FStar_Syntax_Syntax.Pat_var bv ->
                      FStar_Reflection_Data.Pat_Var bv
                  | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -5274,33 +5269,33 @@ let rec (inspect :
                   in
                let brs2 =
                  FStar_List.map
-                   (fun uu___7_11469  ->
-                      match uu___7_11469 with
-                      | (pat,uu____11491,t5) ->
-                          let uu____11509 = inspect_pat pat  in
-                          (uu____11509, t5)) brs1
+                   (fun uu___7_11459  ->
+                      match uu___7_11459 with
+                      | (pat,uu____11481,t5) ->
+                          let uu____11499 = inspect_pat pat  in
+                          (uu____11499, t5)) brs1
                   in
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Match (t4, brs2))
            | FStar_Syntax_Syntax.Tm_unknown  ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____11518 ->
-               ((let uu____11520 =
-                   let uu____11526 =
-                     let uu____11528 = FStar_Syntax_Print.tag_of_term t3  in
-                     let uu____11530 = term_to_string e t3  in
+           | uu____11508 ->
+               ((let uu____11510 =
+                   let uu____11516 =
+                     let uu____11518 = FStar_Syntax_Print.tag_of_term t3  in
+                     let uu____11520 = term_to_string e t3  in
                      FStar_Util.format2
                        "inspect: outside of expected syntax (%s, %s)\n"
-                       uu____11528 uu____11530
+                       uu____11518 uu____11520
                       in
-                   (FStar_Errors.Warning_CantInspect, uu____11526)  in
+                   (FStar_Errors.Warning_CantInspect, uu____11516)  in
                  FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos
-                   uu____11520);
+                   uu____11510);
                 FStar_All.pipe_left FStar_Tactics_Monad.ret
                   FStar_Reflection_Data.Tv_Unknown))
        in
-    FStar_Tactics_Monad.wrap_err "inspect" uu____10657
+    FStar_Tactics_Monad.wrap_err "inspect" uu____10652
   
 let (pack :
   FStar_Reflection_Data.term_view ->
@@ -5309,80 +5304,76 @@ let (pack :
   fun tv  ->
     match tv with
     | FStar_Reflection_Data.Tv_Var bv ->
-        let uu____11548 = FStar_Syntax_Syntax.bv_to_name bv  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11548
+        let uu____11538 = FStar_Syntax_Syntax.bv_to_name bv  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11538
     | FStar_Reflection_Data.Tv_BVar bv ->
-        let uu____11552 = FStar_Syntax_Syntax.bv_to_tm bv  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11552
+        let uu____11542 = FStar_Syntax_Syntax.bv_to_tm bv  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11542
     | FStar_Reflection_Data.Tv_FVar fv ->
-        let uu____11556 = FStar_Syntax_Syntax.fv_to_tm fv  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11556
+        let uu____11546 = FStar_Syntax_Syntax.fv_to_tm fv  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11546
     | FStar_Reflection_Data.Tv_App (l,(r,q)) ->
         let q' = FStar_Reflection_Basic.pack_aqual q  in
-        let uu____11563 = FStar_Syntax_Util.mk_app l [(r, q')]  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11563
+        let uu____11553 = FStar_Syntax_Util.mk_app l [(r, q')]  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11553
     | FStar_Reflection_Data.Tv_Abs (b,t) ->
-        let uu____11588 =
+        let uu____11578 =
           FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11588
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11578
     | FStar_Reflection_Data.Tv_Arrow (b,c) ->
-        let uu____11605 = FStar_Syntax_Util.arrow [b] c  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11605
+        let uu____11595 = FStar_Syntax_Util.arrow [b] c  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11595
     | FStar_Reflection_Data.Tv_Type () ->
         FStar_All.pipe_left FStar_Tactics_Monad.ret FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv,t) ->
-        let uu____11624 = FStar_Syntax_Util.refine bv t  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11624
+        let uu____11614 = FStar_Syntax_Util.refine bv t  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11614
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____11628 =
-          let uu____11629 =
-            let uu____11636 =
-              let uu____11637 = FStar_Reflection_Basic.pack_const c  in
-              FStar_Syntax_Syntax.Tm_constant uu____11637  in
-            FStar_Syntax_Syntax.mk uu____11636  in
-          uu____11629 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11628
+        let uu____11618 =
+          let uu____11619 =
+            let uu____11620 = FStar_Reflection_Basic.pack_const c  in
+            FStar_Syntax_Syntax.Tm_constant uu____11620  in
+          FStar_Syntax_Syntax.mk uu____11619 FStar_Range.dummyRange  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11618
     | FStar_Reflection_Data.Tv_Uvar (_u,ctx_u_s) ->
-        let uu____11642 =
+        let uu____11625 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
-            FStar_Pervasives_Native.None FStar_Range.dummyRange
+            FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11642
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11625
     | FStar_Reflection_Data.Tv_Let (false ,attrs,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange
            in
-        let uu____11656 =
-          let uu____11657 =
-            let uu____11664 =
-              let uu____11665 =
-                let uu____11679 =
-                  let uu____11682 =
-                    let uu____11683 = FStar_Syntax_Syntax.mk_binder bv  in
-                    [uu____11683]  in
-                  FStar_Syntax_Subst.close uu____11682 t2  in
-                ((false, [lb]), uu____11679)  in
-              FStar_Syntax_Syntax.Tm_let uu____11665  in
-            FStar_Syntax_Syntax.mk uu____11664  in
-          uu____11657 FStar_Pervasives_Native.None FStar_Range.dummyRange  in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11656
+        let uu____11639 =
+          let uu____11640 =
+            let uu____11641 =
+              let uu____11655 =
+                let uu____11658 =
+                  let uu____11659 = FStar_Syntax_Syntax.mk_binder bv  in
+                  [uu____11659]  in
+                FStar_Syntax_Subst.close uu____11658 t2  in
+              ((false, [lb]), uu____11655)  in
+            FStar_Syntax_Syntax.Tm_let uu____11641  in
+          FStar_Syntax_Syntax.mk uu____11640 FStar_Range.dummyRange  in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11639
     | FStar_Reflection_Data.Tv_Let (true ,attrs,bv,t1,t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange
            in
-        let uu____11728 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
-        (match uu____11728 with
+        let uu____11704 = FStar_Syntax_Subst.close_let_rec [lb] t2  in
+        (match uu____11704 with
          | (lbs,body) ->
-             let uu____11743 =
+             let uu____11719 =
                FStar_Syntax_Syntax.mk
                  (FStar_Syntax_Syntax.Tm_let ((true, lbs), body))
-                 FStar_Pervasives_Native.None FStar_Range.dummyRange
+                 FStar_Range.dummyRange
                 in
-             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11743)
+             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11719)
     | FStar_Reflection_Data.Tv_Match (t,brs) ->
         let wrap v =
           {
@@ -5392,24 +5383,24 @@ let (pack :
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____11780 =
-                let uu____11781 = FStar_Reflection_Basic.pack_const c  in
-                FStar_Syntax_Syntax.Pat_constant uu____11781  in
-              FStar_All.pipe_left wrap uu____11780
+              let uu____11756 =
+                let uu____11757 = FStar_Reflection_Basic.pack_const c  in
+                FStar_Syntax_Syntax.Pat_constant uu____11757  in
+              FStar_All.pipe_left wrap uu____11756
           | FStar_Reflection_Data.Pat_Cons (fv,ps) ->
-              let uu____11798 =
-                let uu____11799 =
-                  let uu____11813 =
+              let uu____11774 =
+                let uu____11775 =
+                  let uu____11789 =
                     FStar_List.map
-                      (fun uu____11837  ->
-                         match uu____11837 with
+                      (fun uu____11813  ->
+                         match uu____11813 with
                          | (p1,b) ->
-                             let uu____11852 = pack_pat p1  in
-                             (uu____11852, b)) ps
+                             let uu____11828 = pack_pat p1  in
+                             (uu____11828, b)) ps
                      in
-                  (fv, uu____11813)  in
-                FStar_Syntax_Syntax.Pat_cons uu____11799  in
-              FStar_All.pipe_left wrap uu____11798
+                  (fv, uu____11789)  in
+                FStar_Syntax_Syntax.Pat_cons uu____11775  in
+              FStar_All.pipe_left wrap uu____11774
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -5420,42 +5411,40 @@ let (pack :
            in
         let brs1 =
           FStar_List.map
-            (fun uu___8_11900  ->
-               match uu___8_11900 with
+            (fun uu___8_11876  ->
+               match uu___8_11876 with
                | (pat,t1) ->
-                   let uu____11917 = pack_pat pat  in
-                   (uu____11917, FStar_Pervasives_Native.None, t1)) brs
+                   let uu____11893 = pack_pat pat  in
+                   (uu____11893, FStar_Pervasives_Native.None, t1)) brs
            in
         let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1  in
-        let uu____11965 =
+        let uu____11941 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
-            FStar_Pervasives_Native.None FStar_Range.dummyRange
+            FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11965
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11941
     | FStar_Reflection_Data.Tv_AscribedT (e,t,tacopt) ->
-        let uu____11993 =
+        let uu____11969 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inl t), tacopt),
-                 FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
-            FStar_Range.dummyRange
+                 FStar_Pervasives_Native.None)) FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11993
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11969
     | FStar_Reflection_Data.Tv_AscribedC (e,c,tacopt) ->
-        let uu____12039 =
+        let uu____12015 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inr c), tacopt),
-                 FStar_Pervasives_Native.None)) FStar_Pervasives_Native.None
+                 FStar_Pervasives_Native.None)) FStar_Range.dummyRange
+           in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12015
+    | FStar_Reflection_Data.Tv_Unknown  ->
+        let uu____12054 =
+          FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Range.dummyRange
            in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12039
-    | FStar_Reflection_Data.Tv_Unknown  ->
-        let uu____12078 =
-          FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-            FStar_Pervasives_Native.None FStar_Range.dummyRange
-           in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12078
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____12054
   
 let (lget :
   FStar_Reflection_Data.typ ->
@@ -5463,18 +5452,18 @@ let (lget :
   =
   fun ty  ->
     fun k  ->
-      let uu____12098 =
+      let uu____12074 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun ps  ->
-             let uu____12104 =
+             let uu____12080 =
                FStar_Util.psmap_try_find ps.FStar_Tactics_Types.local_state k
                 in
-             match uu____12104 with
+             match uu____12080 with
              | FStar_Pervasives_Native.None  ->
                  FStar_Tactics_Monad.fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t)
          in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____12098
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____12074
   
 let (lset :
   FStar_Reflection_Data.typ ->
@@ -5483,43 +5472,43 @@ let (lset :
   fun _ty  ->
     fun k  ->
       fun t  ->
-        let uu____12138 =
+        let uu____12114 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps  ->
                let ps1 =
-                 let uu___1663_12145 = ps  in
-                 let uu____12146 =
+                 let uu___1663_12121 = ps  in
+                 let uu____12122 =
                    FStar_Util.psmap_add ps.FStar_Tactics_Types.local_state k
                      t
                     in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___1663_12145.FStar_Tactics_Types.main_context);
+                     (uu___1663_12121.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___1663_12145.FStar_Tactics_Types.all_implicits);
+                     (uu___1663_12121.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___1663_12145.FStar_Tactics_Types.goals);
+                     (uu___1663_12121.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___1663_12145.FStar_Tactics_Types.smt_goals);
+                     (uu___1663_12121.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___1663_12145.FStar_Tactics_Types.depth);
+                     (uu___1663_12121.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___1663_12145.FStar_Tactics_Types.__dump);
+                     (uu___1663_12121.FStar_Tactics_Types.__dump);
                    FStar_Tactics_Types.psc =
-                     (uu___1663_12145.FStar_Tactics_Types.psc);
+                     (uu___1663_12121.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___1663_12145.FStar_Tactics_Types.entry_range);
+                     (uu___1663_12121.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___1663_12145.FStar_Tactics_Types.guard_policy);
+                     (uu___1663_12121.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
-                     (uu___1663_12145.FStar_Tactics_Types.freshness);
+                     (uu___1663_12121.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___1663_12145.FStar_Tactics_Types.tac_verb_dbg);
-                   FStar_Tactics_Types.local_state = uu____12146
+                     (uu___1663_12121.FStar_Tactics_Types.tac_verb_dbg);
+                   FStar_Tactics_Types.local_state = uu____12122
                  }  in
                FStar_Tactics_Monad.set ps1)
            in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____12138
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____12114
   
 let (goal_of_goal_ty :
   env ->
@@ -5528,217 +5517,217 @@ let (goal_of_goal_ty :
   =
   fun env1  ->
     fun typ  ->
-      let uu____12173 =
+      let uu____12149 =
         FStar_TypeChecker_Env.new_implicit_var_aux "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env1 typ
           FStar_Syntax_Syntax.Allow_untyped FStar_Pervasives_Native.None
          in
-      match uu____12173 with
+      match uu____12149 with
       | (u,ctx_uvars,g_u) ->
-          let uu____12210 = FStar_List.hd ctx_uvars  in
-          (match uu____12210 with
-           | (ctx_uvar,uu____12224) ->
+          let uu____12186 = FStar_List.hd ctx_uvars  in
+          (match uu____12186 with
+           | (ctx_uvar,uu____12200) ->
                let g =
-                 let uu____12226 = FStar_Options.peek ()  in
-                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____12226 false
+                 let uu____12202 = FStar_Options.peek ()  in
+                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____12202 false
                    ""
                   in
                (g, g_u))
   
 let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env1  ->
-    let uu____12235 = FStar_TypeChecker_Env.clear_expected_typ env1  in
-    match uu____12235 with
-    | (env2,uu____12243) ->
+    let uu____12211 = FStar_TypeChecker_Env.clear_expected_typ env1  in
+    match uu____12211 with
+    | (env2,uu____12219) ->
         let env3 =
-          let uu___1680_12249 = env2  in
+          let uu___1680_12225 = env2  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1680_12249.FStar_TypeChecker_Env.solver);
+              (uu___1680_12225.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1680_12249.FStar_TypeChecker_Env.range);
+              (uu___1680_12225.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1680_12249.FStar_TypeChecker_Env.curmodule);
+              (uu___1680_12225.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1680_12249.FStar_TypeChecker_Env.gamma);
+              (uu___1680_12225.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1680_12249.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1680_12225.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1680_12249.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1680_12225.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1680_12249.FStar_TypeChecker_Env.modules);
+              (uu___1680_12225.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1680_12249.FStar_TypeChecker_Env.expected_typ);
+              (uu___1680_12225.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1680_12249.FStar_TypeChecker_Env.sigtab);
+              (uu___1680_12225.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1680_12249.FStar_TypeChecker_Env.attrtab);
+              (uu___1680_12225.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp = false;
             FStar_TypeChecker_Env.effects =
-              (uu___1680_12249.FStar_TypeChecker_Env.effects);
+              (uu___1680_12225.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1680_12249.FStar_TypeChecker_Env.generalize);
+              (uu___1680_12225.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1680_12249.FStar_TypeChecker_Env.letrecs);
+              (uu___1680_12225.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1680_12249.FStar_TypeChecker_Env.top_level);
+              (uu___1680_12225.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1680_12249.FStar_TypeChecker_Env.check_uvars);
+              (uu___1680_12225.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1680_12249.FStar_TypeChecker_Env.use_eq);
+              (uu___1680_12225.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1680_12249.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1680_12225.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1680_12249.FStar_TypeChecker_Env.is_iface);
+              (uu___1680_12225.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1680_12249.FStar_TypeChecker_Env.admit);
+              (uu___1680_12225.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1680_12249.FStar_TypeChecker_Env.lax);
+              (uu___1680_12225.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1680_12249.FStar_TypeChecker_Env.lax_universes);
+              (uu___1680_12225.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1680_12249.FStar_TypeChecker_Env.phase1);
+              (uu___1680_12225.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1680_12249.FStar_TypeChecker_Env.failhard);
+              (uu___1680_12225.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1680_12249.FStar_TypeChecker_Env.nosynth);
+              (uu___1680_12225.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1680_12249.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1680_12225.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1680_12249.FStar_TypeChecker_Env.tc_term);
+              (uu___1680_12225.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1680_12249.FStar_TypeChecker_Env.type_of);
+              (uu___1680_12225.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1680_12249.FStar_TypeChecker_Env.universe_of);
+              (uu___1680_12225.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1680_12249.FStar_TypeChecker_Env.check_type_of);
+              (uu___1680_12225.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1680_12249.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1680_12225.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1680_12249.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1680_12225.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1680_12249.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1680_12225.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1680_12249.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1680_12225.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1680_12249.FStar_TypeChecker_Env.proof_ns);
+              (uu___1680_12225.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1680_12249.FStar_TypeChecker_Env.synth_hook);
+              (uu___1680_12225.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1680_12249.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1680_12225.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1680_12249.FStar_TypeChecker_Env.splice);
+              (uu___1680_12225.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1680_12249.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1680_12225.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1680_12249.FStar_TypeChecker_Env.postprocess);
+              (uu___1680_12225.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1680_12249.FStar_TypeChecker_Env.identifier_info);
+              (uu___1680_12225.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1680_12249.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1680_12225.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1680_12249.FStar_TypeChecker_Env.dsenv);
+              (uu___1680_12225.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1680_12249.FStar_TypeChecker_Env.nbe);
+              (uu___1680_12225.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1680_12249.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1680_12225.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1680_12249.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___1680_12225.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         let env4 =
-          let uu___1683_12252 = env3  in
+          let uu___1683_12228 = env3  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1683_12252.FStar_TypeChecker_Env.solver);
+              (uu___1683_12228.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1683_12252.FStar_TypeChecker_Env.range);
+              (uu___1683_12228.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1683_12252.FStar_TypeChecker_Env.curmodule);
+              (uu___1683_12228.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1683_12252.FStar_TypeChecker_Env.gamma);
+              (uu___1683_12228.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1683_12252.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1683_12228.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1683_12252.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1683_12228.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1683_12252.FStar_TypeChecker_Env.modules);
+              (uu___1683_12228.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1683_12252.FStar_TypeChecker_Env.expected_typ);
+              (uu___1683_12228.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1683_12252.FStar_TypeChecker_Env.sigtab);
+              (uu___1683_12228.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1683_12252.FStar_TypeChecker_Env.attrtab);
+              (uu___1683_12228.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1683_12252.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1683_12228.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1683_12252.FStar_TypeChecker_Env.effects);
+              (uu___1683_12228.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1683_12252.FStar_TypeChecker_Env.generalize);
+              (uu___1683_12228.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1683_12252.FStar_TypeChecker_Env.letrecs);
+              (uu___1683_12228.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1683_12252.FStar_TypeChecker_Env.top_level);
+              (uu___1683_12228.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1683_12252.FStar_TypeChecker_Env.check_uvars);
+              (uu___1683_12228.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1683_12252.FStar_TypeChecker_Env.use_eq);
+              (uu___1683_12228.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1683_12252.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1683_12228.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1683_12252.FStar_TypeChecker_Env.is_iface);
+              (uu___1683_12228.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1683_12252.FStar_TypeChecker_Env.admit);
+              (uu___1683_12228.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1683_12252.FStar_TypeChecker_Env.lax);
+              (uu___1683_12228.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1683_12252.FStar_TypeChecker_Env.lax_universes);
+              (uu___1683_12228.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1683_12252.FStar_TypeChecker_Env.phase1);
+              (uu___1683_12228.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard = true;
             FStar_TypeChecker_Env.nosynth =
-              (uu___1683_12252.FStar_TypeChecker_Env.nosynth);
+              (uu___1683_12228.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1683_12252.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1683_12228.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1683_12252.FStar_TypeChecker_Env.tc_term);
+              (uu___1683_12228.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1683_12252.FStar_TypeChecker_Env.type_of);
+              (uu___1683_12228.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1683_12252.FStar_TypeChecker_Env.universe_of);
+              (uu___1683_12228.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1683_12252.FStar_TypeChecker_Env.check_type_of);
+              (uu___1683_12228.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1683_12252.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1683_12228.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1683_12252.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1683_12228.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1683_12252.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1683_12228.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1683_12252.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1683_12228.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1683_12252.FStar_TypeChecker_Env.proof_ns);
+              (uu___1683_12228.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1683_12252.FStar_TypeChecker_Env.synth_hook);
+              (uu___1683_12228.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1683_12252.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1683_12228.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1683_12252.FStar_TypeChecker_Env.splice);
+              (uu___1683_12228.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1683_12252.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1683_12228.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1683_12252.FStar_TypeChecker_Env.postprocess);
+              (uu___1683_12228.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1683_12252.FStar_TypeChecker_Env.identifier_info);
+              (uu___1683_12228.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1683_12252.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1683_12228.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1683_12252.FStar_TypeChecker_Env.dsenv);
+              (uu___1683_12228.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1683_12252.FStar_TypeChecker_Env.nbe);
+              (uu___1683_12228.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1683_12252.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1683_12228.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1683_12252.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___1683_12228.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         env4
   
@@ -5755,11 +5744,11 @@ let (proofstate_of_goals :
         fun imps  ->
           let env2 = tac_env env1  in
           let ps =
-            let uu____12285 =
+            let uu____12261 =
               FStar_TypeChecker_Env.debug env2
                 (FStar_Options.Other "TacVerbose")
                in
-            let uu____12288 = FStar_Util.psmap_empty ()  in
+            let uu____12264 = FStar_Util.psmap_empty ()  in
             {
               FStar_Tactics_Types.main_context = env2;
               FStar_Tactics_Types.all_implicits = imps;
@@ -5772,8 +5761,8 @@ let (proofstate_of_goals :
               FStar_Tactics_Types.entry_range = rng;
               FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
               FStar_Tactics_Types.freshness = Prims.int_zero;
-              FStar_Tactics_Types.tac_verb_dbg = uu____12285;
-              FStar_Tactics_Types.local_state = uu____12288
+              FStar_Tactics_Types.tac_verb_dbg = uu____12261;
+              FStar_Tactics_Types.local_state = uu____12264
             }  in
           ps
   
@@ -5787,15 +5776,15 @@ let (proofstate_of_goal_ty :
     fun env1  ->
       fun typ  ->
         let env2 = tac_env env1  in
-        let uu____12314 = goal_of_goal_ty env2 typ  in
-        match uu____12314 with
+        let uu____12290 = goal_of_goal_ty env2 typ  in
+        match uu____12290 with
         | (g,g_u) ->
             let ps =
               proofstate_of_goals rng env2 [g]
                 g_u.FStar_TypeChecker_Common.implicits
                in
-            let uu____12326 = FStar_Tactics_Types.goal_witness g  in
-            (ps, uu____12326)
+            let uu____12302 = FStar_Tactics_Types.goal_witness g  in
+            (ps, uu____12302)
   
 let (goal_of_implicit :
   FStar_TypeChecker_Env.env ->
@@ -5803,9 +5792,9 @@ let (goal_of_implicit :
   =
   fun env1  ->
     fun i  ->
-      let uu____12338 = FStar_Options.peek ()  in
+      let uu____12314 = FStar_Options.peek ()  in
       FStar_Tactics_Types.mk_goal env1 i.FStar_TypeChecker_Common.imp_uvar
-        uu____12338 false ""
+        uu____12314 false ""
   
 let (proofstate_of_all_implicits :
   FStar_Range.range ->
@@ -5818,14 +5807,14 @@ let (proofstate_of_all_implicits :
       fun imps  ->
         let goals = FStar_List.map (goal_of_implicit env1) imps  in
         let w =
-          let uu____12365 = FStar_List.hd goals  in
-          FStar_Tactics_Types.goal_witness uu____12365  in
+          let uu____12341 = FStar_List.hd goals  in
+          FStar_Tactics_Types.goal_witness uu____12341  in
         let ps =
-          let uu____12367 =
+          let uu____12343 =
             FStar_TypeChecker_Env.debug env1
               (FStar_Options.Other "TacVerbose")
              in
-          let uu____12370 = FStar_Util.psmap_empty ()  in
+          let uu____12346 = FStar_Util.psmap_empty ()  in
           {
             FStar_Tactics_Types.main_context = env1;
             FStar_Tactics_Types.all_implicits = imps;
@@ -5839,8 +5828,8 @@ let (proofstate_of_all_implicits :
             FStar_Tactics_Types.entry_range = rng;
             FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
             FStar_Tactics_Types.freshness = Prims.int_zero;
-            FStar_Tactics_Types.tac_verb_dbg = uu____12367;
-            FStar_Tactics_Types.local_state = uu____12370
+            FStar_Tactics_Types.tac_verb_dbg = uu____12343;
+            FStar_Tactics_Types.local_state = uu____12346
           }  in
         (ps, w)
   

--- a/src/ocaml-output/FStar_Tactics_Embedding.ml
+++ b/src/ocaml-output/FStar_Tactics_Embedding.ml
@@ -372,103 +372,95 @@ let (e_exn : Prims.exn FStar_Syntax_Embeddings.embedding) =
     match e with
     | FStar_Tactics_Types.TacticFailure s ->
         let uu____1021 =
-          let uu____1026 =
-            let uu____1027 =
-              let uu____1036 = embed FStar_Syntax_Embeddings.e_string rng s
-                 in
-              FStar_Syntax_Syntax.as_arg uu____1036  in
-            [uu____1027]  in
-          FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t
-            uu____1026
-           in
-        uu____1021 FStar_Pervasives_Native.None rng
+          let uu____1022 =
+            let uu____1031 = embed FStar_Syntax_Embeddings.e_string rng s  in
+            FStar_Syntax_Syntax.as_arg uu____1031  in
+          [uu____1022]  in
+        FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t
+          uu____1021 rng
     | FStar_Tactics_Types.EExn t ->
-        let uu___131_1055 = t  in
+        let uu___131_1050 = t  in
         {
-          FStar_Syntax_Syntax.n = (uu___131_1055.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___131_1050.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___131_1055.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___131_1050.FStar_Syntax_Syntax.vars)
         }
     | e1 ->
         let s =
-          let uu____1059 = FStar_Util.message_of_exn e1  in
-          Prims.op_Hat "uncaught exception: " uu____1059  in
-        let uu____1062 =
-          let uu____1067 =
-            let uu____1068 =
-              let uu____1077 = embed FStar_Syntax_Embeddings.e_string rng s
-                 in
-              FStar_Syntax_Syntax.as_arg uu____1077  in
-            [uu____1068]  in
-          FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t
-            uu____1067
-           in
-        uu____1062 FStar_Pervasives_Native.None rng
+          let uu____1054 = FStar_Util.message_of_exn e1  in
+          Prims.op_Hat "uncaught exception: " uu____1054  in
+        let uu____1057 =
+          let uu____1058 =
+            let uu____1067 = embed FStar_Syntax_Embeddings.e_string rng s  in
+            FStar_Syntax_Syntax.as_arg uu____1067  in
+          [uu____1058]  in
+        FStar_Syntax_Syntax.mk_Tm_app fstar_tactics_TacticFailure.t
+          uu____1057 rng
      in
-  let unembed_exn t w uu____1114 =
-    let uu____1119 = hd'_and_args t  in
-    match uu____1119 with
-    | (FStar_Syntax_Syntax.Tm_fvar fv,(s,uu____1138)::[]) when
+  let unembed_exn t w uu____1104 =
+    let uu____1109 = hd'_and_args t  in
+    match uu____1109 with
+    | (FStar_Syntax_Syntax.Tm_fvar fv,(s,uu____1128)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_TacticFailure.lid ->
-        let uu____1173 = unembed' w FStar_Syntax_Embeddings.e_string s  in
-        FStar_Util.bind_opt uu____1173
+        let uu____1163 = unembed' w FStar_Syntax_Embeddings.e_string s  in
+        FStar_Util.bind_opt uu____1163
           (fun s1  ->
              FStar_Pervasives_Native.Some
                (FStar_Tactics_Types.TacticFailure s1))
-    | uu____1182 -> FStar_Pervasives_Native.Some (FStar_Tactics_Types.EExn t)
+    | uu____1172 -> FStar_Pervasives_Native.Some (FStar_Tactics_Types.EExn t)
      in
-  let uu____1197 =
-    let uu____1198 =
-      let uu____1206 =
+  let uu____1187 =
+    let uu____1188 =
+      let uu____1196 =
         FStar_All.pipe_right FStar_Parser_Const.exn_lid
           FStar_Ident.string_of_lid
          in
-      (uu____1206, [])  in
-    FStar_Syntax_Syntax.ET_app uu____1198  in
+      (uu____1196, [])  in
+    FStar_Syntax_Syntax.ET_app uu____1188  in
   FStar_Syntax_Embeddings.mk_emb_full embed_exn unembed_exn
-    FStar_Syntax_Syntax.t_exn (fun uu____1213  -> "(exn)") uu____1197
+    FStar_Syntax_Syntax.t_exn (fun uu____1203  -> "(exn)") uu____1187
   
 let (e_exn_nbe : Prims.exn FStar_TypeChecker_NBETerm.embedding) =
   let embed_exn cb e =
     match e with
     | FStar_Tactics_Types.TacticFailure s ->
-        let uu____1231 =
-          let uu____1238 =
-            let uu____1243 =
+        let uu____1221 =
+          let uu____1228 =
+            let uu____1233 =
               FStar_TypeChecker_NBETerm.embed
                 FStar_TypeChecker_NBETerm.e_string cb s
                in
-            FStar_TypeChecker_NBETerm.as_arg uu____1243  in
-          [uu____1238]  in
-        mkConstruct fstar_tactics_TacticFailure.fv [] uu____1231
-    | uu____1253 ->
-        let uu____1254 =
-          let uu____1256 = FStar_Util.message_of_exn e  in
-          FStar_Util.format1 "cannot embed exn (NBE) : %s" uu____1256  in
-        failwith uu____1254
+            FStar_TypeChecker_NBETerm.as_arg uu____1233  in
+          [uu____1228]  in
+        mkConstruct fstar_tactics_TacticFailure.fv [] uu____1221
+    | uu____1243 ->
+        let uu____1244 =
+          let uu____1246 = FStar_Util.message_of_exn e  in
+          FStar_Util.format1 "cannot embed exn (NBE) : %s" uu____1246  in
+        failwith uu____1244
      in
   let unembed_exn cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____1275,(s,uu____1277)::[])
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____1265,(s,uu____1267)::[])
         when FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_TacticFailure.lid
         ->
-        let uu____1296 =
+        let uu____1286 =
           FStar_TypeChecker_NBETerm.unembed
             FStar_TypeChecker_NBETerm.e_string cb s
            in
-        FStar_Util.bind_opt uu____1296
+        FStar_Util.bind_opt uu____1286
           (fun s1  ->
              FStar_Pervasives_Native.Some
                (FStar_Tactics_Types.TacticFailure s1))
-    | uu____1305 -> FStar_Pervasives_Native.None  in
+    | uu____1295 -> FStar_Pervasives_Native.None  in
   let fv_exn = FStar_Syntax_Syntax.fvconst FStar_Parser_Const.exn_lid  in
-  let uu____1307 = mkFV fv_exn [] []  in
-  let uu____1312 = fv_as_emb_typ fv_exn  in
+  let uu____1297 = mkFV fv_exn [] []  in
+  let uu____1302 = fv_as_emb_typ fv_exn  in
   {
     FStar_TypeChecker_NBETerm.em = embed_exn;
     FStar_TypeChecker_NBETerm.un = unembed_exn;
-    FStar_TypeChecker_NBETerm.typ = uu____1307;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____1312
+    FStar_TypeChecker_NBETerm.typ = uu____1297;
+    FStar_TypeChecker_NBETerm.emb_typ = uu____1302
   } 
 let e_result :
   'a .
@@ -476,110 +468,106 @@ let e_result :
       'a FStar_Tactics_Result.__result FStar_Syntax_Embeddings.embedding
   =
   fun ea  ->
-    let embed_result res rng uu____1354 uu____1355 =
+    let embed_result res rng uu____1344 uu____1345 =
       match res with
       | FStar_Tactics_Result.Success (a1,ps) ->
-          let uu____1361 =
-            let uu____1366 =
-              FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Success.t
-                [FStar_Syntax_Syntax.U_zero]
-               in
-            let uu____1367 =
-              let uu____1368 =
-                let uu____1377 = FStar_Syntax_Embeddings.type_of ea  in
-                FStar_Syntax_Syntax.iarg uu____1377  in
-              let uu____1378 =
-                let uu____1389 =
-                  let uu____1398 = embed ea rng a1  in
-                  FStar_Syntax_Syntax.as_arg uu____1398  in
-                let uu____1399 =
-                  let uu____1410 =
-                    let uu____1419 = embed e_proofstate rng ps  in
-                    FStar_Syntax_Syntax.as_arg uu____1419  in
-                  [uu____1410]  in
-                uu____1389 :: uu____1399  in
-              uu____1368 :: uu____1378  in
-            FStar_Syntax_Syntax.mk_Tm_app uu____1366 uu____1367  in
-          uu____1361 FStar_Pervasives_Native.None rng
+          let uu____1351 =
+            FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Success.t
+              [FStar_Syntax_Syntax.U_zero]
+             in
+          let uu____1352 =
+            let uu____1353 =
+              let uu____1362 = FStar_Syntax_Embeddings.type_of ea  in
+              FStar_Syntax_Syntax.iarg uu____1362  in
+            let uu____1363 =
+              let uu____1374 =
+                let uu____1383 = embed ea rng a1  in
+                FStar_Syntax_Syntax.as_arg uu____1383  in
+              let uu____1384 =
+                let uu____1395 =
+                  let uu____1404 = embed e_proofstate rng ps  in
+                  FStar_Syntax_Syntax.as_arg uu____1404  in
+                [uu____1395]  in
+              uu____1374 :: uu____1384  in
+            uu____1353 :: uu____1363  in
+          FStar_Syntax_Syntax.mk_Tm_app uu____1351 uu____1352 rng
       | FStar_Tactics_Result.Failed (e,ps) ->
-          let uu____1454 =
-            let uu____1459 =
-              FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Failed.t
-                [FStar_Syntax_Syntax.U_zero]
-               in
-            let uu____1460 =
-              let uu____1461 =
-                let uu____1470 = FStar_Syntax_Embeddings.type_of ea  in
-                FStar_Syntax_Syntax.iarg uu____1470  in
-              let uu____1471 =
-                let uu____1482 =
-                  let uu____1491 = embed e_exn rng e  in
-                  FStar_Syntax_Syntax.as_arg uu____1491  in
-                let uu____1492 =
-                  let uu____1503 =
-                    let uu____1512 = embed e_proofstate rng ps  in
-                    FStar_Syntax_Syntax.as_arg uu____1512  in
-                  [uu____1503]  in
-                uu____1482 :: uu____1492  in
-              uu____1461 :: uu____1471  in
-            FStar_Syntax_Syntax.mk_Tm_app uu____1459 uu____1460  in
-          uu____1454 FStar_Pervasives_Native.None rng
+          let uu____1439 =
+            FStar_Syntax_Syntax.mk_Tm_uinst fstar_tactics_Failed.t
+              [FStar_Syntax_Syntax.U_zero]
+             in
+          let uu____1440 =
+            let uu____1441 =
+              let uu____1450 = FStar_Syntax_Embeddings.type_of ea  in
+              FStar_Syntax_Syntax.iarg uu____1450  in
+            let uu____1451 =
+              let uu____1462 =
+                let uu____1471 = embed e_exn rng e  in
+                FStar_Syntax_Syntax.as_arg uu____1471  in
+              let uu____1472 =
+                let uu____1483 =
+                  let uu____1492 = embed e_proofstate rng ps  in
+                  FStar_Syntax_Syntax.as_arg uu____1492  in
+                [uu____1483]  in
+              uu____1462 :: uu____1472  in
+            uu____1441 :: uu____1451  in
+          FStar_Syntax_Syntax.mk_Tm_app uu____1439 uu____1440 rng
        in
-    let unembed_result t w uu____1566 =
-      let uu____1573 = hd'_and_args t  in
-      match uu____1573 with
+    let unembed_result t w uu____1546 =
+      let uu____1553 = hd'_and_args t  in
+      match uu____1553 with
       | (FStar_Syntax_Syntax.Tm_fvar
-         fv,_t::(a1,uu____1595)::(ps,uu____1597)::[]) when
+         fv,_t::(a1,uu____1575)::(ps,uu____1577)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Success.lid ->
-          let uu____1664 = unembed' w ea a1  in
-          FStar_Util.bind_opt uu____1664
+          let uu____1644 = unembed' w ea a1  in
+          FStar_Util.bind_opt uu____1644
             (fun a2  ->
-               let uu____1672 = unembed' w e_proofstate ps  in
-               FStar_Util.bind_opt uu____1672
+               let uu____1652 = unembed' w e_proofstate ps  in
+               FStar_Util.bind_opt uu____1652
                  (fun ps1  ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Success (a2, ps1))))
       | (FStar_Syntax_Syntax.Tm_fvar
-         fv,_t::(e,uu____1684)::(ps,uu____1686)::[]) when
+         fv,_t::(e,uu____1664)::(ps,uu____1666)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Failed.lid ->
-          let uu____1753 = unembed' w e_exn e  in
-          FStar_Util.bind_opt uu____1753
+          let uu____1733 = unembed' w e_exn e  in
+          FStar_Util.bind_opt uu____1733
             (fun e1  ->
-               let uu____1761 = unembed' w e_proofstate ps  in
-               FStar_Util.bind_opt uu____1761
+               let uu____1741 = unembed' w e_proofstate ps  in
+               FStar_Util.bind_opt uu____1741
                  (fun ps1  ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Failed (e1, ps1))))
-      | uu____1770 ->
+      | uu____1750 ->
           (if w
            then
-             (let uu____1787 =
-                let uu____1793 =
-                  let uu____1795 = FStar_Syntax_Print.term_to_string t  in
+             (let uu____1767 =
+                let uu____1773 =
+                  let uu____1775 = FStar_Syntax_Print.term_to_string t  in
                   FStar_Util.format1 "Not an embedded tactic result: %s"
-                    uu____1795
+                    uu____1775
                    in
-                (FStar_Errors.Warning_NotEmbedded, uu____1793)  in
-              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____1787)
+                (FStar_Errors.Warning_NotEmbedded, uu____1773)  in
+              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____1767)
            else ();
            FStar_Pervasives_Native.None)
        in
-    let uu____1803 =
-      let uu____1804 = FStar_Syntax_Embeddings.type_of ea  in
-      t_result_of uu____1804  in
-    let uu____1805 =
-      let uu____1806 =
-        let uu____1814 =
+    let uu____1783 =
+      let uu____1784 = FStar_Syntax_Embeddings.type_of ea  in
+      t_result_of uu____1784  in
+    let uu____1785 =
+      let uu____1786 =
+        let uu____1794 =
           FStar_All.pipe_right fstar_tactics_result.lid
             FStar_Ident.string_of_lid
            in
-        let uu____1817 =
-          let uu____1820 = FStar_Syntax_Embeddings.emb_typ_of ea  in
-          [uu____1820]  in
-        (uu____1814, uu____1817)  in
-      FStar_Syntax_Syntax.ET_app uu____1806  in
+        let uu____1797 =
+          let uu____1800 = FStar_Syntax_Embeddings.emb_typ_of ea  in
+          [uu____1800]  in
+        (uu____1794, uu____1797)  in
+      FStar_Syntax_Syntax.ET_app uu____1786  in
     FStar_Syntax_Embeddings.mk_emb_full embed_result unembed_result
-      uu____1803 (fun uu____1827  -> "") uu____1805
+      uu____1783 (fun uu____1807  -> "") uu____1785
   
 let e_result_nbe :
   'a .
@@ -590,82 +578,82 @@ let e_result_nbe :
     let embed_result cb res =
       match res with
       | FStar_Tactics_Result.Failed (e,ps) ->
-          let uu____1867 =
-            let uu____1874 =
-              let uu____1879 = FStar_TypeChecker_NBETerm.type_of ea  in
-              FStar_TypeChecker_NBETerm.as_iarg uu____1879  in
-            let uu____1880 =
-              let uu____1887 =
-                let uu____1892 =
+          let uu____1847 =
+            let uu____1854 =
+              let uu____1859 = FStar_TypeChecker_NBETerm.type_of ea  in
+              FStar_TypeChecker_NBETerm.as_iarg uu____1859  in
+            let uu____1860 =
+              let uu____1867 =
+                let uu____1872 =
                   FStar_TypeChecker_NBETerm.embed e_exn_nbe cb e  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1892  in
-              let uu____1893 =
-                let uu____1900 =
-                  let uu____1905 =
+                FStar_TypeChecker_NBETerm.as_arg uu____1872  in
+              let uu____1873 =
+                let uu____1880 =
+                  let uu____1885 =
                     FStar_TypeChecker_NBETerm.embed e_proofstate_nbe cb ps
                      in
-                  FStar_TypeChecker_NBETerm.as_arg uu____1905  in
-                [uu____1900]  in
-              uu____1887 :: uu____1893  in
-            uu____1874 :: uu____1880  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____1885  in
+                [uu____1880]  in
+              uu____1867 :: uu____1873  in
+            uu____1854 :: uu____1860  in
           mkConstruct fstar_tactics_Failed.fv [FStar_Syntax_Syntax.U_zero]
-            uu____1867
+            uu____1847
       | FStar_Tactics_Result.Success (a1,ps) ->
-          let uu____1924 =
-            let uu____1931 =
-              let uu____1936 = FStar_TypeChecker_NBETerm.type_of ea  in
-              FStar_TypeChecker_NBETerm.as_iarg uu____1936  in
-            let uu____1937 =
-              let uu____1944 =
-                let uu____1949 = FStar_TypeChecker_NBETerm.embed ea cb a1  in
-                FStar_TypeChecker_NBETerm.as_arg uu____1949  in
-              let uu____1950 =
-                let uu____1957 =
-                  let uu____1962 =
+          let uu____1904 =
+            let uu____1911 =
+              let uu____1916 = FStar_TypeChecker_NBETerm.type_of ea  in
+              FStar_TypeChecker_NBETerm.as_iarg uu____1916  in
+            let uu____1917 =
+              let uu____1924 =
+                let uu____1929 = FStar_TypeChecker_NBETerm.embed ea cb a1  in
+                FStar_TypeChecker_NBETerm.as_arg uu____1929  in
+              let uu____1930 =
+                let uu____1937 =
+                  let uu____1942 =
                     FStar_TypeChecker_NBETerm.embed e_proofstate_nbe cb ps
                      in
-                  FStar_TypeChecker_NBETerm.as_arg uu____1962  in
-                [uu____1957]  in
-              uu____1944 :: uu____1950  in
-            uu____1931 :: uu____1937  in
+                  FStar_TypeChecker_NBETerm.as_arg uu____1942  in
+                [uu____1937]  in
+              uu____1924 :: uu____1930  in
+            uu____1911 :: uu____1917  in
           mkConstruct fstar_tactics_Success.fv [FStar_Syntax_Syntax.U_zero]
-            uu____1924
+            uu____1904
        in
     let unembed_result cb t =
       match t with
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____1999,(ps,uu____2001)::(a1,uu____2003)::_t::[]) when
+          (fv,uu____1979,(ps,uu____1981)::(a1,uu____1983)::_t::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Success.lid ->
-          let uu____2035 = FStar_TypeChecker_NBETerm.unembed ea cb a1  in
-          FStar_Util.bind_opt uu____2035
+          let uu____2015 = FStar_TypeChecker_NBETerm.unembed ea cb a1  in
+          FStar_Util.bind_opt uu____2015
             (fun a2  ->
-               let uu____2043 =
+               let uu____2023 =
                  FStar_TypeChecker_NBETerm.unembed e_proofstate_nbe cb ps  in
-               FStar_Util.bind_opt uu____2043
+               FStar_Util.bind_opt uu____2023
                  (fun ps1  ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Success (a2, ps1))))
       | FStar_TypeChecker_NBETerm.Construct
-          (fv,uu____2053,(ps,uu____2055)::(e,uu____2057)::_t::[]) when
+          (fv,uu____2033,(ps,uu____2035)::(e,uu____2037)::_t::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Failed.lid ->
-          let uu____2089 = FStar_TypeChecker_NBETerm.unembed e_exn_nbe cb e
+          let uu____2069 = FStar_TypeChecker_NBETerm.unembed e_exn_nbe cb e
              in
-          FStar_Util.bind_opt uu____2089
+          FStar_Util.bind_opt uu____2069
             (fun e1  ->
-               let uu____2097 =
+               let uu____2077 =
                  FStar_TypeChecker_NBETerm.unembed e_proofstate_nbe cb ps  in
-               FStar_Util.bind_opt uu____2097
+               FStar_Util.bind_opt uu____2077
                  (fun ps1  ->
                     FStar_Pervasives_Native.Some
                       (FStar_Tactics_Result.Failed (e1, ps1))))
-      | uu____2106 -> FStar_Pervasives_Native.None  in
-    let uu____2109 = mkFV fstar_tactics_result.fv [] []  in
-    let uu____2114 = fv_as_emb_typ fstar_tactics_result.fv  in
+      | uu____2086 -> FStar_Pervasives_Native.None  in
+    let uu____2089 = mkFV fstar_tactics_result.fv [] []  in
+    let uu____2094 = fv_as_emb_typ fstar_tactics_result.fv  in
     {
       FStar_TypeChecker_NBETerm.em = embed_result;
       FStar_TypeChecker_NBETerm.un = unembed_result;
-      FStar_TypeChecker_NBETerm.typ = uu____2109;
-      FStar_TypeChecker_NBETerm.emb_typ = uu____2114
+      FStar_TypeChecker_NBETerm.typ = uu____2089;
+      FStar_TypeChecker_NBETerm.emb_typ = uu____2094
     }
   
 let (e_direction :
@@ -675,26 +663,26 @@ let (e_direction :
     | FStar_Tactics_Types.TopDown  -> fstar_tactics_topdown.t
     | FStar_Tactics_Types.BottomUp  -> fstar_tactics_bottomup.t  in
   let unembed_direction w t =
-    let uu____2148 =
-      let uu____2149 = FStar_Syntax_Subst.compress t  in
-      uu____2149.FStar_Syntax_Syntax.n  in
-    match uu____2148 with
+    let uu____2128 =
+      let uu____2129 = FStar_Syntax_Subst.compress t  in
+      uu____2129.FStar_Syntax_Syntax.n  in
+    match uu____2128 with
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_topdown.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.TopDown
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_bottomup.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.BottomUp
-    | uu____2156 ->
+    | uu____2136 ->
         (if w
          then
-           (let uu____2159 =
-              let uu____2165 =
-                let uu____2167 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded direction: %s" uu____2167
+           (let uu____2139 =
+              let uu____2145 =
+                let uu____2147 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded direction: %s" uu____2147
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____2165)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2159)
+              (FStar_Errors.Warning_NotEmbedded, uu____2145)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2139)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -710,33 +698,33 @@ let (e_direction_nbe :
      in
   let unembed_direction cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2211,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2191,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_topdown.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.TopDown
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2227,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2207,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_bottomup.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.BottomUp
-    | uu____2242 ->
-        ((let uu____2244 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
-          if uu____2244
+    | uu____2222 ->
+        ((let uu____2224 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
+          if uu____2224
           then
-            let uu____2268 =
-              let uu____2274 =
-                let uu____2276 = FStar_TypeChecker_NBETerm.t_to_string t  in
-                FStar_Util.format1 "Not an embedded direction: %s" uu____2276
+            let uu____2248 =
+              let uu____2254 =
+                let uu____2256 = FStar_TypeChecker_NBETerm.t_to_string t  in
+                FStar_Util.format1 "Not an embedded direction: %s" uu____2256
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____2274)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____2268
+              (FStar_Errors.Warning_NotEmbedded, uu____2254)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____2248
           else ());
          FStar_Pervasives_Native.None)
      in
-  let uu____2282 = mkFV fstar_tactics_direction.fv [] []  in
-  let uu____2287 = fv_as_emb_typ fstar_tactics_direction.fv  in
+  let uu____2262 = mkFV fstar_tactics_direction.fv [] []  in
+  let uu____2267 = fv_as_emb_typ fstar_tactics_direction.fv  in
   {
     FStar_TypeChecker_NBETerm.em = embed_direction;
     FStar_TypeChecker_NBETerm.un = unembed_direction;
-    FStar_TypeChecker_NBETerm.typ = uu____2282;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____2287
+    FStar_TypeChecker_NBETerm.typ = uu____2262;
+    FStar_TypeChecker_NBETerm.emb_typ = uu____2267
   } 
 let (e_ctrl_flag :
   FStar_Tactics_Types.ctrl_flag FStar_Syntax_Embeddings.embedding) =
@@ -746,10 +734,10 @@ let (e_ctrl_flag :
     | FStar_Tactics_Types.Skip  -> fstar_tactics_Skip.t
     | FStar_Tactics_Types.Abort  -> fstar_tactics_Abort.t  in
   let unembed_ctrl_flag w t =
-    let uu____2319 =
-      let uu____2320 = FStar_Syntax_Subst.compress t  in
-      uu____2320.FStar_Syntax_Syntax.n  in
-    match uu____2319 with
+    let uu____2299 =
+      let uu____2300 = FStar_Syntax_Subst.compress t  in
+      uu____2300.FStar_Syntax_Syntax.n  in
+    match uu____2299 with
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Continue.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Continue
@@ -759,16 +747,16 @@ let (e_ctrl_flag :
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Abort.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Abort
-    | uu____2328 ->
+    | uu____2308 ->
         (if w
          then
-           (let uu____2331 =
-              let uu____2337 =
-                let uu____2339 = FStar_Syntax_Print.term_to_string t  in
-                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu____2339
+           (let uu____2311 =
+              let uu____2317 =
+                let uu____2319 = FStar_Syntax_Print.term_to_string t  in
+                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu____2319
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____2337)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2331)
+              (FStar_Errors.Warning_NotEmbedded, uu____2317)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2311)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -784,36 +772,36 @@ let (e_ctrl_flag_nbe :
      in
   let unembed_ctrl_flag cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2387,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2367,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Continue.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Continue
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2403,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2383,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Skip.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Skip
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2419,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2399,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Abort.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Abort
-    | uu____2434 ->
-        ((let uu____2436 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
-          if uu____2436
+    | uu____2414 ->
+        ((let uu____2416 = FStar_ST.op_Bang FStar_Options.debug_embedding  in
+          if uu____2416
           then
-            let uu____2460 =
-              let uu____2466 =
-                let uu____2468 = FStar_TypeChecker_NBETerm.t_to_string t  in
-                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu____2468
+            let uu____2440 =
+              let uu____2446 =
+                let uu____2448 = FStar_TypeChecker_NBETerm.t_to_string t  in
+                FStar_Util.format1 "Not an embedded ctrl_flag: %s" uu____2448
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____2466)  in
-            FStar_Errors.log_issue FStar_Range.dummyRange uu____2460
+              (FStar_Errors.Warning_NotEmbedded, uu____2446)  in
+            FStar_Errors.log_issue FStar_Range.dummyRange uu____2440
           else ());
          FStar_Pervasives_Native.None)
      in
-  let uu____2474 = mkFV fstar_tactics_ctrl_flag.fv [] []  in
-  let uu____2479 = fv_as_emb_typ fstar_tactics_ctrl_flag.fv  in
+  let uu____2454 = mkFV fstar_tactics_ctrl_flag.fv [] []  in
+  let uu____2459 = fv_as_emb_typ fstar_tactics_ctrl_flag.fv  in
   {
     FStar_TypeChecker_NBETerm.em = embed_ctrl_flag;
     FStar_TypeChecker_NBETerm.un = unembed_ctrl_flag;
-    FStar_TypeChecker_NBETerm.typ = uu____2474;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____2479
+    FStar_TypeChecker_NBETerm.typ = uu____2454;
+    FStar_TypeChecker_NBETerm.emb_typ = uu____2459
   } 
 let (e_guard_policy :
   FStar_Tactics_Types.guard_policy FStar_Syntax_Embeddings.embedding) =
@@ -824,10 +812,10 @@ let (e_guard_policy :
     | FStar_Tactics_Types.Force  -> fstar_tactics_Force.t
     | FStar_Tactics_Types.Drop  -> fstar_tactics_Drop.t  in
   let unembed_guard_policy w t =
-    let uu____2511 =
-      let uu____2512 = FStar_Syntax_Subst.compress t  in
-      uu____2512.FStar_Syntax_Syntax.n  in
-    match uu____2511 with
+    let uu____2491 =
+      let uu____2492 = FStar_Syntax_Subst.compress t  in
+      uu____2492.FStar_Syntax_Syntax.n  in
+    match uu____2491 with
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_SMT.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.SMT
@@ -840,17 +828,17 @@ let (e_guard_policy :
     | FStar_Syntax_Syntax.Tm_fvar fv when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Drop.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Drop
-    | uu____2521 ->
+    | uu____2501 ->
         (if w
          then
-           (let uu____2524 =
-              let uu____2530 =
-                let uu____2532 = FStar_Syntax_Print.term_to_string t  in
+           (let uu____2504 =
+              let uu____2510 =
+                let uu____2512 = FStar_Syntax_Print.term_to_string t  in
                 FStar_Util.format1 "Not an embedded guard_policy: %s"
-                  uu____2532
+                  uu____2512
                  in
-              (FStar_Errors.Warning_NotEmbedded, uu____2530)  in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2524)
+              (FStar_Errors.Warning_NotEmbedded, uu____2510)  in
+            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2504)
          else ();
          FStar_Pervasives_Native.None)
      in
@@ -866,24 +854,24 @@ let (e_guard_policy_nbe :
      in
   let unembed_guard_policy cb t =
     match t with
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2586,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2566,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_SMT.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.SMT
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2602,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2582,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Goal.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Goal
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2618,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2598,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Force.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Force
-    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2634,[]) when
+    | FStar_TypeChecker_NBETerm.Construct (fv,uu____2614,[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv fstar_tactics_Drop.lid ->
         FStar_Pervasives_Native.Some FStar_Tactics_Types.Drop
-    | uu____2649 -> FStar_Pervasives_Native.None  in
-  let uu____2650 = mkFV fstar_tactics_guard_policy.fv [] []  in
-  let uu____2655 = fv_as_emb_typ fstar_tactics_guard_policy.fv  in
+    | uu____2629 -> FStar_Pervasives_Native.None  in
+  let uu____2630 = mkFV fstar_tactics_guard_policy.fv [] []  in
+  let uu____2635 = fv_as_emb_typ fstar_tactics_guard_policy.fv  in
   {
     FStar_TypeChecker_NBETerm.em = embed_guard_policy;
     FStar_TypeChecker_NBETerm.un = unembed_guard_policy;
-    FStar_TypeChecker_NBETerm.typ = uu____2650;
-    FStar_TypeChecker_NBETerm.emb_typ = uu____2655
+    FStar_TypeChecker_NBETerm.typ = uu____2630;
+    FStar_TypeChecker_NBETerm.emb_typ = uu____2635
   } 

--- a/src/ocaml-output/FStar_Tactics_Hooks.ml
+++ b/src/ocaml-output/FStar_Tactics_Hooks.ml
@@ -636,45 +636,44 @@ let (synthesize :
         if env.FStar_TypeChecker_Env.nosynth
         then
           let uu____2587 =
-            let uu____2592 =
-              FStar_TypeChecker_Util.fvar_const env
-                FStar_Parser_Const.magic_lid
-               in
-            let uu____2593 =
-              let uu____2594 =
-                FStar_Syntax_Syntax.as_arg FStar_Syntax_Util.exp_unit  in
-              [uu____2594]  in
-            FStar_Syntax_Syntax.mk_Tm_app uu____2592 uu____2593  in
-          uu____2587 FStar_Pervasives_Native.None typ.FStar_Syntax_Syntax.pos
+            FStar_TypeChecker_Util.fvar_const env
+              FStar_Parser_Const.magic_lid
+             in
+          let uu____2588 =
+            let uu____2589 =
+              FStar_Syntax_Syntax.as_arg FStar_Syntax_Util.exp_unit  in
+            [uu____2589]  in
+          FStar_Syntax_Syntax.mk_Tm_app uu____2587 uu____2588
+            typ.FStar_Syntax_Syntax.pos
         else
-          ((let uu____2622 =
+          ((let uu____2617 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
             FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2622);
-           (let uu____2646 =
+              uu____2617);
+           (let uu____2641 =
               run_tactic_on_typ tau.FStar_Syntax_Syntax.pos
                 typ.FStar_Syntax_Syntax.pos tau env typ
                in
-            match uu____2646 with
+            match uu____2641 with
             | (gs,w) ->
                 (FStar_List.iter
                    (fun g  ->
-                      let uu____2667 =
-                        let uu____2670 = FStar_Tactics_Types.goal_env g  in
-                        let uu____2671 = FStar_Tactics_Types.goal_type g  in
-                        getprop uu____2670 uu____2671  in
-                      match uu____2667 with
+                      let uu____2662 =
+                        let uu____2665 = FStar_Tactics_Types.goal_env g  in
+                        let uu____2666 = FStar_Tactics_Types.goal_type g  in
+                        getprop uu____2665 uu____2666  in
+                      match uu____2662 with
                       | FStar_Pervasives_Native.Some vc ->
-                          ((let uu____2674 =
+                          ((let uu____2669 =
                               FStar_ST.op_Bang
                                 FStar_Tactics_Interpreter.tacdbg
                                in
-                            if uu____2674
+                            if uu____2669
                             then
-                              let uu____2698 =
+                              let uu____2693 =
                                 FStar_Syntax_Print.term_to_string vc  in
                               FStar_Util.print1 "Synthesis left a goal: %s\n"
-                                uu____2698
+                                uu____2693
                             else ());
                            (let guard =
                               {
@@ -685,10 +684,10 @@ let (synthesize :
                                   ([], []);
                                 FStar_TypeChecker_Common.implicits = []
                               }  in
-                            let uu____2713 = FStar_Tactics_Types.goal_env g
+                            let uu____2708 = FStar_Tactics_Types.goal_env g
                                in
                             FStar_TypeChecker_Rel.force_trivial_guard
-                              uu____2713 guard))
+                              uu____2708 guard))
                       | FStar_Pervasives_Native.None  ->
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_OpenGoalsInSynthesis,
@@ -706,33 +705,33 @@ let (solve_implicits :
         if env.FStar_TypeChecker_Env.nosynth
         then ()
         else
-          ((let uu____2736 =
+          ((let uu____2731 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
             FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2736);
+              uu____2731);
            (let gs =
-              let uu____2763 = FStar_TypeChecker_Env.get_range env  in
+              let uu____2758 = FStar_TypeChecker_Env.get_range env  in
               run_tactic_on_all_implicits tau.FStar_Syntax_Syntax.pos
-                uu____2763 tau env imps
+                uu____2758 tau env imps
                in
             FStar_All.pipe_right gs
               (FStar_List.iter
                  (fun g  ->
-                    let uu____2774 =
-                      let uu____2777 = FStar_Tactics_Types.goal_env g  in
-                      let uu____2778 = FStar_Tactics_Types.goal_type g  in
-                      getprop uu____2777 uu____2778  in
-                    match uu____2774 with
+                    let uu____2769 =
+                      let uu____2772 = FStar_Tactics_Types.goal_env g  in
+                      let uu____2773 = FStar_Tactics_Types.goal_type g  in
+                      getprop uu____2772 uu____2773  in
+                    match uu____2769 with
                     | FStar_Pervasives_Native.Some vc ->
-                        ((let uu____2781 =
+                        ((let uu____2776 =
                             FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg
                              in
-                          if uu____2781
+                          if uu____2776
                           then
-                            let uu____2805 =
+                            let uu____2800 =
                               FStar_Syntax_Print.term_to_string vc  in
                             FStar_Util.print1 "Synthesis left a goal: %s\n"
-                              uu____2805
+                              uu____2800
                           else ());
                          (let guard =
                             {
@@ -742,15 +741,15 @@ let (solve_implicits :
                               FStar_TypeChecker_Common.univ_ineqs = ([], []);
                               FStar_TypeChecker_Common.implicits = []
                             }  in
-                          let uu____2820 = FStar_Tactics_Types.goal_env g  in
+                          let uu____2815 = FStar_Tactics_Types.goal_env g  in
                           FStar_TypeChecker_Rel.force_trivial_guard
-                            uu____2820 guard))
+                            uu____2815 guard))
                     | FStar_Pervasives_Native.None  ->
-                        let uu____2821 = FStar_TypeChecker_Env.get_range env
+                        let uu____2816 = FStar_TypeChecker_Env.get_range env
                            in
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_OpenGoalsInSynthesis,
-                            "synthesis left open goals") uu____2821))))
+                            "synthesis left open goals") uu____2816))))
   
 let (splice :
   FStar_TypeChecker_Env.env ->
@@ -763,71 +762,71 @@ let (splice :
         if env.FStar_TypeChecker_Env.nosynth
         then []
         else
-          ((let uu____2848 =
+          ((let uu____2843 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
             FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2848);
+              uu____2843);
            (let typ = FStar_Syntax_Syntax.t_decls  in
             let ps =
               FStar_Tactics_Basic.proofstate_of_goals
                 tau.FStar_Syntax_Syntax.pos env [] []
                in
-            let uu____2874 =
-              let uu____2883 =
+            let uu____2869 =
+              let uu____2878 =
                 FStar_Syntax_Embeddings.e_list
                   FStar_Reflection_Embeddings.e_sigelt
                  in
               FStar_Tactics_Interpreter.run_tactic_on_ps
                 tau.FStar_Syntax_Syntax.pos tau.FStar_Syntax_Syntax.pos
-                FStar_Syntax_Embeddings.e_unit () uu____2883 tau ps
+                FStar_Syntax_Embeddings.e_unit () uu____2878 tau ps
                in
-            match uu____2874 with
+            match uu____2869 with
             | (gs,sigelts) ->
-                ((let uu____2903 =
+                ((let uu____2898 =
                     FStar_List.existsML
                       (fun g  ->
-                         let uu____2908 =
-                           let uu____2910 =
-                             let uu____2913 = FStar_Tactics_Types.goal_env g
+                         let uu____2903 =
+                           let uu____2905 =
+                             let uu____2908 = FStar_Tactics_Types.goal_env g
                                 in
-                             let uu____2914 = FStar_Tactics_Types.goal_type g
+                             let uu____2909 = FStar_Tactics_Types.goal_type g
                                 in
-                             getprop uu____2913 uu____2914  in
-                           FStar_Option.isSome uu____2910  in
-                         Prims.op_Negation uu____2908) gs
+                             getprop uu____2908 uu____2909  in
+                           FStar_Option.isSome uu____2905  in
+                         Prims.op_Negation uu____2903) gs
                      in
-                  if uu____2903
+                  if uu____2898
                   then
                     FStar_Errors.raise_error
                       (FStar_Errors.Fatal_OpenGoalsInSynthesis,
                         "splice left open goals") typ.FStar_Syntax_Syntax.pos
                   else ());
-                 (let uu____2921 =
+                 (let uu____2916 =
                     FStar_ST.op_Bang FStar_Tactics_Interpreter.tacdbg  in
-                  if uu____2921
+                  if uu____2916
                   then
-                    let uu____2945 =
+                    let uu____2940 =
                       FStar_Common.string_of_list
                         FStar_Syntax_Print.sigelt_to_string sigelts
                        in
-                    FStar_Util.print1 "splice: got decls = %s\n" uu____2945
+                    FStar_Util.print1 "splice: got decls = %s\n" uu____2940
                   else ());
                  (let sigelts1 =
                     FStar_List.map
                       (fun se  ->
-                         let uu___396_2956 = se  in
+                         let uu___396_2951 = se  in
                          {
                            FStar_Syntax_Syntax.sigel =
-                             (uu___396_2956.FStar_Syntax_Syntax.sigel);
+                             (uu___396_2951.FStar_Syntax_Syntax.sigel);
                            FStar_Syntax_Syntax.sigrng = rng;
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___396_2956.FStar_Syntax_Syntax.sigquals);
+                             (uu___396_2951.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___396_2956.FStar_Syntax_Syntax.sigmeta);
+                             (uu___396_2951.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___396_2956.FStar_Syntax_Syntax.sigattrs);
+                             (uu___396_2951.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___396_2956.FStar_Syntax_Syntax.sigopts)
+                             (uu___396_2951.FStar_Syntax_Syntax.sigopts)
                          }) sigelts
                      in
                   sigelts1))))
@@ -843,21 +842,21 @@ let (mpreprocess :
         if env.FStar_TypeChecker_Env.nosynth
         then tm
         else
-          ((let uu____2977 =
+          ((let uu____2972 =
               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")  in
             FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-              uu____2977);
+              uu____2972);
            (let ps =
               FStar_Tactics_Basic.proofstate_of_goals
                 tm.FStar_Syntax_Syntax.pos env [] []
                in
-            let uu____3002 =
+            let uu____2997 =
               FStar_Tactics_Interpreter.run_tactic_on_ps
                 tau.FStar_Syntax_Syntax.pos tm.FStar_Syntax_Syntax.pos
                 FStar_Reflection_Embeddings.e_term tm
                 FStar_Reflection_Embeddings.e_term tau ps
                in
-            match uu____3002 with | (gs,tm1) -> tm1))
+            match uu____2997 with | (gs,tm1) -> tm1))
   
 let (postprocess :
   FStar_TypeChecker_Env.env ->
@@ -872,54 +871,54 @@ let (postprocess :
           if env.FStar_TypeChecker_Env.nosynth
           then tm
           else
-            ((let uu____3040 =
+            ((let uu____3035 =
                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "Tac")
                  in
               FStar_ST.op_Colon_Equals FStar_Tactics_Interpreter.tacdbg
-                uu____3040);
-             (let uu____3064 =
+                uu____3035);
+             (let uu____3059 =
                 FStar_TypeChecker_Env.new_implicit_var_aux "postprocess RHS"
                   tm.FStar_Syntax_Syntax.pos env typ
                   FStar_Syntax_Syntax.Allow_untyped
                   FStar_Pervasives_Native.None
                  in
-              match uu____3064 with
-              | (uvtm,uu____3083,g_imp) ->
+              match uu____3059 with
+              | (uvtm,uu____3078,g_imp) ->
                   let u = env.FStar_TypeChecker_Env.universe_of env typ  in
                   let goal =
-                    let uu____3101 = FStar_Syntax_Util.mk_eq2 u typ tm uvtm
+                    let uu____3096 = FStar_Syntax_Util.mk_eq2 u typ tm uvtm
                        in
                     FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero
-                      uu____3101
+                      uu____3096
                      in
-                  let uu____3102 =
+                  let uu____3097 =
                     run_tactic_on_typ tau.FStar_Syntax_Syntax.pos
                       tm.FStar_Syntax_Syntax.pos tau env goal
                      in
-                  (match uu____3102 with
+                  (match uu____3097 with
                    | (gs,w) ->
                        (FStar_List.iter
                           (fun g  ->
-                             let uu____3123 =
-                               let uu____3126 =
+                             let uu____3118 =
+                               let uu____3121 =
                                  FStar_Tactics_Types.goal_env g  in
-                               let uu____3127 =
+                               let uu____3122 =
                                  FStar_Tactics_Types.goal_type g  in
-                               getprop uu____3126 uu____3127  in
-                             match uu____3123 with
+                               getprop uu____3121 uu____3122  in
+                             match uu____3118 with
                              | FStar_Pervasives_Native.Some vc ->
-                                 ((let uu____3130 =
+                                 ((let uu____3125 =
                                      FStar_ST.op_Bang
                                        FStar_Tactics_Interpreter.tacdbg
                                       in
-                                   if uu____3130
+                                   if uu____3125
                                    then
-                                     let uu____3154 =
+                                     let uu____3149 =
                                        FStar_Syntax_Print.term_to_string vc
                                         in
                                      FStar_Util.print1
                                        "Postprocessing left a goal: %s\n"
-                                       uu____3154
+                                       uu____3149
                                    else ());
                                   (let guard =
                                      {
@@ -932,10 +931,10 @@ let (postprocess :
                                        FStar_TypeChecker_Common.implicits =
                                          []
                                      }  in
-                                   let uu____3169 =
+                                   let uu____3164 =
                                      FStar_Tactics_Types.goal_env g  in
                                    FStar_TypeChecker_Rel.force_trivial_guard
-                                     uu____3169 guard))
+                                     uu____3164 guard))
                              | FStar_Pervasives_Native.None  ->
                                  FStar_Errors.raise_error
                                    (FStar_Errors.Fatal_OpenGoalsInSynthesis,

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -221,17 +221,16 @@ let unembed_tactic_0 :
              let embedded_tac_b1 = FStar_Syntax_Util.mk_reify embedded_tac_b
                 in
              let tm =
-               let uu____585 =
-                 let uu____590 =
-                   let uu____591 =
-                     let uu____600 =
-                       embed FStar_Tactics_Embedding.e_proofstate rng
-                         proof_state ncb
-                        in
-                     FStar_Syntax_Syntax.as_arg uu____600  in
-                   [uu____591]  in
-                 FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b1 uu____590  in
-               uu____585 FStar_Pervasives_Native.None rng  in
+               let uu____583 =
+                 let uu____584 =
+                   let uu____593 =
+                     embed FStar_Tactics_Embedding.e_proofstate rng
+                       proof_state ncb
+                      in
+                   FStar_Syntax_Syntax.as_arg uu____593  in
+                 [uu____584]  in
+               FStar_Syntax_Syntax.mk_Tm_app embedded_tac_b1 uu____583 rng
+                in
              let steps =
                [FStar_TypeChecker_Env.Weak;
                FStar_TypeChecker_Env.Reify;
@@ -241,42 +240,42 @@ let unembed_tactic_0 :
                FStar_TypeChecker_Env.Primops;
                FStar_TypeChecker_Env.Unascribe]  in
              let norm_f =
-               let uu____641 = FStar_Options.tactics_nbe ()  in
-               if uu____641
+               let uu____634 = FStar_Options.tactics_nbe ()  in
+               if uu____634
                then FStar_TypeChecker_NBE.normalize
                else
                  FStar_TypeChecker_Normalize.normalize_with_primitive_steps
                 in
              let result =
-               let uu____663 = primitive_steps ()  in
-               norm_f uu____663 steps
+               let uu____656 = primitive_steps ()  in
+               norm_f uu____656 steps
                  proof_state.FStar_Tactics_Types.main_context tm
                 in
              let res =
-               let uu____671 = FStar_Tactics_Embedding.e_result eb  in
-               unembed uu____671 result ncb  in
+               let uu____664 = FStar_Tactics_Embedding.e_result eb  in
+               unembed uu____664 result ncb  in
              match res with
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Success
                  (b1,ps)) ->
-                 let uu____684 = FStar_Tactics_Monad.set ps  in
-                 FStar_Tactics_Monad.bind uu____684
-                   (fun uu____688  -> FStar_Tactics_Monad.ret b1)
+                 let uu____677 = FStar_Tactics_Monad.set ps  in
+                 FStar_Tactics_Monad.bind uu____677
+                   (fun uu____681  -> FStar_Tactics_Monad.ret b1)
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Failed
                  (e,ps)) ->
-                 let uu____693 = FStar_Tactics_Monad.set ps  in
-                 FStar_Tactics_Monad.bind uu____693
-                   (fun uu____697  -> FStar_Tactics_Monad.traise e)
+                 let uu____686 = FStar_Tactics_Monad.set ps  in
+                 FStar_Tactics_Monad.bind uu____686
+                   (fun uu____690  -> FStar_Tactics_Monad.traise e)
              | FStar_Pervasives_Native.None  ->
-                 let uu____700 =
-                   let uu____706 =
-                     let uu____708 = FStar_Syntax_Print.term_to_string result
+                 let uu____693 =
+                   let uu____699 =
+                     let uu____701 = FStar_Syntax_Print.term_to_string result
                         in
                      FStar_Util.format1
                        "Tactic got stuck! Please file a bug report with a minimal reproduction of this issue.\n%s"
-                       uu____708
+                       uu____701
                       in
-                   (FStar_Errors.Fatal_TacticGotStuck, uu____706)  in
-                 FStar_Errors.raise_error uu____700
+                   (FStar_Errors.Fatal_TacticGotStuck, uu____699)  in
+                 FStar_Errors.raise_error uu____693
                    (proof_state.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.range)
   
 let unembed_tactic_nbe_0 :
@@ -291,42 +290,42 @@ let unembed_tactic_nbe_0 :
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun proof_state  ->
              let result =
-               let uu____753 =
-                 let uu____754 =
-                   let uu____759 =
+               let uu____746 =
+                 let uu____747 =
+                   let uu____752 =
                      FStar_TypeChecker_NBETerm.embed
                        FStar_Tactics_Embedding.e_proofstate_nbe cb
                        proof_state
                       in
-                   FStar_TypeChecker_NBETerm.as_arg uu____759  in
-                 [uu____754]  in
-               FStar_TypeChecker_NBETerm.iapp_cb cb embedded_tac_b uu____753
+                   FStar_TypeChecker_NBETerm.as_arg uu____752  in
+                 [uu____747]  in
+               FStar_TypeChecker_NBETerm.iapp_cb cb embedded_tac_b uu____746
                 in
              let res =
-               let uu____773 = FStar_Tactics_Embedding.e_result_nbe eb  in
-               FStar_TypeChecker_NBETerm.unembed uu____773 cb result  in
+               let uu____766 = FStar_Tactics_Embedding.e_result_nbe eb  in
+               FStar_TypeChecker_NBETerm.unembed uu____766 cb result  in
              match res with
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Success
                  (b1,ps)) ->
-                 let uu____786 = FStar_Tactics_Monad.set ps  in
-                 FStar_Tactics_Monad.bind uu____786
-                   (fun uu____790  -> FStar_Tactics_Monad.ret b1)
+                 let uu____779 = FStar_Tactics_Monad.set ps  in
+                 FStar_Tactics_Monad.bind uu____779
+                   (fun uu____783  -> FStar_Tactics_Monad.ret b1)
              | FStar_Pervasives_Native.Some (FStar_Tactics_Result.Failed
                  (e,ps)) ->
-                 let uu____795 = FStar_Tactics_Monad.set ps  in
-                 FStar_Tactics_Monad.bind uu____795
-                   (fun uu____799  -> FStar_Tactics_Monad.traise e)
+                 let uu____788 = FStar_Tactics_Monad.set ps  in
+                 FStar_Tactics_Monad.bind uu____788
+                   (fun uu____792  -> FStar_Tactics_Monad.traise e)
              | FStar_Pervasives_Native.None  ->
-                 let uu____802 =
-                   let uu____808 =
-                     let uu____810 =
+                 let uu____795 =
+                   let uu____801 =
+                     let uu____803 =
                        FStar_TypeChecker_NBETerm.t_to_string result  in
                      FStar_Util.format1
                        "Tactic got stuck (in NBE)! Please file a bug report with a minimal reproduction of this issue.\n%s"
-                       uu____810
+                       uu____803
                       in
-                   (FStar_Errors.Fatal_TacticGotStuck, uu____808)  in
-                 FStar_Errors.raise_error uu____802
+                   (FStar_Errors.Fatal_TacticGotStuck, uu____801)  in
+                 FStar_Errors.raise_error uu____795
                    (proof_state.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.range)
   
 let unembed_tactic_1 :
@@ -344,12 +343,10 @@ let unembed_tactic_1 :
             let rng = FStar_Range.dummyRange  in
             let x_tm = embed ea rng x ncb  in
             let app =
-              let uu____872 =
-                let uu____877 =
-                  let uu____878 = FStar_Syntax_Syntax.as_arg x_tm  in
-                  [uu____878]  in
-                FStar_Syntax_Syntax.mk_Tm_app f uu____877  in
-              uu____872 FStar_Pervasives_Native.None rng  in
+              let uu____863 =
+                let uu____864 = FStar_Syntax_Syntax.as_arg x_tm  in
+                [uu____864]  in
+              FStar_Syntax_Syntax.mk_Tm_app f uu____863 rng  in
             unembed_tactic_0 er app ncb
   
 let unembed_tactic_nbe_1 :
@@ -366,10 +363,10 @@ let unembed_tactic_nbe_1 :
           fun x  ->
             let x_tm = FStar_TypeChecker_NBETerm.embed ea cb x  in
             let app =
-              let uu____954 =
-                let uu____955 = FStar_TypeChecker_NBETerm.as_arg x_tm  in
-                [uu____955]  in
-              FStar_TypeChecker_NBETerm.iapp_cb cb f uu____954  in
+              let uu____940 =
+                let uu____941 = FStar_TypeChecker_NBETerm.as_arg x_tm  in
+                [uu____941]  in
+              FStar_TypeChecker_NBETerm.iapp_cb cb f uu____940  in
             unembed_tactic_nbe_0 er cb app
   
 let e_tactic_thunk :
@@ -378,22 +375,22 @@ let e_tactic_thunk :
       'r FStar_Tactics_Monad.tac FStar_Syntax_Embeddings.embedding
   =
   fun er  ->
-    let uu____987 =
+    let uu____973 =
       FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit  in
     FStar_Syntax_Embeddings.mk_emb
-      (fun uu____994  ->
-         fun uu____995  ->
-           fun uu____996  ->
-             fun uu____997  ->
+      (fun uu____980  ->
+         fun uu____981  ->
+           fun uu____982  ->
+             fun uu____983  ->
                failwith "Impossible: embedding tactic (thunk)?")
       (fun t  ->
          fun w  ->
            fun cb  ->
-             let uu____1011 =
-               let uu____1014 =
+             let uu____997 =
+               let uu____1000 =
                  unembed_tactic_1 FStar_Syntax_Embeddings.e_unit er t cb  in
-               uu____1014 ()  in
-             FStar_Pervasives_Native.Some uu____1011) uu____987
+               uu____1000 ()  in
+             FStar_Pervasives_Native.Some uu____997) uu____973
   
 let e_tactic_nbe_thunk :
   'r .
@@ -401,22 +398,22 @@ let e_tactic_nbe_thunk :
       'r FStar_Tactics_Monad.tac FStar_TypeChecker_NBETerm.embedding
   =
   fun er  ->
-    let uu____1042 =
+    let uu____1028 =
       FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit  in
     FStar_TypeChecker_NBETerm.mk_emb
       (fun cb  ->
-         fun uu____1048  ->
+         fun uu____1034  ->
            failwith "Impossible: NBE embedding tactic (thunk)?")
       (fun cb  ->
          fun t  ->
-           let uu____1057 =
-             let uu____1060 =
+           let uu____1043 =
+             let uu____1046 =
                unembed_tactic_nbe_1 FStar_TypeChecker_NBETerm.e_unit er cb t
                 in
-             uu____1060 ()  in
-           FStar_Pervasives_Native.Some uu____1057)
+             uu____1046 ()  in
+           FStar_Pervasives_Native.Some uu____1043)
       (FStar_TypeChecker_NBETerm.Constant FStar_TypeChecker_NBETerm.Unit)
-      uu____1042
+      uu____1028
   
 let e_tactic_1 :
   'a 'r .
@@ -426,19 +423,19 @@ let e_tactic_1 :
   =
   fun ea  ->
     fun er  ->
-      let uu____1105 =
+      let uu____1091 =
         FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit  in
       FStar_Syntax_Embeddings.mk_emb
-        (fun uu____1115  ->
-           fun uu____1116  ->
-             fun uu____1117  ->
-               fun uu____1118  ->
+        (fun uu____1101  ->
+           fun uu____1102  ->
+             fun uu____1103  ->
+               fun uu____1104  ->
                  failwith "Impossible: embedding tactic (1)?")
         (fun t  ->
            fun w  ->
              fun cb  ->
-               let uu____1134 = unembed_tactic_1 ea er t cb  in
-               FStar_Pervasives_Native.Some uu____1134) uu____1105
+               let uu____1120 = unembed_tactic_1 ea er t cb  in
+               FStar_Pervasives_Native.Some uu____1120) uu____1091
   
 let e_tactic_nbe_1 :
   'a 'r .
@@ -449,31 +446,31 @@ let e_tactic_nbe_1 :
   =
   fun ea  ->
     fun er  ->
-      let uu____1182 =
+      let uu____1168 =
         FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_unit  in
       FStar_TypeChecker_NBETerm.mk_emb
         (fun cb  ->
-           fun uu____1191  ->
+           fun uu____1177  ->
              failwith "Impossible: NBE embedding tactic (1)?")
         (fun cb  ->
            fun t  ->
-             let uu____1202 = unembed_tactic_nbe_1 ea er cb t  in
-             FStar_Pervasives_Native.Some uu____1202)
+             let uu____1188 = unembed_tactic_nbe_1 ea er cb t  in
+             FStar_Pervasives_Native.Some uu____1188)
         (FStar_TypeChecker_NBETerm.Constant FStar_TypeChecker_NBETerm.Unit)
-        uu____1182
+        uu____1168
   
 let (uu___143 : unit) =
-  let uu____1215 =
-    let uu____1220 =
-      let uu____1223 =
+  let uu____1201 =
+    let uu____1206 =
+      let uu____1209 =
         mk_total_step_1'_psc Prims.int_zero "tracepoint"
           FStar_Tactics_Types.tracepoint FStar_Tactics_Embedding.e_proofstate
           FStar_Syntax_Embeddings.e_unit FStar_Tactics_Types.tracepoint
           FStar_Tactics_Embedding.e_proofstate_nbe
           FStar_TypeChecker_NBETerm.e_unit
          in
-      let uu____1226 =
-        let uu____1229 =
+      let uu____1212 =
+        let uu____1215 =
           mk_total_step_2' Prims.int_zero "set_proofstate_range"
             FStar_Tactics_Types.set_proofstate_range
             FStar_Tactics_Embedding.e_proofstate
@@ -484,8 +481,8 @@ let (uu___143 : unit) =
             FStar_TypeChecker_NBETerm.e_range
             FStar_Tactics_Embedding.e_proofstate_nbe
            in
-        let uu____1232 =
-          let uu____1235 =
+        let uu____1218 =
+          let uu____1221 =
             mk_total_step_1' Prims.int_zero "incr_depth"
               FStar_Tactics_Types.incr_depth
               FStar_Tactics_Embedding.e_proofstate
@@ -494,8 +491,8 @@ let (uu___143 : unit) =
               FStar_Tactics_Embedding.e_proofstate_nbe
               FStar_Tactics_Embedding.e_proofstate_nbe
              in
-          let uu____1238 =
-            let uu____1241 =
+          let uu____1224 =
+            let uu____1227 =
               mk_total_step_1' Prims.int_zero "decr_depth"
                 FStar_Tactics_Types.decr_depth
                 FStar_Tactics_Embedding.e_proofstate
@@ -504,40 +501,40 @@ let (uu___143 : unit) =
                 FStar_Tactics_Embedding.e_proofstate_nbe
                 FStar_Tactics_Embedding.e_proofstate_nbe
                in
-            let uu____1244 =
-              let uu____1247 =
-                let uu____1248 =
+            let uu____1230 =
+              let uu____1233 =
+                let uu____1234 =
                   FStar_Syntax_Embeddings.e_list
                     FStar_Tactics_Embedding.e_goal
                    in
-                let uu____1253 =
+                let uu____1239 =
                   FStar_TypeChecker_NBETerm.e_list
                     FStar_Tactics_Embedding.e_goal_nbe
                    in
                 mk_total_step_1' Prims.int_zero "goals_of"
                   FStar_Tactics_Types.goals_of
-                  FStar_Tactics_Embedding.e_proofstate uu____1248
+                  FStar_Tactics_Embedding.e_proofstate uu____1234
                   FStar_Tactics_Types.goals_of
-                  FStar_Tactics_Embedding.e_proofstate_nbe uu____1253
+                  FStar_Tactics_Embedding.e_proofstate_nbe uu____1239
                  in
-              let uu____1264 =
-                let uu____1267 =
-                  let uu____1268 =
+              let uu____1250 =
+                let uu____1253 =
+                  let uu____1254 =
                     FStar_Syntax_Embeddings.e_list
                       FStar_Tactics_Embedding.e_goal
                      in
-                  let uu____1273 =
+                  let uu____1259 =
                     FStar_TypeChecker_NBETerm.e_list
                       FStar_Tactics_Embedding.e_goal_nbe
                      in
                   mk_total_step_1' Prims.int_zero "smt_goals_of"
                     FStar_Tactics_Types.smt_goals_of
-                    FStar_Tactics_Embedding.e_proofstate uu____1268
+                    FStar_Tactics_Embedding.e_proofstate uu____1254
                     FStar_Tactics_Types.smt_goals_of
-                    FStar_Tactics_Embedding.e_proofstate_nbe uu____1273
+                    FStar_Tactics_Embedding.e_proofstate_nbe uu____1259
                    in
-                let uu____1284 =
-                  let uu____1287 =
+                let uu____1270 =
+                  let uu____1273 =
                     mk_total_step_1' Prims.int_zero "goal_env"
                       FStar_Tactics_Types.goal_env
                       FStar_Tactics_Embedding.e_goal
@@ -546,8 +543,8 @@ let (uu___143 : unit) =
                       FStar_Tactics_Embedding.e_goal_nbe
                       FStar_Reflection_NBEEmbeddings.e_env
                      in
-                  let uu____1290 =
-                    let uu____1293 =
+                  let uu____1276 =
+                    let uu____1279 =
                       mk_total_step_1' Prims.int_zero "goal_type"
                         FStar_Tactics_Types.goal_type
                         FStar_Tactics_Embedding.e_goal
@@ -556,8 +553,8 @@ let (uu___143 : unit) =
                         FStar_Tactics_Embedding.e_goal_nbe
                         FStar_Reflection_NBEEmbeddings.e_term
                        in
-                    let uu____1296 =
-                      let uu____1299 =
+                    let uu____1282 =
+                      let uu____1285 =
                         mk_total_step_1' Prims.int_zero "goal_witness"
                           FStar_Tactics_Types.goal_witness
                           FStar_Tactics_Embedding.e_goal
@@ -566,8 +563,8 @@ let (uu___143 : unit) =
                           FStar_Tactics_Embedding.e_goal_nbe
                           FStar_Reflection_NBEEmbeddings.e_term
                          in
-                      let uu____1302 =
-                        let uu____1305 =
+                      let uu____1288 =
+                        let uu____1291 =
                           mk_total_step_1' Prims.int_zero "is_guard"
                             FStar_Tactics_Types.is_guard
                             FStar_Tactics_Embedding.e_goal
@@ -576,8 +573,8 @@ let (uu___143 : unit) =
                             FStar_Tactics_Embedding.e_goal_nbe
                             FStar_TypeChecker_NBETerm.e_bool
                            in
-                        let uu____1310 =
-                          let uu____1313 =
+                        let uu____1296 =
+                          let uu____1299 =
                             mk_total_step_1' Prims.int_zero "get_label"
                               FStar_Tactics_Types.get_label
                               FStar_Tactics_Embedding.e_goal
@@ -586,8 +583,8 @@ let (uu___143 : unit) =
                               FStar_Tactics_Embedding.e_goal_nbe
                               FStar_TypeChecker_NBETerm.e_string
                              in
-                          let uu____1318 =
-                            let uu____1321 =
+                          let uu____1304 =
+                            let uu____1307 =
                               mk_total_step_2' Prims.int_zero "set_label"
                                 FStar_Tactics_Types.set_label
                                 FStar_Syntax_Embeddings.e_string
@@ -598,43 +595,43 @@ let (uu___143 : unit) =
                                 FStar_Tactics_Embedding.e_goal_nbe
                                 FStar_Tactics_Embedding.e_goal_nbe
                                in
-                            let uu____1326 =
-                              let uu____1329 =
-                                let uu____1330 =
+                            let uu____1312 =
+                              let uu____1315 =
+                                let uu____1316 =
                                   FStar_Syntax_Embeddings.e_list
                                     FStar_Tactics_Embedding.e_goal
                                    in
-                                let uu____1335 =
+                                let uu____1321 =
                                   FStar_TypeChecker_NBETerm.e_list
                                     FStar_Tactics_Embedding.e_goal_nbe
                                    in
                                 FStar_Tactics_InterpFuns.mk_tac_step_1
                                   Prims.int_zero "set_goals"
-                                  FStar_Tactics_Monad.set_goals uu____1330
+                                  FStar_Tactics_Monad.set_goals uu____1316
                                   FStar_Syntax_Embeddings.e_unit
-                                  FStar_Tactics_Monad.set_goals uu____1335
+                                  FStar_Tactics_Monad.set_goals uu____1321
                                   FStar_TypeChecker_NBETerm.e_unit
                                  in
-                              let uu____1346 =
-                                let uu____1349 =
-                                  let uu____1350 =
+                              let uu____1332 =
+                                let uu____1335 =
+                                  let uu____1336 =
                                     FStar_Syntax_Embeddings.e_list
                                       FStar_Tactics_Embedding.e_goal
                                      in
-                                  let uu____1355 =
+                                  let uu____1341 =
                                     FStar_TypeChecker_NBETerm.e_list
                                       FStar_Tactics_Embedding.e_goal_nbe
                                      in
                                   FStar_Tactics_InterpFuns.mk_tac_step_1
                                     Prims.int_zero "set_smt_goals"
                                     FStar_Tactics_Monad.set_smt_goals
-                                    uu____1350 FStar_Syntax_Embeddings.e_unit
+                                    uu____1336 FStar_Syntax_Embeddings.e_unit
                                     FStar_Tactics_Monad.set_smt_goals
-                                    uu____1355
+                                    uu____1341
                                     FStar_TypeChecker_NBETerm.e_unit
                                    in
-                                let uu____1366 =
-                                  let uu____1369 =
+                                let uu____1352 =
+                                  let uu____1355 =
                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                       Prims.int_zero "trivial"
                                       FStar_Tactics_Basic.trivial
@@ -644,70 +641,70 @@ let (uu___143 : unit) =
                                       FStar_TypeChecker_NBETerm.e_unit
                                       FStar_TypeChecker_NBETerm.e_unit
                                      in
-                                  let uu____1372 =
-                                    let uu____1375 =
-                                      let uu____1376 =
+                                  let uu____1358 =
+                                    let uu____1361 =
+                                      let uu____1362 =
                                         e_tactic_thunk
                                           FStar_Syntax_Embeddings.e_any
                                          in
-                                      let uu____1381 =
+                                      let uu____1367 =
                                         FStar_Syntax_Embeddings.e_either
                                           FStar_Tactics_Embedding.e_exn
                                           FStar_Syntax_Embeddings.e_any
                                          in
-                                      let uu____1388 =
+                                      let uu____1374 =
                                         e_tactic_nbe_thunk
                                           FStar_TypeChecker_NBETerm.e_any
                                          in
-                                      let uu____1393 =
+                                      let uu____1379 =
                                         FStar_TypeChecker_NBETerm.e_either
                                           FStar_Tactics_Embedding.e_exn_nbe
                                           FStar_TypeChecker_NBETerm.e_any
                                          in
                                       FStar_Tactics_InterpFuns.mk_tac_step_2
                                         Prims.int_one "catch"
-                                        (fun uu____1415  ->
+                                        (fun uu____1401  ->
                                            FStar_Tactics_Basic.catch)
                                         FStar_Syntax_Embeddings.e_any
-                                        uu____1376 uu____1381
-                                        (fun uu____1417  ->
+                                        uu____1362 uu____1367
+                                        (fun uu____1403  ->
                                            FStar_Tactics_Basic.catch)
                                         FStar_TypeChecker_NBETerm.e_any
-                                        uu____1388 uu____1393
+                                        uu____1374 uu____1379
                                        in
-                                    let uu____1418 =
-                                      let uu____1421 =
-                                        let uu____1422 =
+                                    let uu____1404 =
+                                      let uu____1407 =
+                                        let uu____1408 =
                                           e_tactic_thunk
                                             FStar_Syntax_Embeddings.e_any
                                            in
-                                        let uu____1427 =
+                                        let uu____1413 =
                                           FStar_Syntax_Embeddings.e_either
                                             FStar_Tactics_Embedding.e_exn
                                             FStar_Syntax_Embeddings.e_any
                                            in
-                                        let uu____1434 =
+                                        let uu____1420 =
                                           e_tactic_nbe_thunk
                                             FStar_TypeChecker_NBETerm.e_any
                                            in
-                                        let uu____1439 =
+                                        let uu____1425 =
                                           FStar_TypeChecker_NBETerm.e_either
                                             FStar_Tactics_Embedding.e_exn_nbe
                                             FStar_TypeChecker_NBETerm.e_any
                                            in
                                         FStar_Tactics_InterpFuns.mk_tac_step_2
                                           Prims.int_one "recover"
-                                          (fun uu____1461  ->
+                                          (fun uu____1447  ->
                                              FStar_Tactics_Basic.recover)
                                           FStar_Syntax_Embeddings.e_any
-                                          uu____1422 uu____1427
-                                          (fun uu____1463  ->
+                                          uu____1408 uu____1413
+                                          (fun uu____1449  ->
                                              FStar_Tactics_Basic.recover)
                                           FStar_TypeChecker_NBETerm.e_any
-                                          uu____1434 uu____1439
+                                          uu____1420 uu____1425
                                          in
-                                      let uu____1464 =
-                                        let uu____1467 =
+                                      let uu____1450 =
+                                        let uu____1453 =
                                           FStar_Tactics_InterpFuns.mk_tac_step_1
                                             Prims.int_zero "intro"
                                             FStar_Tactics_Basic.intro
@@ -717,14 +714,14 @@ let (uu___143 : unit) =
                                             FStar_TypeChecker_NBETerm.e_unit
                                             FStar_Reflection_NBEEmbeddings.e_binder
                                            in
-                                        let uu____1470 =
-                                          let uu____1473 =
-                                            let uu____1474 =
+                                        let uu____1456 =
+                                          let uu____1459 =
+                                            let uu____1460 =
                                               FStar_Syntax_Embeddings.e_tuple2
                                                 FStar_Reflection_Embeddings.e_binder
                                                 FStar_Reflection_Embeddings.e_binder
                                                in
-                                            let uu____1481 =
+                                            let uu____1467 =
                                               FStar_TypeChecker_NBETerm.e_tuple2
                                                 FStar_Reflection_NBEEmbeddings.e_binder
                                                 FStar_Reflection_NBEEmbeddings.e_binder
@@ -733,37 +730,37 @@ let (uu___143 : unit) =
                                               Prims.int_zero "intro_rec"
                                               FStar_Tactics_Basic.intro_rec
                                               FStar_Syntax_Embeddings.e_unit
-                                              uu____1474
+                                              uu____1460
                                               FStar_Tactics_Basic.intro_rec
                                               FStar_TypeChecker_NBETerm.e_unit
-                                              uu____1481
+                                              uu____1467
                                              in
-                                          let uu____1498 =
-                                            let uu____1501 =
-                                              let uu____1502 =
+                                          let uu____1484 =
+                                            let uu____1487 =
+                                              let uu____1488 =
                                                 FStar_Syntax_Embeddings.e_list
                                                   FStar_Syntax_Embeddings.e_norm_step
                                                  in
-                                              let uu____1507 =
+                                              let uu____1493 =
                                                 FStar_TypeChecker_NBETerm.e_list
                                                   FStar_TypeChecker_NBETerm.e_norm_step
                                                  in
                                               FStar_Tactics_InterpFuns.mk_tac_step_1
                                                 Prims.int_zero "norm"
                                                 FStar_Tactics_Basic.norm
-                                                uu____1502
+                                                uu____1488
                                                 FStar_Syntax_Embeddings.e_unit
                                                 FStar_Tactics_Basic.norm
-                                                uu____1507
+                                                uu____1493
                                                 FStar_TypeChecker_NBETerm.e_unit
                                                in
-                                            let uu____1518 =
-                                              let uu____1521 =
-                                                let uu____1522 =
+                                            let uu____1504 =
+                                              let uu____1507 =
+                                                let uu____1508 =
                                                   FStar_Syntax_Embeddings.e_list
                                                     FStar_Syntax_Embeddings.e_norm_step
                                                    in
-                                                let uu____1527 =
+                                                let uu____1513 =
                                                   FStar_TypeChecker_NBETerm.e_list
                                                     FStar_TypeChecker_NBETerm.e_norm_step
                                                    in
@@ -772,22 +769,22 @@ let (uu___143 : unit) =
                                                   "norm_term_env"
                                                   FStar_Tactics_Basic.norm_term_env
                                                   FStar_Reflection_Embeddings.e_env
-                                                  uu____1522
+                                                  uu____1508
                                                   FStar_Reflection_Embeddings.e_term
                                                   FStar_Reflection_Embeddings.e_term
                                                   FStar_Tactics_Basic.norm_term_env
                                                   FStar_Reflection_NBEEmbeddings.e_env
-                                                  uu____1527
+                                                  uu____1513
                                                   FStar_Reflection_NBEEmbeddings.e_term
                                                   FStar_Reflection_NBEEmbeddings.e_term
                                                  in
-                                              let uu____1538 =
-                                                let uu____1541 =
-                                                  let uu____1542 =
+                                              let uu____1524 =
+                                                let uu____1527 =
+                                                  let uu____1528 =
                                                     FStar_Syntax_Embeddings.e_list
                                                       FStar_Syntax_Embeddings.e_norm_step
                                                      in
-                                                  let uu____1547 =
+                                                  let uu____1533 =
                                                     FStar_TypeChecker_NBETerm.e_list
                                                       FStar_TypeChecker_NBETerm.e_norm_step
                                                      in
@@ -795,16 +792,16 @@ let (uu___143 : unit) =
                                                     Prims.int_zero
                                                     "norm_binder_type"
                                                     FStar_Tactics_Basic.norm_binder_type
-                                                    uu____1542
+                                                    uu____1528
                                                     FStar_Reflection_Embeddings.e_binder
                                                     FStar_Syntax_Embeddings.e_unit
                                                     FStar_Tactics_Basic.norm_binder_type
-                                                    uu____1547
+                                                    uu____1533
                                                     FStar_Reflection_NBEEmbeddings.e_binder
                                                     FStar_TypeChecker_NBETerm.e_unit
                                                    in
-                                                let uu____1558 =
-                                                  let uu____1561 =
+                                                let uu____1544 =
+                                                  let uu____1547 =
                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                       Prims.int_zero
                                                       "rename_to"
@@ -817,8 +814,8 @@ let (uu___143 : unit) =
                                                       FStar_TypeChecker_NBETerm.e_string
                                                       FStar_Reflection_NBEEmbeddings.e_binder
                                                      in
-                                                  let uu____1566 =
-                                                    let uu____1569 =
+                                                  let uu____1552 =
+                                                    let uu____1555 =
                                                       FStar_Tactics_InterpFuns.mk_tac_step_1
                                                         Prims.int_zero
                                                         "binder_retype"
@@ -829,8 +826,8 @@ let (uu___143 : unit) =
                                                         FStar_Reflection_NBEEmbeddings.e_binder
                                                         FStar_TypeChecker_NBETerm.e_unit
                                                        in
-                                                    let uu____1572 =
-                                                      let uu____1575 =
+                                                    let uu____1558 =
+                                                      let uu____1561 =
                                                         FStar_Tactics_InterpFuns.mk_tac_step_1
                                                           Prims.int_zero
                                                           "revert"
@@ -841,8 +838,8 @@ let (uu___143 : unit) =
                                                           FStar_TypeChecker_NBETerm.e_unit
                                                           FStar_TypeChecker_NBETerm.e_unit
                                                          in
-                                                      let uu____1578 =
-                                                        let uu____1581 =
+                                                      let uu____1564 =
+                                                        let uu____1567 =
                                                           FStar_Tactics_InterpFuns.mk_tac_step_1
                                                             Prims.int_zero
                                                             "clear_top"
@@ -853,8 +850,8 @@ let (uu___143 : unit) =
                                                             FStar_TypeChecker_NBETerm.e_unit
                                                             FStar_TypeChecker_NBETerm.e_unit
                                                            in
-                                                        let uu____1584 =
-                                                          let uu____1587 =
+                                                        let uu____1570 =
+                                                          let uu____1573 =
                                                             FStar_Tactics_InterpFuns.mk_tac_step_1
                                                               Prims.int_zero
                                                               "clear"
@@ -865,8 +862,8 @@ let (uu___143 : unit) =
                                                               FStar_Reflection_NBEEmbeddings.e_binder
                                                               FStar_TypeChecker_NBETerm.e_unit
                                                              in
-                                                          let uu____1590 =
-                                                            let uu____1593 =
+                                                          let uu____1576 =
+                                                            let uu____1579 =
                                                               FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                 Prims.int_zero
                                                                 "rewrite"
@@ -877,8 +874,8 @@ let (uu___143 : unit) =
                                                                 FStar_Reflection_NBEEmbeddings.e_binder
                                                                 FStar_TypeChecker_NBETerm.e_unit
                                                                in
-                                                            let uu____1596 =
-                                                              let uu____1599
+                                                            let uu____1582 =
+                                                              let uu____1585
                                                                 =
                                                                 FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                   Prims.int_zero
@@ -890,9 +887,9 @@ let (uu___143 : unit) =
                                                                   FStar_TypeChecker_NBETerm.e_unit
                                                                   FStar_TypeChecker_NBETerm.e_unit
                                                                  in
-                                                              let uu____1602
+                                                              let uu____1588
                                                                 =
-                                                                let uu____1605
+                                                                let uu____1591
                                                                   =
                                                                   FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
@@ -908,9 +905,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                    in
-                                                                let uu____1612
+                                                                let uu____1598
                                                                   =
-                                                                  let uu____1615
+                                                                  let uu____1601
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
@@ -926,9 +923,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                  let uu____1622
+                                                                  let uu____1608
                                                                     =
-                                                                    let uu____1625
+                                                                    let uu____1611
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -940,9 +937,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1628
+                                                                    let uu____1614
                                                                     =
-                                                                    let uu____1631
+                                                                    let uu____1617
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -954,9 +951,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1636
+                                                                    let uu____1622
                                                                     =
-                                                                    let uu____1639
+                                                                    let uu____1625
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
@@ -970,9 +967,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_comp
                                                                      in
-                                                                    let uu____1642
+                                                                    let uu____1628
                                                                     =
-                                                                    let uu____1645
+                                                                    let uu____1631
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
@@ -986,9 +983,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                      in
-                                                                    let uu____1648
+                                                                    let uu____1634
                                                                     =
-                                                                    let uu____1651
+                                                                    let uu____1637
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1000,9 +997,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1654
+                                                                    let uu____1640
                                                                     =
-                                                                    let uu____1657
+                                                                    let uu____1643
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_one
@@ -1012,10 +1009,10 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_any
                                                                     (fun
-                                                                    uu____1662
+                                                                    uu____1648
                                                                      ->
                                                                     fun
-                                                                    uu____1663
+                                                                    uu____1649
                                                                      ->
                                                                     failwith
                                                                     "NBE unquote")
@@ -1023,9 +1020,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_any
                                                                      in
-                                                                    let uu____1667
+                                                                    let uu____1653
                                                                     =
-                                                                    let uu____1670
+                                                                    let uu____1656
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1037,9 +1034,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1675
+                                                                    let uu____1661
                                                                     =
-                                                                    let uu____1678
+                                                                    let uu____1664
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1051,9 +1048,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1683
+                                                                    let uu____1669
                                                                     =
-                                                                    let uu____1686
+                                                                    let uu____1672
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1065,9 +1062,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1691
+                                                                    let uu____1677
                                                                     =
-                                                                    let uu____1694
+                                                                    let uu____1680
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1079,9 +1076,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                      in
-                                                                    let uu____1699
+                                                                    let uu____1685
                                                                     =
-                                                                    let uu____1702
+                                                                    let uu____1688
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1093,13 +1090,13 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1707
+                                                                    let uu____1693
+                                                                    =
+                                                                    let uu____1696
+                                                                    =
+                                                                    let uu____1697
                                                                     =
                                                                     let uu____1710
-                                                                    =
-                                                                    let uu____1711
-                                                                    =
-                                                                    let uu____1724
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Syntax_Embeddings.e_bool
@@ -1107,16 +1104,16 @@ let (uu___143 : unit) =
                                                                      in
                                                                     e_tactic_1
                                                                     FStar_Reflection_Embeddings.e_term
-                                                                    uu____1724
+                                                                    uu____1710
                                                                      in
-                                                                    let uu____1738
+                                                                    let uu____1724
                                                                     =
                                                                     e_tactic_thunk
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                      in
-                                                                    let uu____1743
+                                                                    let uu____1729
                                                                     =
-                                                                    let uu____1756
+                                                                    let uu____1742
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     FStar_TypeChecker_NBETerm.e_bool
@@ -1124,9 +1121,9 @@ let (uu___143 : unit) =
                                                                      in
                                                                     e_tactic_nbe_1
                                                                     FStar_Reflection_NBEEmbeddings.e_term
-                                                                    uu____1756
+                                                                    uu____1742
                                                                      in
-                                                                    let uu____1770
+                                                                    let uu____1756
                                                                     =
                                                                     e_tactic_nbe_thunk
                                                                     FStar_TypeChecker_NBETerm.e_unit
@@ -1136,18 +1133,18 @@ let (uu___143 : unit) =
                                                                     "ctrl_rewrite"
                                                                     FStar_Tactics_CtrlRewrite.ctrl_rewrite
                                                                     FStar_Tactics_Embedding.e_direction
-                                                                    uu____1711
-                                                                    uu____1738
+                                                                    uu____1697
+                                                                    uu____1724
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     FStar_Tactics_CtrlRewrite.ctrl_rewrite
                                                                     FStar_Tactics_Embedding.e_direction_nbe
-                                                                    uu____1743
-                                                                    uu____1770
+                                                                    uu____1729
+                                                                    uu____1756
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1801
+                                                                    let uu____1787
                                                                     =
-                                                                    let uu____1804
+                                                                    let uu____1790
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1159,9 +1156,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1807
+                                                                    let uu____1793
                                                                     =
-                                                                    let uu____1810
+                                                                    let uu____1796
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1173,9 +1170,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1813
+                                                                    let uu____1799
                                                                     =
-                                                                    let uu____1816
+                                                                    let uu____1802
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1187,9 +1184,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1819
+                                                                    let uu____1805
                                                                     =
-                                                                    let uu____1822
+                                                                    let uu____1808
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1201,45 +1198,45 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1825
+                                                                    let uu____1811
                                                                     =
-                                                                    let uu____1828
+                                                                    let uu____1814
                                                                     =
-                                                                    let uu____1829
+                                                                    let uu____1815
                                                                     =
-                                                                    let uu____1838
+                                                                    let uu____1824
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Reflection_Embeddings.e_fv
                                                                     FStar_Syntax_Embeddings.e_int
                                                                      in
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    uu____1838
+                                                                    uu____1824
                                                                      in
-                                                                    let uu____1849
+                                                                    let uu____1835
                                                                     =
-                                                                    let uu____1858
+                                                                    let uu____1844
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     FStar_Reflection_NBEEmbeddings.e_fv
                                                                     FStar_TypeChecker_NBETerm.e_int
                                                                      in
                                                                     FStar_TypeChecker_NBETerm.e_list
-                                                                    uu____1858
+                                                                    uu____1844
                                                                      in
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
                                                                     "t_destruct"
                                                                     FStar_Tactics_Basic.t_destruct
                                                                     FStar_Reflection_Embeddings.e_term
-                                                                    uu____1829
+                                                                    uu____1815
                                                                     FStar_Tactics_Basic.t_destruct
                                                                     FStar_Reflection_NBEEmbeddings.e_term
-                                                                    uu____1849
+                                                                    uu____1835
                                                                      in
-                                                                    let uu____1883
+                                                                    let uu____1869
                                                                     =
-                                                                    let uu____1886
+                                                                    let uu____1872
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1251,9 +1248,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                      in
-                                                                    let uu____1889
+                                                                    let uu____1875
                                                                     =
-                                                                    let uu____1892
+                                                                    let uu____1878
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1265,9 +1262,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term_view
                                                                      in
-                                                                    let uu____1895
+                                                                    let uu____1881
                                                                     =
-                                                                    let uu____1898
+                                                                    let uu____1884
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1279,9 +1276,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term_view
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                      in
-                                                                    let uu____1901
+                                                                    let uu____1887
                                                                     =
-                                                                    let uu____1904
+                                                                    let uu____1890
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1293,9 +1290,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_int
                                                                      in
-                                                                    let uu____1907
+                                                                    let uu____1893
                                                                     =
-                                                                    let uu____1910
+                                                                    let uu____1896
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1307,16 +1304,16 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_int
                                                                      in
-                                                                    let uu____1913
+                                                                    let uu____1899
                                                                     =
-                                                                    let uu____1916
+                                                                    let uu____1902
                                                                     =
-                                                                    let uu____1917
+                                                                    let uu____1903
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
                                                                     FStar_Reflection_Embeddings.e_term
                                                                      in
-                                                                    let uu____1922
+                                                                    let uu____1908
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
                                                                     FStar_Reflection_NBEEmbeddings.e_term
@@ -1326,16 +1323,16 @@ let (uu___143 : unit) =
                                                                     "uvar_env"
                                                                     FStar_Tactics_Basic.uvar_env
                                                                     FStar_Reflection_Embeddings.e_env
-                                                                    uu____1917
+                                                                    uu____1903
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Tactics_Basic.uvar_env
                                                                     FStar_Reflection_NBEEmbeddings.e_env
-                                                                    uu____1922
+                                                                    uu____1908
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                      in
-                                                                    let uu____1933
+                                                                    let uu____1919
                                                                     =
-                                                                    let uu____1936
+                                                                    let uu____1922
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
@@ -1351,16 +1348,16 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                      in
-                                                                    let uu____1941
+                                                                    let uu____1927
                                                                     =
-                                                                    let uu____1944
+                                                                    let uu____1930
                                                                     =
-                                                                    let uu____1945
+                                                                    let uu____1931
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string
                                                                      in
-                                                                    let uu____1952
+                                                                    let uu____1938
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string
@@ -1370,18 +1367,18 @@ let (uu___143 : unit) =
                                                                     "launch_process"
                                                                     FStar_Tactics_Basic.launch_process
                                                                     FStar_Syntax_Embeddings.e_string
-                                                                    uu____1945
+                                                                    uu____1931
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Tactics_Basic.launch_process
                                                                     FStar_TypeChecker_NBETerm.e_string
-                                                                    uu____1952
+                                                                    uu____1938
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                      in
-                                                                    let uu____1973
+                                                                    let uu____1959
                                                                     =
-                                                                    let uu____1976
+                                                                    let uu____1962
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
@@ -1395,9 +1392,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_bv
                                                                      in
-                                                                    let uu____1981
+                                                                    let uu____1967
                                                                     =
-                                                                    let uu____1984
+                                                                    let uu____1970
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1409,9 +1406,9 @@ let (uu___143 : unit) =
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1987
+                                                                    let uu____1973
                                                                     =
-                                                                    let uu____1990
+                                                                    let uu____1976
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1423,9 +1420,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Tactics_Embedding.e_guard_policy_nbe
                                                                      in
-                                                                    let uu____1993
+                                                                    let uu____1979
                                                                     =
-                                                                    let uu____1996
+                                                                    let uu____1982
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1437,9 +1434,9 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Embedding.e_guard_policy_nbe
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    let uu____1999
+                                                                    let uu____1985
                                                                     =
-                                                                    let uu____2002
+                                                                    let uu____1988
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
@@ -1451,9 +1448,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                      in
-                                                                    let uu____2007
+                                                                    let uu____1993
                                                                     =
-                                                                    let uu____2010
+                                                                    let uu____1996
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_one
@@ -1463,10 +1460,10 @@ let (uu___143 : unit) =
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Syntax_Embeddings.e_any
                                                                     (fun
-                                                                    uu____2017
+                                                                    uu____2003
                                                                      ->
                                                                     fun
-                                                                    uu____2018
+                                                                    uu____2004
                                                                      ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "sorry, `lget` does not work in NBE")
@@ -1474,9 +1471,9 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_any
                                                                      in
-                                                                    let uu____2021
+                                                                    let uu____2007
                                                                     =
-                                                                    let uu____2024
+                                                                    let uu____2010
                                                                     =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_one
@@ -1487,13 +1484,13 @@ let (uu___143 : unit) =
                                                                     FStar_Syntax_Embeddings.e_any
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     (fun
-                                                                    uu____2032
+                                                                    uu____2018
                                                                      ->
                                                                     fun
-                                                                    uu____2033
+                                                                    uu____2019
                                                                      ->
                                                                     fun
-                                                                    uu____2034
+                                                                    uu____2020
                                                                      ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "sorry, `lset` does not work in NBE")
@@ -1502,184 +1499,184 @@ let (uu___143 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_any
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                      in
-                                                                    [uu____2024]
-                                                                     in
-                                                                    uu____2010
-                                                                    ::
-                                                                    uu____2021
-                                                                     in
-                                                                    uu____2002
-                                                                    ::
-                                                                    uu____2007
+                                                                    [uu____2010]
                                                                      in
                                                                     uu____1996
                                                                     ::
-                                                                    uu____1999
+                                                                    uu____2007
                                                                      in
-                                                                    uu____1990
+                                                                    uu____1988
                                                                     ::
                                                                     uu____1993
                                                                      in
-                                                                    uu____1984
+                                                                    uu____1982
                                                                     ::
-                                                                    uu____1987
+                                                                    uu____1985
                                                                      in
                                                                     uu____1976
                                                                     ::
-                                                                    uu____1981
+                                                                    uu____1979
                                                                      in
-                                                                    uu____1944
+                                                                    uu____1970
                                                                     ::
                                                                     uu____1973
                                                                      in
-                                                                    uu____1936
+                                                                    uu____1962
                                                                     ::
-                                                                    uu____1941
+                                                                    uu____1967
                                                                      in
-                                                                    uu____1916
+                                                                    uu____1930
                                                                     ::
-                                                                    uu____1933
+                                                                    uu____1959
                                                                      in
-                                                                    uu____1910
+                                                                    uu____1922
                                                                     ::
-                                                                    uu____1913
+                                                                    uu____1927
                                                                      in
-                                                                    uu____1904
+                                                                    uu____1902
                                                                     ::
-                                                                    uu____1907
+                                                                    uu____1919
                                                                      in
-                                                                    uu____1898
+                                                                    uu____1896
                                                                     ::
-                                                                    uu____1901
+                                                                    uu____1899
                                                                      in
-                                                                    uu____1892
+                                                                    uu____1890
                                                                     ::
-                                                                    uu____1895
+                                                                    uu____1893
                                                                      in
-                                                                    uu____1886
+                                                                    uu____1884
                                                                     ::
-                                                                    uu____1889
+                                                                    uu____1887
                                                                      in
-                                                                    uu____1828
+                                                                    uu____1878
                                                                     ::
-                                                                    uu____1883
+                                                                    uu____1881
                                                                      in
-                                                                    uu____1822
+                                                                    uu____1872
                                                                     ::
-                                                                    uu____1825
+                                                                    uu____1875
                                                                      in
-                                                                    uu____1816
+                                                                    uu____1814
                                                                     ::
-                                                                    uu____1819
+                                                                    uu____1869
                                                                      in
-                                                                    uu____1810
+                                                                    uu____1808
                                                                     ::
-                                                                    uu____1813
+                                                                    uu____1811
                                                                      in
-                                                                    uu____1804
+                                                                    uu____1802
                                                                     ::
-                                                                    uu____1807
+                                                                    uu____1805
                                                                      in
-                                                                    uu____1710
+                                                                    uu____1796
                                                                     ::
-                                                                    uu____1801
+                                                                    uu____1799
                                                                      in
-                                                                    uu____1702
+                                                                    uu____1790
                                                                     ::
-                                                                    uu____1707
+                                                                    uu____1793
                                                                      in
-                                                                    uu____1694
+                                                                    uu____1696
                                                                     ::
-                                                                    uu____1699
+                                                                    uu____1787
                                                                      in
-                                                                    uu____1686
+                                                                    uu____1688
                                                                     ::
-                                                                    uu____1691
+                                                                    uu____1693
                                                                      in
-                                                                    uu____1678
+                                                                    uu____1680
                                                                     ::
-                                                                    uu____1683
+                                                                    uu____1685
                                                                      in
-                                                                    uu____1670
+                                                                    uu____1672
                                                                     ::
-                                                                    uu____1675
+                                                                    uu____1677
                                                                      in
-                                                                    uu____1657
+                                                                    uu____1664
                                                                     ::
-                                                                    uu____1667
+                                                                    uu____1669
                                                                      in
-                                                                    uu____1651
+                                                                    uu____1656
                                                                     ::
-                                                                    uu____1654
+                                                                    uu____1661
                                                                      in
-                                                                    uu____1645
+                                                                    uu____1643
                                                                     ::
-                                                                    uu____1648
+                                                                    uu____1653
                                                                      in
-                                                                    uu____1639
+                                                                    uu____1637
                                                                     ::
-                                                                    uu____1642
+                                                                    uu____1640
                                                                      in
                                                                     uu____1631
                                                                     ::
-                                                                    uu____1636
+                                                                    uu____1634
                                                                      in
                                                                     uu____1625
                                                                     ::
                                                                     uu____1628
                                                                      in
-                                                                  uu____1615
+                                                                    uu____1617
                                                                     ::
                                                                     uu____1622
+                                                                     in
+                                                                    uu____1611
+                                                                    ::
+                                                                    uu____1614
+                                                                     in
+                                                                  uu____1601
+                                                                    ::
+                                                                    uu____1608
                                                                    in
-                                                                uu____1605 ::
-                                                                  uu____1612
+                                                                uu____1591 ::
+                                                                  uu____1598
                                                                  in
-                                                              uu____1599 ::
-                                                                uu____1602
+                                                              uu____1585 ::
+                                                                uu____1588
                                                                in
-                                                            uu____1593 ::
-                                                              uu____1596
+                                                            uu____1579 ::
+                                                              uu____1582
                                                              in
-                                                          uu____1587 ::
-                                                            uu____1590
+                                                          uu____1573 ::
+                                                            uu____1576
                                                            in
-                                                        uu____1581 ::
-                                                          uu____1584
+                                                        uu____1567 ::
+                                                          uu____1570
                                                          in
-                                                      uu____1575 ::
-                                                        uu____1578
+                                                      uu____1561 ::
+                                                        uu____1564
                                                        in
-                                                    uu____1569 :: uu____1572
+                                                    uu____1555 :: uu____1558
                                                      in
-                                                  uu____1561 :: uu____1566
+                                                  uu____1547 :: uu____1552
                                                    in
-                                                uu____1541 :: uu____1558  in
-                                              uu____1521 :: uu____1538  in
-                                            uu____1501 :: uu____1518  in
-                                          uu____1473 :: uu____1498  in
-                                        uu____1467 :: uu____1470  in
-                                      uu____1421 :: uu____1464  in
-                                    uu____1375 :: uu____1418  in
-                                  uu____1369 :: uu____1372  in
-                                uu____1349 :: uu____1366  in
-                              uu____1329 :: uu____1346  in
-                            uu____1321 :: uu____1326  in
-                          uu____1313 :: uu____1318  in
-                        uu____1305 :: uu____1310  in
-                      uu____1299 :: uu____1302  in
-                    uu____1293 :: uu____1296  in
-                  uu____1287 :: uu____1290  in
-                uu____1267 :: uu____1284  in
-              uu____1247 :: uu____1264  in
-            uu____1241 :: uu____1244  in
-          uu____1235 :: uu____1238  in
-        uu____1229 :: uu____1232  in
-      uu____1223 :: uu____1226  in
+                                                uu____1527 :: uu____1544  in
+                                              uu____1507 :: uu____1524  in
+                                            uu____1487 :: uu____1504  in
+                                          uu____1459 :: uu____1484  in
+                                        uu____1453 :: uu____1456  in
+                                      uu____1407 :: uu____1450  in
+                                    uu____1361 :: uu____1404  in
+                                  uu____1355 :: uu____1358  in
+                                uu____1335 :: uu____1352  in
+                              uu____1315 :: uu____1332  in
+                            uu____1307 :: uu____1312  in
+                          uu____1299 :: uu____1304  in
+                        uu____1291 :: uu____1296  in
+                      uu____1285 :: uu____1288  in
+                    uu____1279 :: uu____1282  in
+                  uu____1273 :: uu____1276  in
+                uu____1253 :: uu____1270  in
+              uu____1233 :: uu____1250  in
+            uu____1227 :: uu____1230  in
+          uu____1221 :: uu____1224  in
+        uu____1215 :: uu____1218  in
+      uu____1209 :: uu____1212  in
     FStar_All.pipe_left
-      (fun uu____2045  -> FStar_Pervasives_Native.Some uu____2045) uu____1220
+      (fun uu____2031  -> FStar_Pervasives_Native.Some uu____2031) uu____1206
      in
-  FStar_ST.op_Colon_Equals __primitive_steps_ref uu____1215 
+  FStar_ST.op_Colon_Equals __primitive_steps_ref uu____1201 
 
 let unembed_tactic_1_alt :
   'a 'r .
@@ -1698,12 +1695,10 @@ let unembed_tactic_1_alt :
                let rng = FStar_Range.dummyRange  in
                let x_tm = embed ea rng x ncb  in
                let app =
-                 let uu____2141 =
-                   let uu____2146 =
-                     let uu____2147 = FStar_Syntax_Syntax.as_arg x_tm  in
-                     [uu____2147]  in
-                   FStar_Syntax_Syntax.mk_Tm_app f uu____2146  in
-                 uu____2141 FStar_Pervasives_Native.None rng  in
+                 let uu____2125 =
+                   let uu____2126 = FStar_Syntax_Syntax.as_arg x_tm  in
+                   [uu____2126]  in
+                 FStar_Syntax_Syntax.mk_Tm_app f uu____2125 rng  in
                unembed_tactic_0 er app ncb)
   
 let e_tactic_1_alt :
@@ -1716,19 +1711,19 @@ let e_tactic_1_alt :
   =
   fun ea  ->
     fun er  ->
-      let em uu____2237 uu____2238 uu____2239 uu____2240 =
+      let em uu____2216 uu____2217 uu____2218 uu____2219 =
         failwith "Impossible: embedding tactic (1)?"  in
       let un t0 w n =
-        let uu____2289 = unembed_tactic_1_alt ea er t0 n  in
-        match uu____2289 with
+        let uu____2268 = unembed_tactic_1_alt ea er t0 n  in
+        match uu____2268 with
         | FStar_Pervasives_Native.Some f ->
             FStar_Pervasives_Native.Some
               ((fun x  ->
-                  let uu____2329 = f x  in FStar_Tactics_Monad.run uu____2329))
+                  let uu____2308 = f x  in FStar_Tactics_Monad.run uu____2308))
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None  in
-      let uu____2345 =
+      let uu____2324 =
         FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit  in
-      FStar_Syntax_Embeddings.mk_emb em un uu____2345
+      FStar_Syntax_Embeddings.mk_emb em un uu____2324
   
 let (report_implicits :
   FStar_Range.range -> FStar_TypeChecker_Env.implicits -> unit) =
@@ -1737,22 +1732,22 @@ let (report_implicits :
       let errs =
         FStar_List.map
           (fun imp  ->
-             let uu____2385 =
-               let uu____2387 =
+             let uu____2364 =
+               let uu____2366 =
                  FStar_Syntax_Print.uvar_to_string
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                   in
-               let uu____2389 =
+               let uu____2368 =
                  FStar_Syntax_Print.term_to_string
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
                   in
                FStar_Util.format3
                  "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
-                 uu____2387 uu____2389
+                 uu____2366 uu____2368
                  imp.FStar_TypeChecker_Common.imp_reason
                 in
              (FStar_Errors.Error_UninstantiatedUnificationVarInTactic,
-               uu____2385, rng)) is
+               uu____2364, rng)) is
          in
       FStar_Errors.add_errors errs; FStar_Errors.stop_if_err ()
   
@@ -1775,24 +1770,24 @@ let run_tactic_on_ps :
             fun tactic  ->
               fun ps  ->
                 let env = ps.FStar_Tactics_Types.main_context  in
-                (let uu____2466 = FStar_ST.op_Bang tacdbg  in
-                 if uu____2466
+                (let uu____2445 = FStar_ST.op_Bang tacdbg  in
+                 if uu____2445
                  then
-                   let uu____2490 = FStar_Syntax_Print.term_to_string tactic
+                   let uu____2469 = FStar_Syntax_Print.term_to_string tactic
                       in
                    FStar_Util.print1 "Typechecking tactic: (%s) {\n"
-                     uu____2490
+                     uu____2469
                  else ());
-                (let uu____2495 =
-                   let uu____2502 = FStar_Syntax_Embeddings.type_of e_arg  in
-                   let uu____2503 = FStar_Syntax_Embeddings.type_of e_res  in
-                   FStar_TypeChecker_TcTerm.tc_tactic uu____2502 uu____2503
+                (let uu____2474 =
+                   let uu____2481 = FStar_Syntax_Embeddings.type_of e_arg  in
+                   let uu____2482 = FStar_Syntax_Embeddings.type_of e_res  in
+                   FStar_TypeChecker_TcTerm.tc_tactic uu____2481 uu____2482
                      env tactic
                     in
-                 match uu____2495 with
-                 | (uu____2510,uu____2511,g) ->
-                     ((let uu____2514 = FStar_ST.op_Bang tacdbg  in
-                       if uu____2514
+                 match uu____2474 with
+                 | (uu____2489,uu____2490,g) ->
+                     ((let uu____2493 = FStar_ST.op_Bang tacdbg  in
+                       if uu____2493
                        then FStar_Util.print_string "}\n"
                        else ());
                       FStar_TypeChecker_Rel.force_trivial_guard env g;
@@ -1804,85 +1799,85 @@ let run_tactic_on_ps :
                        FStar_ST.op_Colon_Equals
                          FStar_Reflection_Basic.env_hook
                          (FStar_Pervasives_Native.Some env);
-                       (let uu____2574 =
+                       (let uu____2553 =
                           FStar_Util.record_time
-                            (fun uu____2586  ->
-                               let uu____2587 = tau arg  in
-                               FStar_Tactics_Monad.run_safe uu____2587 ps)
+                            (fun uu____2565  ->
+                               let uu____2566 = tau arg  in
+                               FStar_Tactics_Monad.run_safe uu____2566 ps)
                            in
-                        match uu____2574 with
+                        match uu____2553 with
                         | (res,ms) ->
-                            ((let uu____2605 = FStar_ST.op_Bang tacdbg  in
-                              if uu____2605
+                            ((let uu____2584 = FStar_ST.op_Bang tacdbg  in
+                              if uu____2584
                               then FStar_Util.print_string "}\n"
                               else ());
-                             (let uu____2633 =
+                             (let uu____2612 =
                                 (FStar_ST.op_Bang tacdbg) ||
                                   (FStar_Options.tactics_info ())
                                  in
-                              if uu____2633
+                              if uu____2612
                               then
-                                let uu____2657 =
+                                let uu____2636 =
                                   FStar_Syntax_Print.term_to_string tactic
                                    in
-                                let uu____2659 = FStar_Util.string_of_int ms
+                                let uu____2638 = FStar_Util.string_of_int ms
                                    in
-                                let uu____2661 =
+                                let uu____2640 =
                                   FStar_Syntax_Print.lid_to_string
                                     env.FStar_TypeChecker_Env.curmodule
                                    in
                                 FStar_Util.print3
-                                  "Tactic %s ran in %s ms (%s)\n" uu____2657
-                                  uu____2659 uu____2661
+                                  "Tactic %s ran in %s ms (%s)\n" uu____2636
+                                  uu____2638 uu____2640
                               else ());
                              (match res with
                               | FStar_Tactics_Result.Success (ret,ps1) ->
                                   (FStar_List.iter
                                      (fun g1  ->
-                                        let uu____2679 =
+                                        let uu____2658 =
                                           FStar_Tactics_Types.is_irrelevant
                                             g1
                                            in
-                                        if uu____2679
+                                        if uu____2658
                                         then
-                                          let uu____2682 =
-                                            let uu____2684 =
+                                          let uu____2661 =
+                                            let uu____2663 =
                                               FStar_Tactics_Types.goal_env g1
                                                in
-                                            let uu____2685 =
+                                            let uu____2664 =
                                               FStar_Tactics_Types.goal_witness
                                                 g1
                                                in
                                             FStar_TypeChecker_Rel.teq_nosmt_force
-                                              uu____2684 uu____2685
+                                              uu____2663 uu____2664
                                               FStar_Syntax_Util.exp_unit
                                              in
-                                          (if uu____2682
+                                          (if uu____2661
                                            then ()
                                            else
-                                             (let uu____2689 =
-                                                let uu____2691 =
-                                                  let uu____2693 =
+                                             (let uu____2668 =
+                                                let uu____2670 =
+                                                  let uu____2672 =
                                                     FStar_Tactics_Types.goal_witness
                                                       g1
                                                      in
                                                   FStar_Syntax_Print.term_to_string
-                                                    uu____2693
+                                                    uu____2672
                                                    in
                                                 FStar_Util.format1
                                                   "Irrelevant tactic witness does not unify with (): %s"
-                                                  uu____2691
+                                                  uu____2670
                                                  in
-                                              failwith uu____2689))
+                                              failwith uu____2668))
                                         else ())
                                      (FStar_List.append
                                         ps1.FStar_Tactics_Types.goals
                                         ps1.FStar_Tactics_Types.smt_goals);
-                                   (let uu____2698 = FStar_ST.op_Bang tacdbg
+                                   (let uu____2677 = FStar_ST.op_Bang tacdbg
                                        in
-                                    if uu____2698
+                                    if uu____2677
                                     then
-                                      let uu____2722 =
+                                      let uu____2701 =
                                         FStar_Common.string_of_list
                                           (fun imp  ->
                                              FStar_Syntax_Print.ctx_uvar_to_string
@@ -1891,19 +1886,19 @@ let run_tactic_on_ps :
                                          in
                                       FStar_Util.print1
                                         "About to check tactic implicits: %s\n"
-                                        uu____2722
+                                        uu____2701
                                     else ());
                                    (let g1 =
-                                      let uu___232_2730 =
+                                      let uu___232_2709 =
                                         FStar_TypeChecker_Env.trivial_guard
                                          in
                                       {
                                         FStar_TypeChecker_Common.guard_f =
-                                          (uu___232_2730.FStar_TypeChecker_Common.guard_f);
+                                          (uu___232_2709.FStar_TypeChecker_Common.guard_f);
                                         FStar_TypeChecker_Common.deferred =
-                                          (uu___232_2730.FStar_TypeChecker_Common.deferred);
+                                          (uu___232_2709.FStar_TypeChecker_Common.deferred);
                                         FStar_TypeChecker_Common.univ_ineqs =
-                                          (uu___232_2730.FStar_TypeChecker_Common.univ_ineqs);
+                                          (uu___232_2709.FStar_TypeChecker_Common.univ_ineqs);
                                         FStar_TypeChecker_Common.implicits =
                                           (ps1.FStar_Tactics_Types.all_implicits)
                                       }  in
@@ -1911,16 +1906,16 @@ let run_tactic_on_ps :
                                       FStar_TypeChecker_Rel.solve_deferred_constraints
                                         env g1
                                        in
-                                    (let uu____2733 = FStar_ST.op_Bang tacdbg
+                                    (let uu____2712 = FStar_ST.op_Bang tacdbg
                                         in
-                                     if uu____2733
+                                     if uu____2712
                                      then
-                                       let uu____2757 =
+                                       let uu____2736 =
                                          FStar_Util.string_of_int
                                            (FStar_List.length
                                               ps1.FStar_Tactics_Types.all_implicits)
                                           in
-                                       let uu____2759 =
+                                       let uu____2738 =
                                          FStar_Common.string_of_list
                                            (fun imp  ->
                                               FStar_Syntax_Print.ctx_uvar_to_string
@@ -1929,22 +1924,22 @@ let run_tactic_on_ps :
                                           in
                                        FStar_Util.print2
                                          "Checked %s implicits (1): %s\n"
-                                         uu____2757 uu____2759
+                                         uu____2736 uu____2738
                                      else ());
                                     (let g3 =
                                        FStar_TypeChecker_Rel.resolve_implicits_tac
                                          env g2
                                         in
-                                     (let uu____2768 =
+                                     (let uu____2747 =
                                         FStar_ST.op_Bang tacdbg  in
-                                      if uu____2768
+                                      if uu____2747
                                       then
-                                        let uu____2792 =
+                                        let uu____2771 =
                                           FStar_Util.string_of_int
                                             (FStar_List.length
                                                ps1.FStar_Tactics_Types.all_implicits)
                                            in
-                                        let uu____2794 =
+                                        let uu____2773 =
                                           FStar_Common.string_of_list
                                             (fun imp  ->
                                                FStar_Syntax_Print.ctx_uvar_to_string
@@ -1953,61 +1948,61 @@ let run_tactic_on_ps :
                                            in
                                         FStar_Util.print2
                                           "Checked %s implicits (2): %s\n"
-                                          uu____2792 uu____2794
+                                          uu____2771 uu____2773
                                       else ());
                                      report_implicits rng_goal
                                        g3.FStar_TypeChecker_Common.implicits;
-                                     (let uu____2803 =
+                                     (let uu____2782 =
                                         FStar_ST.op_Bang tacdbg  in
-                                      if uu____2803
+                                      if uu____2782
                                       then
-                                        let uu____2827 =
-                                          let uu____2828 =
+                                        let uu____2806 =
+                                          let uu____2807 =
                                             FStar_TypeChecker_Cfg.psc_subst
                                               ps1.FStar_Tactics_Types.psc
                                              in
                                           FStar_Tactics_Types.subst_proof_state
-                                            uu____2828 ps1
+                                            uu____2807 ps1
                                            in
                                         FStar_Tactics_Printing.do_dump_proofstate
-                                          uu____2827 "at the finish line"
+                                          uu____2806 "at the finish line"
                                       else ());
                                      ((FStar_List.append
                                          ps1.FStar_Tactics_Types.goals
                                          ps1.FStar_Tactics_Types.smt_goals),
                                        ret))))
                               | FStar_Tactics_Result.Failed (e,ps1) ->
-                                  ((let uu____2837 =
-                                      let uu____2838 =
+                                  ((let uu____2816 =
+                                      let uu____2817 =
                                         FStar_TypeChecker_Cfg.psc_subst
                                           ps1.FStar_Tactics_Types.psc
                                          in
                                       FStar_Tactics_Types.subst_proof_state
-                                        uu____2838 ps1
+                                        uu____2817 ps1
                                        in
                                     FStar_Tactics_Printing.do_dump_proofstate
-                                      uu____2837 "at the time of failure");
+                                      uu____2816 "at the time of failure");
                                    (let texn_to_string e1 =
                                       match e1 with
                                       | FStar_Tactics_Types.TacticFailure s
                                           -> s
                                       | FStar_Tactics_Types.EExn t ->
-                                          let uu____2851 =
+                                          let uu____2830 =
                                             FStar_Syntax_Print.term_to_string
                                               t
                                              in
                                           Prims.op_Hat "uncaught exception: "
-                                            uu____2851
+                                            uu____2830
                                       | e2 -> FStar_Exn.raise e2  in
-                                    let uu____2856 =
-                                      let uu____2862 =
-                                        let uu____2864 = texn_to_string e  in
+                                    let uu____2835 =
+                                      let uu____2841 =
+                                        let uu____2843 = texn_to_string e  in
                                         FStar_Util.format1
-                                          "user tactic failed: %s" uu____2864
+                                          "user tactic failed: %s" uu____2843
                                          in
                                       (FStar_Errors.Fatal_UserTacticFailure,
-                                        uu____2862)
+                                        uu____2841)
                                        in
-                                    FStar_Errors.raise_error uu____2856
+                                    FStar_Errors.raise_error uu____2835
                                       ps1.FStar_Tactics_Types.entry_range))))))))
   

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -42,7 +42,7 @@ let (goal_witness : goal -> FStar_Syntax_Syntax.term) =
     FStar_Syntax_Syntax.mk
       (FStar_Syntax_Syntax.Tm_uvar
          ((g.goal_ctx_uvar), ([], FStar_Syntax_Syntax.NoUseRange)))
-      FStar_Pervasives_Native.None FStar_Range.dummyRange
+      FStar_Range.dummyRange
   
 let (goal_type : goal -> FStar_Syntax_Syntax.term) =
   fun g  -> (g.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_typ 

--- a/src/ocaml-output/FStar_Tests_Norm.ml
+++ b/src/ocaml-output/FStar_Tests_Norm.ml
@@ -72,8 +72,7 @@ let (mk_let :
                    FStar_Syntax_Syntax.lbdef = e;
                    FStar_Syntax_Syntax.lbattrs = [];
                    FStar_Syntax_Syntax.lbpos = FStar_Range.dummyRange
-                 }]), e'1)) FStar_Pervasives_Native.None
-          FStar_Range.dummyRange
+                 }]), e'1)) FStar_Range.dummyRange
   
 let (lid : Prims.string -> FStar_Ident.lident) =
   fun x  -> FStar_Ident.lid_of_path ["Test"; x] FStar_Range.dummyRange 
@@ -93,7 +92,7 @@ let (tm_fv :
   =
   fun fv  ->
     FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-      FStar_Pervasives_Native.None FStar_Range.dummyRange
+      FStar_Range.dummyRange
   
 let (znat : FStar_Syntax_Syntax.term) = tm_fv znat_l 
 let (snat :
@@ -102,26 +101,24 @@ let (snat :
   =
   fun s  ->
     let uu____177 =
-      let uu____184 =
-        let uu____185 =
-          let uu____202 = tm_fv snat_l  in
-          let uu____205 =
-            let uu____216 = FStar_Syntax_Syntax.as_arg s  in [uu____216]  in
-          (uu____202, uu____205)  in
-        FStar_Syntax_Syntax.Tm_app uu____185  in
-      FStar_Syntax_Syntax.mk uu____184  in
-    uu____177 FStar_Pervasives_Native.None FStar_Range.dummyRange
+      let uu____178 =
+        let uu____195 = tm_fv snat_l  in
+        let uu____198 =
+          let uu____209 = FStar_Syntax_Syntax.as_arg s  in [uu____209]  in
+        (uu____195, uu____198)  in
+      FStar_Syntax_Syntax.Tm_app uu____178  in
+    FStar_Syntax_Syntax.mk uu____177 FStar_Range.dummyRange
   
 let pat :
-  'uuuuuu258 . 'uuuuuu258 -> 'uuuuuu258 FStar_Syntax_Syntax.withinfo_t =
+  'uuuuuu251 . 'uuuuuu251 -> 'uuuuuu251 FStar_Syntax_Syntax.withinfo_t =
   fun p  -> FStar_Syntax_Syntax.withinfo p FStar_Range.dummyRange 
 let (snat_type : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
-  let uu____269 =
-    let uu____270 = lid "snat"  in
-    FStar_Syntax_Syntax.lid_as_fv uu____270
+  let uu____262 =
+    let uu____263 = lid "snat"  in
+    FStar_Syntax_Syntax.lid_as_fv uu____263
       FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
      in
-  tm_fv uu____269 
+  tm_fv uu____262 
 let (mk_match :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.branch Prims.list ->
@@ -134,7 +131,7 @@ let (mk_match :
           (FStar_List.map FStar_Syntax_Util.branch)
          in
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (h, branches1))
-        FStar_Pervasives_Native.None FStar_Range.dummyRange
+        FStar_Range.dummyRange
   
 let (pred_nat :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -142,34 +139,34 @@ let (pred_nat :
   =
   fun s  ->
     let zbranch =
-      let uu____373 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, []))  in
-      (uu____373, FStar_Pervasives_Native.None, znat)  in
+      let uu____366 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, []))  in
+      (uu____366, FStar_Pervasives_Native.None, znat)  in
     let sbranch =
-      let uu____417 =
-        let uu____420 =
-          let uu____421 =
-            let uu____435 =
-              let uu____445 =
-                let uu____453 =
+      let uu____410 =
+        let uu____413 =
+          let uu____414 =
+            let uu____428 =
+              let uu____438 =
+                let uu____446 =
                   pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.x)  in
-                (uu____453, false)  in
-              [uu____445]  in
-            (snat_l, uu____435)  in
-          FStar_Syntax_Syntax.Pat_cons uu____421  in
-        pat uu____420  in
-      let uu____483 =
+                (uu____446, false)  in
+              [uu____438]  in
+            (snat_l, uu____428)  in
+          FStar_Syntax_Syntax.Pat_cons uu____414  in
+        pat uu____413  in
+      let uu____476 =
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_bvar
-             (let uu___21_488 = FStar_Tests_Util.x  in
+             (let uu___21_481 = FStar_Tests_Util.x  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___21_488.FStar_Syntax_Syntax.ppname);
+                  (uu___21_481.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index = Prims.int_zero;
                 FStar_Syntax_Syntax.sort =
-                  (uu___21_488.FStar_Syntax_Syntax.sort)
-              })) FStar_Pervasives_Native.None FStar_Range.dummyRange
+                  (uu___21_481.FStar_Syntax_Syntax.sort)
+              })) FStar_Range.dummyRange
          in
-      (uu____417, FStar_Pervasives_Native.None, uu____483)  in
+      (uu____410, FStar_Pervasives_Native.None, uu____476)  in
     mk_match s [zbranch; sbranch]
   
 let (minus_nat :
@@ -181,98 +178,96 @@ let (minus_nat :
     fun t2  ->
       let minus1 = FStar_Tests_Util.m  in
       let x =
-        let uu___27_515 = FStar_Tests_Util.x  in
+        let uu___27_508 = FStar_Tests_Util.x  in
         {
           FStar_Syntax_Syntax.ppname =
-            (uu___27_515.FStar_Syntax_Syntax.ppname);
-          FStar_Syntax_Syntax.index = (uu___27_515.FStar_Syntax_Syntax.index);
+            (uu___27_508.FStar_Syntax_Syntax.ppname);
+          FStar_Syntax_Syntax.index = (uu___27_508.FStar_Syntax_Syntax.index);
           FStar_Syntax_Syntax.sort = snat_type
         }  in
       let y =
-        let uu___30_517 = FStar_Tests_Util.y  in
+        let uu___30_510 = FStar_Tests_Util.y  in
         {
           FStar_Syntax_Syntax.ppname =
-            (uu___30_517.FStar_Syntax_Syntax.ppname);
-          FStar_Syntax_Syntax.index = (uu___30_517.FStar_Syntax_Syntax.index);
+            (uu___30_510.FStar_Syntax_Syntax.ppname);
+          FStar_Syntax_Syntax.index = (uu___30_510.FStar_Syntax_Syntax.index);
           FStar_Syntax_Syntax.sort = snat_type
         }  in
       let zbranch =
-        let uu____533 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, []))  in
-        let uu____552 = FStar_Tests_Util.nm x  in
-        (uu____533, FStar_Pervasives_Native.None, uu____552)  in
+        let uu____526 = pat (FStar_Syntax_Syntax.Pat_cons (znat_l, []))  in
+        let uu____545 = FStar_Tests_Util.nm x  in
+        (uu____526, FStar_Pervasives_Native.None, uu____545)  in
       let sbranch =
-        let uu____580 =
-          let uu____583 =
-            let uu____584 =
-              let uu____598 =
-                let uu____608 =
-                  let uu____616 =
+        let uu____573 =
+          let uu____576 =
+            let uu____577 =
+              let uu____591 =
+                let uu____601 =
+                  let uu____609 =
                     pat (FStar_Syntax_Syntax.Pat_var FStar_Tests_Util.n)  in
-                  (uu____616, false)  in
-                [uu____608]  in
-              (snat_l, uu____598)  in
-            FStar_Syntax_Syntax.Pat_cons uu____584  in
-          pat uu____583  in
-        let uu____646 =
-          let uu____649 = FStar_Tests_Util.nm minus1  in
-          let uu____652 =
-            let uu____655 =
-              let uu____656 = FStar_Tests_Util.nm x  in pred_nat uu____656
+                  (uu____609, false)  in
+                [uu____601]  in
+              (snat_l, uu____591)  in
+            FStar_Syntax_Syntax.Pat_cons uu____577  in
+          pat uu____576  in
+        let uu____639 =
+          let uu____642 = FStar_Tests_Util.nm minus1  in
+          let uu____645 =
+            let uu____648 =
+              let uu____649 = FStar_Tests_Util.nm x  in pred_nat uu____649
                in
-            let uu____659 =
-              let uu____662 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-              [uu____662]  in
-            uu____655 :: uu____659  in
-          FStar_Tests_Util.app uu____649 uu____652  in
-        (uu____580, FStar_Pervasives_Native.None, uu____646)  in
+            let uu____652 =
+              let uu____655 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+              [uu____655]  in
+            uu____648 :: uu____652  in
+          FStar_Tests_Util.app uu____642 uu____645  in
+        (uu____573, FStar_Pervasives_Native.None, uu____639)  in
       let lb =
-        let uu____674 =
+        let uu____667 =
           FStar_Ident.lid_of_path ["Pure"] FStar_Range.dummyRange  in
-        let uu____678 =
-          let uu____681 =
-            let uu____682 =
-              let uu____683 = b x  in
-              let uu____690 = let uu____699 = b y  in [uu____699]  in
-              uu____683 :: uu____690  in
-            let uu____724 =
-              let uu____727 = FStar_Tests_Util.nm y  in
-              mk_match uu____727 [zbranch; sbranch]  in
-            FStar_Syntax_Util.abs uu____682 uu____724
+        let uu____671 =
+          let uu____674 =
+            let uu____675 =
+              let uu____676 = b x  in
+              let uu____683 = let uu____692 = b y  in [uu____692]  in
+              uu____676 :: uu____683  in
+            let uu____717 =
+              let uu____720 = FStar_Tests_Util.nm y  in
+              mk_match uu____720 [zbranch; sbranch]  in
+            FStar_Syntax_Util.abs uu____675 uu____717
               FStar_Pervasives_Native.None
              in
           FStar_Syntax_Subst.subst
-            [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu____681
+            [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu____674
            in
         {
           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl minus1);
           FStar_Syntax_Syntax.lbunivs = [];
           FStar_Syntax_Syntax.lbtyp = FStar_Syntax_Syntax.tun;
-          FStar_Syntax_Syntax.lbeff = uu____674;
-          FStar_Syntax_Syntax.lbdef = uu____678;
+          FStar_Syntax_Syntax.lbeff = uu____667;
+          FStar_Syntax_Syntax.lbdef = uu____671;
           FStar_Syntax_Syntax.lbattrs = [];
           FStar_Syntax_Syntax.lbpos = FStar_Range.dummyRange
         }  in
-      let uu____734 =
-        let uu____741 =
+      let uu____727 =
+        let uu____728 =
           let uu____742 =
-            let uu____756 =
-              let uu____759 =
-                let uu____760 = FStar_Tests_Util.nm minus1  in
-                FStar_Tests_Util.app uu____760 [t1; t2]  in
-              FStar_Syntax_Subst.subst
-                [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu____759
-               in
-            ((true, [lb]), uu____756)  in
-          FStar_Syntax_Syntax.Tm_let uu____742  in
-        FStar_Syntax_Syntax.mk uu____741  in
-      uu____734 FStar_Pervasives_Native.None FStar_Range.dummyRange
+            let uu____745 =
+              let uu____746 = FStar_Tests_Util.nm minus1  in
+              FStar_Tests_Util.app uu____746 [t1; t2]  in
+            FStar_Syntax_Subst.subst
+              [FStar_Syntax_Syntax.NM (minus1, Prims.int_zero)] uu____745
+             in
+          ((true, [lb]), uu____742)  in
+        FStar_Syntax_Syntax.Tm_let uu____728  in
+      FStar_Syntax_Syntax.mk uu____727 FStar_Range.dummyRange
   
 let (encode_nat : Prims.int -> FStar_Syntax_Syntax.term) =
   fun n  ->
     let rec aux out n1 =
       if n1 = Prims.int_zero
       then out
-      else (let uu____804 = snat out  in aux uu____804 (n1 - Prims.int_one))
+      else (let uu____790 = snat out  in aux uu____790 (n1 - Prims.int_one))
        in
     aux znat n
   
@@ -319,1168 +314,1168 @@ let (tests :
   FStar_Tests_Pars.pars_and_tc_fragment "let fst_a (x: 'a) (y: 'a) = x";
   FStar_Tests_Pars.pars_and_tc_fragment "let id_list (x: list 'a) = x";
   FStar_Tests_Pars.pars_and_tc_fragment "let id_list_m (x: list tb) = x";
-  (let uu____870 =
-     let uu____882 =
-       let uu____885 =
-         let uu____888 =
-           let uu____891 =
-             let uu____894 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-             [uu____894]  in
-           id :: uu____891  in
-         one :: uu____888  in
-       FStar_Tests_Util.app apply uu____885  in
-     let uu____895 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-     (Prims.int_zero, uu____882, uu____895)  in
-   let uu____904 =
-     let uu____918 =
-       let uu____930 =
-         let uu____933 =
-           let uu____936 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-           [uu____936]  in
-         FStar_Tests_Util.app id uu____933  in
-       let uu____937 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-       (Prims.int_one, uu____930, uu____937)  in
-     let uu____946 =
-       let uu____960 =
-         let uu____972 =
-           let uu____975 =
-             let uu____978 =
-               let uu____981 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-               let uu____982 =
-                 let uu____985 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
-                 [uu____985]  in
-               uu____981 :: uu____982  in
-             tt :: uu____978  in
-           FStar_Tests_Util.app apply uu____975  in
-         let uu____986 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-         (Prims.int_one, uu____972, uu____986)  in
-       let uu____995 =
-         let uu____1009 =
-           let uu____1021 =
-             let uu____1024 =
-               let uu____1027 =
-                 let uu____1030 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
-                 let uu____1031 =
-                   let uu____1034 = FStar_Tests_Util.nm FStar_Tests_Util.m
+  (let uu____856 =
+     let uu____868 =
+       let uu____871 =
+         let uu____874 =
+           let uu____877 =
+             let uu____880 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+             [uu____880]  in
+           id :: uu____877  in
+         one :: uu____874  in
+       FStar_Tests_Util.app apply uu____871  in
+     let uu____881 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+     (Prims.int_zero, uu____868, uu____881)  in
+   let uu____890 =
+     let uu____904 =
+       let uu____916 =
+         let uu____919 =
+           let uu____922 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
+           [uu____922]  in
+         FStar_Tests_Util.app id uu____919  in
+       let uu____923 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
+       (Prims.int_one, uu____916, uu____923)  in
+     let uu____932 =
+       let uu____946 =
+         let uu____958 =
+           let uu____961 =
+             let uu____964 =
+               let uu____967 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+               let uu____968 =
+                 let uu____971 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
+                 [uu____971]  in
+               uu____967 :: uu____968  in
+             tt :: uu____964  in
+           FStar_Tests_Util.app apply uu____961  in
+         let uu____972 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+         (Prims.int_one, uu____958, uu____972)  in
+       let uu____981 =
+         let uu____995 =
+           let uu____1007 =
+             let uu____1010 =
+               let uu____1013 =
+                 let uu____1016 = FStar_Tests_Util.nm FStar_Tests_Util.n  in
+                 let uu____1017 =
+                   let uu____1020 = FStar_Tests_Util.nm FStar_Tests_Util.m
                       in
-                   [uu____1034]  in
-                 uu____1030 :: uu____1031  in
-               ff :: uu____1027  in
-             FStar_Tests_Util.app apply uu____1024  in
-           let uu____1035 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
-           ((Prims.of_int (2)), uu____1021, uu____1035)  in
-         let uu____1044 =
-           let uu____1058 =
-             let uu____1070 =
-               let uu____1073 =
-                 let uu____1076 =
-                   let uu____1079 =
-                     let uu____1082 =
-                       let uu____1085 =
-                         let uu____1088 =
-                           let uu____1091 =
-                             let uu____1094 =
+                   [uu____1020]  in
+                 uu____1016 :: uu____1017  in
+               ff :: uu____1013  in
+             FStar_Tests_Util.app apply uu____1010  in
+           let uu____1021 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
+           ((Prims.of_int (2)), uu____1007, uu____1021)  in
+         let uu____1030 =
+           let uu____1044 =
+             let uu____1056 =
+               let uu____1059 =
+                 let uu____1062 =
+                   let uu____1065 =
+                     let uu____1068 =
+                       let uu____1071 =
+                         let uu____1074 =
+                           let uu____1077 =
+                             let uu____1080 =
                                FStar_Tests_Util.nm FStar_Tests_Util.n  in
-                             let uu____1095 =
-                               let uu____1098 =
+                             let uu____1081 =
+                               let uu____1084 =
                                  FStar_Tests_Util.nm FStar_Tests_Util.m  in
-                               [uu____1098]  in
-                             uu____1094 :: uu____1095  in
-                           ff :: uu____1091  in
-                         apply :: uu____1088  in
-                       apply :: uu____1085  in
-                     apply :: uu____1082  in
-                   apply :: uu____1079  in
-                 apply :: uu____1076  in
-               FStar_Tests_Util.app apply uu____1073  in
-             let uu____1099 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
-             ((Prims.of_int (3)), uu____1070, uu____1099)  in
-           let uu____1108 =
-             let uu____1122 =
-               let uu____1134 =
-                 let uu____1137 =
-                   let uu____1140 =
-                     let uu____1143 =
-                       let uu____1146 =
+                               [uu____1084]  in
+                             uu____1080 :: uu____1081  in
+                           ff :: uu____1077  in
+                         apply :: uu____1074  in
+                       apply :: uu____1071  in
+                     apply :: uu____1068  in
+                   apply :: uu____1065  in
+                 apply :: uu____1062  in
+               FStar_Tests_Util.app apply uu____1059  in
+             let uu____1085 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
+             ((Prims.of_int (3)), uu____1056, uu____1085)  in
+           let uu____1094 =
+             let uu____1108 =
+               let uu____1120 =
+                 let uu____1123 =
+                   let uu____1126 =
+                     let uu____1129 =
+                       let uu____1132 =
                          FStar_Tests_Util.nm FStar_Tests_Util.n  in
-                       let uu____1147 =
-                         let uu____1150 =
+                       let uu____1133 =
+                         let uu____1136 =
                            FStar_Tests_Util.nm FStar_Tests_Util.m  in
-                         [uu____1150]  in
-                       uu____1146 :: uu____1147  in
-                     ff :: uu____1143  in
-                   apply :: uu____1140  in
-                 FStar_Tests_Util.app twice uu____1137  in
-               let uu____1151 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
-               ((Prims.of_int (4)), uu____1134, uu____1151)  in
-             let uu____1160 =
-               let uu____1174 =
-                 let uu____1186 = minus one z  in
-                 ((Prims.of_int (5)), uu____1186, one)  in
-               let uu____1195 =
-                 let uu____1209 =
-                   let uu____1221 = FStar_Tests_Util.app pred [one]  in
-                   ((Prims.of_int (6)), uu____1221, z)  in
-                 let uu____1230 =
-                   let uu____1244 =
-                     let uu____1256 = minus one one  in
-                     ((Prims.of_int (7)), uu____1256, z)  in
-                   let uu____1265 =
-                     let uu____1279 =
-                       let uu____1291 = FStar_Tests_Util.app mul [one; one]
+                         [uu____1136]  in
+                       uu____1132 :: uu____1133  in
+                     ff :: uu____1129  in
+                   apply :: uu____1126  in
+                 FStar_Tests_Util.app twice uu____1123  in
+               let uu____1137 = FStar_Tests_Util.nm FStar_Tests_Util.m  in
+               ((Prims.of_int (4)), uu____1120, uu____1137)  in
+             let uu____1146 =
+               let uu____1160 =
+                 let uu____1172 = minus one z  in
+                 ((Prims.of_int (5)), uu____1172, one)  in
+               let uu____1181 =
+                 let uu____1195 =
+                   let uu____1207 = FStar_Tests_Util.app pred [one]  in
+                   ((Prims.of_int (6)), uu____1207, z)  in
+                 let uu____1216 =
+                   let uu____1230 =
+                     let uu____1242 = minus one one  in
+                     ((Prims.of_int (7)), uu____1242, z)  in
+                   let uu____1251 =
+                     let uu____1265 =
+                       let uu____1277 = FStar_Tests_Util.app mul [one; one]
                           in
-                       ((Prims.of_int (8)), uu____1291, one)  in
-                     let uu____1300 =
-                       let uu____1314 =
-                         let uu____1326 = FStar_Tests_Util.app mul [two; one]
+                       ((Prims.of_int (8)), uu____1277, one)  in
+                     let uu____1286 =
+                       let uu____1300 =
+                         let uu____1312 = FStar_Tests_Util.app mul [two; one]
                             in
-                         ((Prims.of_int (9)), uu____1326, two)  in
-                       let uu____1335 =
-                         let uu____1349 =
-                           let uu____1361 =
-                             let uu____1364 =
-                               let uu____1367 =
+                         ((Prims.of_int (9)), uu____1312, two)  in
+                       let uu____1321 =
+                         let uu____1335 =
+                           let uu____1347 =
+                             let uu____1350 =
+                               let uu____1353 =
                                  FStar_Tests_Util.app succ [one]  in
-                               [uu____1367; one]  in
-                             FStar_Tests_Util.app mul uu____1364  in
-                           ((Prims.of_int (10)), uu____1361, two)  in
-                         let uu____1374 =
-                           let uu____1388 =
-                             let uu____1400 =
-                               let uu____1403 = encode (Prims.of_int (10))
+                               [uu____1353; one]  in
+                             FStar_Tests_Util.app mul uu____1350  in
+                           ((Prims.of_int (10)), uu____1347, two)  in
+                         let uu____1360 =
+                           let uu____1374 =
+                             let uu____1386 =
+                               let uu____1389 = encode (Prims.of_int (10))
                                   in
-                               let uu____1405 = encode (Prims.of_int (10))
+                               let uu____1391 = encode (Prims.of_int (10))
                                   in
-                               minus uu____1403 uu____1405  in
-                             ((Prims.of_int (11)), uu____1400, z)  in
-                           let uu____1415 =
-                             let uu____1429 =
-                               let uu____1441 =
-                                 let uu____1444 = encode (Prims.of_int (100))
+                               minus uu____1389 uu____1391  in
+                             ((Prims.of_int (11)), uu____1386, z)  in
+                           let uu____1401 =
+                             let uu____1415 =
+                               let uu____1427 =
+                                 let uu____1430 = encode (Prims.of_int (100))
                                     in
-                                 let uu____1446 = encode (Prims.of_int (100))
+                                 let uu____1432 = encode (Prims.of_int (100))
                                     in
-                                 minus uu____1444 uu____1446  in
-                               ((Prims.of_int (12)), uu____1441, z)  in
-                             let uu____1456 =
-                               let uu____1470 =
-                                 let uu____1482 =
-                                   let uu____1485 =
+                                 minus uu____1430 uu____1432  in
+                               ((Prims.of_int (12)), uu____1427, z)  in
+                             let uu____1442 =
+                               let uu____1456 =
+                                 let uu____1468 =
+                                   let uu____1471 =
                                      encode (Prims.of_int (100))  in
-                                   let uu____1487 =
-                                     let uu____1490 =
+                                   let uu____1473 =
+                                     let uu____1476 =
                                        FStar_Tests_Util.nm FStar_Tests_Util.x
                                         in
-                                     let uu____1491 =
+                                     let uu____1477 =
                                        FStar_Tests_Util.nm FStar_Tests_Util.x
                                         in
-                                     minus uu____1490 uu____1491  in
-                                   let_ FStar_Tests_Util.x uu____1485
-                                     uu____1487
+                                     minus uu____1476 uu____1477  in
+                                   let_ FStar_Tests_Util.x uu____1471
+                                     uu____1473
                                     in
-                                 ((Prims.of_int (13)), uu____1482, z)  in
-                               let uu____1500 =
-                                 let uu____1514 =
-                                   let uu____1526 =
-                                     let uu____1529 =
+                                 ((Prims.of_int (13)), uu____1468, z)  in
+                               let uu____1486 =
+                                 let uu____1500 =
+                                   let uu____1512 =
+                                     let uu____1515 =
                                        FStar_Tests_Util.app succ [one]  in
-                                     let uu____1530 =
-                                       let uu____1533 =
-                                         let uu____1534 =
-                                           let uu____1537 =
+                                     let uu____1516 =
+                                       let uu____1519 =
+                                         let uu____1520 =
+                                           let uu____1523 =
                                              FStar_Tests_Util.nm
                                                FStar_Tests_Util.x
                                               in
-                                           let uu____1538 =
-                                             let uu____1541 =
+                                           let uu____1524 =
+                                             let uu____1527 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.x
                                                 in
-                                             [uu____1541]  in
-                                           uu____1537 :: uu____1538  in
-                                         FStar_Tests_Util.app mul uu____1534
+                                             [uu____1527]  in
+                                           uu____1523 :: uu____1524  in
+                                         FStar_Tests_Util.app mul uu____1520
                                           in
-                                       let uu____1542 =
-                                         let uu____1545 =
-                                           let uu____1546 =
-                                             let uu____1549 =
+                                       let uu____1528 =
+                                         let uu____1531 =
+                                           let uu____1532 =
+                                             let uu____1535 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.y
                                                 in
-                                             let uu____1550 =
-                                               let uu____1553 =
+                                             let uu____1536 =
+                                               let uu____1539 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.y
                                                   in
-                                               [uu____1553]  in
-                                             uu____1549 :: uu____1550  in
+                                               [uu____1539]  in
+                                             uu____1535 :: uu____1536  in
                                            FStar_Tests_Util.app mul
-                                             uu____1546
+                                             uu____1532
                                             in
-                                         let uu____1554 =
-                                           let uu____1557 =
+                                         let uu____1540 =
+                                           let uu____1543 =
                                              FStar_Tests_Util.nm
                                                FStar_Tests_Util.h
                                               in
-                                           let uu____1558 =
+                                           let uu____1544 =
                                              FStar_Tests_Util.nm
                                                FStar_Tests_Util.h
                                               in
-                                           minus uu____1557 uu____1558  in
-                                         let_ FStar_Tests_Util.h uu____1545
-                                           uu____1554
+                                           minus uu____1543 uu____1544  in
+                                         let_ FStar_Tests_Util.h uu____1531
+                                           uu____1540
                                           in
-                                       let_ FStar_Tests_Util.y uu____1533
-                                         uu____1542
+                                       let_ FStar_Tests_Util.y uu____1519
+                                         uu____1528
                                         in
-                                     let_ FStar_Tests_Util.x uu____1529
-                                       uu____1530
+                                     let_ FStar_Tests_Util.x uu____1515
+                                       uu____1516
                                       in
-                                   ((Prims.of_int (15)), uu____1526, z)  in
-                                 let uu____1567 =
-                                   let uu____1581 =
-                                     let uu____1593 =
-                                       let uu____1596 =
+                                   ((Prims.of_int (15)), uu____1512, z)  in
+                                 let uu____1553 =
+                                   let uu____1567 =
+                                     let uu____1579 =
+                                       let uu____1582 =
                                          FStar_Tests_Util.app succ [one]  in
-                                       let uu____1599 =
-                                         let uu____1600 =
-                                           let uu____1603 =
-                                             let uu____1606 =
+                                       let uu____1585 =
+                                         let uu____1586 =
+                                           let uu____1589 =
+                                             let uu____1592 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.x
                                                 in
-                                             let uu____1607 =
-                                               let uu____1610 =
+                                             let uu____1593 =
+                                               let uu____1596 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.x
                                                   in
-                                               [uu____1610]  in
-                                             uu____1606 :: uu____1607  in
+                                               [uu____1596]  in
+                                             uu____1592 :: uu____1593  in
                                            FStar_Tests_Util.app mul
-                                             uu____1603
+                                             uu____1589
                                             in
-                                         let uu____1611 =
-                                           let uu____1612 =
-                                             let uu____1615 =
-                                               let uu____1618 =
+                                         let uu____1597 =
+                                           let uu____1598 =
+                                             let uu____1601 =
+                                               let uu____1604 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.y
                                                   in
-                                               let uu____1619 =
-                                                 let uu____1622 =
+                                               let uu____1605 =
+                                                 let uu____1608 =
                                                    FStar_Tests_Util.nm
                                                      FStar_Tests_Util.y
                                                     in
-                                                 [uu____1622]  in
-                                               uu____1618 :: uu____1619  in
+                                                 [uu____1608]  in
+                                               uu____1604 :: uu____1605  in
                                              FStar_Tests_Util.app mul
-                                               uu____1615
+                                               uu____1601
                                               in
-                                           let uu____1623 =
-                                             let uu____1624 =
+                                           let uu____1609 =
+                                             let uu____1610 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.h
                                                 in
-                                             let uu____1625 =
+                                             let uu____1611 =
                                                FStar_Tests_Util.nm
                                                  FStar_Tests_Util.h
                                                 in
-                                             minus uu____1624 uu____1625  in
+                                             minus uu____1610 uu____1611  in
                                            mk_let FStar_Tests_Util.h
-                                             uu____1612 uu____1623
+                                             uu____1598 uu____1609
                                             in
-                                         mk_let FStar_Tests_Util.y uu____1600
-                                           uu____1611
+                                         mk_let FStar_Tests_Util.y uu____1586
+                                           uu____1597
                                           in
-                                       mk_let FStar_Tests_Util.x uu____1596
-                                         uu____1599
+                                       mk_let FStar_Tests_Util.x uu____1582
+                                         uu____1585
                                         in
-                                     ((Prims.of_int (16)), uu____1593, z)  in
-                                   let uu____1634 =
-                                     let uu____1648 =
-                                       let uu____1660 =
-                                         let uu____1663 =
+                                     ((Prims.of_int (16)), uu____1579, z)  in
+                                   let uu____1620 =
+                                     let uu____1634 =
+                                       let uu____1646 =
+                                         let uu____1649 =
                                            FStar_Tests_Util.app succ [one]
                                             in
-                                         let uu____1664 =
-                                           let uu____1667 =
-                                             let uu____1668 =
-                                               let uu____1671 =
+                                         let uu____1650 =
+                                           let uu____1653 =
+                                             let uu____1654 =
+                                               let uu____1657 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.x
                                                   in
-                                               let uu____1672 =
-                                                 let uu____1675 =
+                                               let uu____1658 =
+                                                 let uu____1661 =
                                                    FStar_Tests_Util.nm
                                                      FStar_Tests_Util.x
                                                     in
-                                                 [uu____1675]  in
-                                               uu____1671 :: uu____1672  in
+                                                 [uu____1661]  in
+                                               uu____1657 :: uu____1658  in
                                              FStar_Tests_Util.app mul
-                                               uu____1668
+                                               uu____1654
                                               in
-                                           let uu____1676 =
-                                             let uu____1679 =
-                                               let uu____1680 =
-                                                 let uu____1683 =
+                                           let uu____1662 =
+                                             let uu____1665 =
+                                               let uu____1666 =
+                                                 let uu____1669 =
                                                    FStar_Tests_Util.nm
                                                      FStar_Tests_Util.y
                                                     in
-                                                 let uu____1684 =
-                                                   let uu____1687 =
+                                                 let uu____1670 =
+                                                   let uu____1673 =
                                                      FStar_Tests_Util.nm
                                                        FStar_Tests_Util.y
                                                       in
-                                                   [uu____1687]  in
-                                                 uu____1683 :: uu____1684  in
+                                                   [uu____1673]  in
+                                                 uu____1669 :: uu____1670  in
                                                FStar_Tests_Util.app mul
-                                                 uu____1680
+                                                 uu____1666
                                                 in
-                                             let uu____1688 =
-                                               let uu____1691 =
+                                             let uu____1674 =
+                                               let uu____1677 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.h
                                                   in
-                                               let uu____1692 =
+                                               let uu____1678 =
                                                  FStar_Tests_Util.nm
                                                    FStar_Tests_Util.h
                                                   in
-                                               minus uu____1691 uu____1692
+                                               minus uu____1677 uu____1678
                                                 in
                                              let_ FStar_Tests_Util.h
-                                               uu____1679 uu____1688
+                                               uu____1665 uu____1674
                                               in
-                                           let_ FStar_Tests_Util.y uu____1667
-                                             uu____1676
+                                           let_ FStar_Tests_Util.y uu____1653
+                                             uu____1662
                                             in
-                                         let_ FStar_Tests_Util.x uu____1663
-                                           uu____1664
+                                         let_ FStar_Tests_Util.x uu____1649
+                                           uu____1650
                                           in
-                                       ((Prims.of_int (17)), uu____1660, z)
+                                       ((Prims.of_int (17)), uu____1646, z)
                                         in
-                                     let uu____1701 =
-                                       let uu____1715 =
-                                         let uu____1727 =
-                                           let uu____1730 =
-                                             let uu____1733 = snat znat  in
-                                             snat uu____1733  in
-                                           pred_nat uu____1730  in
-                                         let uu____1734 = snat znat  in
-                                         ((Prims.of_int (18)), uu____1727,
-                                           uu____1734)
+                                     let uu____1687 =
+                                       let uu____1701 =
+                                         let uu____1713 =
+                                           let uu____1716 =
+                                             let uu____1719 = snat znat  in
+                                             snat uu____1719  in
+                                           pred_nat uu____1716  in
+                                         let uu____1720 = snat znat  in
+                                         ((Prims.of_int (18)), uu____1713,
+                                           uu____1720)
                                           in
-                                       let uu____1743 =
-                                         let uu____1757 =
-                                           let uu____1769 =
-                                             let uu____1772 =
-                                               let uu____1773 =
-                                                 let uu____1774 = snat znat
+                                       let uu____1729 =
+                                         let uu____1743 =
+                                           let uu____1755 =
+                                             let uu____1758 =
+                                               let uu____1759 =
+                                                 let uu____1760 = snat znat
                                                     in
-                                                 snat uu____1774  in
-                                               let uu____1775 = snat znat  in
-                                               minus_nat uu____1773
-                                                 uu____1775
+                                                 snat uu____1760  in
+                                               let uu____1761 = snat znat  in
+                                               minus_nat uu____1759
+                                                 uu____1761
                                                 in
                                              FStar_Tests_Pars.tc_nbe_term
-                                               uu____1772
+                                               uu____1758
                                               in
-                                           let uu____1776 = snat znat  in
-                                           ((Prims.of_int (19)), uu____1769,
-                                             uu____1776)
+                                           let uu____1762 = snat znat  in
+                                           ((Prims.of_int (19)), uu____1755,
+                                             uu____1762)
                                             in
-                                         let uu____1785 =
-                                           let uu____1799 =
-                                             let uu____1811 =
-                                               let uu____1814 =
-                                                 let uu____1815 =
+                                         let uu____1771 =
+                                           let uu____1785 =
+                                             let uu____1797 =
+                                               let uu____1800 =
+                                                 let uu____1801 =
                                                    encode_nat
                                                      (Prims.of_int (10))
                                                     in
-                                                 let uu____1817 =
+                                                 let uu____1803 =
                                                    encode_nat
                                                      (Prims.of_int (10))
                                                     in
-                                                 minus_nat uu____1815
-                                                   uu____1817
+                                                 minus_nat uu____1801
+                                                   uu____1803
                                                   in
                                                FStar_Tests_Pars.tc_nbe_term
-                                                 uu____1814
+                                                 uu____1800
                                                 in
                                              ((Prims.of_int (20)),
-                                               uu____1811, znat)
+                                               uu____1797, znat)
                                               in
-                                           let uu____1825 =
-                                             let uu____1839 =
-                                               let uu____1851 =
-                                                 let uu____1854 =
-                                                   let uu____1855 =
+                                           let uu____1811 =
+                                             let uu____1825 =
+                                               let uu____1837 =
+                                                 let uu____1840 =
+                                                   let uu____1841 =
                                                      encode_nat
                                                        (Prims.of_int (100))
                                                       in
-                                                   let uu____1857 =
+                                                   let uu____1843 =
                                                      encode_nat
                                                        (Prims.of_int (100))
                                                       in
-                                                   minus_nat uu____1855
-                                                     uu____1857
+                                                   minus_nat uu____1841
+                                                     uu____1843
                                                     in
                                                  FStar_Tests_Pars.tc_nbe_term
-                                                   uu____1854
+                                                   uu____1840
                                                   in
                                                ((Prims.of_int (21)),
-                                                 uu____1851, znat)
+                                                 uu____1837, znat)
                                                 in
-                                             let uu____1865 =
-                                               let uu____1879 =
-                                                 let uu____1891 =
+                                             let uu____1851 =
+                                               let uu____1865 =
+                                                 let uu____1877 =
                                                    FStar_Tests_Pars.tc_nbe
                                                      "recons [0;1]"
                                                     in
-                                                 let uu____1895 =
+                                                 let uu____1881 =
                                                    FStar_Tests_Pars.tc_nbe
                                                      "[0;1]"
                                                     in
                                                  ((Prims.of_int (24)),
-                                                   uu____1891, uu____1895)
+                                                   uu____1877, uu____1881)
                                                   in
-                                               let uu____1905 =
-                                                 let uu____1919 =
-                                                   let uu____1931 =
+                                               let uu____1891 =
+                                                 let uu____1905 =
+                                                   let uu____1917 =
                                                      FStar_Tests_Pars.tc_nbe
                                                        "recons [false;true;false]"
                                                       in
-                                                   let uu____1935 =
+                                                   let uu____1921 =
                                                      FStar_Tests_Pars.tc_nbe
                                                        "[false;true;false]"
                                                       in
                                                    ((Prims.of_int (241)),
-                                                     uu____1931, uu____1935)
+                                                     uu____1917, uu____1921)
                                                     in
-                                                 let uu____1945 =
-                                                   let uu____1959 =
-                                                     let uu____1971 =
+                                                 let uu____1931 =
+                                                   let uu____1945 =
+                                                     let uu____1957 =
                                                        FStar_Tests_Pars.tc_nbe
                                                          "copy [0;1]"
                                                         in
-                                                     let uu____1975 =
+                                                     let uu____1961 =
                                                        FStar_Tests_Pars.tc_nbe
                                                          "[0;1]"
                                                         in
                                                      ((Prims.of_int (25)),
-                                                       uu____1971,
-                                                       uu____1975)
+                                                       uu____1957,
+                                                       uu____1961)
                                                       in
-                                                   let uu____1985 =
-                                                     let uu____1999 =
-                                                       let uu____2011 =
+                                                   let uu____1971 =
+                                                     let uu____1985 =
+                                                       let uu____1997 =
                                                          FStar_Tests_Pars.tc_nbe
                                                            "rev [0;1;2;3;4;5;6;7;8;9;10]"
                                                           in
-                                                       let uu____2015 =
+                                                       let uu____2001 =
                                                          FStar_Tests_Pars.tc_nbe
                                                            "[10;9;8;7;6;5;4;3;2;1;0]"
                                                           in
                                                        ((Prims.of_int (26)),
-                                                         uu____2011,
-                                                         uu____2015)
+                                                         uu____1997,
+                                                         uu____2001)
                                                         in
-                                                     let uu____2025 =
-                                                       let uu____2039 =
-                                                         let uu____2051 =
+                                                     let uu____2011 =
+                                                       let uu____2025 =
+                                                         let uu____2037 =
                                                            FStar_Tests_Pars.tc_nbe
                                                              "(fun x y z q -> z) T T F T"
                                                             in
-                                                         let uu____2055 =
+                                                         let uu____2041 =
                                                            FStar_Tests_Pars.tc_nbe
                                                              "F"
                                                             in
                                                          ((Prims.of_int (28)),
-                                                           uu____2051,
-                                                           uu____2055)
+                                                           uu____2037,
+                                                           uu____2041)
                                                           in
-                                                       let uu____2065 =
-                                                         let uu____2079 =
-                                                           let uu____2091 =
+                                                       let uu____2051 =
+                                                         let uu____2065 =
+                                                           let uu____2077 =
                                                              FStar_Tests_Pars.tc_nbe
                                                                "[T; F]"
                                                               in
-                                                           let uu____2095 =
+                                                           let uu____2081 =
                                                              FStar_Tests_Pars.tc_nbe
                                                                "[T; F]"
                                                               in
                                                            ((Prims.of_int (29)),
-                                                             uu____2091,
-                                                             uu____2095)
+                                                             uu____2077,
+                                                             uu____2081)
                                                             in
-                                                         let uu____2105 =
-                                                           let uu____2119 =
-                                                             let uu____2131 =
+                                                         let uu____2091 =
+                                                           let uu____2105 =
+                                                             let uu____2117 =
                                                                FStar_Tests_Pars.tc_nbe
                                                                  "id_tb T"
                                                                 in
-                                                             let uu____2135 =
+                                                             let uu____2121 =
                                                                FStar_Tests_Pars.tc_nbe
                                                                  "T"
                                                                 in
                                                              ((Prims.of_int (31)),
-                                                               uu____2131,
-                                                               uu____2135)
+                                                               uu____2117,
+                                                               uu____2121)
                                                               in
-                                                           let uu____2145 =
-                                                             let uu____2159 =
-                                                               let uu____2171
+                                                           let uu____2131 =
+                                                             let uu____2145 =
+                                                               let uu____2157
                                                                  =
                                                                  FStar_Tests_Pars.tc_nbe
                                                                    "(fun #a x -> x) #tb T"
                                                                   in
-                                                               let uu____2175
+                                                               let uu____2161
                                                                  =
                                                                  FStar_Tests_Pars.tc_nbe
                                                                    "T"
                                                                   in
                                                                ((Prims.of_int (32)),
-                                                                 uu____2171,
-                                                                 uu____2175)
+                                                                 uu____2157,
+                                                                 uu____2161)
                                                                 in
-                                                             let uu____2185 =
-                                                               let uu____2199
+                                                             let uu____2171 =
+                                                               let uu____2185
                                                                  =
-                                                                 let uu____2211
+                                                                 let uu____2197
                                                                    =
                                                                    FStar_Tests_Pars.tc_nbe
                                                                     "revtb T"
                                                                     in
-                                                                 let uu____2215
+                                                                 let uu____2201
                                                                    =
                                                                    FStar_Tests_Pars.tc_nbe
                                                                     "F"
                                                                     in
                                                                  ((Prims.of_int (33)),
-                                                                   uu____2211,
-                                                                   uu____2215)
+                                                                   uu____2197,
+                                                                   uu____2201)
                                                                   in
-                                                               let uu____2225
+                                                               let uu____2211
                                                                  =
-                                                                 let uu____2239
+                                                                 let uu____2225
                                                                    =
-                                                                   let uu____2251
+                                                                   let uu____2237
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "(fun x y -> x) T F"
                                                                      in
-                                                                   let uu____2255
+                                                                   let uu____2241
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T"  in
                                                                    ((Prims.of_int (34)),
-                                                                    uu____2251,
-                                                                    uu____2255)
+                                                                    uu____2237,
+                                                                    uu____2241)
                                                                     in
-                                                                 let uu____2265
+                                                                 let uu____2251
                                                                    =
-                                                                   let uu____2279
+                                                                   let uu____2265
                                                                     =
-                                                                    let uu____2291
+                                                                    let uu____2277
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "fst_a T F"
                                                                      in
-                                                                    let uu____2295
+                                                                    let uu____2281
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T"  in
                                                                     ((Prims.of_int (35)),
-                                                                    uu____2291,
-                                                                    uu____2295)
+                                                                    uu____2277,
+                                                                    uu____2281)
                                                                      in
-                                                                   let uu____2305
+                                                                   let uu____2291
                                                                     =
-                                                                    let uu____2319
+                                                                    let uu____2305
                                                                     =
-                                                                    let uu____2331
+                                                                    let uu____2317
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "idd T"
                                                                      in
-                                                                    let uu____2335
+                                                                    let uu____2321
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T"  in
                                                                     ((Prims.of_int (36)),
-                                                                    uu____2331,
-                                                                    uu____2335)
+                                                                    uu____2317,
+                                                                    uu____2321)
                                                                      in
+                                                                    let uu____2331
+                                                                    =
                                                                     let uu____2345
                                                                     =
-                                                                    let uu____2359
-                                                                    =
-                                                                    let uu____2371
+                                                                    let uu____2357
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "id_list [T]"
                                                                      in
-                                                                    let uu____2375
+                                                                    let uu____2361
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T]"  in
                                                                     ((Prims.of_int (301)),
-                                                                    uu____2371,
-                                                                    uu____2375)
+                                                                    uu____2357,
+                                                                    uu____2361)
                                                                      in
+                                                                    let uu____2371
+                                                                    =
                                                                     let uu____2385
                                                                     =
-                                                                    let uu____2399
-                                                                    =
-                                                                    let uu____2411
+                                                                    let uu____2397
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "id_list_m [T]"
                                                                      in
-                                                                    let uu____2415
+                                                                    let uu____2401
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T]"  in
                                                                     ((Prims.of_int (3012)),
-                                                                    uu____2411,
-                                                                    uu____2415)
+                                                                    uu____2397,
+                                                                    uu____2401)
                                                                      in
+                                                                    let uu____2411
+                                                                    =
                                                                     let uu____2425
                                                                     =
-                                                                    let uu____2439
-                                                                    =
-                                                                    let uu____2451
+                                                                    let uu____2437
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "recons_m [T; F]"
                                                                      in
-                                                                    let uu____2455
+                                                                    let uu____2441
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T; F]"
                                                                      in
                                                                     ((Prims.of_int (302)),
-                                                                    uu____2451,
-                                                                    uu____2455)
+                                                                    uu____2437,
+                                                                    uu____2441)
                                                                      in
+                                                                    let uu____2451
+                                                                    =
                                                                     let uu____2465
                                                                     =
-                                                                    let uu____2479
-                                                                    =
-                                                                    let uu____2491
+                                                                    let uu____2477
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select T A1 A3"
                                                                      in
-                                                                    let uu____2495
+                                                                    let uu____2481
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "A1"  in
                                                                     ((Prims.of_int (303)),
-                                                                    uu____2491,
-                                                                    uu____2495)
+                                                                    uu____2477,
+                                                                    uu____2481)
                                                                      in
+                                                                    let uu____2491
+                                                                    =
                                                                     let uu____2505
                                                                     =
-                                                                    let uu____2519
-                                                                    =
-                                                                    let uu____2531
+                                                                    let uu____2517
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select T 3 4"
                                                                      in
-                                                                    let uu____2535
+                                                                    let uu____2521
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "3"  in
                                                                     ((Prims.of_int (3031)),
-                                                                    uu____2531,
-                                                                    uu____2535)
+                                                                    uu____2517,
+                                                                    uu____2521)
                                                                      in
+                                                                    let uu____2531
+                                                                    =
                                                                     let uu____2545
                                                                     =
-                                                                    let uu____2559
-                                                                    =
-                                                                    let uu____2571
+                                                                    let uu____2557
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select_bool false 3 4"
                                                                      in
-                                                                    let uu____2575
+                                                                    let uu____2561
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "4"  in
                                                                     ((Prims.of_int (3032)),
-                                                                    uu____2571,
-                                                                    uu____2575)
+                                                                    uu____2557,
+                                                                    uu____2561)
                                                                      in
+                                                                    let uu____2571
+                                                                    =
                                                                     let uu____2585
                                                                     =
-                                                                    let uu____2599
-                                                                    =
-                                                                    let uu____2611
+                                                                    let uu____2597
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select_int3 1 7 8 9"
                                                                      in
-                                                                    let uu____2615
+                                                                    let uu____2601
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "8"  in
                                                                     ((Prims.of_int (3033)),
-                                                                    uu____2611,
-                                                                    uu____2615)
+                                                                    uu____2597,
+                                                                    uu____2601)
                                                                      in
+                                                                    let uu____2611
+                                                                    =
                                                                     let uu____2625
                                                                     =
-                                                                    let uu____2639
-                                                                    =
-                                                                    let uu____2651
+                                                                    let uu____2637
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[5]"  in
-                                                                    let uu____2655
+                                                                    let uu____2641
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[5]"  in
                                                                     ((Prims.of_int (3034)),
-                                                                    uu____2651,
-                                                                    uu____2655)
+                                                                    uu____2637,
+                                                                    uu____2641)
                                                                      in
+                                                                    let uu____2651
+                                                                    =
                                                                     let uu____2665
                                                                     =
-                                                                    let uu____2679
-                                                                    =
-                                                                    let uu____2691
+                                                                    let uu____2677
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[\"abcd\"]"
                                                                      in
-                                                                    let uu____2695
+                                                                    let uu____2681
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[\"abcd\"]"
                                                                      in
                                                                     ((Prims.of_int (3035)),
-                                                                    uu____2691,
-                                                                    uu____2695)
+                                                                    uu____2677,
+                                                                    uu____2681)
                                                                      in
+                                                                    let uu____2691
+                                                                    =
                                                                     let uu____2705
                                                                     =
-                                                                    let uu____2719
-                                                                    =
-                                                                    let uu____2731
+                                                                    let uu____2717
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "select_string3 \"def\" 5 6 7"
                                                                      in
-                                                                    let uu____2735
+                                                                    let uu____2721
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "6"  in
                                                                     ((Prims.of_int (3036)),
-                                                                    uu____2731,
-                                                                    uu____2735)
+                                                                    uu____2717,
+                                                                    uu____2721)
                                                                      in
+                                                                    let uu____2731
+                                                                    =
                                                                     let uu____2745
                                                                     =
-                                                                    let uu____2759
-                                                                    =
-                                                                    let uu____2771
+                                                                    let uu____2757
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "idd T"
                                                                      in
-                                                                    let uu____2775
+                                                                    let uu____2761
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "T"  in
                                                                     ((Prims.of_int (305)),
-                                                                    uu____2771,
-                                                                    uu____2775)
+                                                                    uu____2757,
+                                                                    uu____2761)
                                                                      in
+                                                                    let uu____2771
+                                                                    =
                                                                     let uu____2785
                                                                     =
-                                                                    let uu____2799
-                                                                    =
-                                                                    let uu____2811
+                                                                    let uu____2797
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "recons [T]"
                                                                      in
-                                                                    let uu____2815
+                                                                    let uu____2801
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T]"  in
                                                                     ((Prims.of_int (306)),
-                                                                    uu____2811,
-                                                                    uu____2815)
+                                                                    uu____2797,
+                                                                    uu____2801)
                                                                      in
+                                                                    let uu____2811
+                                                                    =
                                                                     let uu____2825
                                                                     =
-                                                                    let uu____2839
-                                                                    =
-                                                                    let uu____2851
+                                                                    let uu____2837
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "copy_tb_list_2 [T;F;T;F;T;F;F]"
                                                                      in
-                                                                    let uu____2855
+                                                                    let uu____2841
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T;F;T;F;T;F;F]"
                                                                      in
                                                                     ((Prims.of_int (307)),
-                                                                    uu____2851,
-                                                                    uu____2855)
+                                                                    uu____2837,
+                                                                    uu____2841)
                                                                      in
+                                                                    let uu____2851
+                                                                    =
                                                                     let uu____2865
                                                                     =
-                                                                    let uu____2879
-                                                                    =
-                                                                    let uu____2891
+                                                                    let uu____2877
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "copy_list_2    [T;F;T;F;T;F;F]"
                                                                      in
-                                                                    let uu____2895
+                                                                    let uu____2881
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[T;F;T;F;T;F;F]"
                                                                      in
                                                                     ((Prims.of_int (308)),
-                                                                    uu____2891,
-                                                                    uu____2895)
+                                                                    uu____2877,
+                                                                    uu____2881)
                                                                      in
+                                                                    let uu____2891
+                                                                    =
                                                                     let uu____2905
                                                                     =
-                                                                    let uu____2919
-                                                                    =
-                                                                    let uu____2931
+                                                                    let uu____2917
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "rev [T; F; F]"
                                                                      in
-                                                                    let uu____2935
+                                                                    let uu____2921
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[F; F; T]"
                                                                      in
                                                                     ((Prims.of_int (304)),
-                                                                    uu____2931,
-                                                                    uu____2935)
+                                                                    uu____2917,
+                                                                    uu____2921)
                                                                      in
+                                                                    let uu____2931
+                                                                    =
                                                                     let uu____2945
                                                                     =
-                                                                    let uu____2959
-                                                                    =
-                                                                    let uu____2971
+                                                                    let uu____2957
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "rev [[T]; [F; T]]"
                                                                      in
-                                                                    let uu____2975
+                                                                    let uu____2961
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "[[F; T]; [T]]"
                                                                      in
                                                                     ((Prims.of_int (305)),
-                                                                    uu____2971,
-                                                                    uu____2975)
+                                                                    uu____2957,
+                                                                    uu____2961)
                                                                      in
+                                                                    let uu____2971
+                                                                    =
                                                                     let uu____2985
                                                                     =
-                                                                    let uu____2999
-                                                                    =
-                                                                    let uu____3011
+                                                                    let uu____2997
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "x1"  in
-                                                                    let uu____3015
+                                                                    let uu____3001
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "6"  in
                                                                     ((Prims.of_int (309)),
-                                                                    uu____3011,
-                                                                    uu____3015)
+                                                                    uu____2997,
+                                                                    uu____3001)
                                                                      in
+                                                                    let uu____3011
+                                                                    =
                                                                     let uu____3025
                                                                     =
-                                                                    let uu____3039
-                                                                    =
-                                                                    let uu____3051
+                                                                    let uu____3037
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "x2"  in
-                                                                    let uu____3055
+                                                                    let uu____3041
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "2"  in
                                                                     ((Prims.of_int (310)),
-                                                                    uu____3051,
-                                                                    uu____3055)
+                                                                    uu____3037,
+                                                                    uu____3041)
                                                                      in
+                                                                    let uu____3051
+                                                                    =
                                                                     let uu____3065
                                                                     =
-                                                                    let uu____3079
-                                                                    =
-                                                                    let uu____3091
+                                                                    let uu____3077
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "7 + 3"
                                                                      in
-                                                                    let uu____3095
+                                                                    let uu____3081
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "10"  in
                                                                     ((Prims.of_int (401)),
-                                                                    uu____3091,
-                                                                    uu____3095)
+                                                                    uu____3077,
+                                                                    uu____3081)
                                                                      in
+                                                                    let uu____3091
+                                                                    =
                                                                     let uu____3105
                                                                     =
-                                                                    let uu____3119
-                                                                    =
-                                                                    let uu____3131
+                                                                    let uu____3117
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "true && false"
                                                                      in
-                                                                    let uu____3135
+                                                                    let uu____3121
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "false"
                                                                      in
                                                                     ((Prims.of_int (402)),
-                                                                    uu____3131,
-                                                                    uu____3135)
+                                                                    uu____3117,
+                                                                    uu____3121)
                                                                      in
+                                                                    let uu____3131
+                                                                    =
                                                                     let uu____3145
                                                                     =
-                                                                    let uu____3159
-                                                                    =
-                                                                    let uu____3171
+                                                                    let uu____3157
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "3 = 5"
                                                                      in
-                                                                    let uu____3175
+                                                                    let uu____3161
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "false"
                                                                      in
                                                                     ((Prims.of_int (403)),
-                                                                    uu____3171,
-                                                                    uu____3175)
+                                                                    uu____3157,
+                                                                    uu____3161)
                                                                      in
+                                                                    let uu____3171
+                                                                    =
                                                                     let uu____3185
                                                                     =
-                                                                    let uu____3199
-                                                                    =
-                                                                    let uu____3211
+                                                                    let uu____3197
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "\"abc\" ^ \"def\""
                                                                      in
-                                                                    let uu____3215
+                                                                    let uu____3201
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "\"abcdef\""
                                                                      in
                                                                     ((Prims.of_int (404)),
-                                                                    uu____3211,
-                                                                    uu____3215)
+                                                                    uu____3197,
+                                                                    uu____3201)
                                                                      in
+                                                                    let uu____3211
+                                                                    =
                                                                     let uu____3225
                                                                     =
-                                                                    let uu____3239
-                                                                    =
-                                                                    let uu____3251
+                                                                    let uu____3237
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "(fun (x:list int) -> match x with | [] -> 0 | hd::tl -> 1) []"
                                                                      in
-                                                                    let uu____3255
+                                                                    let uu____3241
                                                                     =
                                                                     FStar_Tests_Pars.tc_nbe
                                                                     "0"  in
                                                                     ((Prims.of_int (405)),
-                                                                    uu____3251,
-                                                                    uu____3255)
+                                                                    uu____3237,
+                                                                    uu____3241)
                                                                      in
-                                                                    [uu____3239]
+                                                                    [uu____3225]
                                                                      in
-                                                                    uu____3199
-                                                                    ::
-                                                                    uu____3225
-                                                                     in
-                                                                    uu____3159
-                                                                    ::
                                                                     uu____3185
-                                                                     in
-                                                                    uu____3119
                                                                     ::
+                                                                    uu____3211
+                                                                     in
                                                                     uu____3145
-                                                                     in
-                                                                    uu____3079
                                                                     ::
+                                                                    uu____3171
+                                                                     in
                                                                     uu____3105
-                                                                     in
-                                                                    uu____3039
                                                                     ::
+                                                                    uu____3131
+                                                                     in
                                                                     uu____3065
-                                                                     in
-                                                                    uu____2999
                                                                     ::
+                                                                    uu____3091
+                                                                     in
                                                                     uu____3025
-                                                                     in
-                                                                    uu____2959
                                                                     ::
+                                                                    uu____3051
+                                                                     in
                                                                     uu____2985
-                                                                     in
-                                                                    uu____2919
                                                                     ::
+                                                                    uu____3011
+                                                                     in
                                                                     uu____2945
-                                                                     in
-                                                                    uu____2879
                                                                     ::
+                                                                    uu____2971
+                                                                     in
                                                                     uu____2905
-                                                                     in
-                                                                    uu____2839
                                                                     ::
+                                                                    uu____2931
+                                                                     in
                                                                     uu____2865
-                                                                     in
-                                                                    uu____2799
                                                                     ::
+                                                                    uu____2891
+                                                                     in
                                                                     uu____2825
-                                                                     in
-                                                                    uu____2759
                                                                     ::
+                                                                    uu____2851
+                                                                     in
                                                                     uu____2785
-                                                                     in
-                                                                    uu____2719
                                                                     ::
+                                                                    uu____2811
+                                                                     in
                                                                     uu____2745
-                                                                     in
-                                                                    uu____2679
                                                                     ::
+                                                                    uu____2771
+                                                                     in
                                                                     uu____2705
-                                                                     in
-                                                                    uu____2639
                                                                     ::
+                                                                    uu____2731
+                                                                     in
                                                                     uu____2665
-                                                                     in
-                                                                    uu____2599
                                                                     ::
+                                                                    uu____2691
+                                                                     in
                                                                     uu____2625
-                                                                     in
-                                                                    uu____2559
                                                                     ::
+                                                                    uu____2651
+                                                                     in
                                                                     uu____2585
-                                                                     in
-                                                                    uu____2519
                                                                     ::
+                                                                    uu____2611
+                                                                     in
                                                                     uu____2545
-                                                                     in
-                                                                    uu____2479
                                                                     ::
+                                                                    uu____2571
+                                                                     in
                                                                     uu____2505
-                                                                     in
-                                                                    uu____2439
                                                                     ::
+                                                                    uu____2531
+                                                                     in
                                                                     uu____2465
-                                                                     in
-                                                                    uu____2399
                                                                     ::
+                                                                    uu____2491
+                                                                     in
                                                                     uu____2425
-                                                                     in
-                                                                    uu____2359
                                                                     ::
+                                                                    uu____2451
+                                                                     in
                                                                     uu____2385
-                                                                     in
-                                                                    uu____2319
                                                                     ::
+                                                                    uu____2411
+                                                                     in
                                                                     uu____2345
-                                                                     in
-                                                                   uu____2279
                                                                     ::
+                                                                    uu____2371
+                                                                     in
                                                                     uu____2305
-                                                                    in
-                                                                 uu____2239
-                                                                   ::
+                                                                    ::
+                                                                    uu____2331
+                                                                     in
                                                                    uu____2265
-                                                                  in
-                                                               uu____2199 ::
+                                                                    ::
+                                                                    uu____2291
+                                                                    in
                                                                  uu____2225
+                                                                   ::
+                                                                   uu____2251
+                                                                  in
+                                                               uu____2185 ::
+                                                                 uu____2211
                                                                 in
-                                                             uu____2159 ::
-                                                               uu____2185
+                                                             uu____2145 ::
+                                                               uu____2171
                                                               in
-                                                           uu____2119 ::
-                                                             uu____2145
+                                                           uu____2105 ::
+                                                             uu____2131
                                                             in
-                                                         uu____2079 ::
-                                                           uu____2105
+                                                         uu____2065 ::
+                                                           uu____2091
                                                           in
-                                                       uu____2039 ::
-                                                         uu____2065
+                                                       uu____2025 ::
+                                                         uu____2051
                                                         in
-                                                     uu____1999 :: uu____2025
+                                                     uu____1985 :: uu____2011
                                                       in
-                                                   uu____1959 :: uu____1985
+                                                   uu____1945 :: uu____1971
                                                     in
-                                                 uu____1919 :: uu____1945  in
-                                               uu____1879 :: uu____1905  in
-                                             uu____1839 :: uu____1865  in
-                                           uu____1799 :: uu____1825  in
-                                         uu____1757 :: uu____1785  in
-                                       uu____1715 :: uu____1743  in
-                                     uu____1648 :: uu____1701  in
-                                   uu____1581 :: uu____1634  in
-                                 uu____1514 :: uu____1567  in
-                               uu____1470 :: uu____1500  in
-                             uu____1429 :: uu____1456  in
-                           uu____1388 :: uu____1415  in
-                         uu____1349 :: uu____1374  in
-                       uu____1314 :: uu____1335  in
-                     uu____1279 :: uu____1300  in
-                   uu____1244 :: uu____1265  in
-                 uu____1209 :: uu____1230  in
-               uu____1174 :: uu____1195  in
-             uu____1122 :: uu____1160  in
-           uu____1058 :: uu____1108  in
-         uu____1009 :: uu____1044  in
-       uu____960 :: uu____995  in
-     uu____918 :: uu____946  in
-   uu____870 :: uu____904)
+                                                 uu____1905 :: uu____1931  in
+                                               uu____1865 :: uu____1891  in
+                                             uu____1825 :: uu____1851  in
+                                           uu____1785 :: uu____1811  in
+                                         uu____1743 :: uu____1771  in
+                                       uu____1701 :: uu____1729  in
+                                     uu____1634 :: uu____1687  in
+                                   uu____1567 :: uu____1620  in
+                                 uu____1500 :: uu____1553  in
+                               uu____1456 :: uu____1486  in
+                             uu____1415 :: uu____1442  in
+                           uu____1374 :: uu____1401  in
+                         uu____1335 :: uu____1360  in
+                       uu____1300 :: uu____1321  in
+                     uu____1265 :: uu____1286  in
+                   uu____1230 :: uu____1251  in
+                 uu____1195 :: uu____1216  in
+               uu____1160 :: uu____1181  in
+             uu____1108 :: uu____1146  in
+           uu____1044 :: uu____1094  in
+         uu____995 :: uu____1030  in
+       uu____946 :: uu____981  in
+     uu____904 :: uu____932  in
+   uu____856 :: uu____890)
   
 let run_either :
-  'uuuuuu3914 .
+  'uuuuuu3900 .
     Prims.int ->
-      'uuuuuu3914 ->
+      'uuuuuu3900 ->
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           (FStar_TypeChecker_Env.env ->
-             'uuuuuu3914 -> FStar_Syntax_Syntax.term)
+             'uuuuuu3900 -> FStar_Syntax_Syntax.term)
             -> unit
   =
   fun i  ->
     fun r  ->
       fun expected  ->
         fun normalizer  ->
-          (let uu____3952 = FStar_Util.string_of_int i  in
-           FStar_Util.print1 "%s: ... \n\n" uu____3952);
+          (let uu____3938 = FStar_Util.string_of_int i  in
+           FStar_Util.print1 "%s: ... \n\n" uu____3938);
           (let tcenv = FStar_Tests_Pars.init ()  in
-           (let uu____3957 = FStar_Main.process_args ()  in
-            FStar_All.pipe_right uu____3957 (fun uu____3972  -> ()));
+           (let uu____3943 = FStar_Main.process_args ()  in
+            FStar_All.pipe_right uu____3943 (fun uu____3958  -> ()));
            (let x = normalizer tcenv r  in
             FStar_Options.init ();
             FStar_Options.set_option "print_universes"
               (FStar_Options.Bool true);
             FStar_Options.set_option "print_implicits"
               (FStar_Options.Bool true);
-            (let uu____3981 =
-               let uu____3983 = FStar_Syntax_Util.unascribe x  in
-               FStar_Tests_Util.term_eq uu____3983 expected  in
-             FStar_Tests_Util.always i uu____3981)))
+            (let uu____3967 =
+               let uu____3969 = FStar_Syntax_Util.unascribe x  in
+               FStar_Tests_Util.term_eq uu____3969 expected  in
+             FStar_Tests_Util.always i uu____3967)))
   
 let (run_interpreter :
   Prims.int ->
@@ -1519,11 +1514,11 @@ let (run_interpreter_with_time :
   fun i  ->
     fun r  ->
       fun expected  ->
-        let interp uu____4062 = run_interpreter i r expected  in
-        let uu____4063 =
-          let uu____4064 = FStar_Util.return_execution_time interp  in
-          FStar_Pervasives_Native.snd uu____4064  in
-        (i, uu____4063)
+        let interp uu____4048 = run_interpreter i r expected  in
+        let uu____4049 =
+          let uu____4050 = FStar_Util.return_execution_time interp  in
+          FStar_Pervasives_Native.snd uu____4050  in
+        (i, uu____4049)
   
 let (run_nbe_with_time :
   Prims.int ->
@@ -1534,50 +1529,50 @@ let (run_nbe_with_time :
   fun i  ->
     fun r  ->
       fun expected  ->
-        let nbe uu____4102 = run_nbe i r expected  in
-        let uu____4103 =
-          let uu____4104 = FStar_Util.return_execution_time nbe  in
-          FStar_Pervasives_Native.snd uu____4104  in
-        (i, uu____4103)
+        let nbe uu____4088 = run_nbe i r expected  in
+        let uu____4089 =
+          let uu____4090 = FStar_Util.return_execution_time nbe  in
+          FStar_Pervasives_Native.snd uu____4090  in
+        (i, uu____4089)
   
 let run_tests :
-  'uuuuuu4115 .
+  'uuuuuu4101 .
     (Prims.int ->
        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'uuuuuu4115)
-      -> 'uuuuuu4115 Prims.list
+         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> 'uuuuuu4101)
+      -> 'uuuuuu4101 Prims.list
   =
   fun run  ->
     FStar_Options.__set_unit_tests ();
     (let l =
        FStar_List.map
-         (fun uu___0_4167  ->
-            match uu___0_4167 with | (no,test,res) -> run no test res) tests
+         (fun uu___0_4153  ->
+            match uu___0_4153 with | (no,test,res) -> run no test res) tests
         in
      FStar_Options.__clear_unit_tests (); l)
   
 let (run_all_nbe : unit -> unit) =
-  fun uu____4198  ->
+  fun uu____4184  ->
     FStar_Util.print_string "Testing NBE\n";
-    (let uu____4201 = run_tests run_nbe  in
+    (let uu____4187 = run_tests run_nbe  in
      FStar_Util.print_string "NBE ok\n")
   
 let (run_all_interpreter : unit -> unit) =
-  fun uu____4210  ->
+  fun uu____4196  ->
     FStar_Util.print_string "Testing the normalizer\n";
-    (let uu____4213 = run_tests run_interpreter  in
+    (let uu____4199 = run_tests run_interpreter  in
      FStar_Util.print_string "Normalizer ok\n")
   
 let (run_all_nbe_with_time :
   unit -> (Prims.int * FStar_BaseTypes.float) Prims.list) =
-  fun uu____4229  ->
+  fun uu____4215  ->
     FStar_Util.print_string "Testing NBE\n";
     (let l = run_tests run_nbe_with_time  in
      FStar_Util.print_string "NBE ok\n"; l)
   
 let (run_all_interpreter_with_time :
   unit -> (Prims.int * FStar_BaseTypes.float) Prims.list) =
-  fun uu____4259  ->
+  fun uu____4245  ->
     FStar_Util.print_string "Testing the normalizer\n";
     (let l = run_tests run_interpreter_with_time  in
      FStar_Util.print_string "Normalizer ok\n"; l)
@@ -1590,24 +1585,24 @@ let (run_both_with_time :
   fun i  ->
     fun r  ->
       fun expected  ->
-        let nbe uu____4304 = run_nbe i r expected  in
-        let norm uu____4310 = run_interpreter i r expected  in
+        let nbe uu____4290 = run_nbe i r expected  in
+        let norm uu____4296 = run_interpreter i r expected  in
         FStar_Util.measure_execution_time "nbe" nbe;
         FStar_Util.print_string "\n";
         FStar_Util.measure_execution_time "normalizer" norm;
         FStar_Util.print_string "\n"
   
 let (compare : unit -> unit) =
-  fun uu____4323  ->
+  fun uu____4309  ->
     FStar_Util.print_string "Comparing times for normalization and nbe\n";
-    (let uu____4326 =
-       let uu____4327 = encode (Prims.of_int (1000))  in
-       let uu____4329 =
-         let uu____4332 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-         let uu____4333 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
-         minus uu____4332 uu____4333  in
-       let_ FStar_Tests_Util.x uu____4327 uu____4329  in
-     run_both_with_time (Prims.of_int (14)) uu____4326 z)
+    (let uu____4312 =
+       let uu____4313 = encode (Prims.of_int (1000))  in
+       let uu____4315 =
+         let uu____4318 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
+         let uu____4319 = FStar_Tests_Util.nm FStar_Tests_Util.x  in
+         minus uu____4318 uu____4319  in
+       let_ FStar_Tests_Util.x uu____4313 uu____4315  in
+     run_both_with_time (Prims.of_int (14)) uu____4312 z)
   
 let (compare_times :
   (Prims.int * FStar_BaseTypes.float) Prims.list ->
@@ -1619,26 +1614,26 @@ let (compare_times :
       FStar_List.iter2
         (fun res1  ->
            fun res2  ->
-             let uu____4409 = res1  in
-             match uu____4409 with
+             let uu____4395 = res1  in
+             match uu____4395 with
              | (t1,time_int) ->
-                 let uu____4419 = res2  in
-                 (match uu____4419 with
+                 let uu____4405 = res2  in
+                 (match uu____4405 with
                   | (t2,time_nbe) ->
                       if t1 = t2
                       then
-                        let uu____4431 = FStar_Util.string_of_int t1  in
+                        let uu____4417 = FStar_Util.string_of_int t1  in
                         FStar_Util.print3 "Test %s\nNBE %s\nInterpreter %s\n"
-                          uu____4431 (FStar_Util.string_of_float time_nbe)
+                          uu____4417 (FStar_Util.string_of_float time_nbe)
                           (FStar_Util.string_of_float time_int)
                       else
                         FStar_Util.print_string
                           "Test numbers do not match...\n")) l_int l_nbe
   
 let (run_all : unit -> unit) =
-  fun uu____4442  ->
-    (let uu____4444 = FStar_Syntax_Print.term_to_string znat  in
-     FStar_Util.print1 "%s" uu____4444);
+  fun uu____4428  ->
+    (let uu____4430 = FStar_Syntax_Print.term_to_string znat  in
+     FStar_Util.print1 "%s" uu____4430);
     (let l_int = run_all_interpreter_with_time ()  in
      let l_nbe = run_all_nbe_with_time ()  in compare_times l_int l_nbe)
   

--- a/src/ocaml-output/FStar_Tests_Util.ml
+++ b/src/ocaml-output/FStar_Tests_Util.ml
@@ -33,10 +33,7 @@ let (m : FStar_Syntax_Syntax.bv) =
     FStar_Syntax_Syntax.tun
   
 let tm : 'uuuuuu44 . 'uuuuuu44 -> 'uuuuuu44 FStar_Syntax_Syntax.syntax =
-  fun t  ->
-    FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None
-      FStar_Range.dummyRange
-  
+  fun t  -> FStar_Syntax_Syntax.mk t FStar_Range.dummyRange 
 let (nm : FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term) =
   fun x1  -> FStar_Syntax_Syntax.bv_to_name x1 
 let (app :
@@ -47,13 +44,11 @@ let (app :
   fun x1  ->
     fun ts  ->
       let uu____79 =
-        let uu____86 =
-          let uu____87 =
-            let uu____104 = FStar_List.map FStar_Syntax_Syntax.as_arg ts  in
-            (x1, uu____104)  in
-          FStar_Syntax_Syntax.Tm_app uu____87  in
-        FStar_Syntax_Syntax.mk uu____86  in
-      uu____79 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____80 =
+          let uu____97 = FStar_List.map FStar_Syntax_Syntax.as_arg ts  in
+          (x1, uu____97)  in
+        FStar_Syntax_Syntax.Tm_app uu____80  in
+      FStar_Syntax_Syntax.mk uu____79 FStar_Range.dummyRange
   
 let rec (term_eq' :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -66,29 +61,29 @@ let rec (term_eq' :
       let binders_eq xs ys =
         ((FStar_List.length xs) = (FStar_List.length ys)) &&
           (FStar_List.forall2
-             (fun uu____183  ->
-                fun uu____184  ->
-                  match (uu____183, uu____184) with
-                  | ((x1,uu____199),(y1,uu____201)) ->
+             (fun uu____176  ->
+                fun uu____177  ->
+                  match (uu____176, uu____177) with
+                  | ((x1,uu____192),(y1,uu____194)) ->
                       term_eq' x1.FStar_Syntax_Syntax.sort
                         y1.FStar_Syntax_Syntax.sort) xs ys)
          in
       let args_eq xs ys =
         ((FStar_List.length xs) = (FStar_List.length ys)) &&
           (FStar_List.forall2
-             (fun uu____312  ->
-                fun uu____313  ->
-                  match (uu____312, uu____313) with
+             (fun uu____305  ->
+                fun uu____306  ->
+                  match (uu____305, uu____306) with
                   | ((a,imp),(b,imp')) ->
                       (term_eq' a b) &&
-                        (let uu____384 = FStar_Syntax_Util.eq_aqual imp imp'
+                        (let uu____377 = FStar_Syntax_Util.eq_aqual imp imp'
                             in
-                         uu____384 = FStar_Syntax_Util.Equal)) xs ys)
+                         uu____377 = FStar_Syntax_Util.Equal)) xs ys)
          in
       let comp_eq c d =
         match ((c.FStar_Syntax_Syntax.n), (d.FStar_Syntax_Syntax.n)) with
-        | (FStar_Syntax_Syntax.Total (t,uu____399),FStar_Syntax_Syntax.Total
-           (s,uu____401)) -> term_eq' t s
+        | (FStar_Syntax_Syntax.Total (t,uu____392),FStar_Syntax_Syntax.Total
+           (s,uu____394)) -> term_eq' t s
         | (FStar_Syntax_Syntax.Comp ct1,FStar_Syntax_Syntax.Comp ct2) ->
             ((FStar_Ident.lid_equals ct1.FStar_Syntax_Syntax.effect_name
                 ct2.FStar_Syntax_Syntax.effect_name)
@@ -98,24 +93,24 @@ let rec (term_eq' :
               &&
               (args_eq ct1.FStar_Syntax_Syntax.effect_args
                  ct2.FStar_Syntax_Syntax.effect_args)
-        | uu____420 -> false  in
+        | uu____413 -> false  in
       match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
-      | (FStar_Syntax_Syntax.Tm_lazy l,uu____428) ->
-          let uu____429 =
-            let uu____432 =
-              let uu____441 =
+      | (FStar_Syntax_Syntax.Tm_lazy l,uu____421) ->
+          let uu____422 =
+            let uu____425 =
+              let uu____434 =
                 FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
-              FStar_Util.must uu____441  in
-            uu____432 l.FStar_Syntax_Syntax.lkind l  in
-          term_eq' uu____429 t21
-      | (uu____491,FStar_Syntax_Syntax.Tm_lazy l) ->
-          let uu____493 =
-            let uu____496 =
-              let uu____505 =
+              FStar_Util.must uu____434  in
+            uu____425 l.FStar_Syntax_Syntax.lkind l  in
+          term_eq' uu____422 t21
+      | (uu____484,FStar_Syntax_Syntax.Tm_lazy l) ->
+          let uu____486 =
+            let uu____489 =
+              let uu____498 =
                 FStar_ST.op_Bang FStar_Syntax_Syntax.lazy_chooser  in
-              FStar_Util.must uu____505  in
-            uu____496 l.FStar_Syntax_Syntax.lkind l  in
-          term_eq' t11 uu____493
+              FStar_Util.must uu____498  in
+            uu____489 l.FStar_Syntax_Syntax.lkind l  in
+          term_eq' t11 uu____486
       | (FStar_Syntax_Syntax.Tm_bvar x1,FStar_Syntax_Syntax.Tm_bvar y1) ->
           x1.FStar_Syntax_Syntax.index = y1.FStar_Syntax_Syntax.index
       | (FStar_Syntax_Syntax.Tm_name x1,FStar_Syntax_Syntax.Tm_name y1) ->
@@ -123,60 +118,54 @@ let rec (term_eq' :
       | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
           FStar_Syntax_Syntax.fv_eq f g
       | (FStar_Syntax_Syntax.Tm_uinst
-         (t,uu____563),FStar_Syntax_Syntax.Tm_uinst (s,uu____565)) ->
+         (t,uu____556),FStar_Syntax_Syntax.Tm_uinst (s,uu____558)) ->
           term_eq' t s
       | (FStar_Syntax_Syntax.Tm_constant c1,FStar_Syntax_Syntax.Tm_constant
          c2) -> FStar_Const.eq_const c1 c2
       | (FStar_Syntax_Syntax.Tm_type u,FStar_Syntax_Syntax.Tm_type v) ->
           u = v
       | (FStar_Syntax_Syntax.Tm_abs
-         (xs,t,uu____580),FStar_Syntax_Syntax.Tm_abs (ys,u,uu____583)) when
+         (xs,t,uu____573),FStar_Syntax_Syntax.Tm_abs (ys,u,uu____576)) when
           (FStar_List.length xs) = (FStar_List.length ys) ->
           (binders_eq xs ys) && (term_eq' t u)
       | (FStar_Syntax_Syntax.Tm_abs
-         (xs,t,uu____646),FStar_Syntax_Syntax.Tm_abs (ys,u,uu____649)) ->
+         (xs,t,uu____639),FStar_Syntax_Syntax.Tm_abs (ys,u,uu____642)) ->
           if (FStar_List.length xs) > (FStar_List.length ys)
           then
-            let uu____712 = FStar_Util.first_N (FStar_List.length ys) xs  in
-            (match uu____712 with
+            let uu____705 = FStar_Util.first_N (FStar_List.length ys) xs  in
+            (match uu____705 with
              | (xs1,xs') ->
                  let t12 =
-                   let uu____783 =
-                     let uu____790 =
-                       let uu____791 =
-                         let uu____810 =
-                           FStar_Syntax_Syntax.mk
-                             (FStar_Syntax_Syntax.Tm_abs
-                                (xs', t, FStar_Pervasives_Native.None))
-                             FStar_Pervasives_Native.None
-                             t11.FStar_Syntax_Syntax.pos
-                            in
-                         (xs1, uu____810, FStar_Pervasives_Native.None)  in
-                       FStar_Syntax_Syntax.Tm_abs uu____791  in
-                     FStar_Syntax_Syntax.mk uu____790  in
-                   uu____783 FStar_Pervasives_Native.None
+                   let uu____776 =
+                     let uu____777 =
+                       let uu____796 =
+                         FStar_Syntax_Syntax.mk
+                           (FStar_Syntax_Syntax.Tm_abs
+                              (xs', t, FStar_Pervasives_Native.None))
+                           t11.FStar_Syntax_Syntax.pos
+                          in
+                       (xs1, uu____796, FStar_Pervasives_Native.None)  in
+                     FStar_Syntax_Syntax.Tm_abs uu____777  in
+                   FStar_Syntax_Syntax.mk uu____776
                      t11.FStar_Syntax_Syntax.pos
                     in
                  term_eq' t12 t21)
           else
-            (let uu____839 = FStar_Util.first_N (FStar_List.length xs) ys  in
-             match uu____839 with
+            (let uu____825 = FStar_Util.first_N (FStar_List.length xs) ys  in
+             match uu____825 with
              | (ys1,ys') ->
                  let t22 =
-                   let uu____910 =
-                     let uu____917 =
-                       let uu____918 =
-                         let uu____937 =
-                           FStar_Syntax_Syntax.mk
-                             (FStar_Syntax_Syntax.Tm_abs
-                                (ys', u, FStar_Pervasives_Native.None))
-                             FStar_Pervasives_Native.None
-                             t21.FStar_Syntax_Syntax.pos
-                            in
-                         (ys1, uu____937, FStar_Pervasives_Native.None)  in
-                       FStar_Syntax_Syntax.Tm_abs uu____918  in
-                     FStar_Syntax_Syntax.mk uu____917  in
-                   uu____910 FStar_Pervasives_Native.None
+                   let uu____896 =
+                     let uu____897 =
+                       let uu____916 =
+                         FStar_Syntax_Syntax.mk
+                           (FStar_Syntax_Syntax.Tm_abs
+                              (ys', u, FStar_Pervasives_Native.None))
+                           t21.FStar_Syntax_Syntax.pos
+                          in
+                       (ys1, uu____916, FStar_Pervasives_Native.None)  in
+                     FStar_Syntax_Syntax.Tm_abs uu____897  in
+                   FStar_Syntax_Syntax.mk uu____896
                      t21.FStar_Syntax_Syntax.pos
                     in
                  term_eq' t11 t22)
@@ -188,15 +177,15 @@ let rec (term_eq' :
             && (term_eq' t u)
       | (FStar_Syntax_Syntax.Tm_app
          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv_eq_1;
-            FStar_Syntax_Syntax.pos = uu____1021;
-            FStar_Syntax_Syntax.vars = uu____1022;_},(uu____1023,FStar_Pervasives_Native.Some
+            FStar_Syntax_Syntax.pos = uu____1000;
+            FStar_Syntax_Syntax.vars = uu____1001;_},(uu____1002,FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
-                                                      uu____1024))::t12::t22::[]),FStar_Syntax_Syntax.Tm_app
+                                                      uu____1003))::t12::t22::[]),FStar_Syntax_Syntax.Tm_app
          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv_eq_2;
-            FStar_Syntax_Syntax.pos = uu____1028;
-            FStar_Syntax_Syntax.vars = uu____1029;_},(uu____1030,FStar_Pervasives_Native.Some
+            FStar_Syntax_Syntax.pos = uu____1007;
+            FStar_Syntax_Syntax.vars = uu____1008;_},(uu____1009,FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
-                                                      uu____1031))::s1::s2::[]))
+                                                      uu____1010))::s1::s2::[]))
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv_eq_1 FStar_Parser_Const.eq2_lid)
             &&
@@ -208,15 +197,15 @@ let rec (term_eq' :
          (t',pats')) ->
           (((FStar_List.length pats) = (FStar_List.length pats')) &&
              (FStar_List.forall2
-                (fun uu____1412  ->
-                   fun uu____1413  ->
-                     match (uu____1412, uu____1413) with
-                     | ((uu____1471,uu____1472,e),(uu____1474,uu____1475,e'))
+                (fun uu____1391  ->
+                   fun uu____1392  ->
+                     match (uu____1391, uu____1392) with
+                     | ((uu____1450,uu____1451,e),(uu____1453,uu____1454,e'))
                          -> term_eq' e e') pats pats'))
             && (term_eq' t t')
       | (FStar_Syntax_Syntax.Tm_ascribed
-         (t12,(FStar_Util.Inl t22,uu____1539),uu____1540),FStar_Syntax_Syntax.Tm_ascribed
-         (s1,(FStar_Util.Inl s2,uu____1543),uu____1544)) ->
+         (t12,(FStar_Util.Inl t22,uu____1518),uu____1519),FStar_Syntax_Syntax.Tm_ascribed
+         (s1,(FStar_Util.Inl s2,uu____1522),uu____1523)) ->
           (term_eq' t12 s1) && (term_eq' t22 s2)
       | (FStar_Syntax_Syntax.Tm_let
          ((is_rec,lbs),t),FStar_Syntax_Syntax.Tm_let ((is_rec',lbs'),s)) when
@@ -232,30 +221,30 @@ let rec (term_eq' :
                           lb2.FStar_Syntax_Syntax.lbdef)) lbs lbs'))
             && (term_eq' t s)
       | (FStar_Syntax_Syntax.Tm_uvar
-         (u,uu____1683),FStar_Syntax_Syntax.Tm_uvar (u',uu____1685)) ->
+         (u,uu____1662),FStar_Syntax_Syntax.Tm_uvar (u',uu____1664)) ->
           FStar_Syntax_Unionfind.equiv u.FStar_Syntax_Syntax.ctx_uvar_head
             u'.FStar_Syntax_Syntax.ctx_uvar_head
-      | (FStar_Syntax_Syntax.Tm_meta (t12,uu____1719),uu____1720) ->
+      | (FStar_Syntax_Syntax.Tm_meta (t12,uu____1698),uu____1699) ->
           term_eq' t12 t21
-      | (uu____1725,FStar_Syntax_Syntax.Tm_meta (t22,uu____1727)) ->
+      | (uu____1704,FStar_Syntax_Syntax.Tm_meta (t22,uu____1706)) ->
           term_eq' t11 t22
-      | (FStar_Syntax_Syntax.Tm_delayed uu____1732,uu____1733) ->
-          let uu____1748 =
-            let uu____1750 = FStar_Syntax_Print.tag_of_term t11  in
-            let uu____1752 = FStar_Syntax_Print.tag_of_term t21  in
-            FStar_Util.format2 "Impossible: %s and %s" uu____1750 uu____1752
+      | (FStar_Syntax_Syntax.Tm_delayed uu____1711,uu____1712) ->
+          let uu____1727 =
+            let uu____1729 = FStar_Syntax_Print.tag_of_term t11  in
+            let uu____1731 = FStar_Syntax_Print.tag_of_term t21  in
+            FStar_Util.format2 "Impossible: %s and %s" uu____1729 uu____1731
              in
-          failwith uu____1748
-      | (uu____1756,FStar_Syntax_Syntax.Tm_delayed uu____1757) ->
-          let uu____1772 =
-            let uu____1774 = FStar_Syntax_Print.tag_of_term t11  in
-            let uu____1776 = FStar_Syntax_Print.tag_of_term t21  in
-            FStar_Util.format2 "Impossible: %s and %s" uu____1774 uu____1776
+          failwith uu____1727
+      | (uu____1735,FStar_Syntax_Syntax.Tm_delayed uu____1736) ->
+          let uu____1751 =
+            let uu____1753 = FStar_Syntax_Print.tag_of_term t11  in
+            let uu____1755 = FStar_Syntax_Print.tag_of_term t21  in
+            FStar_Util.format2 "Impossible: %s and %s" uu____1753 uu____1755
              in
-          failwith uu____1772
+          failwith uu____1751
       | (FStar_Syntax_Syntax.Tm_unknown ,FStar_Syntax_Syntax.Tm_unknown ) ->
           true
-      | uu____1781 -> false
+      | uu____1760 -> false
   
 let (term_eq :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -266,10 +255,10 @@ let (term_eq :
       let b = term_eq' t1 t2  in
       if Prims.op_Negation b
       then
-        (let uu____1811 = FStar_Syntax_Print.term_to_string t1  in
-         let uu____1813 = FStar_Syntax_Print.term_to_string t2  in
+        (let uu____1790 = FStar_Syntax_Print.term_to_string t1  in
+         let uu____1792 = FStar_Syntax_Print.term_to_string t2  in
          FStar_Util.print2 ">>>>>>>>>>>Term %s is not equal to %s\n"
-           uu____1811 uu____1813)
+           uu____1790 uu____1792)
       else ();
       b
   

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -51,7 +51,6 @@ let (desugar_disjunctive_pattern :
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_let
                                       ((false, [lb]), branch1))
-                                   FStar_Pervasives_Native.None
                                    br.FStar_Syntax_Syntax.pos) branch annots
                        in
                     FStar_Syntax_Util.branch (pat, when_opt, branch1)))
@@ -857,8 +856,7 @@ let (mk_ref_read :
           [uu____2391]  in
         (uu____2376, uu____2380)  in
       FStar_Syntax_Syntax.Tm_app uu____2359  in
-    FStar_Syntax_Syntax.mk tm' FStar_Pervasives_Native.None
-      tm.FStar_Syntax_Syntax.pos
+    FStar_Syntax_Syntax.mk tm' tm.FStar_Syntax_Syntax.pos
   
 let (mk_ref_alloc :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -880,8 +878,7 @@ let (mk_ref_alloc :
           [uu____2481]  in
         (uu____2466, uu____2470)  in
       FStar_Syntax_Syntax.Tm_app uu____2449  in
-    FStar_Syntax_Syntax.mk tm' FStar_Pervasives_Native.None
-      tm.FStar_Syntax_Syntax.pos
+    FStar_Syntax_Syntax.mk tm' tm.FStar_Syntax_Syntax.pos
   
 let (mk_ref_assign :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -913,7 +910,7 @@ let (mk_ref_assign :
               uu____2585 :: uu____2602  in
             (uu____2570, uu____2574)  in
           FStar_Syntax_Syntax.Tm_app uu____2553  in
-        FStar_Syntax_Syntax.mk tm FStar_Pervasives_Native.None pos
+        FStar_Syntax_Syntax.mk tm pos
   
 let rec (generalize_annotated_univs :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt) =
@@ -2251,22 +2248,19 @@ and (desugar_machine_integer :
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_constant
                        (FStar_Const.Const_int
-                          (repr, FStar_Pervasives_Native.None)))
-                    FStar_Pervasives_Native.None range
+                          (repr, FStar_Pervasives_Native.None))) range
                    in
                 let uu____7667 =
-                  let uu____7674 =
-                    let uu____7675 =
-                      let uu____7692 =
-                        let uu____7703 =
-                          let uu____7712 =
-                            FStar_Syntax_Syntax.as_implicit false  in
-                          (repr1, uu____7712)  in
-                        [uu____7703]  in
-                      (lid1, uu____7692)  in
-                    FStar_Syntax_Syntax.Tm_app uu____7675  in
-                  FStar_Syntax_Syntax.mk uu____7674  in
-                uu____7667 FStar_Pervasives_Native.None range))
+                  let uu____7668 =
+                    let uu____7685 =
+                      let uu____7696 =
+                        let uu____7705 =
+                          FStar_Syntax_Syntax.as_implicit false  in
+                        (repr1, uu____7705)  in
+                      [uu____7696]  in
+                    (lid1, uu____7685)  in
+                  FStar_Syntax_Syntax.Tm_app uu____7668  in
+                FStar_Syntax_Syntax.mk uu____7667 range))
 
 and (desugar_term_maybe_top :
   Prims.bool ->
@@ -2277,283 +2271,293 @@ and (desugar_term_maybe_top :
   fun top_level  ->
     fun env  ->
       fun top  ->
-        let mk e =
-          FStar_Syntax_Syntax.mk e FStar_Pervasives_Native.None
-            top.FStar_Parser_AST.range
-           in
+        let mk e = FStar_Syntax_Syntax.mk e top.FStar_Parser_AST.range  in
         let noaqs = []  in
         let join_aqs aqs = FStar_List.flatten aqs  in
         let setpos e =
-          let uu___1269_7831 = e  in
+          let uu___1269_7824 = e  in
           {
-            FStar_Syntax_Syntax.n = (uu___1269_7831.FStar_Syntax_Syntax.n);
+            FStar_Syntax_Syntax.n = (uu___1269_7824.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = (top.FStar_Parser_AST.range);
             FStar_Syntax_Syntax.vars =
-              (uu___1269_7831.FStar_Syntax_Syntax.vars)
+              (uu___1269_7824.FStar_Syntax_Syntax.vars)
           }  in
-        let uu____7834 =
-          let uu____7835 = unparen top  in uu____7835.FStar_Parser_AST.tm  in
-        match uu____7834 with
+        let uu____7827 =
+          let uu____7828 = unparen top  in uu____7828.FStar_Parser_AST.tm  in
+        match uu____7827 with
         | FStar_Parser_AST.Wild  -> ((setpos FStar_Syntax_Syntax.tun), noaqs)
-        | FStar_Parser_AST.Labeled uu____7840 ->
-            let uu____7849 = desugar_formula env top  in (uu____7849, noaqs)
+        | FStar_Parser_AST.Labeled uu____7833 ->
+            let uu____7842 = desugar_formula env top  in (uu____7842, noaqs)
         | FStar_Parser_AST.Requires (t,lopt) ->
-            let uu____7858 = desugar_formula env t  in (uu____7858, noaqs)
+            let uu____7851 = desugar_formula env t  in (uu____7851, noaqs)
         | FStar_Parser_AST.Ensures (t,lopt) ->
-            let uu____7867 = desugar_formula env t  in (uu____7867, noaqs)
+            let uu____7860 = desugar_formula env t  in (uu____7860, noaqs)
         | FStar_Parser_AST.Attributes ts ->
             failwith
               "Attributes should not be desugared by desugar_term_maybe_top"
         | FStar_Parser_AST.Const (FStar_Const.Const_int
             (i,FStar_Pervasives_Native.Some size)) ->
-            let uu____7894 =
+            let uu____7887 =
               desugar_machine_integer env i size top.FStar_Parser_AST.range
                in
-            (uu____7894, noaqs)
+            (uu____7887, noaqs)
         | FStar_Parser_AST.Const c ->
-            let uu____7896 = mk (FStar_Syntax_Syntax.Tm_constant c)  in
-            (uu____7896, noaqs)
+            let uu____7889 = mk (FStar_Syntax_Syntax.Tm_constant c)  in
+            (uu____7889, noaqs)
         | FStar_Parser_AST.Op (id,args) when
-            let uu____7903 = FStar_Ident.text_of_id id  in uu____7903 = "=!="
+            let uu____7896 = FStar_Ident.text_of_id id  in uu____7896 = "=!="
             ->
             let r = FStar_Ident.range_of_id id  in
             let e =
-              let uu____7909 =
-                let uu____7910 =
-                  let uu____7917 = FStar_Ident.mk_ident ("==", r)  in
-                  (uu____7917, args)  in
-                FStar_Parser_AST.Op uu____7910  in
-              FStar_Parser_AST.mk_term uu____7909 top.FStar_Parser_AST.range
+              let uu____7902 =
+                let uu____7903 =
+                  let uu____7910 = FStar_Ident.mk_ident ("==", r)  in
+                  (uu____7910, args)  in
+                FStar_Parser_AST.Op uu____7903  in
+              FStar_Parser_AST.mk_term uu____7902 top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level
                in
-            let uu____7922 =
-              let uu____7923 =
-                let uu____7924 =
-                  let uu____7931 = FStar_Ident.mk_ident ("~", r)  in
-                  (uu____7931, [e])  in
-                FStar_Parser_AST.Op uu____7924  in
-              FStar_Parser_AST.mk_term uu____7923 top.FStar_Parser_AST.range
+            let uu____7915 =
+              let uu____7916 =
+                let uu____7917 =
+                  let uu____7924 = FStar_Ident.mk_ident ("~", r)  in
+                  (uu____7924, [e])  in
+                FStar_Parser_AST.Op uu____7917  in
+              FStar_Parser_AST.mk_term uu____7916 top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level
                in
-            desugar_term_aq env uu____7922
+            desugar_term_aq env uu____7915
         | FStar_Parser_AST.Op (op_star,lhs::rhs::[]) when
-            (let uu____7943 = FStar_Ident.text_of_id op_star  in
-             uu____7943 = "*") &&
-              (let uu____7948 = op_as_term env (Prims.of_int (2)) op_star  in
-               FStar_All.pipe_right uu____7948 FStar_Option.isNone)
+            (let uu____7936 = FStar_Ident.text_of_id op_star  in
+             uu____7936 = "*") &&
+              (let uu____7941 = op_as_term env (Prims.of_int (2)) op_star  in
+               FStar_All.pipe_right uu____7941 FStar_Option.isNone)
             ->
             let rec flatten t =
               match t.FStar_Parser_AST.tm with
               | FStar_Parser_AST.Op (id,t1::t2::[]) when
-                  (let uu____7972 = FStar_Ident.text_of_id id  in
-                   uu____7972 = "*") &&
-                    (let uu____7977 =
+                  (let uu____7965 = FStar_Ident.text_of_id id  in
+                   uu____7965 = "*") &&
+                    (let uu____7970 =
                        op_as_term env (Prims.of_int (2)) op_star  in
-                     FStar_All.pipe_right uu____7977 FStar_Option.isNone)
+                     FStar_All.pipe_right uu____7970 FStar_Option.isNone)
                   ->
-                  let uu____7984 = flatten t1  in
-                  FStar_List.append uu____7984 [t2]
-              | uu____7987 -> [t]  in
+                  let uu____7977 = flatten t1  in
+                  FStar_List.append uu____7977 [t2]
+              | uu____7980 -> [t]  in
             let terms = flatten lhs  in
             let t =
-              let uu___1314_7992 = top  in
-              let uu____7993 =
-                let uu____7994 =
-                  let uu____8005 =
+              let uu___1314_7985 = top  in
+              let uu____7986 =
+                let uu____7987 =
+                  let uu____7998 =
                     FStar_List.map
-                      (fun uu____8016  -> FStar_Util.Inr uu____8016) terms
+                      (fun uu____8009  -> FStar_Util.Inr uu____8009) terms
                      in
-                  (uu____8005, rhs)  in
-                FStar_Parser_AST.Sum uu____7994  in
+                  (uu____7998, rhs)  in
+                FStar_Parser_AST.Sum uu____7987  in
               {
-                FStar_Parser_AST.tm = uu____7993;
+                FStar_Parser_AST.tm = uu____7986;
                 FStar_Parser_AST.range =
-                  (uu___1314_7992.FStar_Parser_AST.range);
+                  (uu___1314_7985.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
-                  (uu___1314_7992.FStar_Parser_AST.level)
+                  (uu___1314_7985.FStar_Parser_AST.level)
               }  in
             desugar_term_maybe_top top_level env t
         | FStar_Parser_AST.Tvar a ->
-            let uu____8024 =
-              let uu____8025 =
+            let uu____8017 =
+              let uu____8018 =
                 FStar_Syntax_DsEnv.fail_or2
                   (FStar_Syntax_DsEnv.try_lookup_id env) a
                  in
-              FStar_All.pipe_left setpos uu____8025  in
-            (uu____8024, noaqs)
+              FStar_All.pipe_left setpos uu____8018  in
+            (uu____8017, noaqs)
         | FStar_Parser_AST.Uvar u ->
-            let uu____8031 =
-              let uu____8037 =
-                let uu____8039 =
-                  let uu____8041 = FStar_Ident.text_of_id u  in
-                  Prims.op_Hat uu____8041 " in non-universe context"  in
-                Prims.op_Hat "Unexpected universe variable " uu____8039  in
-              (FStar_Errors.Fatal_UnexpectedUniverseVariable, uu____8037)  in
-            FStar_Errors.raise_error uu____8031 top.FStar_Parser_AST.range
+            let uu____8024 =
+              let uu____8030 =
+                let uu____8032 =
+                  let uu____8034 = FStar_Ident.text_of_id u  in
+                  Prims.op_Hat uu____8034 " in non-universe context"  in
+                Prims.op_Hat "Unexpected universe variable " uu____8032  in
+              (FStar_Errors.Fatal_UnexpectedUniverseVariable, uu____8030)  in
+            FStar_Errors.raise_error uu____8024 top.FStar_Parser_AST.range
         | FStar_Parser_AST.Op (s,args) ->
-            let uu____8056 = op_as_term env (FStar_List.length args) s  in
-            (match uu____8056 with
+            let uu____8049 = op_as_term env (FStar_List.length args) s  in
+            (match uu____8049 with
              | FStar_Pervasives_Native.None  ->
-                 let uu____8063 =
-                   let uu____8069 =
-                     let uu____8071 = FStar_Ident.text_of_id s  in
+                 let uu____8056 =
+                   let uu____8062 =
+                     let uu____8064 = FStar_Ident.text_of_id s  in
                      Prims.op_Hat "Unexpected or unbound operator: "
-                       uu____8071
+                       uu____8064
                       in
                    (FStar_Errors.Fatal_UnepxectedOrUnboundOperator,
-                     uu____8069)
+                     uu____8062)
                     in
-                 FStar_Errors.raise_error uu____8063
+                 FStar_Errors.raise_error uu____8056
                    top.FStar_Parser_AST.range
              | FStar_Pervasives_Native.Some op ->
                  if (FStar_List.length args) > Prims.int_zero
                  then
-                   let uu____8086 =
-                     let uu____8111 =
+                   let uu____8079 =
+                     let uu____8104 =
                        FStar_All.pipe_right args
                          (FStar_List.map
                             (fun t  ->
-                               let uu____8173 = desugar_term_aq env t  in
-                               match uu____8173 with
+                               let uu____8166 = desugar_term_aq env t  in
+                               match uu____8166 with
                                | (t',s1) ->
                                    ((t', FStar_Pervasives_Native.None), s1)))
                         in
-                     FStar_All.pipe_right uu____8111 FStar_List.unzip  in
-                   (match uu____8086 with
+                     FStar_All.pipe_right uu____8104 FStar_List.unzip  in
+                   (match uu____8079 with
                     | (args1,aqs) ->
-                        let uu____8306 =
+                        let uu____8299 =
                           mk (FStar_Syntax_Syntax.Tm_app (op, args1))  in
-                        (uu____8306, (join_aqs aqs)))
+                        (uu____8299, (join_aqs aqs)))
                  else (op, noaqs))
-        | FStar_Parser_AST.Construct (n,(a,uu____8323)::[]) when
-            let uu____8338 = FStar_Ident.string_of_lid n  in
-            uu____8338 = "SMTPat" ->
-            let uu____8342 =
-              let uu___1343_8343 = top  in
-              let uu____8344 =
-                let uu____8345 =
-                  let uu____8352 =
-                    let uu___1345_8353 = top  in
-                    let uu____8354 =
-                      let uu____8355 = smt_pat_lid top.FStar_Parser_AST.range
+        | FStar_Parser_AST.Construct (n,(a,uu____8316)::[]) when
+            let uu____8331 = FStar_Ident.string_of_lid n  in
+            uu____8331 = "SMTPat" ->
+            let uu____8335 =
+              let uu___1343_8336 = top  in
+              let uu____8337 =
+                let uu____8338 =
+                  let uu____8345 =
+                    let uu___1345_8346 = top  in
+                    let uu____8347 =
+                      let uu____8348 = smt_pat_lid top.FStar_Parser_AST.range
                          in
-                      FStar_Parser_AST.Var uu____8355  in
+                      FStar_Parser_AST.Var uu____8348  in
                     {
-                      FStar_Parser_AST.tm = uu____8354;
+                      FStar_Parser_AST.tm = uu____8347;
                       FStar_Parser_AST.range =
-                        (uu___1345_8353.FStar_Parser_AST.range);
+                        (uu___1345_8346.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
-                        (uu___1345_8353.FStar_Parser_AST.level)
+                        (uu___1345_8346.FStar_Parser_AST.level)
                     }  in
-                  (uu____8352, a, FStar_Parser_AST.Nothing)  in
-                FStar_Parser_AST.App uu____8345  in
+                  (uu____8345, a, FStar_Parser_AST.Nothing)  in
+                FStar_Parser_AST.App uu____8338  in
               {
-                FStar_Parser_AST.tm = uu____8344;
+                FStar_Parser_AST.tm = uu____8337;
                 FStar_Parser_AST.range =
-                  (uu___1343_8343.FStar_Parser_AST.range);
+                  (uu___1343_8336.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
-                  (uu___1343_8343.FStar_Parser_AST.level)
+                  (uu___1343_8336.FStar_Parser_AST.level)
               }  in
-            desugar_term_maybe_top top_level env uu____8342
-        | FStar_Parser_AST.Construct (n,(a,uu____8358)::[]) when
-            let uu____8373 = FStar_Ident.string_of_lid n  in
-            uu____8373 = "SMTPatT" ->
+            desugar_term_maybe_top top_level env uu____8335
+        | FStar_Parser_AST.Construct (n,(a,uu____8351)::[]) when
+            let uu____8366 = FStar_Ident.string_of_lid n  in
+            uu____8366 = "SMTPatT" ->
             (FStar_Errors.log_issue top.FStar_Parser_AST.range
                (FStar_Errors.Warning_SMTPatTDeprecated,
                  "SMTPatT is deprecated; please just use SMTPat");
-             (let uu____8380 =
-                let uu___1355_8381 = top  in
-                let uu____8382 =
-                  let uu____8383 =
-                    let uu____8390 =
-                      let uu___1357_8391 = top  in
-                      let uu____8392 =
-                        let uu____8393 =
+             (let uu____8373 =
+                let uu___1355_8374 = top  in
+                let uu____8375 =
+                  let uu____8376 =
+                    let uu____8383 =
+                      let uu___1357_8384 = top  in
+                      let uu____8385 =
+                        let uu____8386 =
                           smt_pat_lid top.FStar_Parser_AST.range  in
-                        FStar_Parser_AST.Var uu____8393  in
+                        FStar_Parser_AST.Var uu____8386  in
                       {
-                        FStar_Parser_AST.tm = uu____8392;
+                        FStar_Parser_AST.tm = uu____8385;
                         FStar_Parser_AST.range =
-                          (uu___1357_8391.FStar_Parser_AST.range);
+                          (uu___1357_8384.FStar_Parser_AST.range);
                         FStar_Parser_AST.level =
-                          (uu___1357_8391.FStar_Parser_AST.level)
+                          (uu___1357_8384.FStar_Parser_AST.level)
                       }  in
-                    (uu____8390, a, FStar_Parser_AST.Nothing)  in
-                  FStar_Parser_AST.App uu____8383  in
+                    (uu____8383, a, FStar_Parser_AST.Nothing)  in
+                  FStar_Parser_AST.App uu____8376  in
                 {
-                  FStar_Parser_AST.tm = uu____8382;
+                  FStar_Parser_AST.tm = uu____8375;
                   FStar_Parser_AST.range =
-                    (uu___1355_8381.FStar_Parser_AST.range);
+                    (uu___1355_8374.FStar_Parser_AST.range);
                   FStar_Parser_AST.level =
-                    (uu___1355_8381.FStar_Parser_AST.level)
+                    (uu___1355_8374.FStar_Parser_AST.level)
                 }  in
-              desugar_term_maybe_top top_level env uu____8380))
-        | FStar_Parser_AST.Construct (n,(a,uu____8396)::[]) when
-            let uu____8411 = FStar_Ident.string_of_lid n  in
-            uu____8411 = "SMTPatOr" ->
-            let uu____8415 =
-              let uu___1366_8416 = top  in
-              let uu____8417 =
-                let uu____8418 =
-                  let uu____8425 =
-                    let uu___1368_8426 = top  in
-                    let uu____8427 =
-                      let uu____8428 =
+              desugar_term_maybe_top top_level env uu____8373))
+        | FStar_Parser_AST.Construct (n,(a,uu____8389)::[]) when
+            let uu____8404 = FStar_Ident.string_of_lid n  in
+            uu____8404 = "SMTPatOr" ->
+            let uu____8408 =
+              let uu___1366_8409 = top  in
+              let uu____8410 =
+                let uu____8411 =
+                  let uu____8418 =
+                    let uu___1368_8419 = top  in
+                    let uu____8420 =
+                      let uu____8421 =
                         smt_pat_or_lid top.FStar_Parser_AST.range  in
-                      FStar_Parser_AST.Var uu____8428  in
+                      FStar_Parser_AST.Var uu____8421  in
                     {
-                      FStar_Parser_AST.tm = uu____8427;
+                      FStar_Parser_AST.tm = uu____8420;
                       FStar_Parser_AST.range =
-                        (uu___1368_8426.FStar_Parser_AST.range);
+                        (uu___1368_8419.FStar_Parser_AST.range);
                       FStar_Parser_AST.level =
-                        (uu___1368_8426.FStar_Parser_AST.level)
+                        (uu___1368_8419.FStar_Parser_AST.level)
                     }  in
-                  (uu____8425, a, FStar_Parser_AST.Nothing)  in
-                FStar_Parser_AST.App uu____8418  in
+                  (uu____8418, a, FStar_Parser_AST.Nothing)  in
+                FStar_Parser_AST.App uu____8411  in
               {
-                FStar_Parser_AST.tm = uu____8417;
+                FStar_Parser_AST.tm = uu____8410;
                 FStar_Parser_AST.range =
-                  (uu___1366_8416.FStar_Parser_AST.range);
+                  (uu___1366_8409.FStar_Parser_AST.range);
                 FStar_Parser_AST.level =
-                  (uu___1366_8416.FStar_Parser_AST.level)
+                  (uu___1366_8409.FStar_Parser_AST.level)
               }  in
-            desugar_term_maybe_top top_level env uu____8415
+            desugar_term_maybe_top top_level env uu____8408
         | FStar_Parser_AST.Name lid when
-            let uu____8430 = FStar_Ident.string_of_lid lid  in
-            uu____8430 = "Type0" ->
-            let uu____8434 =
+            let uu____8423 = FStar_Ident.string_of_lid lid  in
+            uu____8423 = "Type0" ->
+            let uu____8427 =
               mk (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_zero)  in
-            (uu____8434, noaqs)
+            (uu____8427, noaqs)
         | FStar_Parser_AST.Name lid when
-            let uu____8436 = FStar_Ident.string_of_lid lid  in
-            uu____8436 = "Type" ->
-            let uu____8440 =
+            let uu____8429 = FStar_Ident.string_of_lid lid  in
+            uu____8429 = "Type" ->
+            let uu____8433 =
               mk (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
                in
-            (uu____8440, noaqs)
+            (uu____8433, noaqs)
         | FStar_Parser_AST.Construct (lid,(t,FStar_Parser_AST.UnivApp )::[])
             when
-            let uu____8457 = FStar_Ident.string_of_lid lid  in
-            uu____8457 = "Type" ->
-            let uu____8461 =
-              let uu____8462 =
-                let uu____8463 = desugar_universe t  in
-                FStar_Syntax_Syntax.Tm_type uu____8463  in
-              mk uu____8462  in
-            (uu____8461, noaqs)
+            let uu____8450 = FStar_Ident.string_of_lid lid  in
+            uu____8450 = "Type" ->
+            let uu____8454 =
+              let uu____8455 =
+                let uu____8456 = desugar_universe t  in
+                FStar_Syntax_Syntax.Tm_type uu____8456  in
+              mk uu____8455  in
+            (uu____8454, noaqs)
         | FStar_Parser_AST.Name lid when
-            let uu____8465 = FStar_Ident.string_of_lid lid  in
-            uu____8465 = "Effect" ->
-            let uu____8469 =
+            let uu____8458 = FStar_Ident.string_of_lid lid  in
+            uu____8458 = "Effect" ->
+            let uu____8462 =
               mk (FStar_Syntax_Syntax.Tm_constant FStar_Const.Const_effect)
                in
-            (uu____8469, noaqs)
+            (uu____8462, noaqs)
+        | FStar_Parser_AST.Name lid when
+            let uu____8464 = FStar_Ident.string_of_lid lid  in
+            uu____8464 = "True" ->
+            let uu____8468 =
+              let uu____8469 =
+                FStar_Ident.set_lid_range FStar_Parser_Const.true_lid
+                  top.FStar_Parser_AST.range
+                 in
+              FStar_Syntax_Syntax.fvar uu____8469
+                FStar_Syntax_Syntax.delta_constant
+                FStar_Pervasives_Native.None
+               in
+            (uu____8468, noaqs)
         | FStar_Parser_AST.Name lid when
             let uu____8471 = FStar_Ident.string_of_lid lid  in
-            uu____8471 = "True" ->
+            uu____8471 = "False" ->
             let uu____8475 =
               let uu____8476 =
-                FStar_Ident.set_lid_range FStar_Parser_Const.true_lid
+                FStar_Ident.set_lid_range FStar_Parser_Const.false_lid
                   top.FStar_Parser_AST.range
                  in
               FStar_Syntax_Syntax.fvar uu____8476
@@ -2561,119 +2565,106 @@ and (desugar_term_maybe_top :
                 FStar_Pervasives_Native.None
                in
             (uu____8475, noaqs)
-        | FStar_Parser_AST.Name lid when
-            let uu____8478 = FStar_Ident.string_of_lid lid  in
-            uu____8478 = "False" ->
-            let uu____8482 =
-              let uu____8483 =
-                FStar_Ident.set_lid_range FStar_Parser_Const.false_lid
-                  top.FStar_Parser_AST.range
-                 in
-              FStar_Syntax_Syntax.fvar uu____8483
-                FStar_Syntax_Syntax.delta_constant
-                FStar_Pervasives_Native.None
-               in
-            (uu____8482, noaqs)
         | FStar_Parser_AST.Projector (eff_name,id) when
-            (let uu____8488 = FStar_Ident.text_of_id id  in
-             is_special_effect_combinator uu____8488) &&
+            (let uu____8481 = FStar_Ident.text_of_id id  in
+             is_special_effect_combinator uu____8481) &&
               (FStar_Syntax_DsEnv.is_effect_name env eff_name)
             ->
             let txt = FStar_Ident.text_of_id id  in
-            let uu____8492 =
+            let uu____8485 =
               FStar_Syntax_DsEnv.try_lookup_effect_defn env eff_name  in
-            (match uu____8492 with
+            (match uu____8485 with
              | FStar_Pervasives_Native.Some ed ->
                  let lid = FStar_Syntax_Util.dm4f_lid ed txt  in
-                 let uu____8501 =
+                 let uu____8494 =
                    FStar_Syntax_Syntax.fvar lid
                      (FStar_Syntax_Syntax.Delta_constant_at_level
                         Prims.int_one) FStar_Pervasives_Native.None
                     in
-                 (uu____8501, noaqs)
+                 (uu____8494, noaqs)
              | FStar_Pervasives_Native.None  ->
-                 let uu____8503 =
-                   let uu____8505 = FStar_Ident.string_of_lid eff_name  in
+                 let uu____8496 =
+                   let uu____8498 = FStar_Ident.string_of_lid eff_name  in
                    FStar_Util.format2
                      "Member %s of effect %s is not accessible (using an effect abbreviation instead of the original effect ?)"
-                     uu____8505 txt
+                     uu____8498 txt
                     in
-                 failwith uu____8503)
+                 failwith uu____8496)
         | FStar_Parser_AST.Var l ->
-            let uu____8513 = desugar_name mk setpos env true l  in
-            (uu____8513, noaqs)
+            let uu____8506 = desugar_name mk setpos env true l  in
+            (uu____8506, noaqs)
         | FStar_Parser_AST.Name l ->
-            let uu____8521 = desugar_name mk setpos env true l  in
-            (uu____8521, noaqs)
+            let uu____8514 = desugar_name mk setpos env true l  in
+            (uu____8514, noaqs)
         | FStar_Parser_AST.Projector (l,i) ->
             let name =
-              let uu____8538 = FStar_Syntax_DsEnv.try_lookup_datacon env l
+              let uu____8531 = FStar_Syntax_DsEnv.try_lookup_datacon env l
                  in
-              match uu____8538 with
-              | FStar_Pervasives_Native.Some uu____8548 ->
+              match uu____8531 with
+              | FStar_Pervasives_Native.Some uu____8541 ->
                   FStar_Pervasives_Native.Some (true, l)
               | FStar_Pervasives_Native.None  ->
-                  let uu____8556 =
+                  let uu____8549 =
                     FStar_Syntax_DsEnv.try_lookup_root_effect_name env l  in
-                  (match uu____8556 with
+                  (match uu____8549 with
                    | FStar_Pervasives_Native.Some new_name ->
                        FStar_Pervasives_Native.Some (false, new_name)
-                   | uu____8574 -> FStar_Pervasives_Native.None)
+                   | uu____8567 -> FStar_Pervasives_Native.None)
                in
             (match name with
              | FStar_Pervasives_Native.Some (resolve,new_name) ->
-                 let uu____8595 =
-                   let uu____8596 =
+                 let uu____8588 =
+                   let uu____8589 =
                      FStar_Syntax_Util.mk_field_projector_name_from_ident
                        new_name i
                       in
-                   desugar_name mk setpos env resolve uu____8596  in
-                 (uu____8595, noaqs)
-             | uu____8602 ->
-                 let uu____8610 =
-                   let uu____8616 =
-                     let uu____8618 = FStar_Ident.string_of_lid l  in
+                   desugar_name mk setpos env resolve uu____8589  in
+                 (uu____8588, noaqs)
+             | uu____8595 ->
+                 let uu____8603 =
+                   let uu____8609 =
+                     let uu____8611 = FStar_Ident.string_of_lid l  in
                      FStar_Util.format1
-                       "Data constructor or effect %s not found" uu____8618
+                       "Data constructor or effect %s not found" uu____8611
                       in
-                   (FStar_Errors.Fatal_EffectNotFound, uu____8616)  in
-                 FStar_Errors.raise_error uu____8610
+                   (FStar_Errors.Fatal_EffectNotFound, uu____8609)  in
+                 FStar_Errors.raise_error uu____8603
                    top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Discrim lid ->
-            let uu____8627 = FStar_Syntax_DsEnv.try_lookup_datacon env lid
+            let uu____8620 = FStar_Syntax_DsEnv.try_lookup_datacon env lid
                in
-            (match uu____8627 with
+            (match uu____8620 with
              | FStar_Pervasives_Native.None  ->
-                 let uu____8634 =
-                   let uu____8640 =
-                     let uu____8642 = FStar_Ident.string_of_lid lid  in
+                 let uu____8627 =
+                   let uu____8633 =
+                     let uu____8635 = FStar_Ident.string_of_lid lid  in
                      FStar_Util.format1 "Data constructor %s not found"
-                       uu____8642
+                       uu____8635
                       in
-                   (FStar_Errors.Fatal_DataContructorNotFound, uu____8640)
+                   (FStar_Errors.Fatal_DataContructorNotFound, uu____8633)
                     in
-                 FStar_Errors.raise_error uu____8634
+                 FStar_Errors.raise_error uu____8627
                    top.FStar_Parser_AST.range
-             | uu____8650 ->
+             | uu____8643 ->
                  let lid' = FStar_Syntax_Util.mk_discriminator lid  in
-                 let uu____8654 = desugar_name mk setpos env true lid'  in
-                 (uu____8654, noaqs))
+                 let uu____8647 = desugar_name mk setpos env true lid'  in
+                 (uu____8647, noaqs))
         | FStar_Parser_AST.Construct (l,args) ->
-            let uu____8675 = FStar_Syntax_DsEnv.try_lookup_datacon env l  in
-            (match uu____8675 with
+            let uu____8668 = FStar_Syntax_DsEnv.try_lookup_datacon env l  in
+            (match uu____8668 with
              | FStar_Pervasives_Native.Some head ->
                  let head1 = mk (FStar_Syntax_Syntax.Tm_fvar head)  in
                  (match args with
                   | [] -> (head1, noaqs)
-                  | uu____8694 ->
-                      let uu____8701 =
+                  | uu____8687 ->
+                      let uu____8694 =
                         FStar_Util.take
-                          (fun uu____8725  ->
-                             match uu____8725 with
-                             | (uu____8731,imp) ->
+                          (fun uu____8718  ->
+                             match uu____8718 with
+                             | (uu____8724,imp) ->
                                  imp = FStar_Parser_AST.UnivApp) args
                          in
-                      (match uu____8701 with
+                      (match uu____8694 with
                        | (universes,args1) ->
                            let universes1 =
                              FStar_List.map
@@ -2682,22 +2673,22 @@ and (desugar_term_maybe_top :
                                     (FStar_Pervasives_Native.fst x))
                                universes
                               in
-                           let uu____8776 =
-                             let uu____8801 =
+                           let uu____8769 =
+                             let uu____8794 =
                                FStar_List.map
-                                 (fun uu____8844  ->
-                                    match uu____8844 with
+                                 (fun uu____8837  ->
+                                    match uu____8837 with
                                     | (t,imp) ->
-                                        let uu____8861 =
+                                        let uu____8854 =
                                           desugar_term_aq env t  in
-                                        (match uu____8861 with
+                                        (match uu____8854 with
                                          | (te,aq) ->
                                              ((arg_withimp_e imp te), aq)))
                                  args1
                                 in
-                             FStar_All.pipe_right uu____8801 FStar_List.unzip
+                             FStar_All.pipe_right uu____8794 FStar_List.unzip
                               in
-                           (match uu____8776 with
+                           (match uu____8769 with
                             | (args2,aqs) ->
                                 let head2 =
                                   if universes1 = []
@@ -2707,195 +2698,195 @@ and (desugar_term_maybe_top :
                                       (FStar_Syntax_Syntax.Tm_uinst
                                          (head1, universes1))
                                    in
-                                let uu____9004 =
+                                let uu____8997 =
                                   mk
                                     (FStar_Syntax_Syntax.Tm_app
                                        (head2, args2))
                                    in
-                                (uu____9004, (join_aqs aqs)))))
+                                (uu____8997, (join_aqs aqs)))))
              | FStar_Pervasives_Native.None  ->
                  let err =
-                   let uu____9023 =
+                   let uu____9016 =
                      FStar_Syntax_DsEnv.try_lookup_effect_name env l  in
-                   match uu____9023 with
+                   match uu____9016 with
                    | FStar_Pervasives_Native.None  ->
-                       let uu____9031 =
-                         let uu____9033 =
-                           let uu____9035 = FStar_Ident.string_of_lid l  in
-                           Prims.op_Hat uu____9035 " not found"  in
-                         Prims.op_Hat "Constructor " uu____9033  in
-                       (FStar_Errors.Fatal_ConstructorNotFound, uu____9031)
-                   | FStar_Pervasives_Native.Some uu____9040 ->
-                       let uu____9041 =
-                         let uu____9043 =
-                           let uu____9045 = FStar_Ident.string_of_lid l  in
-                           Prims.op_Hat uu____9045
+                       let uu____9024 =
+                         let uu____9026 =
+                           let uu____9028 = FStar_Ident.string_of_lid l  in
+                           Prims.op_Hat uu____9028 " not found"  in
+                         Prims.op_Hat "Constructor " uu____9026  in
+                       (FStar_Errors.Fatal_ConstructorNotFound, uu____9024)
+                   | FStar_Pervasives_Native.Some uu____9033 ->
+                       let uu____9034 =
+                         let uu____9036 =
+                           let uu____9038 = FStar_Ident.string_of_lid l  in
+                           Prims.op_Hat uu____9038
                              " used at an unexpected position"
                             in
-                         Prims.op_Hat "Effect " uu____9043  in
-                       (FStar_Errors.Fatal_UnexpectedEffect, uu____9041)
+                         Prims.op_Hat "Effect " uu____9036  in
+                       (FStar_Errors.Fatal_UnexpectedEffect, uu____9034)
                     in
                  FStar_Errors.raise_error err top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Sum (binders,t) when
             FStar_Util.for_all
-              (fun uu___8_9074  ->
-                 match uu___8_9074 with
-                 | FStar_Util.Inr uu____9080 -> true
-                 | uu____9082 -> false) binders
+              (fun uu___8_9067  ->
+                 match uu___8_9067 with
+                 | FStar_Util.Inr uu____9073 -> true
+                 | uu____9075 -> false) binders
             ->
             let terms =
-              let uu____9091 =
+              let uu____9084 =
                 FStar_All.pipe_right binders
                   (FStar_List.map
-                     (fun uu___9_9108  ->
-                        match uu___9_9108 with
+                     (fun uu___9_9101  ->
+                        match uu___9_9101 with
                         | FStar_Util.Inr x -> x
-                        | FStar_Util.Inl uu____9114 -> failwith "Impossible"))
+                        | FStar_Util.Inl uu____9107 -> failwith "Impossible"))
                  in
-              FStar_List.append uu____9091 [t]  in
-            let uu____9116 =
-              let uu____9141 =
+              FStar_List.append uu____9084 [t]  in
+            let uu____9109 =
+              let uu____9134 =
                 FStar_All.pipe_right terms
                   (FStar_List.map
                      (fun t1  ->
-                        let uu____9198 = desugar_typ_aq env t1  in
-                        match uu____9198 with
+                        let uu____9191 = desugar_typ_aq env t1  in
+                        match uu____9191 with
                         | (t',aq) ->
-                            let uu____9209 = FStar_Syntax_Syntax.as_arg t'
+                            let uu____9202 = FStar_Syntax_Syntax.as_arg t'
                                in
-                            (uu____9209, aq)))
+                            (uu____9202, aq)))
                  in
-              FStar_All.pipe_right uu____9141 FStar_List.unzip  in
-            (match uu____9116 with
+              FStar_All.pipe_right uu____9134 FStar_List.unzip  in
+            (match uu____9109 with
              | (targs,aqs) ->
                  let tup =
-                   let uu____9319 =
+                   let uu____9312 =
                      FStar_Parser_Const.mk_tuple_lid
                        (FStar_List.length targs) top.FStar_Parser_AST.range
                       in
                    FStar_Syntax_DsEnv.fail_or env
-                     (FStar_Syntax_DsEnv.try_lookup_lid env) uu____9319
+                     (FStar_Syntax_DsEnv.try_lookup_lid env) uu____9312
                     in
-                 let uu____9328 =
+                 let uu____9321 =
                    mk (FStar_Syntax_Syntax.Tm_app (tup, targs))  in
-                 (uu____9328, (join_aqs aqs)))
+                 (uu____9321, (join_aqs aqs)))
         | FStar_Parser_AST.Sum (binders,t) ->
-            let uu____9355 =
-              let uu____9372 =
-                let uu____9379 =
-                  let uu____9386 =
+            let uu____9348 =
+              let uu____9365 =
+                let uu____9372 =
+                  let uu____9379 =
                     FStar_All.pipe_left
-                      (fun uu____9395  -> FStar_Util.Inl uu____9395)
+                      (fun uu____9388  -> FStar_Util.Inl uu____9388)
                       (FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName t)
                          t.FStar_Parser_AST.range FStar_Parser_AST.Type_level
                          FStar_Pervasives_Native.None)
                      in
-                  [uu____9386]  in
-                FStar_List.append binders uu____9379  in
+                  [uu____9379]  in
+                FStar_List.append binders uu____9372  in
               FStar_List.fold_left
-                (fun uu____9440  ->
+                (fun uu____9433  ->
                    fun b  ->
-                     match uu____9440 with
+                     match uu____9433 with
                      | (env1,tparams,typs) ->
-                         let uu____9501 =
+                         let uu____9494 =
                            match b with
                            | FStar_Util.Inl b1 -> desugar_binder env1 b1
                            | FStar_Util.Inr t1 ->
-                               let uu____9516 = desugar_typ env1 t1  in
-                               (FStar_Pervasives_Native.None, uu____9516)
+                               let uu____9509 = desugar_typ env1 t1  in
+                               (FStar_Pervasives_Native.None, uu____9509)
                             in
-                         (match uu____9501 with
+                         (match uu____9494 with
                           | (xopt,t1) ->
-                              let uu____9541 =
+                              let uu____9534 =
                                 match xopt with
                                 | FStar_Pervasives_Native.None  ->
-                                    let uu____9550 =
+                                    let uu____9543 =
                                       FStar_Syntax_Syntax.new_bv
                                         (FStar_Pervasives_Native.Some
                                            (top.FStar_Parser_AST.range))
                                         (setpos FStar_Syntax_Syntax.tun)
                                        in
-                                    (env1, uu____9550)
+                                    (env1, uu____9543)
                                 | FStar_Pervasives_Native.Some x ->
                                     FStar_Syntax_DsEnv.push_bv env1 x
                                  in
-                              (match uu____9541 with
+                              (match uu____9534 with
                                | (env2,x) ->
-                                   let uu____9570 =
-                                     let uu____9573 =
-                                       let uu____9576 =
-                                         let uu____9577 =
+                                   let uu____9563 =
+                                     let uu____9566 =
+                                       let uu____9569 =
+                                         let uu____9570 =
                                            no_annot_abs tparams t1  in
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____9577
+                                           uu____9570
                                           in
-                                       [uu____9576]  in
-                                     FStar_List.append typs uu____9573  in
+                                       [uu____9569]  in
+                                     FStar_List.append typs uu____9566  in
                                    (env2,
                                      (FStar_List.append tparams
-                                        [(((let uu___1497_9603 = x  in
+                                        [(((let uu___1497_9596 = x  in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___1497_9603.FStar_Syntax_Syntax.ppname);
+                                                (uu___1497_9596.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___1497_9603.FStar_Syntax_Syntax.index);
+                                                (uu___1497_9596.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort = t1
                                             })),
                                            FStar_Pervasives_Native.None)]),
-                                     uu____9570)))) (env, [], []) uu____9372
+                                     uu____9563)))) (env, [], []) uu____9365
                in
-            (match uu____9355 with
-             | (env1,uu____9631,targs) ->
+            (match uu____9348 with
+             | (env1,uu____9624,targs) ->
                  let tup =
-                   let uu____9654 =
+                   let uu____9647 =
                      FStar_Parser_Const.mk_dtuple_lid
                        (FStar_List.length targs) top.FStar_Parser_AST.range
                       in
                    FStar_Syntax_DsEnv.fail_or env1
-                     (FStar_Syntax_DsEnv.try_lookup_lid env1) uu____9654
+                     (FStar_Syntax_DsEnv.try_lookup_lid env1) uu____9647
                     in
-                 let uu____9655 =
+                 let uu____9648 =
                    FStar_All.pipe_left mk
                      (FStar_Syntax_Syntax.Tm_app (tup, targs))
                     in
-                 (uu____9655, noaqs))
+                 (uu____9648, noaqs))
         | FStar_Parser_AST.Product (binders,t) ->
-            let uu____9674 = uncurry binders t  in
-            (match uu____9674 with
+            let uu____9667 = uncurry binders t  in
+            (match uu____9667 with
              | (bs,t1) ->
-                 let rec aux env1 bs1 uu___10_9718 =
-                   match uu___10_9718 with
+                 let rec aux env1 bs1 uu___10_9711 =
+                   match uu___10_9711 with
                    | [] ->
                        let cod =
                          desugar_comp top.FStar_Parser_AST.range true env1 t1
                           in
-                       let uu____9735 =
+                       let uu____9728 =
                          FStar_Syntax_Util.arrow (FStar_List.rev bs1) cod  in
-                       FStar_All.pipe_left setpos uu____9735
+                       FStar_All.pipe_left setpos uu____9728
                    | hd::tl ->
                        let bb = desugar_binder env1 hd  in
-                       let uu____9759 =
+                       let uu____9752 =
                          as_binder env1 hd.FStar_Parser_AST.aqual bb  in
-                       (match uu____9759 with
+                       (match uu____9752 with
                         | (b,env2) -> aux env2 (b :: bs1) tl)
                     in
-                 let uu____9792 = aux env [] bs  in (uu____9792, noaqs))
+                 let uu____9785 = aux env [] bs  in (uu____9785, noaqs))
         | FStar_Parser_AST.Refine (b,f) ->
-            let uu____9801 = desugar_binder env b  in
-            (match uu____9801 with
-             | (FStar_Pervasives_Native.None ,uu____9812) ->
+            let uu____9794 = desugar_binder env b  in
+            (match uu____9794 with
+             | (FStar_Pervasives_Native.None ,uu____9805) ->
                  failwith "Missing binder in refinement"
              | b1 ->
-                 let uu____9827 =
+                 let uu____9820 =
                    as_binder env FStar_Pervasives_Native.None b1  in
-                 (match uu____9827 with
-                  | ((x,uu____9843),env1) ->
+                 (match uu____9820 with
+                  | ((x,uu____9836),env1) ->
                       let f1 = desugar_formula env1 f  in
-                      let uu____9856 =
-                        let uu____9857 = FStar_Syntax_Util.refine x f1  in
-                        FStar_All.pipe_left setpos uu____9857  in
-                      (uu____9856, noaqs)))
+                      let uu____9849 =
+                        let uu____9850 = FStar_Syntax_Util.refine x f1  in
+                        FStar_All.pipe_left setpos uu____9850  in
+                      (uu____9849, noaqs)))
         | FStar_Parser_AST.Abs (binders,body) ->
             let bvss = FStar_List.map gather_pattern_bound_vars binders  in
             let check_disjoint sets =
@@ -2904,75 +2895,75 @@ and (desugar_term_maybe_top :
                 | [] -> FStar_Pervasives_Native.None
                 | set::sets2 ->
                     let i = FStar_Util.set_intersect acc set  in
-                    let uu____9935 = FStar_Util.set_is_empty i  in
-                    if uu____9935
+                    let uu____9928 = FStar_Util.set_is_empty i  in
+                    if uu____9928
                     then
-                      let uu____9940 = FStar_Util.set_union acc set  in
-                      aux uu____9940 sets2
+                      let uu____9933 = FStar_Util.set_union acc set  in
+                      aux uu____9933 sets2
                     else
-                      (let uu____9945 =
-                         let uu____9946 = FStar_Util.set_elements i  in
-                         FStar_List.hd uu____9946  in
-                       FStar_Pervasives_Native.Some uu____9945)
+                      (let uu____9938 =
+                         let uu____9939 = FStar_Util.set_elements i  in
+                         FStar_List.hd uu____9939  in
+                       FStar_Pervasives_Native.Some uu____9938)
                  in
-              let uu____9949 = FStar_Syntax_Syntax.new_id_set ()  in
-              aux uu____9949 sets  in
-            ((let uu____9953 = check_disjoint bvss  in
-              match uu____9953 with
+              let uu____9942 = FStar_Syntax_Syntax.new_id_set ()  in
+              aux uu____9942 sets  in
+            ((let uu____9946 = check_disjoint bvss  in
+              match uu____9946 with
               | FStar_Pervasives_Native.None  -> ()
               | FStar_Pervasives_Native.Some id ->
-                  let uu____9957 =
-                    let uu____9963 =
-                      let uu____9965 = FStar_Ident.text_of_id id  in
+                  let uu____9950 =
+                    let uu____9956 =
+                      let uu____9958 = FStar_Ident.text_of_id id  in
                       FStar_Util.format1
                         "Non-linear patterns are not permitted: `%s` appears more than once in this function definition."
-                        uu____9965
+                        uu____9958
                        in
                     (FStar_Errors.Fatal_NonLinearPatternNotPermitted,
-                      uu____9963)
+                      uu____9956)
                      in
-                  let uu____9969 = FStar_Ident.range_of_id id  in
-                  FStar_Errors.raise_error uu____9957 uu____9969);
+                  let uu____9962 = FStar_Ident.range_of_id id  in
+                  FStar_Errors.raise_error uu____9950 uu____9962);
              (let binders1 =
                 FStar_All.pipe_right binders
                   (FStar_List.map replace_unit_pattern)
                  in
-              let uu____9977 =
+              let uu____9970 =
                 FStar_List.fold_left
-                  (fun uu____9997  ->
+                  (fun uu____9990  ->
                      fun pat  ->
-                       match uu____9997 with
+                       match uu____9990 with
                        | (env1,ftvs) ->
                            (match pat.FStar_Parser_AST.pat with
                             | FStar_Parser_AST.PatAscribed
-                                (uu____10023,(t,FStar_Pervasives_Native.None
+                                (uu____10016,(t,FStar_Pervasives_Native.None
                                               ))
                                 ->
-                                let uu____10033 =
-                                  let uu____10036 = free_type_vars env1 t  in
-                                  FStar_List.append uu____10036 ftvs  in
-                                (env1, uu____10033)
+                                let uu____10026 =
+                                  let uu____10029 = free_type_vars env1 t  in
+                                  FStar_List.append uu____10029 ftvs  in
+                                (env1, uu____10026)
                             | FStar_Parser_AST.PatAscribed
-                                (uu____10041,(t,FStar_Pervasives_Native.Some
+                                (uu____10034,(t,FStar_Pervasives_Native.Some
                                               tac))
                                 ->
-                                let uu____10052 =
-                                  let uu____10055 = free_type_vars env1 t  in
-                                  let uu____10058 =
-                                    let uu____10061 = free_type_vars env1 tac
+                                let uu____10045 =
+                                  let uu____10048 = free_type_vars env1 t  in
+                                  let uu____10051 =
+                                    let uu____10054 = free_type_vars env1 tac
                                        in
-                                    FStar_List.append uu____10061 ftvs  in
-                                  FStar_List.append uu____10055 uu____10058
+                                    FStar_List.append uu____10054 ftvs  in
+                                  FStar_List.append uu____10048 uu____10051
                                    in
-                                (env1, uu____10052)
-                            | uu____10066 -> (env1, ftvs))) (env, [])
+                                (env1, uu____10045)
+                            | uu____10059 -> (env1, ftvs))) (env, [])
                   binders1
                  in
-              match uu____9977 with
-              | (uu____10075,ftv) ->
+              match uu____9970 with
+              | (uu____10068,ftv) ->
                   let ftv1 = sort_ftv ftv  in
                   let binders2 =
-                    let uu____10087 =
+                    let uu____10080 =
                       FStar_All.pipe_right ftv1
                         (FStar_List.map
                            (fun a  ->
@@ -2983,25 +2974,25 @@ and (desugar_term_maybe_top :
                                         FStar_Parser_AST.Implicit)))
                                 top.FStar_Parser_AST.range))
                        in
-                    FStar_List.append uu____10087 binders1  in
+                    FStar_List.append uu____10080 binders1  in
                   let rec aux env1 bs sc_pat_opt pats =
                     match pats with
                     | [] ->
-                        let uu____10167 = desugar_term_aq env1 body  in
-                        (match uu____10167 with
+                        let uu____10160 = desugar_term_aq env1 body  in
+                        (match uu____10160 with
                          | (body1,aq) ->
                              let body2 =
                                match sc_pat_opt with
                                | FStar_Pervasives_Native.Some (sc,pat) ->
                                    let body2 =
-                                     let uu____10202 =
-                                       let uu____10203 =
+                                     let uu____10195 =
+                                       let uu____10196 =
                                          FStar_Syntax_Syntax.pat_bvs pat  in
-                                       FStar_All.pipe_right uu____10203
+                                       FStar_All.pipe_right uu____10196
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.mk_binder)
                                         in
-                                     FStar_Syntax_Subst.close uu____10202
+                                     FStar_Syntax_Subst.close uu____10195
                                        body1
                                       in
                                    FStar_Syntax_Syntax.mk
@@ -3010,47 +3001,46 @@ and (desugar_term_maybe_top :
                                           [(pat,
                                              FStar_Pervasives_Native.None,
                                              body2)]))
-                                     FStar_Pervasives_Native.None
                                      body2.FStar_Syntax_Syntax.pos
                                | FStar_Pervasives_Native.None  -> body1  in
-                             let uu____10272 =
-                               let uu____10273 =
+                             let uu____10265 =
+                               let uu____10266 =
                                  no_annot_abs (FStar_List.rev bs) body2  in
-                               setpos uu____10273  in
-                             (uu____10272, aq))
+                               setpos uu____10266  in
+                             (uu____10265, aq))
                     | p::rest ->
-                        let uu____10286 = desugar_binding_pat env1 p  in
-                        (match uu____10286 with
+                        let uu____10279 = desugar_binding_pat env1 p  in
+                        (match uu____10279 with
                          | (env2,b,pat) ->
                              let pat1 =
                                match pat with
                                | [] -> FStar_Pervasives_Native.None
-                               | (p1,uu____10318)::[] ->
+                               | (p1,uu____10311)::[] ->
                                    FStar_Pervasives_Native.Some p1
-                               | uu____10333 ->
+                               | uu____10326 ->
                                    FStar_Errors.raise_error
                                      (FStar_Errors.Fatal_UnsupportedDisjuctivePatterns,
                                        "Disjunctive patterns are not supported in abstractions")
                                      p.FStar_Parser_AST.prange
                                 in
-                             let uu____10342 =
+                             let uu____10335 =
                                match b with
-                               | LetBinder uu____10383 ->
+                               | LetBinder uu____10376 ->
                                    failwith "Impossible"
                                | LocalBinder (x,aq) ->
                                    let sc_pat_opt1 =
                                      match (pat1, sc_pat_opt) with
                                      | (FStar_Pervasives_Native.None
-                                        ,uu____10452) -> sc_pat_opt
+                                        ,uu____10445) -> sc_pat_opt
                                      | (FStar_Pervasives_Native.Some
                                         p1,FStar_Pervasives_Native.None ) ->
-                                         let uu____10506 =
-                                           let uu____10515 =
+                                         let uu____10499 =
+                                           let uu____10508 =
                                              FStar_Syntax_Syntax.bv_to_name x
                                               in
-                                           (uu____10515, p1)  in
+                                           (uu____10508, p1)  in
                                          FStar_Pervasives_Native.Some
-                                           uu____10506
+                                           uu____10499
                                      | (FStar_Pervasives_Native.Some
                                         p1,FStar_Pervasives_Native.Some
                                         (sc,p')) ->
@@ -3058,62 +3048,58 @@ and (desugar_term_maybe_top :
                                                   (p'.FStar_Syntax_Syntax.v))
                                           with
                                           | (FStar_Syntax_Syntax.Tm_name
-                                             uu____10577,uu____10578) ->
+                                             uu____10570,uu____10571) ->
                                               let tup2 =
-                                                let uu____10580 =
+                                                let uu____10573 =
                                                   FStar_Parser_Const.mk_tuple_data_lid
                                                     (Prims.of_int (2))
                                                     top.FStar_Parser_AST.range
                                                    in
                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                  uu____10580
+                                                  uu____10573
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
                                                      FStar_Syntax_Syntax.Data_ctor)
                                                  in
                                               let sc1 =
-                                                let uu____10585 =
-                                                  let uu____10592 =
-                                                    let uu____10593 =
-                                                      let uu____10610 =
-                                                        mk
-                                                          (FStar_Syntax_Syntax.Tm_fvar
-                                                             tup2)
-                                                         in
-                                                      let uu____10613 =
-                                                        let uu____10624 =
-                                                          FStar_Syntax_Syntax.as_arg
-                                                            sc
-                                                           in
-                                                        let uu____10633 =
-                                                          let uu____10644 =
-                                                            let uu____10653 =
-                                                              FStar_Syntax_Syntax.bv_to_name
-                                                                x
-                                                               in
-                                                            FStar_All.pipe_left
-                                                              FStar_Syntax_Syntax.as_arg
-                                                              uu____10653
-                                                             in
-                                                          [uu____10644]  in
-                                                        uu____10624 ::
-                                                          uu____10633
-                                                         in
-                                                      (uu____10610,
-                                                        uu____10613)
+                                                let uu____10578 =
+                                                  let uu____10579 =
+                                                    let uu____10596 =
+                                                      mk
+                                                        (FStar_Syntax_Syntax.Tm_fvar
+                                                           tup2)
                                                        in
-                                                    FStar_Syntax_Syntax.Tm_app
-                                                      uu____10593
+                                                    let uu____10599 =
+                                                      let uu____10610 =
+                                                        FStar_Syntax_Syntax.as_arg
+                                                          sc
+                                                         in
+                                                      let uu____10619 =
+                                                        let uu____10630 =
+                                                          let uu____10639 =
+                                                            FStar_Syntax_Syntax.bv_to_name
+                                                              x
+                                                             in
+                                                          FStar_All.pipe_left
+                                                            FStar_Syntax_Syntax.as_arg
+                                                            uu____10639
+                                                           in
+                                                        [uu____10630]  in
+                                                      uu____10610 ::
+                                                        uu____10619
+                                                       in
+                                                    (uu____10596,
+                                                      uu____10599)
                                                      in
-                                                  FStar_Syntax_Syntax.mk
-                                                    uu____10592
+                                                  FStar_Syntax_Syntax.Tm_app
+                                                    uu____10579
                                                    in
-                                                uu____10585
-                                                  FStar_Pervasives_Native.None
+                                                FStar_Syntax_Syntax.mk
+                                                  uu____10578
                                                   top.FStar_Parser_AST.range
                                                  in
                                               let p2 =
-                                                let uu____10701 =
+                                                let uu____10687 =
                                                   FStar_Range.union_ranges
                                                     p'.FStar_Syntax_Syntax.p
                                                     p1.FStar_Syntax_Syntax.p
@@ -3123,15 +3109,15 @@ and (desugar_term_maybe_top :
                                                      (tup2,
                                                        [(p', false);
                                                        (p1, false)]))
-                                                  uu____10701
+                                                  uu____10687
                                                  in
                                               FStar_Pervasives_Native.Some
                                                 (sc1, p2)
                                           | (FStar_Syntax_Syntax.Tm_app
-                                             (uu____10752,args),FStar_Syntax_Syntax.Pat_cons
-                                             (uu____10754,pats1)) ->
+                                             (uu____10738,args),FStar_Syntax_Syntax.Pat_cons
+                                             (uu____10740,pats1)) ->
                                               let tupn =
-                                                let uu____10799 =
+                                                let uu____10785 =
                                                   FStar_Parser_Const.mk_tuple_data_lid
                                                     (Prims.int_one +
                                                        (FStar_List.length
@@ -3139,43 +3125,43 @@ and (desugar_term_maybe_top :
                                                     top.FStar_Parser_AST.range
                                                    in
                                                 FStar_Syntax_Syntax.lid_as_fv
-                                                  uu____10799
+                                                  uu____10785
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
                                                      FStar_Syntax_Syntax.Data_ctor)
                                                  in
                                               let sc1 =
-                                                let uu____10812 =
-                                                  let uu____10813 =
-                                                    let uu____10830 =
+                                                let uu____10798 =
+                                                  let uu____10799 =
+                                                    let uu____10816 =
                                                       mk
                                                         (FStar_Syntax_Syntax.Tm_fvar
                                                            tupn)
                                                        in
-                                                    let uu____10833 =
-                                                      let uu____10844 =
-                                                        let uu____10855 =
-                                                          let uu____10864 =
+                                                    let uu____10819 =
+                                                      let uu____10830 =
+                                                        let uu____10841 =
+                                                          let uu____10850 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x
                                                              in
                                                           FStar_All.pipe_left
                                                             FStar_Syntax_Syntax.as_arg
-                                                            uu____10864
+                                                            uu____10850
                                                            in
-                                                        [uu____10855]  in
+                                                        [uu____10841]  in
                                                       FStar_List.append args
-                                                        uu____10844
+                                                        uu____10830
                                                        in
-                                                    (uu____10830,
-                                                      uu____10833)
+                                                    (uu____10816,
+                                                      uu____10819)
                                                      in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____10813
+                                                    uu____10799
                                                    in
-                                                mk uu____10812  in
+                                                mk uu____10798  in
                                               let p2 =
-                                                let uu____10912 =
+                                                let uu____10898 =
                                                   FStar_Range.union_ranges
                                                     p'.FStar_Syntax_Syntax.p
                                                     p1.FStar_Syntax_Syntax.p
@@ -3185,86 +3171,86 @@ and (desugar_term_maybe_top :
                                                      (tupn,
                                                        (FStar_List.append
                                                           pats1 [(p1, false)])))
-                                                  uu____10912
+                                                  uu____10898
                                                  in
                                               FStar_Pervasives_Native.Some
                                                 (sc1, p2)
-                                          | uu____10959 ->
+                                          | uu____10945 ->
                                               failwith "Impossible")
                                       in
                                    ((x, aq), sc_pat_opt1)
                                 in
-                             (match uu____10342 with
+                             (match uu____10335 with
                               | (b1,sc_pat_opt1) ->
                                   aux env2 (b1 :: bs) sc_pat_opt1 rest))
                      in
                   aux env [] FStar_Pervasives_Native.None binders2))
         | FStar_Parser_AST.App
-            (uu____11051,uu____11052,FStar_Parser_AST.UnivApp ) ->
+            (uu____11037,uu____11038,FStar_Parser_AST.UnivApp ) ->
             let rec aux universes e =
-              let uu____11074 =
-                let uu____11075 = unparen e  in
-                uu____11075.FStar_Parser_AST.tm  in
-              match uu____11074 with
+              let uu____11060 =
+                let uu____11061 = unparen e  in
+                uu____11061.FStar_Parser_AST.tm  in
+              match uu____11060 with
               | FStar_Parser_AST.App (e1,t,FStar_Parser_AST.UnivApp ) ->
                   let univ_arg = desugar_universe t  in
                   aux (univ_arg :: universes) e1
-              | uu____11085 ->
-                  let uu____11086 = desugar_term_aq env e  in
-                  (match uu____11086 with
+              | uu____11071 ->
+                  let uu____11072 = desugar_term_aq env e  in
+                  (match uu____11072 with
                    | (head,aq) ->
-                       let uu____11099 =
+                       let uu____11085 =
                          mk (FStar_Syntax_Syntax.Tm_uinst (head, universes))
                           in
-                       (uu____11099, aq))
+                       (uu____11085, aq))
                in
             aux [] top
-        | FStar_Parser_AST.App uu____11106 ->
+        | FStar_Parser_AST.App uu____11092 ->
             let rec aux args aqs e =
-              let uu____11183 =
-                let uu____11184 = unparen e  in
-                uu____11184.FStar_Parser_AST.tm  in
-              match uu____11183 with
+              let uu____11169 =
+                let uu____11170 = unparen e  in
+                uu____11170.FStar_Parser_AST.tm  in
+              match uu____11169 with
               | FStar_Parser_AST.App (e1,t,imp) when
                   imp <> FStar_Parser_AST.UnivApp ->
-                  let uu____11202 = desugar_term_aq env t  in
-                  (match uu____11202 with
+                  let uu____11188 = desugar_term_aq env t  in
+                  (match uu____11188 with
                    | (t1,aq) ->
                        let arg = arg_withimp_e imp t1  in
                        aux (arg :: args) (aq :: aqs) e1)
-              | uu____11250 ->
-                  let uu____11251 = desugar_term_aq env e  in
-                  (match uu____11251 with
+              | uu____11236 ->
+                  let uu____11237 = desugar_term_aq env e  in
+                  (match uu____11237 with
                    | (head,aq) ->
-                       let uu____11272 =
+                       let uu____11258 =
                          mk (FStar_Syntax_Syntax.Tm_app (head, args))  in
-                       (uu____11272, (join_aqs (aq :: aqs))))
+                       (uu____11258, (join_aqs (aq :: aqs))))
                in
             aux [] [] top
         | FStar_Parser_AST.Bind (x,t1,t2) ->
             let xpat =
-              let uu____11325 = FStar_Ident.range_of_id x  in
+              let uu____11311 = FStar_Ident.range_of_id x  in
               FStar_Parser_AST.mk_pattern
                 (FStar_Parser_AST.PatVar (x, FStar_Pervasives_Native.None))
-                uu____11325
+                uu____11311
                in
             let k =
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Abs ([xpat], t2))
                 t2.FStar_Parser_AST.range t2.FStar_Parser_AST.level
                in
             let bind_lid =
-              let uu____11332 = FStar_Ident.range_of_id x  in
-              FStar_Ident.lid_of_path ["bind"] uu____11332  in
+              let uu____11318 = FStar_Ident.range_of_id x  in
+              FStar_Ident.lid_of_path ["bind"] uu____11318  in
             let bind =
-              let uu____11337 = FStar_Ident.range_of_id x  in
+              let uu____11323 = FStar_Ident.range_of_id x  in
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Var bind_lid)
-                uu____11337 FStar_Parser_AST.Expr
+                uu____11323 FStar_Parser_AST.Expr
                in
-            let uu____11338 =
+            let uu____11324 =
               FStar_Parser_AST.mkExplicitApp bind [t1; k]
                 top.FStar_Parser_AST.range
                in
-            desugar_term_aq env uu____11338
+            desugar_term_aq env uu____11324
         | FStar_Parser_AST.Seq (t1,t2) ->
             let t =
               FStar_Parser_AST.mk_term
@@ -3277,152 +3263,152 @@ and (desugar_term_maybe_top :
                             t1.FStar_Parser_AST.range), t1))], t2))
                 top.FStar_Parser_AST.range FStar_Parser_AST.Expr
                in
-            let uu____11390 = desugar_term_aq env t  in
-            (match uu____11390 with
+            let uu____11376 = desugar_term_aq env t  in
+            (match uu____11376 with
              | (tm,s) ->
-                 let uu____11401 =
+                 let uu____11387 =
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
                         (tm,
                           (FStar_Syntax_Syntax.Meta_desugared
                              FStar_Syntax_Syntax.Sequence)))
                     in
-                 (uu____11401, s))
+                 (uu____11387, s))
         | FStar_Parser_AST.LetOpen (lid,e) ->
             let env1 = FStar_Syntax_DsEnv.push_namespace env lid  in
-            let uu____11407 =
-              let uu____11420 = FStar_Syntax_DsEnv.expect_typ env1  in
-              if uu____11420 then desugar_typ_aq else desugar_term_aq  in
-            uu____11407 env1 e
+            let uu____11393 =
+              let uu____11406 = FStar_Syntax_DsEnv.expect_typ env1  in
+              if uu____11406 then desugar_typ_aq else desugar_term_aq  in
+            uu____11393 env1 e
         | FStar_Parser_AST.Let (qual,lbs,body) ->
             let is_rec = qual = FStar_Parser_AST.Rec  in
-            let ds_let_rec_or_app uu____11487 =
+            let ds_let_rec_or_app uu____11473 =
               let bindings = lbs  in
               let funs =
                 FStar_All.pipe_right bindings
                   (FStar_List.map
-                     (fun uu____11630  ->
-                        match uu____11630 with
+                     (fun uu____11616  ->
+                        match uu____11616 with
                         | (attr_opt,(p,def)) ->
-                            let uu____11688 = is_app_pattern p  in
-                            if uu____11688
+                            let uu____11674 = is_app_pattern p  in
+                            if uu____11674
                             then
-                              let uu____11721 =
+                              let uu____11707 =
                                 destruct_app_pattern env top_level p  in
-                              (attr_opt, uu____11721, def)
+                              (attr_opt, uu____11707, def)
                             else
                               (match FStar_Parser_AST.un_function p def with
                                | FStar_Pervasives_Native.Some (p1,def1) ->
-                                   let uu____11804 =
+                                   let uu____11790 =
                                      destruct_app_pattern env top_level p1
                                       in
-                                   (attr_opt, uu____11804, def1)
-                               | uu____11849 ->
+                                   (attr_opt, uu____11790, def1)
+                               | uu____11835 ->
                                    (match p.FStar_Parser_AST.pat with
                                     | FStar_Parser_AST.PatAscribed
                                         ({
                                            FStar_Parser_AST.pat =
                                              FStar_Parser_AST.PatVar
-                                             (id,uu____11887);
+                                             (id,uu____11873);
                                            FStar_Parser_AST.prange =
-                                             uu____11888;_},t)
+                                             uu____11874;_},t)
                                         ->
                                         if top_level
                                         then
-                                          let uu____11937 =
-                                            let uu____11958 =
-                                              let uu____11963 =
+                                          let uu____11923 =
+                                            let uu____11944 =
+                                              let uu____11949 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id
                                                  in
-                                              FStar_Util.Inr uu____11963  in
-                                            (uu____11958, [],
+                                              FStar_Util.Inr uu____11949  in
+                                            (uu____11944, [],
                                               (FStar_Pervasives_Native.Some t))
                                              in
-                                          (attr_opt, uu____11937, def)
+                                          (attr_opt, uu____11923, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               (FStar_Pervasives_Native.Some t)),
                                             def)
                                     | FStar_Parser_AST.PatVar
-                                        (id,uu____12055) ->
+                                        (id,uu____12041) ->
                                         if top_level
                                         then
-                                          let uu____12091 =
-                                            let uu____12112 =
-                                              let uu____12117 =
+                                          let uu____12077 =
+                                            let uu____12098 =
+                                              let uu____12103 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id
                                                  in
-                                              FStar_Util.Inr uu____12117  in
-                                            (uu____12112, [],
+                                              FStar_Util.Inr uu____12103  in
+                                            (uu____12098, [],
                                               FStar_Pervasives_Native.None)
                                              in
-                                          (attr_opt, uu____12091, def)
+                                          (attr_opt, uu____12077, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               FStar_Pervasives_Native.None),
                                             def)
-                                    | uu____12208 ->
+                                    | uu____12194 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_UnexpectedLetBinding,
                                             "Unexpected let binding")
                                           p.FStar_Parser_AST.prange))))
                  in
-              let uu____12241 =
+              let uu____12227 =
                 FStar_List.fold_left
-                  (fun uu____12330  ->
-                     fun uu____12331  ->
-                       match (uu____12330, uu____12331) with
+                  (fun uu____12316  ->
+                     fun uu____12317  ->
+                       match (uu____12316, uu____12317) with
                        | ((env1,fnames,rec_bindings,used_markers),(_attr_opt,
-                                                                   (f,uu____12461,uu____12462),uu____12463))
+                                                                   (f,uu____12447,uu____12448),uu____12449))
                            ->
-                           let uu____12597 =
+                           let uu____12583 =
                              match f with
                              | FStar_Util.Inl x ->
-                                 let uu____12637 =
+                                 let uu____12623 =
                                    FStar_Syntax_DsEnv.push_bv' env1 x  in
-                                 (match uu____12637 with
+                                 (match uu____12623 with
                                   | (env2,xx,used_marker) ->
                                       let dummy_ref = FStar_Util.mk_ref true
                                          in
-                                      let uu____12672 =
-                                        let uu____12675 =
+                                      let uu____12658 =
+                                        let uu____12661 =
                                           FStar_Syntax_Syntax.mk_binder xx
                                            in
-                                        uu____12675 :: rec_bindings  in
+                                        uu____12661 :: rec_bindings  in
                                       (env2, (FStar_Util.Inl xx),
-                                        uu____12672, (used_marker ::
+                                        uu____12658, (used_marker ::
                                         used_markers)))
                              | FStar_Util.Inr l ->
-                                 let uu____12691 =
-                                   let uu____12699 =
+                                 let uu____12677 =
+                                   let uu____12685 =
                                      FStar_Ident.ident_of_lid l  in
                                    FStar_Syntax_DsEnv.push_top_level_rec_binding
-                                     env1 uu____12699
+                                     env1 uu____12685
                                      FStar_Syntax_Syntax.delta_equational
                                     in
-                                 (match uu____12691 with
+                                 (match uu____12677 with
                                   | (env2,used_marker) ->
                                       (env2, (FStar_Util.Inr l),
                                         rec_bindings, (used_marker ::
                                         used_markers)))
                               in
-                           (match uu____12597 with
+                           (match uu____12583 with
                             | (env2,lbname,rec_bindings1,used_markers1) ->
                                 (env2, (lbname :: fnames), rec_bindings1,
                                   used_markers1))) (env, [], [], []) funs
                  in
-              match uu____12241 with
+              match uu____12227 with
               | (env',fnames,rec_bindings,used_markers) ->
                   let fnames1 = FStar_List.rev fnames  in
                   let rec_bindings1 = FStar_List.rev rec_bindings  in
                   let used_markers1 = FStar_List.rev used_markers  in
-                  let desugar_one_def env1 lbname uu____12945 =
-                    match uu____12945 with
-                    | (attrs_opt,(uu____12985,args,result_t),def) ->
+                  let desugar_one_def env1 lbname uu____12931 =
+                    match uu____12931 with
+                    | (attrs_opt,(uu____12971,args,result_t),def) ->
                         let args1 =
                           FStar_All.pipe_right args
                             (FStar_List.map replace_unit_pattern)
@@ -3433,18 +3419,18 @@ and (desugar_term_maybe_top :
                           | FStar_Pervasives_Native.None  -> def
                           | FStar_Pervasives_Native.Some (t,tacopt) ->
                               let t1 =
-                                let uu____13077 = is_comp_type env1 t  in
-                                if uu____13077
+                                let uu____13063 = is_comp_type env1 t  in
+                                if uu____13063
                                 then
-                                  ((let uu____13081 =
+                                  ((let uu____13067 =
                                       FStar_All.pipe_right args1
                                         (FStar_List.tryFind
                                            (fun x  ->
-                                              let uu____13091 =
+                                              let uu____13077 =
                                                 is_var_pattern x  in
-                                              Prims.op_Negation uu____13091))
+                                              Prims.op_Negation uu____13077))
                                        in
-                                    match uu____13081 with
+                                    match uu____13067 with
                                     | FStar_Pervasives_Native.None  -> ()
                                     | FStar_Pervasives_Native.Some p ->
                                         FStar_Errors.raise_error
@@ -3453,20 +3439,20 @@ and (desugar_term_maybe_top :
                                           p.FStar_Parser_AST.prange);
                                    t)
                                 else
-                                  (let uu____13098 =
+                                  (let uu____13084 =
                                      ((FStar_Options.ml_ish ()) &&
-                                        (let uu____13101 =
+                                        (let uu____13087 =
                                            FStar_Syntax_DsEnv.try_lookup_effect_name
                                              env1
                                              FStar_Parser_Const.effect_ML_lid
                                             in
-                                         FStar_Option.isSome uu____13101))
+                                         FStar_Option.isSome uu____13087))
                                        &&
                                        ((Prims.op_Negation is_rec) ||
                                           ((FStar_List.length args1) <>
                                              Prims.int_zero))
                                       in
-                                   if uu____13098
+                                   if uu____13084
                                    then FStar_Parser_AST.ml_comp t
                                    else FStar_Parser_AST.tot_comp t)
                                  in
@@ -3478,29 +3464,29 @@ and (desugar_term_maybe_top :
                         let def2 =
                           match args1 with
                           | [] -> def1
-                          | uu____13112 ->
+                          | uu____13098 ->
                               FStar_Parser_AST.mk_term
                                 (FStar_Parser_AST.un_curry_abs args1 def1)
                                 top.FStar_Parser_AST.range
                                 top.FStar_Parser_AST.level
                            in
-                        let uu____13115 = desugar_term_aq env1 def2  in
-                        (match uu____13115 with
+                        let uu____13101 = desugar_term_aq env1 def2  in
+                        (match uu____13101 with
                          | (body1,aq) ->
                              let lbname1 =
                                match lbname with
                                | FStar_Util.Inl x -> FStar_Util.Inl x
                                | FStar_Util.Inr l ->
-                                   let uu____13137 =
-                                     let uu____13138 =
+                                   let uu____13123 =
+                                     let uu____13124 =
                                        FStar_Syntax_Util.incr_delta_qualifier
                                          body1
                                         in
                                      FStar_Syntax_Syntax.lid_as_fv l
-                                       uu____13138
+                                       uu____13124
                                        FStar_Pervasives_Native.None
                                       in
-                                   FStar_Util.Inr uu____13137
+                                   FStar_Util.Inr uu____13123
                                 in
                              let body2 =
                                if is_rec
@@ -3518,82 +3504,82 @@ and (desugar_term_maybe_top :
                                    (setpos FStar_Syntax_Syntax.tun), body2,
                                    pos)), aq))
                      in
-                  let uu____13179 =
-                    let uu____13196 =
+                  let uu____13165 =
+                    let uu____13182 =
                       FStar_List.map2
                         (desugar_one_def (if is_rec then env' else env))
                         fnames1 funs
                        in
-                    FStar_All.pipe_right uu____13196 FStar_List.unzip  in
-                  (match uu____13179 with
+                    FStar_All.pipe_right uu____13182 FStar_List.unzip  in
+                  (match uu____13165 with
                    | (lbs1,aqss) ->
-                       let uu____13338 = desugar_term_aq env' body  in
-                       (match uu____13338 with
+                       let uu____13324 = desugar_term_aq env' body  in
+                       (match uu____13324 with
                         | (body1,aq) ->
                             (if is_rec
                              then
                                FStar_List.iter2
-                                 (fun uu____13444  ->
+                                 (fun uu____13430  ->
                                     fun used_marker  ->
-                                      match uu____13444 with
-                                      | (_attr_opt,(f,uu____13518,uu____13519),uu____13520)
+                                      match uu____13430 with
+                                      | (_attr_opt,(f,uu____13504,uu____13505),uu____13506)
                                           ->
-                                          let uu____13577 =
-                                            let uu____13579 =
+                                          let uu____13563 =
+                                            let uu____13565 =
                                               FStar_ST.op_Bang used_marker
                                                in
-                                            Prims.op_Negation uu____13579  in
-                                          if uu____13577
+                                            Prims.op_Negation uu____13565  in
+                                          if uu____13563
                                           then
-                                            let uu____13603 =
+                                            let uu____13589 =
                                               match f with
                                               | FStar_Util.Inl x ->
-                                                  let uu____13621 =
+                                                  let uu____13607 =
                                                     FStar_Ident.text_of_id x
                                                      in
-                                                  let uu____13623 =
+                                                  let uu____13609 =
                                                     FStar_Ident.range_of_id x
                                                      in
-                                                  (uu____13621, "Local",
-                                                    uu____13623)
+                                                  (uu____13607, "Local",
+                                                    uu____13609)
                                               | FStar_Util.Inr l ->
-                                                  let uu____13628 =
+                                                  let uu____13614 =
                                                     FStar_Ident.string_of_lid
                                                       l
                                                      in
-                                                  let uu____13630 =
+                                                  let uu____13616 =
                                                     FStar_Ident.range_of_lid
                                                       l
                                                      in
-                                                  (uu____13628, "Global",
-                                                    uu____13630)
+                                                  (uu____13614, "Global",
+                                                    uu____13616)
                                                in
-                                            (match uu____13603 with
+                                            (match uu____13589 with
                                              | (nm,gl,rng) ->
-                                                 let uu____13641 =
-                                                   let uu____13647 =
+                                                 let uu____13627 =
+                                                   let uu____13633 =
                                                      FStar_Util.format2
                                                        "%s binding %s is recursive but not used in its body"
                                                        gl nm
                                                       in
                                                    (FStar_Errors.Warning_UnusedLetRec,
-                                                     uu____13647)
+                                                     uu____13633)
                                                     in
                                                  FStar_Errors.log_issue rng
-                                                   uu____13641)
+                                                   uu____13627)
                                           else ()) funs used_markers1
                              else ();
-                             (let uu____13655 =
-                                let uu____13658 =
-                                  let uu____13659 =
-                                    let uu____13673 =
+                             (let uu____13641 =
+                                let uu____13644 =
+                                  let uu____13645 =
+                                    let uu____13659 =
                                       FStar_Syntax_Subst.close rec_bindings1
                                         body1
                                        in
-                                    ((is_rec, lbs1), uu____13673)  in
-                                  FStar_Syntax_Syntax.Tm_let uu____13659  in
-                                FStar_All.pipe_left mk uu____13658  in
-                              (uu____13655,
+                                    ((is_rec, lbs1), uu____13659)  in
+                                  FStar_Syntax_Syntax.Tm_let uu____13645  in
+                                FStar_All.pipe_left mk uu____13644  in
+                              (uu____13641,
                                 (FStar_List.append aq
                                    (FStar_List.flatten aqss)))))))
                in
@@ -3604,29 +3590,29 @@ and (desugar_term_maybe_top :
                 | FStar_Pervasives_Native.Some l ->
                     FStar_List.map (desugar_term env) l
                  in
-              let uu____13775 = desugar_term_aq env t1  in
-              match uu____13775 with
+              let uu____13761 = desugar_term_aq env t1  in
+              match uu____13761 with
               | (t11,aq0) ->
-                  let uu____13796 =
+                  let uu____13782 =
                     desugar_binding_pat_maybe_top top_level env pat  in
-                  (match uu____13796 with
+                  (match uu____13782 with
                    | (env1,binder,pat1) ->
-                       let uu____13826 =
+                       let uu____13812 =
                          match binder with
                          | LetBinder (l,(t,_tacopt)) ->
-                             let uu____13868 = desugar_term_aq env1 t2  in
-                             (match uu____13868 with
+                             let uu____13854 = desugar_term_aq env1 t2  in
+                             (match uu____13854 with
                               | (body1,aq) ->
                                   let fv =
-                                    let uu____13890 =
+                                    let uu____13876 =
                                       FStar_Syntax_Util.incr_delta_qualifier
                                         t11
                                        in
                                     FStar_Syntax_Syntax.lid_as_fv l
-                                      uu____13890
+                                      uu____13876
                                       FStar_Pervasives_Native.None
                                      in
-                                  let uu____13891 =
+                                  let uu____13877 =
                                     FStar_All.pipe_left mk
                                       (FStar_Syntax_Syntax.Tm_let
                                          ((false,
@@ -3636,10 +3622,10 @@ and (desugar_term_maybe_top :
                                                  (t11.FStar_Syntax_Syntax.pos))]),
                                            body1))
                                      in
-                                  (uu____13891, aq))
-                         | LocalBinder (x,uu____13932) ->
-                             let uu____13933 = desugar_term_aq env1 t2  in
-                             (match uu____13933 with
+                                  (uu____13877, aq))
+                         | LocalBinder (x,uu____13918) ->
+                             let uu____13919 = desugar_term_aq env1 t2  in
+                             (match uu____13919 with
                               | (body1,aq) ->
                                   let body2 =
                                     match pat1 with
@@ -3647,44 +3633,40 @@ and (desugar_term_maybe_top :
                                     | ({
                                          FStar_Syntax_Syntax.v =
                                            FStar_Syntax_Syntax.Pat_wild
-                                           uu____13955;
-                                         FStar_Syntax_Syntax.p = uu____13956;_},uu____13957)::[]
+                                           uu____13941;
+                                         FStar_Syntax_Syntax.p = uu____13942;_},uu____13943)::[]
                                         -> body1
-                                    | uu____13970 ->
-                                        let uu____13973 =
-                                          let uu____13980 =
-                                            let uu____13981 =
-                                              let uu____14004 =
-                                                FStar_Syntax_Syntax.bv_to_name
-                                                  x
-                                                 in
-                                              let uu____14007 =
-                                                desugar_disjunctive_pattern
-                                                  pat1
-                                                  FStar_Pervasives_Native.None
-                                                  body1
-                                                 in
-                                              (uu____14004, uu____14007)  in
-                                            FStar_Syntax_Syntax.Tm_match
-                                              uu____13981
-                                             in
-                                          FStar_Syntax_Syntax.mk uu____13980
+                                    | uu____13956 ->
+                                        let uu____13959 =
+                                          let uu____13960 =
+                                            let uu____13983 =
+                                              FStar_Syntax_Syntax.bv_to_name
+                                                x
+                                               in
+                                            let uu____13986 =
+                                              desugar_disjunctive_pattern
+                                                pat1
+                                                FStar_Pervasives_Native.None
+                                                body1
+                                               in
+                                            (uu____13983, uu____13986)  in
+                                          FStar_Syntax_Syntax.Tm_match
+                                            uu____13960
                                            in
-                                        uu____13973
-                                          FStar_Pervasives_Native.None
+                                        FStar_Syntax_Syntax.mk uu____13959
                                           top.FStar_Parser_AST.range
                                      in
-                                  let uu____14044 =
-                                    let uu____14047 =
-                                      let uu____14048 =
-                                        let uu____14062 =
-                                          let uu____14065 =
-                                            let uu____14066 =
+                                  let uu____14023 =
+                                    let uu____14026 =
+                                      let uu____14027 =
+                                        let uu____14041 =
+                                          let uu____14044 =
+                                            let uu____14045 =
                                               FStar_Syntax_Syntax.mk_binder x
                                                in
-                                            [uu____14066]  in
+                                            [uu____14045]  in
                                           FStar_Syntax_Subst.close
-                                            uu____14065 body2
+                                            uu____14044 body2
                                            in
                                         ((false,
                                            [mk_lb
@@ -3692,78 +3674,78 @@ and (desugar_term_maybe_top :
                                                 (x.FStar_Syntax_Syntax.sort),
                                                 t11,
                                                 (t11.FStar_Syntax_Syntax.pos))]),
-                                          uu____14062)
+                                          uu____14041)
                                          in
-                                      FStar_Syntax_Syntax.Tm_let uu____14048
+                                      FStar_Syntax_Syntax.Tm_let uu____14027
                                        in
-                                    FStar_All.pipe_left mk uu____14047  in
-                                  (uu____14044, aq))
+                                    FStar_All.pipe_left mk uu____14026  in
+                                  (uu____14023, aq))
                           in
-                       (match uu____13826 with
+                       (match uu____13812 with
                         | (tm,aq1) -> (tm, (FStar_List.append aq0 aq1))))
                in
-            let uu____14174 = FStar_List.hd lbs  in
-            (match uu____14174 with
+            let uu____14153 = FStar_List.hd lbs  in
+            (match uu____14153 with
              | (attrs,(head_pat,defn)) ->
-                 let uu____14218 = is_rec || (is_app_pattern head_pat)  in
-                 if uu____14218
+                 let uu____14197 = is_rec || (is_app_pattern head_pat)  in
+                 if uu____14197
                  then ds_let_rec_or_app ()
                  else ds_non_rec attrs head_pat defn body)
         | FStar_Parser_AST.If (t1,t2,t3) ->
             let x =
-              let uu____14231 = tun_r t3.FStar_Parser_AST.range  in
+              let uu____14210 = tun_r t3.FStar_Parser_AST.range  in
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (t3.FStar_Parser_AST.range))
-                uu____14231
+                uu____14210
                in
             let t_bool =
-              let uu____14235 =
-                let uu____14236 =
+              let uu____14214 =
+                let uu____14215 =
                   FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.bool_lid
                     FStar_Syntax_Syntax.delta_constant
                     FStar_Pervasives_Native.None
                    in
-                FStar_Syntax_Syntax.Tm_fvar uu____14236  in
-              mk uu____14235  in
-            let uu____14237 = desugar_term_aq env t1  in
-            (match uu____14237 with
+                FStar_Syntax_Syntax.Tm_fvar uu____14215  in
+              mk uu____14214  in
+            let uu____14216 = desugar_term_aq env t1  in
+            (match uu____14216 with
              | (t1',aq1) ->
-                 let uu____14248 = desugar_term_aq env t2  in
-                 (match uu____14248 with
+                 let uu____14227 = desugar_term_aq env t2  in
+                 (match uu____14227 with
                   | (t2',aq2) ->
-                      let uu____14259 = desugar_term_aq env t3  in
-                      (match uu____14259 with
+                      let uu____14238 = desugar_term_aq env t3  in
+                      (match uu____14238 with
                        | (t3',aq3) ->
-                           let uu____14270 =
-                             let uu____14271 =
-                               let uu____14272 =
-                                 let uu____14295 =
-                                   let uu____14312 =
-                                     let uu____14327 =
+                           let uu____14249 =
+                             let uu____14250 =
+                               let uu____14251 =
+                                 let uu____14274 =
+                                   let uu____14291 =
+                                     let uu____14306 =
                                        FStar_Syntax_Syntax.withinfo
                                          (FStar_Syntax_Syntax.Pat_constant
                                             (FStar_Const.Const_bool true))
                                          t1.FStar_Parser_AST.range
                                         in
-                                     (uu____14327,
+                                     (uu____14306,
                                        FStar_Pervasives_Native.None, t2')
                                       in
-                                   let uu____14341 =
-                                     let uu____14358 =
-                                       let uu____14373 =
+                                   let uu____14320 =
+                                     let uu____14337 =
+                                       let uu____14352 =
                                          FStar_Syntax_Syntax.withinfo
                                            (FStar_Syntax_Syntax.Pat_wild x)
                                            t1.FStar_Parser_AST.range
                                           in
-                                       (uu____14373,
+                                       (uu____14352,
                                          FStar_Pervasives_Native.None, t3')
                                         in
-                                     [uu____14358]  in
-                                   uu____14312 :: uu____14341  in
-                                 (t1', uu____14295)  in
-                               FStar_Syntax_Syntax.Tm_match uu____14272  in
-                             mk uu____14271  in
-                           (uu____14270, (join_aqs [aq1; aq2; aq3])))))
+                                     [uu____14337]  in
+                                   uu____14291 :: uu____14320  in
+                                 (t1', uu____14274)  in
+                               FStar_Syntax_Syntax.Tm_match uu____14251  in
+                             mk uu____14250  in
+                           (uu____14249, (join_aqs [aq1; aq2; aq3])))))
         | FStar_Parser_AST.TryWith (e,branches) ->
             let r = top.FStar_Parser_AST.range  in
             let handler = FStar_Parser_AST.mk_function branches r r  in
@@ -3791,75 +3773,75 @@ and (desugar_term_maybe_top :
                in
             desugar_term_aq env a2
         | FStar_Parser_AST.Match (e,branches) ->
-            let desugar_branch uu____14569 =
-              match uu____14569 with
+            let desugar_branch uu____14548 =
+              match uu____14548 with
               | (pat,wopt,b) ->
-                  let uu____14591 = desugar_match_pat env pat  in
-                  (match uu____14591 with
+                  let uu____14570 = desugar_match_pat env pat  in
+                  (match uu____14570 with
                    | (env1,pat1) ->
                        let wopt1 =
                          match wopt with
                          | FStar_Pervasives_Native.None  ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some e1 ->
-                             let uu____14622 = desugar_term env1 e1  in
-                             FStar_Pervasives_Native.Some uu____14622
+                             let uu____14601 = desugar_term env1 e1  in
+                             FStar_Pervasives_Native.Some uu____14601
                           in
-                       let uu____14627 = desugar_term_aq env1 b  in
-                       (match uu____14627 with
+                       let uu____14606 = desugar_term_aq env1 b  in
+                       (match uu____14606 with
                         | (b1,aq) ->
-                            let uu____14640 =
+                            let uu____14619 =
                               desugar_disjunctive_pattern pat1 wopt1 b1  in
-                            (uu____14640, aq)))
+                            (uu____14619, aq)))
                in
-            let uu____14645 = desugar_term_aq env e  in
-            (match uu____14645 with
+            let uu____14624 = desugar_term_aq env e  in
+            (match uu____14624 with
              | (e1,aq) ->
-                 let uu____14656 =
-                   let uu____14687 =
-                     let uu____14720 = FStar_List.map desugar_branch branches
+                 let uu____14635 =
+                   let uu____14666 =
+                     let uu____14699 = FStar_List.map desugar_branch branches
                         in
-                     FStar_All.pipe_right uu____14720 FStar_List.unzip  in
-                   FStar_All.pipe_right uu____14687
-                     (fun uu____14938  ->
-                        match uu____14938 with
+                     FStar_All.pipe_right uu____14699 FStar_List.unzip  in
+                   FStar_All.pipe_right uu____14666
+                     (fun uu____14917  ->
+                        match uu____14917 with
                         | (x,y) -> ((FStar_List.flatten x), y))
                     in
-                 (match uu____14656 with
+                 (match uu____14635 with
                   | (brs,aqs) ->
-                      let uu____15157 =
+                      let uu____15136 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_match (e1, brs))
                          in
-                      (uu____15157, (join_aqs (aq :: aqs)))))
+                      (uu____15136, (join_aqs (aq :: aqs)))))
         | FStar_Parser_AST.Ascribed (e,t,tac_opt) ->
-            let uu____15191 =
-              let uu____15212 = is_comp_type env t  in
-              if uu____15212
+            let uu____15170 =
+              let uu____15191 = is_comp_type env t  in
+              if uu____15191
               then
                 let comp = desugar_comp t.FStar_Parser_AST.range true env t
                    in
                 ((FStar_Util.Inr comp), [])
               else
-                (let uu____15267 = desugar_term_aq env t  in
-                 match uu____15267 with
+                (let uu____15246 = desugar_term_aq env t  in
+                 match uu____15246 with
                  | (tm,aq) -> ((FStar_Util.Inl tm), aq))
                in
-            (match uu____15191 with
+            (match uu____15170 with
              | (annot,aq0) ->
                  let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env)
                     in
-                 let uu____15359 = desugar_term_aq env e  in
-                 (match uu____15359 with
+                 let uu____15338 = desugar_term_aq env e  in
+                 (match uu____15338 with
                   | (e1,aq) ->
-                      let uu____15370 =
+                      let uu____15349 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_ascribed
                              (e1, (annot, tac_opt1),
                                FStar_Pervasives_Native.None))
                          in
-                      (uu____15370, (FStar_List.append aq0 aq))))
-        | FStar_Parser_AST.Record (uu____15409,[]) ->
+                      (uu____15349, (FStar_List.append aq0 aq))))
+        | FStar_Parser_AST.Record (uu____15388,[]) ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnexpectedEmptyRecord,
                 "Unexpected empty record") top.FStar_Parser_AST.range
@@ -3867,45 +3849,45 @@ and (desugar_term_maybe_top :
             let record = check_fields env fields top.FStar_Parser_AST.range
                in
             let user_ns =
-              let uu____15452 = FStar_List.hd fields  in
-              match uu____15452 with
-              | (f,uu____15464) -> FStar_Ident.ns_of_lid f  in
+              let uu____15431 = FStar_List.hd fields  in
+              match uu____15431 with
+              | (f,uu____15443) -> FStar_Ident.ns_of_lid f  in
             let get_field xopt f =
               let found =
                 FStar_All.pipe_right fields
                   (FStar_Util.find_opt
-                     (fun uu____15512  ->
-                        match uu____15512 with
-                        | (g,uu____15519) ->
-                            let uu____15520 = FStar_Ident.text_of_id f  in
-                            let uu____15522 =
-                              let uu____15524 = FStar_Ident.ident_of_lid g
+                     (fun uu____15491  ->
+                        match uu____15491 with
+                        | (g,uu____15498) ->
+                            let uu____15499 = FStar_Ident.text_of_id f  in
+                            let uu____15501 =
+                              let uu____15503 = FStar_Ident.ident_of_lid g
                                  in
-                              FStar_Ident.text_of_id uu____15524  in
-                            uu____15520 = uu____15522))
+                              FStar_Ident.text_of_id uu____15503  in
+                            uu____15499 = uu____15501))
                  in
               let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f])
                  in
               match found with
-              | FStar_Pervasives_Native.Some (uu____15531,e) -> (fn, e)
+              | FStar_Pervasives_Native.Some (uu____15510,e) -> (fn, e)
               | FStar_Pervasives_Native.None  ->
                   (match xopt with
                    | FStar_Pervasives_Native.None  ->
-                       let uu____15545 =
-                         let uu____15551 =
-                           let uu____15553 = FStar_Ident.text_of_id f  in
-                           let uu____15555 =
+                       let uu____15524 =
+                         let uu____15530 =
+                           let uu____15532 = FStar_Ident.text_of_id f  in
+                           let uu____15534 =
                              FStar_Ident.string_of_lid
                                record.FStar_Syntax_DsEnv.typename
                               in
                            FStar_Util.format2
                              "Field %s of record type %s is missing"
-                             uu____15553 uu____15555
+                             uu____15532 uu____15534
                             in
                          (FStar_Errors.Fatal_MissingFieldInRecord,
-                           uu____15551)
+                           uu____15530)
                           in
-                       FStar_Errors.raise_error uu____15545
+                       FStar_Errors.raise_error uu____15524
                          top.FStar_Parser_AST.range
                    | FStar_Pervasives_Native.Some x ->
                        (fn,
@@ -3921,206 +3903,206 @@ and (desugar_term_maybe_top :
             let recterm =
               match eopt with
               | FStar_Pervasives_Native.None  ->
-                  let uu____15566 =
-                    let uu____15577 =
+                  let uu____15545 =
+                    let uu____15556 =
                       FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                         (FStar_List.map
-                           (fun uu____15608  ->
-                              match uu____15608 with
-                              | (f,uu____15618) ->
-                                  let uu____15619 =
-                                    let uu____15620 =
+                           (fun uu____15587  ->
+                              match uu____15587 with
+                              | (f,uu____15597) ->
+                                  let uu____15598 =
+                                    let uu____15599 =
                                       get_field FStar_Pervasives_Native.None
                                         f
                                        in
                                     FStar_All.pipe_left
-                                      FStar_Pervasives_Native.snd uu____15620
+                                      FStar_Pervasives_Native.snd uu____15599
                                      in
-                                  (uu____15619, FStar_Parser_AST.Nothing)))
+                                  (uu____15598, FStar_Parser_AST.Nothing)))
                        in
-                    (user_constrname, uu____15577)  in
-                  FStar_Parser_AST.Construct uu____15566
+                    (user_constrname, uu____15556)  in
+                  FStar_Parser_AST.Construct uu____15545
               | FStar_Pervasives_Native.Some e ->
                   let x = FStar_Ident.gen e.FStar_Parser_AST.range  in
                   let xterm =
-                    let uu____15638 =
-                      let uu____15639 = FStar_Ident.lid_of_ids [x]  in
-                      FStar_Parser_AST.Var uu____15639  in
-                    let uu____15640 = FStar_Ident.range_of_id x  in
-                    FStar_Parser_AST.mk_term uu____15638 uu____15640
+                    let uu____15617 =
+                      let uu____15618 = FStar_Ident.lid_of_ids [x]  in
+                      FStar_Parser_AST.Var uu____15618  in
+                    let uu____15619 = FStar_Ident.range_of_id x  in
+                    FStar_Parser_AST.mk_term uu____15617 uu____15619
                       FStar_Parser_AST.Expr
                      in
                   let record1 =
-                    let uu____15642 =
-                      let uu____15655 =
+                    let uu____15621 =
+                      let uu____15634 =
                         FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                           (FStar_List.map
-                             (fun uu____15685  ->
-                                match uu____15685 with
-                                | (f,uu____15695) ->
+                             (fun uu____15664  ->
+                                match uu____15664 with
+                                | (f,uu____15674) ->
                                     get_field
                                       (FStar_Pervasives_Native.Some xterm) f))
                          in
-                      (FStar_Pervasives_Native.None, uu____15655)  in
-                    FStar_Parser_AST.Record uu____15642  in
-                  let uu____15704 =
-                    let uu____15725 =
-                      let uu____15740 =
-                        let uu____15753 =
-                          let uu____15758 =
-                            let uu____15759 = FStar_Ident.range_of_id x  in
+                      (FStar_Pervasives_Native.None, uu____15634)  in
+                    FStar_Parser_AST.Record uu____15621  in
+                  let uu____15683 =
+                    let uu____15704 =
+                      let uu____15719 =
+                        let uu____15732 =
+                          let uu____15737 =
+                            let uu____15738 = FStar_Ident.range_of_id x  in
                             FStar_Parser_AST.mk_pattern
                               (FStar_Parser_AST.PatVar
                                  (x, FStar_Pervasives_Native.None))
-                              uu____15759
+                              uu____15738
                              in
-                          (uu____15758, e)  in
-                        (FStar_Pervasives_Native.None, uu____15753)  in
-                      [uu____15740]  in
-                    (FStar_Parser_AST.NoLetQualifier, uu____15725,
+                          (uu____15737, e)  in
+                        (FStar_Pervasives_Native.None, uu____15732)  in
+                      [uu____15719]  in
+                    (FStar_Parser_AST.NoLetQualifier, uu____15704,
                       (FStar_Parser_AST.mk_term record1
                          top.FStar_Parser_AST.range
                          top.FStar_Parser_AST.level))
                      in
-                  FStar_Parser_AST.Let uu____15704
+                  FStar_Parser_AST.Let uu____15683
                in
             let recterm1 =
               FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level
                in
-            let uu____15811 = desugar_term_aq env recterm1  in
-            (match uu____15811 with
+            let uu____15790 = desugar_term_aq env recterm1  in
+            (match uu____15790 with
              | (e,s) ->
                  (match e.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____15827;
-                         FStar_Syntax_Syntax.vars = uu____15828;_},args)
+                         FStar_Syntax_Syntax.pos = uu____15806;
+                         FStar_Syntax_Syntax.vars = uu____15807;_},args)
                       ->
-                      let uu____15854 =
-                        let uu____15855 =
-                          let uu____15856 =
-                            let uu____15873 =
-                              let uu____15876 =
+                      let uu____15833 =
+                        let uu____15834 =
+                          let uu____15835 =
+                            let uu____15852 =
+                              let uu____15855 =
                                 FStar_Ident.set_lid_range
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   e.FStar_Syntax_Syntax.pos
                                  in
-                              let uu____15877 =
-                                let uu____15880 =
-                                  let uu____15881 =
-                                    let uu____15888 =
+                              let uu____15856 =
+                                let uu____15859 =
+                                  let uu____15860 =
+                                    let uu____15867 =
                                       FStar_All.pipe_right
                                         record.FStar_Syntax_DsEnv.fields
                                         (FStar_List.map
                                            FStar_Pervasives_Native.fst)
                                        in
                                     ((record.FStar_Syntax_DsEnv.typename),
-                                      uu____15888)
+                                      uu____15867)
                                      in
-                                  FStar_Syntax_Syntax.Record_ctor uu____15881
+                                  FStar_Syntax_Syntax.Record_ctor uu____15860
                                    in
-                                FStar_Pervasives_Native.Some uu____15880  in
-                              FStar_Syntax_Syntax.fvar uu____15876
+                                FStar_Pervasives_Native.Some uu____15859  in
+                              FStar_Syntax_Syntax.fvar uu____15855
                                 FStar_Syntax_Syntax.delta_constant
-                                uu____15877
+                                uu____15856
                                in
-                            (uu____15873, args)  in
-                          FStar_Syntax_Syntax.Tm_app uu____15856  in
-                        FStar_All.pipe_left mk uu____15855  in
-                      (uu____15854, s)
-                  | uu____15917 -> (e, s)))
+                            (uu____15852, args)  in
+                          FStar_Syntax_Syntax.Tm_app uu____15835  in
+                        FStar_All.pipe_left mk uu____15834  in
+                      (uu____15833, s)
+                  | uu____15896 -> (e, s)))
         | FStar_Parser_AST.Project (e,f) ->
-            let uu____15920 =
+            let uu____15899 =
               FStar_Syntax_DsEnv.fail_or env
                 (FStar_Syntax_DsEnv.try_lookup_dc_by_field_name env) f
                in
-            (match uu____15920 with
+            (match uu____15899 with
              | (constrname,is_rec) ->
-                 let uu____15939 = desugar_term_aq env e  in
-                 (match uu____15939 with
+                 let uu____15918 = desugar_term_aq env e  in
+                 (match uu____15918 with
                   | (e1,s) ->
                       let projname =
-                        let uu____15951 = FStar_Ident.ident_of_lid f  in
+                        let uu____15930 = FStar_Ident.ident_of_lid f  in
                         FStar_Syntax_Util.mk_field_projector_name_from_ident
-                          constrname uu____15951
+                          constrname uu____15930
                          in
                       let qual =
                         if is_rec
                         then
-                          let uu____15958 =
-                            let uu____15959 =
-                              let uu____15964 = FStar_Ident.ident_of_lid f
+                          let uu____15937 =
+                            let uu____15938 =
+                              let uu____15943 = FStar_Ident.ident_of_lid f
                                  in
-                              (constrname, uu____15964)  in
-                            FStar_Syntax_Syntax.Record_projector uu____15959
+                              (constrname, uu____15943)  in
+                            FStar_Syntax_Syntax.Record_projector uu____15938
                              in
-                          FStar_Pervasives_Native.Some uu____15958
+                          FStar_Pervasives_Native.Some uu____15937
                         else FStar_Pervasives_Native.None  in
-                      let uu____15967 =
-                        let uu____15968 =
-                          let uu____15969 =
-                            let uu____15986 =
-                              let uu____15989 =
+                      let uu____15946 =
+                        let uu____15947 =
+                          let uu____15948 =
+                            let uu____15965 =
+                              let uu____15968 =
                                 FStar_Ident.set_lid_range projname
                                   top.FStar_Parser_AST.range
                                  in
-                              FStar_Syntax_Syntax.fvar uu____15989
+                              FStar_Syntax_Syntax.fvar uu____15968
                                 (FStar_Syntax_Syntax.Delta_equational_at_level
                                    Prims.int_one) qual
                                in
-                            let uu____15991 =
-                              let uu____16002 = FStar_Syntax_Syntax.as_arg e1
+                            let uu____15970 =
+                              let uu____15981 = FStar_Syntax_Syntax.as_arg e1
                                  in
-                              [uu____16002]  in
-                            (uu____15986, uu____15991)  in
-                          FStar_Syntax_Syntax.Tm_app uu____15969  in
-                        FStar_All.pipe_left mk uu____15968  in
-                      (uu____15967, s)))
+                              [uu____15981]  in
+                            (uu____15965, uu____15970)  in
+                          FStar_Syntax_Syntax.Tm_app uu____15948  in
+                        FStar_All.pipe_left mk uu____15947  in
+                      (uu____15946, s)))
         | FStar_Parser_AST.NamedTyp (n,e) ->
-            ((let uu____16042 = FStar_Ident.range_of_id n  in
-              FStar_Errors.log_issue uu____16042
+            ((let uu____16021 = FStar_Ident.range_of_id n  in
+              FStar_Errors.log_issue uu____16021
                 (FStar_Errors.Warning_IgnoredBinding,
                   "This name is being ignored"));
              desugar_term_aq env e)
         | FStar_Parser_AST.Paren e -> failwith "impossible"
         | FStar_Parser_AST.VQuote e ->
             let tm = desugar_term env e  in
-            let uu____16053 =
-              let uu____16054 = FStar_Syntax_Subst.compress tm  in
-              uu____16054.FStar_Syntax_Syntax.n  in
-            (match uu____16053 with
+            let uu____16032 =
+              let uu____16033 = FStar_Syntax_Subst.compress tm  in
+              uu____16033.FStar_Syntax_Syntax.n  in
+            (match uu____16032 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____16062 =
-                   let uu___2065_16063 =
-                     let uu____16064 =
-                       let uu____16066 = FStar_Syntax_Syntax.lid_of_fv fv  in
-                       FStar_Ident.string_of_lid uu____16066  in
-                     FStar_Syntax_Util.exp_string uu____16064  in
+                 let uu____16041 =
+                   let uu___2065_16042 =
+                     let uu____16043 =
+                       let uu____16045 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                       FStar_Ident.string_of_lid uu____16045  in
+                     FStar_Syntax_Util.exp_string uu____16043  in
                    {
                      FStar_Syntax_Syntax.n =
-                       (uu___2065_16063.FStar_Syntax_Syntax.n);
+                       (uu___2065_16042.FStar_Syntax_Syntax.n);
                      FStar_Syntax_Syntax.pos = (e.FStar_Parser_AST.range);
                      FStar_Syntax_Syntax.vars =
-                       (uu___2065_16063.FStar_Syntax_Syntax.vars)
+                       (uu___2065_16042.FStar_Syntax_Syntax.vars)
                    }  in
-                 (uu____16062, noaqs)
-             | uu____16067 ->
-                 let uu____16068 =
-                   let uu____16074 =
-                     let uu____16076 = FStar_Syntax_Print.term_to_string tm
+                 (uu____16041, noaqs)
+             | uu____16046 ->
+                 let uu____16047 =
+                   let uu____16053 =
+                     let uu____16055 = FStar_Syntax_Print.term_to_string tm
                         in
                      Prims.op_Hat "VQuote, expected an fvar, got: "
-                       uu____16076
+                       uu____16055
                       in
-                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____16074)  in
-                 FStar_Errors.raise_error uu____16068
+                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____16053)  in
+                 FStar_Errors.raise_error uu____16047
                    top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Quote (e,FStar_Parser_AST.Static ) ->
-            let uu____16085 = desugar_term_aq env e  in
-            (match uu____16085 with
+            let uu____16064 = desugar_term_aq env e  in
+            (match uu____16064 with
              | (tm,vts) ->
                  let qi =
                    {
@@ -4128,38 +4110,38 @@ and (desugar_term_maybe_top :
                        FStar_Syntax_Syntax.Quote_static;
                      FStar_Syntax_Syntax.antiquotes = vts
                    }  in
-                 let uu____16097 =
+                 let uu____16076 =
                    FStar_All.pipe_left mk
                      (FStar_Syntax_Syntax.Tm_quoted (tm, qi))
                     in
-                 (uu____16097, noaqs))
+                 (uu____16076, noaqs))
         | FStar_Parser_AST.Antiquote e ->
             let bv =
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (e.FStar_Parser_AST.range))
                 FStar_Syntax_Syntax.tun
                in
-            let uu____16102 = FStar_Syntax_Syntax.bv_to_name bv  in
-            let uu____16103 =
-              let uu____16104 =
-                let uu____16111 = desugar_term env e  in (bv, uu____16111)
+            let uu____16081 = FStar_Syntax_Syntax.bv_to_name bv  in
+            let uu____16082 =
+              let uu____16083 =
+                let uu____16090 = desugar_term env e  in (bv, uu____16090)
                  in
-              [uu____16104]  in
-            (uu____16102, uu____16103)
+              [uu____16083]  in
+            (uu____16081, uu____16082)
         | FStar_Parser_AST.Quote (e,FStar_Parser_AST.Dynamic ) ->
             let qi =
               {
                 FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
                 FStar_Syntax_Syntax.antiquotes = []
               }  in
-            let uu____16136 =
-              let uu____16137 =
-                let uu____16138 =
-                  let uu____16145 = desugar_term env e  in (uu____16145, qi)
+            let uu____16115 =
+              let uu____16116 =
+                let uu____16117 =
+                  let uu____16124 = desugar_term env e  in (uu____16124, qi)
                    in
-                FStar_Syntax_Syntax.Tm_quoted uu____16138  in
-              FStar_All.pipe_left mk uu____16137  in
-            (uu____16136, noaqs)
+                FStar_Syntax_Syntax.Tm_quoted uu____16117  in
+              FStar_All.pipe_left mk uu____16116  in
+            (uu____16115, noaqs)
         | FStar_Parser_AST.CalcProof (rel,init_expr,steps) ->
             let is_impl rel1 =
               let is_impl_t t =
@@ -4167,29 +4149,29 @@ and (desugar_term_maybe_top :
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.imp_lid
-                | uu____16174 -> false  in
-              let uu____16176 =
-                let uu____16177 = unparen rel1  in
-                uu____16177.FStar_Parser_AST.tm  in
-              match uu____16176 with
-              | FStar_Parser_AST.Op (id,uu____16180) ->
-                  let uu____16185 = op_as_term env (Prims.of_int (2)) id  in
-                  (match uu____16185 with
+                | uu____16153 -> false  in
+              let uu____16155 =
+                let uu____16156 = unparen rel1  in
+                uu____16156.FStar_Parser_AST.tm  in
+              match uu____16155 with
+              | FStar_Parser_AST.Op (id,uu____16159) ->
+                  let uu____16164 = op_as_term env (Prims.of_int (2)) id  in
+                  (match uu____16164 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None  -> false)
               | FStar_Parser_AST.Var lid ->
-                  let uu____16193 = desugar_name' (fun x  -> x) env true lid
+                  let uu____16172 = desugar_name' (fun x  -> x) env true lid
                      in
-                  (match uu____16193 with
+                  (match uu____16172 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None  -> false)
               | FStar_Parser_AST.Tvar id ->
-                  let uu____16204 = FStar_Syntax_DsEnv.try_lookup_id env id
+                  let uu____16183 = FStar_Syntax_DsEnv.try_lookup_id env id
                      in
-                  (match uu____16204 with
+                  (match uu____16183 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None  -> false)
-              | uu____16210 -> false  in
+              | uu____16189 -> false  in
             let eta_and_annot rel1 =
               let x = FStar_Ident.gen' "x" rel1.FStar_Parser_AST.range  in
               let y = FStar_Ident.gen' "y" rel1.FStar_Parser_AST.range  in
@@ -4209,35 +4191,35 @@ and (desugar_term_maybe_top :
                   (FStar_Parser_AST.PatVar (y, FStar_Pervasives_Native.None))
                   rel1.FStar_Parser_AST.range]
                  in
-              let uu____16231 =
-                let uu____16232 =
-                  let uu____16239 =
-                    let uu____16240 =
-                      let uu____16241 =
-                        let uu____16250 =
+              let uu____16210 =
+                let uu____16211 =
+                  let uu____16218 =
+                    let uu____16219 =
+                      let uu____16220 =
+                        let uu____16229 =
                           FStar_Parser_AST.mkApp rel1
                             [(xt, FStar_Parser_AST.Nothing);
                             (yt, FStar_Parser_AST.Nothing)]
                             rel1.FStar_Parser_AST.range
                            in
-                        let uu____16263 =
-                          let uu____16264 =
-                            let uu____16265 = FStar_Ident.lid_of_str "Type0"
+                        let uu____16242 =
+                          let uu____16243 =
+                            let uu____16244 = FStar_Ident.lid_of_str "Type0"
                                in
-                            FStar_Parser_AST.Name uu____16265  in
-                          FStar_Parser_AST.mk_term uu____16264
+                            FStar_Parser_AST.Name uu____16244  in
+                          FStar_Parser_AST.mk_term uu____16243
                             rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                            in
-                        (uu____16250, uu____16263,
+                        (uu____16229, uu____16242,
                           FStar_Pervasives_Native.None)
                          in
-                      FStar_Parser_AST.Ascribed uu____16241  in
-                    FStar_Parser_AST.mk_term uu____16240
+                      FStar_Parser_AST.Ascribed uu____16220  in
+                    FStar_Parser_AST.mk_term uu____16219
                       rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                      in
-                  (pats, uu____16239)  in
-                FStar_Parser_AST.Abs uu____16232  in
-              FStar_Parser_AST.mk_term uu____16231
+                  (pats, uu____16218)  in
+                FStar_Parser_AST.Abs uu____16211  in
+              FStar_Parser_AST.mk_term uu____16210
                 rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr
                in
             let rel1 = eta_and_annot rel  in
@@ -4256,10 +4238,10 @@ and (desugar_term_maybe_top :
                 r FStar_Parser_AST.Expr
                in
             let last_expr =
-              let uu____16286 = FStar_List.last steps  in
-              match uu____16286 with
+              let uu____16265 = FStar_List.last steps  in
+              match uu____16265 with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.CalcStep
-                  (uu____16289,uu____16290,last_expr)) -> last_expr
+                  (uu____16268,uu____16269,last_expr)) -> last_expr
               | FStar_Pervasives_Native.None  -> init_expr  in
             let step r =
               FStar_Parser_AST.mk_term
@@ -4278,98 +4260,98 @@ and (desugar_term_maybe_top :
                 [(init_expr, FStar_Parser_AST.Nothing)]
                 init_expr.FStar_Parser_AST.range
                in
-            let uu____16316 =
+            let uu____16295 =
               FStar_List.fold_left
-                (fun uu____16334  ->
-                   fun uu____16335  ->
-                     match (uu____16334, uu____16335) with
+                (fun uu____16313  ->
+                   fun uu____16314  ->
+                     match (uu____16313, uu____16314) with
                      | ((e1,prev),FStar_Parser_AST.CalcStep
                         (rel2,just,next_expr)) ->
                          let just1 =
-                           let uu____16358 = is_impl rel2  in
-                           if uu____16358
+                           let uu____16337 = is_impl rel2  in
+                           if uu____16337
                            then
-                             let uu____16361 =
-                               let uu____16368 =
-                                 let uu____16373 =
+                             let uu____16340 =
+                               let uu____16347 =
+                                 let uu____16352 =
                                    FStar_Parser_AST.thunk just  in
-                                 (uu____16373, FStar_Parser_AST.Nothing)  in
-                               [uu____16368]  in
+                                 (uu____16352, FStar_Parser_AST.Nothing)  in
+                               [uu____16347]  in
                              FStar_Parser_AST.mkApp
                                (push_impl just.FStar_Parser_AST.range)
-                               uu____16361 just.FStar_Parser_AST.range
+                               uu____16340 just.FStar_Parser_AST.range
                            else just  in
                          let pf =
-                           let uu____16385 =
-                             let uu____16392 =
-                               let uu____16399 =
-                                 let uu____16406 =
-                                   let uu____16413 =
-                                     let uu____16418 = eta_and_annot rel2  in
-                                     (uu____16418, FStar_Parser_AST.Nothing)
+                           let uu____16364 =
+                             let uu____16371 =
+                               let uu____16378 =
+                                 let uu____16385 =
+                                   let uu____16392 =
+                                     let uu____16397 = eta_and_annot rel2  in
+                                     (uu____16397, FStar_Parser_AST.Nothing)
                                       in
-                                   let uu____16419 =
-                                     let uu____16426 =
-                                       let uu____16433 =
-                                         let uu____16438 =
+                                   let uu____16398 =
+                                     let uu____16405 =
+                                       let uu____16412 =
+                                         let uu____16417 =
                                            FStar_Parser_AST.thunk e1  in
-                                         (uu____16438,
+                                         (uu____16417,
                                            FStar_Parser_AST.Nothing)
                                           in
-                                       let uu____16439 =
-                                         let uu____16446 =
-                                           let uu____16451 =
+                                       let uu____16418 =
+                                         let uu____16425 =
+                                           let uu____16430 =
                                              FStar_Parser_AST.thunk just1  in
-                                           (uu____16451,
+                                           (uu____16430,
                                              FStar_Parser_AST.Nothing)
                                             in
-                                         [uu____16446]  in
-                                       uu____16433 :: uu____16439  in
+                                         [uu____16425]  in
+                                       uu____16412 :: uu____16418  in
                                      (next_expr, FStar_Parser_AST.Nothing) ::
-                                       uu____16426
+                                       uu____16405
                                       in
-                                   uu____16413 :: uu____16419  in
-                                 (prev, FStar_Parser_AST.Hash) :: uu____16406
+                                   uu____16392 :: uu____16398  in
+                                 (prev, FStar_Parser_AST.Hash) :: uu____16385
                                   in
                                (init_expr, FStar_Parser_AST.Hash) ::
-                                 uu____16399
+                                 uu____16378
                                 in
                              ((wild rel2.FStar_Parser_AST.range),
-                               FStar_Parser_AST.Hash) :: uu____16392
+                               FStar_Parser_AST.Hash) :: uu____16371
                               in
                            FStar_Parser_AST.mkApp
-                             (step rel2.FStar_Parser_AST.range) uu____16385
+                             (step rel2.FStar_Parser_AST.range) uu____16364
                              FStar_Range.dummyRange
                             in
                          (pf, next_expr)) (e, init_expr) steps
                in
-            (match uu____16316 with
-             | (e1,uu____16489) ->
+            (match uu____16295 with
+             | (e1,uu____16468) ->
                  let e2 =
-                   let uu____16491 =
-                     let uu____16498 =
-                       let uu____16505 =
-                         let uu____16512 =
-                           let uu____16517 = FStar_Parser_AST.thunk e1  in
-                           (uu____16517, FStar_Parser_AST.Nothing)  in
-                         [uu____16512]  in
-                       (last_expr, FStar_Parser_AST.Hash) :: uu____16505  in
-                     (init_expr, FStar_Parser_AST.Hash) :: uu____16498  in
-                   FStar_Parser_AST.mkApp finish uu____16491
+                   let uu____16470 =
+                     let uu____16477 =
+                       let uu____16484 =
+                         let uu____16491 =
+                           let uu____16496 = FStar_Parser_AST.thunk e1  in
+                           (uu____16496, FStar_Parser_AST.Nothing)  in
+                         [uu____16491]  in
+                       (last_expr, FStar_Parser_AST.Hash) :: uu____16484  in
+                     (init_expr, FStar_Parser_AST.Hash) :: uu____16477  in
+                   FStar_Parser_AST.mkApp finish uu____16470
                      top.FStar_Parser_AST.range
                     in
                  desugar_term_maybe_top top_level env e2)
-        | uu____16534 when
+        | uu____16513 when
             top.FStar_Parser_AST.level = FStar_Parser_AST.Formula ->
-            let uu____16535 = desugar_formula env top  in
-            (uu____16535, noaqs)
-        | uu____16536 ->
-            let uu____16537 =
-              let uu____16543 =
-                let uu____16545 = FStar_Parser_AST.term_to_string top  in
-                Prims.op_Hat "Unexpected term: " uu____16545  in
-              (FStar_Errors.Fatal_UnexpectedTerm, uu____16543)  in
-            FStar_Errors.raise_error uu____16537 top.FStar_Parser_AST.range
+            let uu____16514 = desugar_formula env top  in
+            (uu____16514, noaqs)
+        | uu____16515 ->
+            let uu____16516 =
+              let uu____16522 =
+                let uu____16524 = FStar_Parser_AST.term_to_string top  in
+                Prims.op_Hat "Unexpected term: " uu____16524  in
+              (FStar_Errors.Fatal_UnexpectedTerm, uu____16522)  in
+            FStar_Errors.raise_error uu____16516 top.FStar_Parser_AST.range
 
 and (desugar_args :
   FStar_Syntax_DsEnv.env ->
@@ -4381,11 +4363,11 @@ and (desugar_args :
     fun args  ->
       FStar_All.pipe_right args
         (FStar_List.map
-           (fun uu____16589  ->
-              match uu____16589 with
+           (fun uu____16568  ->
+              match uu____16568 with
               | (a,imp) ->
-                  let uu____16602 = desugar_term env a  in
-                  arg_withimp_e imp uu____16602))
+                  let uu____16581 = desugar_term env a  in
+                  arg_withimp_e imp uu____16581))
 
 and (desugar_comp :
   FStar_Range.range ->
@@ -4399,94 +4381,94 @@ and (desugar_comp :
       fun env  ->
         fun t  ->
           let fail err = FStar_Errors.raise_error err r  in
-          let is_requires uu____16639 =
-            match uu____16639 with
-            | (t1,uu____16646) ->
-                let uu____16647 =
-                  let uu____16648 = unparen t1  in
-                  uu____16648.FStar_Parser_AST.tm  in
-                (match uu____16647 with
-                 | FStar_Parser_AST.Requires uu____16650 -> true
-                 | uu____16659 -> false)
+          let is_requires uu____16618 =
+            match uu____16618 with
+            | (t1,uu____16625) ->
+                let uu____16626 =
+                  let uu____16627 = unparen t1  in
+                  uu____16627.FStar_Parser_AST.tm  in
+                (match uu____16626 with
+                 | FStar_Parser_AST.Requires uu____16629 -> true
+                 | uu____16638 -> false)
              in
-          let is_ensures uu____16671 =
-            match uu____16671 with
-            | (t1,uu____16678) ->
-                let uu____16679 =
-                  let uu____16680 = unparen t1  in
-                  uu____16680.FStar_Parser_AST.tm  in
-                (match uu____16679 with
-                 | FStar_Parser_AST.Ensures uu____16682 -> true
-                 | uu____16691 -> false)
+          let is_ensures uu____16650 =
+            match uu____16650 with
+            | (t1,uu____16657) ->
+                let uu____16658 =
+                  let uu____16659 = unparen t1  in
+                  uu____16659.FStar_Parser_AST.tm  in
+                (match uu____16658 with
+                 | FStar_Parser_AST.Ensures uu____16661 -> true
+                 | uu____16670 -> false)
              in
-          let is_app head uu____16709 =
-            match uu____16709 with
-            | (t1,uu____16717) ->
-                let uu____16718 =
-                  let uu____16719 = unparen t1  in
-                  uu____16719.FStar_Parser_AST.tm  in
-                (match uu____16718 with
+          let is_app head uu____16688 =
+            match uu____16688 with
+            | (t1,uu____16696) ->
+                let uu____16697 =
+                  let uu____16698 = unparen t1  in
+                  uu____16698.FStar_Parser_AST.tm  in
+                (match uu____16697 with
                  | FStar_Parser_AST.App
                      ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var d;
-                        FStar_Parser_AST.range = uu____16722;
-                        FStar_Parser_AST.level = uu____16723;_},uu____16724,uu____16725)
+                        FStar_Parser_AST.range = uu____16701;
+                        FStar_Parser_AST.level = uu____16702;_},uu____16703,uu____16704)
                      ->
-                     let uu____16726 =
-                       let uu____16728 = FStar_Ident.ident_of_lid d  in
-                       FStar_Ident.text_of_id uu____16728  in
-                     uu____16726 = head
-                 | uu____16730 -> false)
+                     let uu____16705 =
+                       let uu____16707 = FStar_Ident.ident_of_lid d  in
+                       FStar_Ident.text_of_id uu____16707  in
+                     uu____16705 = head
+                 | uu____16709 -> false)
              in
-          let is_smt_pat uu____16742 =
-            match uu____16742 with
-            | (t1,uu____16749) ->
-                let uu____16750 =
-                  let uu____16751 = unparen t1  in
-                  uu____16751.FStar_Parser_AST.tm  in
-                (match uu____16750 with
+          let is_smt_pat uu____16721 =
+            match uu____16721 with
+            | (t1,uu____16728) ->
+                let uu____16729 =
+                  let uu____16730 = unparen t1  in
+                  uu____16730.FStar_Parser_AST.tm  in
+                (match uu____16729 with
                  | FStar_Parser_AST.Construct
                      (cons,({
                               FStar_Parser_AST.tm =
                                 FStar_Parser_AST.Construct
-                                (smtpat,uu____16755);
-                              FStar_Parser_AST.range = uu____16756;
-                              FStar_Parser_AST.level = uu____16757;_},uu____16758)::uu____16759::[])
+                                (smtpat,uu____16734);
+                              FStar_Parser_AST.range = uu____16735;
+                              FStar_Parser_AST.level = uu____16736;_},uu____16737)::uu____16738::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
                           (fun s  ->
-                             let uu____16799 =
+                             let uu____16778 =
                                FStar_Ident.string_of_lid smtpat  in
-                             uu____16799 = s)
+                             uu____16778 = s)
                           ["SMTPat"; "SMTPatT"; "SMTPatOr"])
                  | FStar_Parser_AST.Construct
                      (cons,({
                               FStar_Parser_AST.tm = FStar_Parser_AST.Var
                                 smtpat;
-                              FStar_Parser_AST.range = uu____16811;
-                              FStar_Parser_AST.level = uu____16812;_},uu____16813)::uu____16814::[])
+                              FStar_Parser_AST.range = uu____16790;
+                              FStar_Parser_AST.level = uu____16791;_},uu____16792)::uu____16793::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
                           (fun s  ->
-                             let uu____16842 =
+                             let uu____16821 =
                                FStar_Ident.string_of_lid smtpat  in
-                             uu____16842 = s) ["smt_pat"; "smt_pat_or"])
-                 | uu____16850 -> false)
+                             uu____16821 = s) ["smt_pat"; "smt_pat_or"])
+                 | uu____16829 -> false)
              in
           let is_decreases = is_app "decreases"  in
           let pre_process_comp_typ t1 =
-            let uu____16885 = head_and_args t1  in
-            match uu____16885 with
+            let uu____16864 = head_and_args t1  in
+            match uu____16864 with
             | (head,args) ->
                 (match head.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.Name lemma when
-                     let uu____16943 =
-                       let uu____16945 = FStar_Ident.ident_of_lid lemma  in
-                       FStar_Ident.text_of_id uu____16945  in
-                     uu____16943 = "Lemma" ->
+                     let uu____16922 =
+                       let uu____16924 = FStar_Ident.ident_of_lid lemma  in
+                       FStar_Ident.text_of_id uu____16924  in
+                     uu____16922 = "Lemma" ->
                      let unit_tm =
                        ((FStar_Parser_AST.mk_term
                            (FStar_Parser_AST.Name FStar_Parser_Const.unit_lid)
@@ -4515,13 +4497,13 @@ and (desugar_comp :
                            FStar_Parser_AST.Type_level),
                          FStar_Parser_AST.Nothing)
                         in
-                     let thunk_ens uu____16981 =
-                       match uu____16981 with
+                     let thunk_ens uu____16960 =
+                       match uu____16960 with
                        | (e,i) ->
-                           let uu____16992 = FStar_Parser_AST.thunk e  in
-                           (uu____16992, i)
+                           let uu____16971 = FStar_Parser_AST.thunk e  in
+                           (uu____16971, i)
                         in
-                     let fail_lemma uu____17004 =
+                     let fail_lemma uu____16983 =
                        let expected_one_of =
                          ["Lemma post";
                          "Lemma (ensures post)";
@@ -4549,85 +4531,85 @@ and (desugar_comp :
                        | smtpat::[] when is_smt_pat smtpat -> fail_lemma ()
                        | dec::[] when is_decreases dec -> fail_lemma ()
                        | ens::[] ->
-                           let uu____17110 =
-                             let uu____17117 =
-                               let uu____17124 = thunk_ens ens  in
-                               [uu____17124; nil_pat]  in
-                             req_true :: uu____17117  in
-                           unit_tm :: uu____17110
+                           let uu____17089 =
+                             let uu____17096 =
+                               let uu____17103 = thunk_ens ens  in
+                               [uu____17103; nil_pat]  in
+                             req_true :: uu____17096  in
+                           unit_tm :: uu____17089
                        | req::ens::[] when
                            (is_requires req) && (is_ensures ens) ->
-                           let uu____17171 =
-                             let uu____17178 =
-                               let uu____17185 = thunk_ens ens  in
-                               [uu____17185; nil_pat]  in
-                             req :: uu____17178  in
-                           unit_tm :: uu____17171
+                           let uu____17150 =
+                             let uu____17157 =
+                               let uu____17164 = thunk_ens ens  in
+                               [uu____17164; nil_pat]  in
+                             req :: uu____17157  in
+                           unit_tm :: uu____17150
                        | ens::smtpat::[] when
-                           (((let uu____17234 = is_requires ens  in
-                              Prims.op_Negation uu____17234) &&
-                               (let uu____17237 = is_smt_pat ens  in
-                                Prims.op_Negation uu____17237))
+                           (((let uu____17213 = is_requires ens  in
+                              Prims.op_Negation uu____17213) &&
+                               (let uu____17216 = is_smt_pat ens  in
+                                Prims.op_Negation uu____17216))
                               &&
-                              (let uu____17240 = is_decreases ens  in
-                               Prims.op_Negation uu____17240))
+                              (let uu____17219 = is_decreases ens  in
+                               Prims.op_Negation uu____17219))
                              && (is_smt_pat smtpat)
                            ->
-                           let uu____17242 =
-                             let uu____17249 =
-                               let uu____17256 = thunk_ens ens  in
-                               [uu____17256; smtpat]  in
-                             req_true :: uu____17249  in
-                           unit_tm :: uu____17242
+                           let uu____17221 =
+                             let uu____17228 =
+                               let uu____17235 = thunk_ens ens  in
+                               [uu____17235; smtpat]  in
+                             req_true :: uu____17228  in
+                           unit_tm :: uu____17221
                        | ens::dec::[] when
                            (is_ensures ens) && (is_decreases dec) ->
-                           let uu____17303 =
-                             let uu____17310 =
-                               let uu____17317 = thunk_ens ens  in
-                               [uu____17317; nil_pat; dec]  in
-                             req_true :: uu____17310  in
-                           unit_tm :: uu____17303
+                           let uu____17282 =
+                             let uu____17289 =
+                               let uu____17296 = thunk_ens ens  in
+                               [uu____17296; nil_pat; dec]  in
+                             req_true :: uu____17289  in
+                           unit_tm :: uu____17282
                        | ens::dec::smtpat::[] when
                            ((is_ensures ens) && (is_decreases dec)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____17377 =
-                             let uu____17384 =
-                               let uu____17391 = thunk_ens ens  in
-                               [uu____17391; smtpat; dec]  in
-                             req_true :: uu____17384  in
-                           unit_tm :: uu____17377
+                           let uu____17356 =
+                             let uu____17363 =
+                               let uu____17370 = thunk_ens ens  in
+                               [uu____17370; smtpat; dec]  in
+                             req_true :: uu____17363  in
+                           unit_tm :: uu____17356
                        | req::ens::dec::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_decreases dec)
                            ->
-                           let uu____17451 =
-                             let uu____17458 =
-                               let uu____17465 = thunk_ens ens  in
-                               [uu____17465; nil_pat; dec]  in
-                             req :: uu____17458  in
-                           unit_tm :: uu____17451
+                           let uu____17430 =
+                             let uu____17437 =
+                               let uu____17444 = thunk_ens ens  in
+                               [uu____17444; nil_pat; dec]  in
+                             req :: uu____17437  in
+                           unit_tm :: uu____17430
                        | req::ens::smtpat::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____17525 =
-                             let uu____17532 =
-                               let uu____17539 = thunk_ens ens  in
-                               [uu____17539; smtpat]  in
-                             req :: uu____17532  in
-                           unit_tm :: uu____17525
+                           let uu____17504 =
+                             let uu____17511 =
+                               let uu____17518 = thunk_ens ens  in
+                               [uu____17518; smtpat]  in
+                             req :: uu____17511  in
+                           unit_tm :: uu____17504
                        | req::ens::dec::smtpat::[] when
                            (((is_requires req) && (is_ensures ens)) &&
                               (is_smt_pat smtpat))
                              && (is_decreases dec)
                            ->
-                           let uu____17604 =
-                             let uu____17611 =
-                               let uu____17618 = thunk_ens ens  in
-                               [uu____17618; dec; smtpat]  in
-                             req :: uu____17611  in
-                           unit_tm :: uu____17604
+                           let uu____17583 =
+                             let uu____17590 =
+                               let uu____17597 = thunk_ens ens  in
+                               [uu____17597; dec; smtpat]  in
+                             req :: uu____17590  in
+                           unit_tm :: uu____17583
                        | _other -> fail_lemma ()  in
                      let head_and_attributes =
                        FStar_Syntax_DsEnv.fail_or env
@@ -4637,82 +4619,82 @@ and (desugar_comp :
                      (head_and_attributes, args1)
                  | FStar_Parser_AST.Name l when
                      FStar_Syntax_DsEnv.is_effect_name env l ->
-                     let uu____17680 =
+                     let uu____17659 =
                        FStar_Syntax_DsEnv.fail_or env
                          (FStar_Syntax_DsEnv.try_lookup_effect_name_and_attributes
                             env) l
                         in
-                     (uu____17680, args)
+                     (uu____17659, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____17708 = FStar_Syntax_DsEnv.current_module env
+                     (let uu____17687 = FStar_Syntax_DsEnv.current_module env
                          in
-                      FStar_Ident.lid_equals uu____17708
+                      FStar_Ident.lid_equals uu____17687
                         FStar_Parser_Const.prims_lid)
                        &&
-                       (let uu____17710 =
-                          let uu____17712 = FStar_Ident.ident_of_lid l  in
-                          FStar_Ident.text_of_id uu____17712  in
-                        uu____17710 = "Tot")
+                       (let uu____17689 =
+                          let uu____17691 = FStar_Ident.ident_of_lid l  in
+                          FStar_Ident.text_of_id uu____17691  in
+                        uu____17689 = "Tot")
                      ->
-                     let uu____17715 =
-                       let uu____17722 =
+                     let uu____17694 =
+                       let uu____17701 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17722, [])  in
-                     (uu____17715, args)
+                       (uu____17701, [])  in
+                     (uu____17694, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____17740 = FStar_Syntax_DsEnv.current_module env
+                     (let uu____17719 = FStar_Syntax_DsEnv.current_module env
                          in
-                      FStar_Ident.lid_equals uu____17740
+                      FStar_Ident.lid_equals uu____17719
                         FStar_Parser_Const.prims_lid)
                        &&
-                       (let uu____17742 =
-                          let uu____17744 = FStar_Ident.ident_of_lid l  in
-                          FStar_Ident.text_of_id uu____17744  in
-                        uu____17742 = "GTot")
+                       (let uu____17721 =
+                          let uu____17723 = FStar_Ident.ident_of_lid l  in
+                          FStar_Ident.text_of_id uu____17723  in
+                        uu____17721 = "GTot")
                      ->
-                     let uu____17747 =
-                       let uu____17754 =
+                     let uu____17726 =
+                       let uu____17733 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_GTot_lid
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17754, [])  in
-                     (uu____17747, args)
+                       (uu____17733, [])  in
+                     (uu____17726, args)
                  | FStar_Parser_AST.Name l when
-                     ((let uu____17772 =
-                         let uu____17774 = FStar_Ident.ident_of_lid l  in
-                         FStar_Ident.text_of_id uu____17774  in
-                       uu____17772 = "Type") ||
-                        (let uu____17778 =
-                           let uu____17780 = FStar_Ident.ident_of_lid l  in
-                           FStar_Ident.text_of_id uu____17780  in
-                         uu____17778 = "Type0"))
+                     ((let uu____17751 =
+                         let uu____17753 = FStar_Ident.ident_of_lid l  in
+                         FStar_Ident.text_of_id uu____17753  in
+                       uu____17751 = "Type") ||
+                        (let uu____17757 =
+                           let uu____17759 = FStar_Ident.ident_of_lid l  in
+                           FStar_Ident.text_of_id uu____17759  in
+                         uu____17757 = "Type0"))
                        ||
-                       (let uu____17784 =
-                          let uu____17786 = FStar_Ident.ident_of_lid l  in
-                          FStar_Ident.text_of_id uu____17786  in
-                        uu____17784 = "Effect")
+                       (let uu____17763 =
+                          let uu____17765 = FStar_Ident.ident_of_lid l  in
+                          FStar_Ident.text_of_id uu____17765  in
+                        uu____17763 = "Effect")
                      ->
-                     let uu____17789 =
-                       let uu____17796 =
+                     let uu____17768 =
+                       let uu____17775 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17796, [])  in
-                     (uu____17789, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____17819 when allow_type_promotion ->
+                       (uu____17775, [])  in
+                     (uu____17768, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____17798 when allow_type_promotion ->
                      let default_effect =
-                       let uu____17821 = FStar_Options.ml_ish ()  in
-                       if uu____17821
+                       let uu____17800 = FStar_Options.ml_ish ()  in
+                       if uu____17800
                        then FStar_Parser_Const.effect_ML_lid
                        else
-                         ((let uu____17827 =
+                         ((let uu____17806 =
                              FStar_Options.warn_default_effects ()  in
-                           if uu____17827
+                           if uu____17806
                            then
                              FStar_Errors.log_issue
                                head.FStar_Parser_AST.range
@@ -4721,152 +4703,152 @@ and (desugar_comp :
                            else ());
                           FStar_Parser_Const.effect_Tot_lid)
                         in
-                     let uu____17834 =
-                       let uu____17841 =
+                     let uu____17813 =
+                       let uu____17820 =
                          FStar_Ident.set_lid_range default_effect
                            head.FStar_Parser_AST.range
                           in
-                       (uu____17841, [])  in
-                     (uu____17834, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____17864 ->
+                       (uu____17820, [])  in
+                     (uu____17813, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____17843 ->
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_EffectNotFound,
                          "Expected an effect constructor")
                        t1.FStar_Parser_AST.range)
              in
-          let uu____17883 = pre_process_comp_typ t  in
-          match uu____17883 with
+          let uu____17862 = pre_process_comp_typ t  in
+          match uu____17862 with
           | ((eff,cattributes),args) ->
               (if (FStar_List.length args) = Prims.int_zero
                then
-                 (let uu____17935 =
-                    let uu____17941 =
-                      let uu____17943 = FStar_Syntax_Print.lid_to_string eff
+                 (let uu____17914 =
+                    let uu____17920 =
+                      let uu____17922 = FStar_Syntax_Print.lid_to_string eff
                          in
                       FStar_Util.format1 "Not enough args to effect %s"
-                        uu____17943
+                        uu____17922
                        in
-                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____17941)
+                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____17920)
                      in
-                  fail uu____17935)
+                  fail uu____17914)
                else ();
-               (let is_universe uu____17959 =
-                  match uu____17959 with
-                  | (uu____17965,imp) -> imp = FStar_Parser_AST.UnivApp  in
-                let uu____17967 = FStar_Util.take is_universe args  in
-                match uu____17967 with
+               (let is_universe uu____17938 =
+                  match uu____17938 with
+                  | (uu____17944,imp) -> imp = FStar_Parser_AST.UnivApp  in
+                let uu____17946 = FStar_Util.take is_universe args  in
+                match uu____17946 with
                 | (universes,args1) ->
                     let universes1 =
                       FStar_List.map
-                        (fun uu____18026  ->
-                           match uu____18026 with
+                        (fun uu____18005  ->
+                           match uu____18005 with
                            | (u,imp) -> desugar_universe u) universes
                        in
-                    let uu____18033 =
-                      let uu____18048 = FStar_List.hd args1  in
-                      let uu____18057 = FStar_List.tl args1  in
-                      (uu____18048, uu____18057)  in
-                    (match uu____18033 with
+                    let uu____18012 =
+                      let uu____18027 = FStar_List.hd args1  in
+                      let uu____18036 = FStar_List.tl args1  in
+                      (uu____18027, uu____18036)  in
+                    (match uu____18012 with
                      | (result_arg,rest) ->
                          let result_typ =
                            desugar_typ env
                              (FStar_Pervasives_Native.fst result_arg)
                             in
                          let rest1 = desugar_args env rest  in
-                         let uu____18112 =
-                           let is_decrease uu____18151 =
-                             match uu____18151 with
-                             | (t1,uu____18162) ->
+                         let uu____18091 =
+                           let is_decrease uu____18130 =
+                             match uu____18130 with
+                             | (t1,uu____18141) ->
                                  (match t1.FStar_Syntax_Syntax.n with
                                   | FStar_Syntax_Syntax.Tm_app
                                       ({
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_fvar fv;
                                          FStar_Syntax_Syntax.pos =
-                                           uu____18173;
+                                           uu____18152;
                                          FStar_Syntax_Syntax.vars =
-                                           uu____18174;_},uu____18175::[])
+                                           uu____18153;_},uu____18154::[])
                                       ->
                                       FStar_Syntax_Syntax.fv_eq_lid fv
                                         FStar_Parser_Const.decreases_lid
-                                  | uu____18214 -> false)
+                                  | uu____18193 -> false)
                               in
                            FStar_All.pipe_right rest1
                              (FStar_List.partition is_decrease)
                             in
-                         (match uu____18112 with
+                         (match uu____18091 with
                           | (dec,rest2) ->
                               let decreases_clause =
                                 FStar_All.pipe_right dec
                                   (FStar_List.map
-                                     (fun uu____18331  ->
-                                        match uu____18331 with
-                                        | (t1,uu____18341) ->
+                                     (fun uu____18310  ->
+                                        match uu____18310 with
+                                        | (t1,uu____18320) ->
                                             (match t1.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_app
-                                                 (uu____18350,(arg,uu____18352)::[])
+                                                 (uu____18329,(arg,uu____18331)::[])
                                                  ->
                                                  FStar_Syntax_Syntax.DECREASES
                                                    arg
-                                             | uu____18391 ->
+                                             | uu____18370 ->
                                                  failwith "impos")))
                                  in
                               let no_additional_args =
                                 let is_empty l =
                                   match l with
                                   | [] -> true
-                                  | uu____18412 -> false  in
+                                  | uu____18391 -> false  in
                                 (((is_empty decreases_clause) &&
                                     (is_empty rest2))
                                    && (is_empty cattributes))
                                   && (is_empty universes1)
                                  in
-                              let uu____18424 =
+                              let uu____18403 =
                                 no_additional_args &&
                                   (FStar_Ident.lid_equals eff
                                      FStar_Parser_Const.effect_Tot_lid)
                                  in
-                              if uu____18424
+                              if uu____18403
                               then FStar_Syntax_Syntax.mk_Total result_typ
                               else
-                                (let uu____18431 =
+                                (let uu____18410 =
                                    no_additional_args &&
                                      (FStar_Ident.lid_equals eff
                                         FStar_Parser_Const.effect_GTot_lid)
                                     in
-                                 if uu____18431
+                                 if uu____18410
                                  then
                                    FStar_Syntax_Syntax.mk_GTotal result_typ
                                  else
                                    (let flags =
-                                      let uu____18441 =
+                                      let uu____18420 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid
                                          in
-                                      if uu____18441
+                                      if uu____18420
                                       then [FStar_Syntax_Syntax.LEMMA]
                                       else
-                                        (let uu____18448 =
+                                        (let uu____18427 =
                                            FStar_Ident.lid_equals eff
                                              FStar_Parser_Const.effect_Tot_lid
                                             in
-                                         if uu____18448
+                                         if uu____18427
                                          then [FStar_Syntax_Syntax.TOTAL]
                                          else
-                                           (let uu____18455 =
+                                           (let uu____18434 =
                                               FStar_Ident.lid_equals eff
                                                 FStar_Parser_Const.effect_ML_lid
                                                in
-                                            if uu____18455
+                                            if uu____18434
                                             then
                                               [FStar_Syntax_Syntax.MLEFFECT]
                                             else
-                                              (let uu____18462 =
+                                              (let uu____18441 =
                                                  FStar_Ident.lid_equals eff
                                                    FStar_Parser_Const.effect_GTot_lid
                                                   in
-                                               if uu____18462
+                                               if uu____18441
                                                then
                                                  [FStar_Syntax_Syntax.SOMETRIVIAL]
                                                else [])))
@@ -4874,11 +4856,11 @@ and (desugar_comp :
                                     let flags1 =
                                       FStar_List.append flags cattributes  in
                                     let rest3 =
-                                      let uu____18483 =
+                                      let uu____18462 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid
                                          in
-                                      if uu____18483
+                                      if uu____18462
                                       then
                                         match rest2 with
                                         | req::ens::(pat,aq)::[] ->
@@ -4897,13 +4879,13 @@ and (desugar_comp :
                                                       [FStar_Syntax_Syntax.U_zero]
                                                      in
                                                   let pattern =
-                                                    let uu____18574 =
+                                                    let uu____18553 =
                                                       FStar_Ident.set_lid_range
                                                         FStar_Parser_Const.pattern_lid
                                                         pat.FStar_Syntax_Syntax.pos
                                                        in
                                                     FStar_Syntax_Syntax.fvar
-                                                      uu____18574
+                                                      uu____18553
                                                       FStar_Syntax_Syntax.delta_constant
                                                       FStar_Pervasives_Native.None
                                                      in
@@ -4912,26 +4894,24 @@ and (desugar_comp :
                                                     [(pattern,
                                                        (FStar_Pervasives_Native.Some
                                                           FStar_Syntax_Syntax.imp_tag))]
-                                                    FStar_Pervasives_Native.None
                                                     pat.FStar_Syntax_Syntax.pos
-                                              | uu____18595 -> pat  in
-                                            let uu____18596 =
-                                              let uu____18607 =
-                                                let uu____18618 =
-                                                  let uu____18627 =
+                                              | uu____18574 -> pat  in
+                                            let uu____18575 =
+                                              let uu____18586 =
+                                                let uu____18597 =
+                                                  let uu____18606 =
                                                     FStar_Syntax_Syntax.mk
                                                       (FStar_Syntax_Syntax.Tm_meta
                                                          (pat1,
                                                            (FStar_Syntax_Syntax.Meta_desugared
                                                               FStar_Syntax_Syntax.Meta_smt_pat)))
-                                                      FStar_Pervasives_Native.None
                                                       pat1.FStar_Syntax_Syntax.pos
                                                      in
-                                                  (uu____18627, aq)  in
-                                                [uu____18618]  in
-                                              ens :: uu____18607  in
-                                            req :: uu____18596
-                                        | uu____18668 -> rest2
+                                                  (uu____18606, aq)  in
+                                                [uu____18597]  in
+                                              ens :: uu____18586  in
+                                            req :: uu____18575
+                                        | uu____18647 -> rest2
                                       else rest2  in
                                     FStar_Syntax_Syntax.mk_Comp
                                       {
@@ -4952,55 +4932,52 @@ and (desugar_formula :
   =
   fun env  ->
     fun f  ->
-      let mk t =
-        FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None
-          f.FStar_Parser_AST.range
-         in
+      let mk t = FStar_Syntax_Syntax.mk t f.FStar_Parser_AST.range  in
       let setpos t =
-        let uu___2390_18703 = t  in
+        let uu___2390_18682 = t  in
         {
-          FStar_Syntax_Syntax.n = (uu___2390_18703.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___2390_18682.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
           FStar_Syntax_Syntax.vars =
-            (uu___2390_18703.FStar_Syntax_Syntax.vars)
+            (uu___2390_18682.FStar_Syntax_Syntax.vars)
         }  in
       let desugar_quant q b pats body =
         let tk =
           desugar_binder env
-            (let uu___2397_18757 = b  in
+            (let uu___2397_18736 = b  in
              {
-               FStar_Parser_AST.b = (uu___2397_18757.FStar_Parser_AST.b);
+               FStar_Parser_AST.b = (uu___2397_18736.FStar_Parser_AST.b);
                FStar_Parser_AST.brange =
-                 (uu___2397_18757.FStar_Parser_AST.brange);
+                 (uu___2397_18736.FStar_Parser_AST.brange);
                FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                FStar_Parser_AST.aqual =
-                 (uu___2397_18757.FStar_Parser_AST.aqual)
+                 (uu___2397_18736.FStar_Parser_AST.aqual)
              })
            in
-        let with_pats env1 uu____18786 body1 =
-          match uu____18786 with
+        let with_pats env1 uu____18765 body1 =
+          match uu____18765 with
           | (names,pats1) ->
               (match (names, pats1) with
                | ([],[]) -> body1
-               | ([],uu____18832::uu____18833) ->
+               | ([],uu____18811::uu____18812) ->
                    failwith
                      "Impossible: Annotated pattern without binders in scope"
-               | uu____18851 ->
+               | uu____18830 ->
                    let names1 =
                      FStar_All.pipe_right names
                        (FStar_List.map
                           (fun i  ->
-                             let uu___2416_18879 =
+                             let uu___2416_18858 =
                                FStar_Syntax_DsEnv.fail_or2
                                  (FStar_Syntax_DsEnv.try_lookup_id env1) i
                                 in
-                             let uu____18880 = FStar_Ident.range_of_id i  in
+                             let uu____18859 = FStar_Ident.range_of_id i  in
                              {
                                FStar_Syntax_Syntax.n =
-                                 (uu___2416_18879.FStar_Syntax_Syntax.n);
-                               FStar_Syntax_Syntax.pos = uu____18880;
+                                 (uu___2416_18858.FStar_Syntax_Syntax.n);
+                               FStar_Syntax_Syntax.pos = uu____18859;
                                FStar_Syntax_Syntax.vars =
-                                 (uu___2416_18879.FStar_Syntax_Syntax.vars)
+                                 (uu___2416_18858.FStar_Syntax_Syntax.vars)
                              }))
                       in
                    let pats2 =
@@ -5010,12 +4987,12 @@ and (desugar_formula :
                              FStar_All.pipe_right es
                                (FStar_List.map
                                   (fun e  ->
-                                     let uu____18943 = desugar_term env1 e
+                                     let uu____18922 = desugar_term env1 e
                                         in
                                      FStar_All.pipe_left
                                        (arg_withimp_t
                                           FStar_Parser_AST.Nothing)
-                                       uu____18943))))
+                                       uu____18922))))
                       in
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
@@ -5024,65 +5001,65 @@ and (desugar_formula :
            in
         match tk with
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____18974 = FStar_Syntax_DsEnv.push_bv env a  in
-            (match uu____18974 with
+            let uu____18953 = FStar_Syntax_DsEnv.push_bv env a  in
+            (match uu____18953 with
              | (env1,a1) ->
                  let a2 =
-                   let uu___2429_18984 = a1  in
+                   let uu___2429_18963 = a1  in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___2429_18984.FStar_Syntax_Syntax.ppname);
+                       (uu___2429_18963.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___2429_18984.FStar_Syntax_Syntax.index);
+                       (uu___2429_18963.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort = k
                    }  in
                  let body1 = desugar_formula env1 body  in
                  let body2 = with_pats env1 pats body1  in
                  let body3 =
-                   let uu____18990 =
-                     let uu____18993 =
-                       let uu____18994 = FStar_Syntax_Syntax.mk_binder a2  in
-                       [uu____18994]  in
-                     no_annot_abs uu____18993 body2  in
-                   FStar_All.pipe_left setpos uu____18990  in
-                 let uu____19015 =
-                   let uu____19016 =
-                     let uu____19033 =
-                       let uu____19036 =
+                   let uu____18969 =
+                     let uu____18972 =
+                       let uu____18973 = FStar_Syntax_Syntax.mk_binder a2  in
+                       [uu____18973]  in
+                     no_annot_abs uu____18972 body2  in
+                   FStar_All.pipe_left setpos uu____18969  in
+                 let uu____18994 =
+                   let uu____18995 =
+                     let uu____19012 =
+                       let uu____19015 =
                          FStar_Ident.set_lid_range q
                            b.FStar_Parser_AST.brange
                           in
-                       FStar_Syntax_Syntax.fvar uu____19036
+                       FStar_Syntax_Syntax.fvar uu____19015
                          (FStar_Syntax_Syntax.Delta_constant_at_level
                             Prims.int_one) FStar_Pervasives_Native.None
                         in
-                     let uu____19038 =
-                       let uu____19049 = FStar_Syntax_Syntax.as_arg body3  in
-                       [uu____19049]  in
-                     (uu____19033, uu____19038)  in
-                   FStar_Syntax_Syntax.Tm_app uu____19016  in
-                 FStar_All.pipe_left mk uu____19015)
-        | uu____19088 -> failwith "impossible"  in
+                     let uu____19017 =
+                       let uu____19028 = FStar_Syntax_Syntax.as_arg body3  in
+                       [uu____19028]  in
+                     (uu____19012, uu____19017)  in
+                   FStar_Syntax_Syntax.Tm_app uu____18995  in
+                 FStar_All.pipe_left mk uu____18994)
+        | uu____19067 -> failwith "impossible"  in
       let push_quant q binders pats body =
         match binders with
         | b::b'::_rest ->
             let rest = b' :: _rest  in
             let body1 =
-              let uu____19153 = q (rest, pats, body)  in
-              let uu____19156 =
+              let uu____19132 = q (rest, pats, body)  in
+              let uu____19135 =
                 FStar_Range.union_ranges b'.FStar_Parser_AST.brange
                   body.FStar_Parser_AST.range
                  in
-              FStar_Parser_AST.mk_term uu____19153 uu____19156
+              FStar_Parser_AST.mk_term uu____19132 uu____19135
                 FStar_Parser_AST.Formula
                in
-            let uu____19157 = q ([b], ([], []), body1)  in
-            FStar_Parser_AST.mk_term uu____19157 f.FStar_Parser_AST.range
+            let uu____19136 = q ([b], ([], []), body1)  in
+            FStar_Parser_AST.mk_term uu____19136 f.FStar_Parser_AST.range
               FStar_Parser_AST.Formula
-        | uu____19168 -> failwith "impossible"  in
-      let uu____19172 =
-        let uu____19173 = unparen f  in uu____19173.FStar_Parser_AST.tm  in
-      match uu____19172 with
+        | uu____19147 -> failwith "impossible"  in
+      let uu____19151 =
+        let uu____19152 = unparen f  in uu____19152.FStar_Parser_AST.tm  in
+      match uu____19151 with
       | FStar_Parser_AST.Labeled (f1,l,p) ->
           let f2 = desugar_formula env f1  in
           FStar_All.pipe_left mk
@@ -5090,30 +5067,30 @@ and (desugar_formula :
                (f2,
                  (FStar_Syntax_Syntax.Meta_labeled
                     (l, (f2.FStar_Syntax_Syntax.pos), p))))
-      | FStar_Parser_AST.QForall ([],uu____19186,uu____19187) ->
+      | FStar_Parser_AST.QForall ([],uu____19165,uu____19166) ->
           failwith "Impossible: Quantifier without binders"
-      | FStar_Parser_AST.QExists ([],uu____19211,uu____19212) ->
+      | FStar_Parser_AST.QExists ([],uu____19190,uu____19191) ->
           failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QForall (_1::_2::_3,pats,body) ->
           let binders = _1 :: _2 :: _3  in
-          let uu____19268 =
+          let uu____19247 =
             push_quant (fun x  -> FStar_Parser_AST.QForall x) binders pats
               body
              in
-          desugar_formula env uu____19268
+          desugar_formula env uu____19247
       | FStar_Parser_AST.QExists (_1::_2::_3,pats,body) ->
           let binders = _1 :: _2 :: _3  in
-          let uu____19312 =
+          let uu____19291 =
             push_quant (fun x  -> FStar_Parser_AST.QExists x) binders pats
               body
              in
-          desugar_formula env uu____19312
+          desugar_formula env uu____19291
       | FStar_Parser_AST.QForall (b::[],pats,body) ->
           desugar_quant FStar_Parser_Const.forall_lid b pats body
       | FStar_Parser_AST.QExists (b::[],pats,body) ->
           desugar_quant FStar_Parser_Const.exists_lid b pats body
       | FStar_Parser_AST.Paren f1 -> failwith "impossible"
-      | uu____19376 -> desugar_term env f
+      | uu____19355 -> desugar_term env f
 
 and (desugar_binder :
   FStar_Syntax_DsEnv.env ->
@@ -5125,27 +5102,27 @@ and (desugar_binder :
     fun b  ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.TAnnotated (x,t) ->
-          let uu____19387 = desugar_typ env t  in
-          ((FStar_Pervasives_Native.Some x), uu____19387)
+          let uu____19366 = desugar_typ env t  in
+          ((FStar_Pervasives_Native.Some x), uu____19366)
       | FStar_Parser_AST.Annotated (x,t) ->
-          let uu____19392 = desugar_typ env t  in
-          ((FStar_Pervasives_Native.Some x), uu____19392)
+          let uu____19371 = desugar_typ env t  in
+          ((FStar_Pervasives_Native.Some x), uu____19371)
       | FStar_Parser_AST.TVariable x ->
-          let uu____19396 =
-            let uu____19397 = FStar_Ident.range_of_id x  in
+          let uu____19375 =
+            let uu____19376 = FStar_Ident.range_of_id x  in
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
-              FStar_Pervasives_Native.None uu____19397
+              uu____19376
              in
-          ((FStar_Pervasives_Native.Some x), uu____19396)
+          ((FStar_Pervasives_Native.Some x), uu____19375)
       | FStar_Parser_AST.NoName t ->
-          let uu____19401 = desugar_typ env t  in
-          (FStar_Pervasives_Native.None, uu____19401)
+          let uu____19380 = desugar_typ env t  in
+          (FStar_Pervasives_Native.None, uu____19380)
       | FStar_Parser_AST.Variable x ->
-          let uu____19405 =
-            let uu____19406 = FStar_Ident.range_of_id x  in tun_r uu____19406
+          let uu____19384 =
+            let uu____19385 = FStar_Ident.range_of_id x  in tun_r uu____19385
              in
-          ((FStar_Pervasives_Native.Some x), uu____19405)
+          ((FStar_Pervasives_Native.Some x), uu____19384)
 
 and (as_binder :
   FStar_Syntax_DsEnv.env ->
@@ -5157,27 +5134,27 @@ and (as_binder :
   =
   fun env  ->
     fun imp  ->
-      fun uu___11_19411  ->
-        match uu___11_19411 with
+      fun uu___11_19390  ->
+        match uu___11_19390 with
         | (FStar_Pervasives_Native.None ,k) ->
-            let uu____19433 = FStar_Syntax_Syntax.null_binder k  in
-            (uu____19433, env)
+            let uu____19412 = FStar_Syntax_Syntax.null_binder k  in
+            (uu____19412, env)
         | (FStar_Pervasives_Native.Some a,k) ->
-            let uu____19450 = FStar_Syntax_DsEnv.push_bv env a  in
-            (match uu____19450 with
+            let uu____19429 = FStar_Syntax_DsEnv.push_bv env a  in
+            (match uu____19429 with
              | (env1,a1) ->
-                 let uu____19467 =
-                   let uu____19474 = trans_aqual env1 imp  in
-                   ((let uu___2529_19480 = a1  in
+                 let uu____19446 =
+                   let uu____19453 = trans_aqual env1 imp  in
+                   ((let uu___2529_19459 = a1  in
                      {
                        FStar_Syntax_Syntax.ppname =
-                         (uu___2529_19480.FStar_Syntax_Syntax.ppname);
+                         (uu___2529_19459.FStar_Syntax_Syntax.ppname);
                        FStar_Syntax_Syntax.index =
-                         (uu___2529_19480.FStar_Syntax_Syntax.index);
+                         (uu___2529_19459.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort = k
-                     }), uu____19474)
+                     }), uu____19453)
                     in
-                 (uu____19467, env1))
+                 (uu____19446, env1))
 
 and (trans_aqual :
   env_t ->
@@ -5185,17 +5162,17 @@ and (trans_aqual :
       FStar_Syntax_Syntax.aqual)
   =
   fun env  ->
-    fun uu___12_19488  ->
-      match uu___12_19488 with
+    fun uu___12_19467  ->
+      match uu___12_19467 with
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit ) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Equality ) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Equality
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta t) ->
-          let uu____19492 =
-            let uu____19493 = desugar_term env t  in
-            FStar_Syntax_Syntax.Meta uu____19493  in
-          FStar_Pervasives_Native.Some uu____19492
+          let uu____19471 =
+            let uu____19472 = desugar_term env t  in
+            FStar_Syntax_Syntax.Meta uu____19472  in
+          FStar_Pervasives_Native.Some uu____19471
       | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
 
 let (typars_of_binders :
@@ -5206,55 +5183,55 @@ let (typars_of_binders :
   =
   fun env  ->
     fun bs  ->
-      let uu____19521 =
+      let uu____19500 =
         FStar_List.fold_left
-          (fun uu____19554  ->
+          (fun uu____19533  ->
              fun b  ->
-               match uu____19554 with
+               match uu____19533 with
                | (env1,out) ->
                    let tk =
                      desugar_binder env1
-                       (let uu___2547_19598 = b  in
+                       (let uu___2547_19577 = b  in
                         {
                           FStar_Parser_AST.b =
-                            (uu___2547_19598.FStar_Parser_AST.b);
+                            (uu___2547_19577.FStar_Parser_AST.b);
                           FStar_Parser_AST.brange =
-                            (uu___2547_19598.FStar_Parser_AST.brange);
+                            (uu___2547_19577.FStar_Parser_AST.brange);
                           FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                           FStar_Parser_AST.aqual =
-                            (uu___2547_19598.FStar_Parser_AST.aqual)
+                            (uu___2547_19577.FStar_Parser_AST.aqual)
                         })
                       in
                    (match tk with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____19613 = FStar_Syntax_DsEnv.push_bv env1 a
+                        let uu____19592 = FStar_Syntax_DsEnv.push_bv env1 a
                            in
-                        (match uu____19613 with
+                        (match uu____19592 with
                          | (env2,a1) ->
                              let a2 =
-                               let uu___2557_19631 = a1  in
+                               let uu___2557_19610 = a1  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2557_19631.FStar_Syntax_Syntax.ppname);
+                                   (uu___2557_19610.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2557_19631.FStar_Syntax_Syntax.index);
+                                   (uu___2557_19610.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = k
                                }  in
-                             let uu____19632 =
-                               let uu____19639 =
-                                 let uu____19644 =
+                             let uu____19611 =
+                               let uu____19618 =
+                                 let uu____19623 =
                                    trans_aqual env2 b.FStar_Parser_AST.aqual
                                     in
-                                 (a2, uu____19644)  in
-                               uu____19639 :: out  in
-                             (env2, uu____19632))
-                    | uu____19655 ->
+                                 (a2, uu____19623)  in
+                               uu____19618 :: out  in
+                             (env2, uu____19611))
+                    | uu____19634 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_UnexpectedBinder,
                             "Unexpected binder") b.FStar_Parser_AST.brange))
           (env, []) bs
          in
-      match uu____19521 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
+      match uu____19500 with | (env1,tpars) -> (env1, (FStar_List.rev tpars))
   
 let (desugar_attributes :
   env_t ->
@@ -5263,19 +5240,19 @@ let (desugar_attributes :
   fun env  ->
     fun cattributes  ->
       let desugar_attribute t =
-        let uu____19743 =
-          let uu____19744 = unparen t  in uu____19744.FStar_Parser_AST.tm  in
-        match uu____19743 with
+        let uu____19722 =
+          let uu____19723 = unparen t  in uu____19723.FStar_Parser_AST.tm  in
+        match uu____19722 with
         | FStar_Parser_AST.Var lid when
-            let uu____19746 = FStar_Ident.string_of_lid lid  in
-            uu____19746 = "cps" -> FStar_Syntax_Syntax.CPS
-        | uu____19750 ->
-            let uu____19751 =
-              let uu____19757 =
-                let uu____19759 = FStar_Parser_AST.term_to_string t  in
-                Prims.op_Hat "Unknown attribute " uu____19759  in
-              (FStar_Errors.Fatal_UnknownAttribute, uu____19757)  in
-            FStar_Errors.raise_error uu____19751 t.FStar_Parser_AST.range
+            let uu____19725 = FStar_Ident.string_of_lid lid  in
+            uu____19725 = "cps" -> FStar_Syntax_Syntax.CPS
+        | uu____19729 ->
+            let uu____19730 =
+              let uu____19736 =
+                let uu____19738 = FStar_Parser_AST.term_to_string t  in
+                Prims.op_Hat "Unknown attribute " uu____19738  in
+              (FStar_Errors.Fatal_UnknownAttribute, uu____19736)  in
+            FStar_Errors.raise_error uu____19730 t.FStar_Parser_AST.range
          in
       FStar_List.map desugar_attribute cattributes
   
@@ -5284,21 +5261,21 @@ let (binder_ident :
   =
   fun b  ->
     match b.FStar_Parser_AST.b with
-    | FStar_Parser_AST.TAnnotated (x,uu____19776) ->
+    | FStar_Parser_AST.TAnnotated (x,uu____19755) ->
         FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.Annotated (x,uu____19778) ->
+    | FStar_Parser_AST.Annotated (x,uu____19757) ->
         FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.TVariable x -> FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.Variable x -> FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.NoName uu____19781 -> FStar_Pervasives_Native.None
+    | FStar_Parser_AST.NoName uu____19760 -> FStar_Pervasives_Native.None
   
 let (binder_idents :
   FStar_Parser_AST.binder Prims.list -> FStar_Ident.ident Prims.list) =
   fun bs  ->
     FStar_List.collect
       (fun b  ->
-         let uu____19799 = binder_ident b  in
-         FStar_Common.list_of_option uu____19799) bs
+         let uu____19778 = binder_ident b  in
+         FStar_Common.list_of_option uu____19778) bs
   
 let (mk_data_discriminators :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -5311,28 +5288,28 @@ let (mk_data_discriminators :
         let quals1 =
           FStar_All.pipe_right quals
             (FStar_List.filter
-               (fun uu___13_19836  ->
-                  match uu___13_19836 with
+               (fun uu___13_19815  ->
+                  match uu___13_19815 with
                   | FStar_Syntax_Syntax.NoExtract  -> true
                   | FStar_Syntax_Syntax.Abstract  -> true
                   | FStar_Syntax_Syntax.Private  -> true
-                  | uu____19841 -> false))
+                  | uu____19820 -> false))
            in
         let quals2 q =
-          let uu____19855 =
-            (let uu____19859 = FStar_Syntax_DsEnv.iface env  in
-             Prims.op_Negation uu____19859) ||
+          let uu____19834 =
+            (let uu____19838 = FStar_Syntax_DsEnv.iface env  in
+             Prims.op_Negation uu____19838) ||
               (FStar_Syntax_DsEnv.admitted_iface env)
              in
-          if uu____19855
+          if uu____19834
           then FStar_List.append (FStar_Syntax_Syntax.Assumption :: q) quals1
           else FStar_List.append q quals1  in
         FStar_All.pipe_right datas
           (FStar_List.map
              (fun d  ->
                 let disc_name = FStar_Syntax_Util.mk_discriminator d  in
-                let uu____19876 = FStar_Ident.range_of_lid disc_name  in
-                let uu____19877 =
+                let uu____19855 = FStar_Ident.range_of_lid disc_name  in
+                let uu____19856 =
                   quals2
                     [FStar_Syntax_Syntax.OnlyName;
                     FStar_Syntax_Syntax.Discriminator d]
@@ -5341,8 +5318,8 @@ let (mk_data_discriminators :
                   FStar_Syntax_Syntax.sigel =
                     (FStar_Syntax_Syntax.Sig_declare_typ
                        (disc_name, [], FStar_Syntax_Syntax.tun));
-                  FStar_Syntax_Syntax.sigrng = uu____19876;
-                  FStar_Syntax_Syntax.sigquals = uu____19877;
+                  FStar_Syntax_Syntax.sigrng = uu____19855;
+                  FStar_Syntax_Syntax.sigquals = uu____19856;
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = [];
@@ -5363,31 +5340,31 @@ let (mk_indexed_projector_names :
         fun lid  ->
           fun fields  ->
             let p = FStar_Ident.range_of_lid lid  in
-            let uu____19917 =
+            let uu____19896 =
               FStar_All.pipe_right fields
                 (FStar_List.mapi
                    (fun i  ->
-                      fun uu____19953  ->
-                        match uu____19953 with
-                        | (x,uu____19964) ->
+                      fun uu____19932  ->
+                        match uu____19932 with
+                        | (x,uu____19943) ->
                             let field_name =
                               FStar_Syntax_Util.mk_field_projector_name lid x
                                 i
                                in
                             let only_decl =
-                              ((let uu____19974 =
+                              ((let uu____19953 =
                                   FStar_Syntax_DsEnv.current_module env  in
                                 FStar_Ident.lid_equals
-                                  FStar_Parser_Const.prims_lid uu____19974)
+                                  FStar_Parser_Const.prims_lid uu____19953)
                                  || (fvq <> FStar_Syntax_Syntax.Data_ctor))
                                 ||
-                                (let uu____19976 =
-                                   let uu____19978 =
+                                (let uu____19955 =
+                                   let uu____19957 =
                                      FStar_Syntax_DsEnv.current_module env
                                       in
-                                   FStar_Ident.string_of_lid uu____19978  in
+                                   FStar_Ident.string_of_lid uu____19957  in
                                  FStar_Options.dont_gen_projectors
-                                   uu____19976)
+                                   uu____19955)
                                in
                             let no_decl =
                               FStar_Syntax_Syntax.is_type
@@ -5396,29 +5373,29 @@ let (mk_indexed_projector_names :
                             let quals q =
                               if only_decl
                               then
-                                let uu____19996 =
+                                let uu____19975 =
                                   FStar_List.filter
-                                    (fun uu___14_20000  ->
-                                       match uu___14_20000 with
+                                    (fun uu___14_19979  ->
+                                       match uu___14_19979 with
                                        | FStar_Syntax_Syntax.Abstract  ->
                                            false
-                                       | uu____20003 -> true) q
+                                       | uu____19982 -> true) q
                                    in
-                                FStar_Syntax_Syntax.Assumption :: uu____19996
+                                FStar_Syntax_Syntax.Assumption :: uu____19975
                               else q  in
                             let quals1 =
                               let iquals1 =
                                 FStar_All.pipe_right iquals
                                   (FStar_List.filter
-                                     (fun uu___15_20018  ->
-                                        match uu___15_20018 with
+                                     (fun uu___15_19997  ->
+                                        match uu___15_19997 with
                                         | FStar_Syntax_Syntax.NoExtract  ->
                                             true
                                         | FStar_Syntax_Syntax.Abstract  ->
                                             true
                                         | FStar_Syntax_Syntax.Private  ->
                                             true
-                                        | uu____20023 -> false))
+                                        | uu____20002 -> false))
                                  in
                               quals (FStar_Syntax_Syntax.OnlyName ::
                                 (FStar_Syntax_Syntax.Projector
@@ -5426,14 +5403,14 @@ let (mk_indexed_projector_names :
                                 iquals1)
                                in
                             let decl =
-                              let uu____20026 =
+                              let uu____20005 =
                                 FStar_Ident.range_of_lid field_name  in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_declare_typ
                                      (field_name, [],
                                        FStar_Syntax_Syntax.tun));
-                                FStar_Syntax_Syntax.sigrng = uu____20026;
+                                FStar_Syntax_Syntax.sigrng = uu____20005;
                                 FStar_Syntax_Syntax.sigquals = quals1;
                                 FStar_Syntax_Syntax.sigmeta =
                                   FStar_Syntax_Syntax.default_sigmeta;
@@ -5445,12 +5422,12 @@ let (mk_indexed_projector_names :
                             then [decl]
                             else
                               (let dd =
-                                 let uu____20033 =
+                                 let uu____20012 =
                                    FStar_All.pipe_right quals1
                                      (FStar_List.contains
                                         FStar_Syntax_Syntax.Abstract)
                                     in
-                                 if uu____20033
+                                 if uu____20012
                                  then
                                    FStar_Syntax_Syntax.Delta_abstract
                                      (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -5460,14 +5437,14 @@ let (mk_indexed_projector_names :
                                      Prims.int_one
                                   in
                                let lb =
-                                 let uu____20044 =
-                                   let uu____20049 =
+                                 let uu____20023 =
+                                   let uu____20028 =
                                      FStar_Syntax_Syntax.lid_as_fv field_name
                                        dd FStar_Pervasives_Native.None
                                       in
-                                   FStar_Util.Inr uu____20049  in
+                                   FStar_Util.Inr uu____20028  in
                                  {
-                                   FStar_Syntax_Syntax.lbname = uu____20044;
+                                   FStar_Syntax_Syntax.lbname = uu____20023;
                                    FStar_Syntax_Syntax.lbunivs = [];
                                    FStar_Syntax_Syntax.lbtyp =
                                      FStar_Syntax_Syntax.tun;
@@ -5480,25 +5457,25 @@ let (mk_indexed_projector_names :
                                      FStar_Range.dummyRange
                                  }  in
                                let impl =
-                                 let uu____20053 =
-                                   let uu____20054 =
-                                     let uu____20061 =
-                                       let uu____20064 =
-                                         let uu____20065 =
+                                 let uu____20032 =
+                                   let uu____20033 =
+                                     let uu____20040 =
+                                       let uu____20043 =
+                                         let uu____20044 =
                                            FStar_All.pipe_right
                                              lb.FStar_Syntax_Syntax.lbname
                                              FStar_Util.right
                                             in
-                                         FStar_All.pipe_right uu____20065
+                                         FStar_All.pipe_right uu____20044
                                            (fun fv  ->
                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                           in
-                                       [uu____20064]  in
-                                     ((false, [lb]), uu____20061)  in
-                                   FStar_Syntax_Syntax.Sig_let uu____20054
+                                       [uu____20043]  in
+                                     ((false, [lb]), uu____20040)  in
+                                   FStar_Syntax_Syntax.Sig_let uu____20033
                                     in
                                  {
-                                   FStar_Syntax_Syntax.sigel = uu____20053;
+                                   FStar_Syntax_Syntax.sigel = uu____20032;
                                    FStar_Syntax_Syntax.sigrng = p;
                                    FStar_Syntax_Syntax.sigquals = quals1;
                                    FStar_Syntax_Syntax.sigmeta =
@@ -5509,7 +5486,7 @@ let (mk_indexed_projector_names :
                                  }  in
                                if no_decl then [impl] else [decl; impl])))
                in
-            FStar_All.pipe_right uu____19917 FStar_List.flatten
+            FStar_All.pipe_right uu____19896 FStar_List.flatten
   
 let (mk_data_projector_names :
   FStar_Syntax_Syntax.qualifier Prims.list ->
@@ -5521,29 +5498,29 @@ let (mk_data_projector_names :
       fun se  ->
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_datacon
-            (lid,uu____20114,t,uu____20116,n,uu____20118) when
-            let uu____20125 =
+            (lid,uu____20093,t,uu____20095,n,uu____20097) when
+            let uu____20104 =
               FStar_Ident.lid_equals lid FStar_Parser_Const.lexcons_lid  in
-            Prims.op_Negation uu____20125 ->
-            let uu____20127 = FStar_Syntax_Util.arrow_formals t  in
-            (match uu____20127 with
-             | (formals,uu____20137) ->
+            Prims.op_Negation uu____20104 ->
+            let uu____20106 = FStar_Syntax_Util.arrow_formals t  in
+            (match uu____20106 with
+             | (formals,uu____20116) ->
                  (match formals with
                   | [] -> []
-                  | uu____20150 ->
-                      let filter_records uu___16_20158 =
-                        match uu___16_20158 with
+                  | uu____20129 ->
+                      let filter_records uu___16_20137 =
+                        match uu___16_20137 with
                         | FStar_Syntax_Syntax.RecordConstructor
-                            (uu____20161,fns) ->
+                            (uu____20140,fns) ->
                             FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Record_ctor (lid, fns))
-                        | uu____20173 -> FStar_Pervasives_Native.None  in
+                        | uu____20152 -> FStar_Pervasives_Native.None  in
                       let fv_qual =
-                        let uu____20175 =
+                        let uu____20154 =
                           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
                             filter_records
                            in
-                        match uu____20175 with
+                        match uu____20154 with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Syntax_Syntax.Data_ctor
                         | FStar_Pervasives_Native.Some q -> q  in
@@ -5557,12 +5534,12 @@ let (mk_data_projector_names :
                                   FStar_Syntax_Syntax.Private iquals))
                         then FStar_Syntax_Syntax.Private :: iquals
                         else iquals  in
-                      let uu____20187 = FStar_Util.first_N n formals  in
-                      (match uu____20187 with
-                       | (uu____20216,rest) ->
+                      let uu____20166 = FStar_Util.first_N n formals  in
+                      (match uu____20166 with
+                       | (uu____20195,rest) ->
                            mk_indexed_projector_names iquals1 fv_qual env lid
                              rest)))
-        | uu____20250 -> []
+        | uu____20229 -> []
   
 let (mk_typ_abbrev :
   FStar_Syntax_DsEnv.env ->
@@ -5592,48 +5569,48 @@ let (mk_typ_abbrev :
                           d.FStar_Parser_AST.attrs
                          in
                       let val_attrs =
-                        let uu____20344 =
+                        let uu____20323 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env lid
                            in
-                        FStar_All.pipe_right uu____20344
+                        FStar_All.pipe_right uu____20323
                           FStar_Pervasives_Native.snd
                          in
                       let dd =
-                        let uu____20368 =
+                        let uu____20347 =
                           FStar_All.pipe_right quals
                             (FStar_List.contains FStar_Syntax_Syntax.Abstract)
                            in
-                        if uu____20368
+                        if uu____20347
                         then
-                          let uu____20374 =
+                          let uu____20353 =
                             FStar_Syntax_Util.incr_delta_qualifier t  in
-                          FStar_Syntax_Syntax.Delta_abstract uu____20374
+                          FStar_Syntax_Syntax.Delta_abstract uu____20353
                         else FStar_Syntax_Util.incr_delta_qualifier t  in
                       let lb =
-                        let uu____20378 =
-                          let uu____20383 =
+                        let uu____20357 =
+                          let uu____20362 =
                             FStar_Syntax_Syntax.lid_as_fv lid dd
                               FStar_Pervasives_Native.None
                              in
-                          FStar_Util.Inr uu____20383  in
-                        let uu____20384 =
+                          FStar_Util.Inr uu____20362  in
+                        let uu____20363 =
                           if FStar_Util.is_some kopt
                           then
-                            let uu____20390 =
-                              let uu____20393 =
+                            let uu____20369 =
+                              let uu____20372 =
                                 FStar_All.pipe_right kopt FStar_Util.must  in
-                              FStar_Syntax_Syntax.mk_Total uu____20393  in
-                            FStar_Syntax_Util.arrow typars uu____20390
+                              FStar_Syntax_Syntax.mk_Total uu____20372  in
+                            FStar_Syntax_Util.arrow typars uu____20369
                           else FStar_Syntax_Syntax.tun  in
-                        let uu____20398 = no_annot_abs typars t  in
+                        let uu____20377 = no_annot_abs typars t  in
                         {
-                          FStar_Syntax_Syntax.lbname = uu____20378;
+                          FStar_Syntax_Syntax.lbname = uu____20357;
                           FStar_Syntax_Syntax.lbunivs = uvs;
-                          FStar_Syntax_Syntax.lbtyp = uu____20384;
+                          FStar_Syntax_Syntax.lbtyp = uu____20363;
                           FStar_Syntax_Syntax.lbeff =
                             FStar_Parser_Const.effect_Tot_lid;
-                          FStar_Syntax_Syntax.lbdef = uu____20398;
+                          FStar_Syntax_Syntax.lbdef = uu____20377;
                           FStar_Syntax_Syntax.lbattrs = [];
                           FStar_Syntax_Syntax.lbpos = rng
                         }  in
@@ -5662,41 +5639,41 @@ let rec (desugar_tycon :
       fun quals  ->
         fun tcs  ->
           let rng = d.FStar_Parser_AST.drange  in
-          let tycon_id uu___17_20452 =
-            match uu___17_20452 with
-            | FStar_Parser_AST.TyconAbstract (id,uu____20454,uu____20455) ->
+          let tycon_id uu___17_20431 =
+            match uu___17_20431 with
+            | FStar_Parser_AST.TyconAbstract (id,uu____20433,uu____20434) ->
                 id
             | FStar_Parser_AST.TyconAbbrev
-                (id,uu____20465,uu____20466,uu____20467) -> id
+                (id,uu____20444,uu____20445,uu____20446) -> id
             | FStar_Parser_AST.TyconRecord
-                (id,uu____20477,uu____20478,uu____20479) -> id
+                (id,uu____20456,uu____20457,uu____20458) -> id
             | FStar_Parser_AST.TyconVariant
-                (id,uu____20501,uu____20502,uu____20503) -> id
+                (id,uu____20480,uu____20481,uu____20482) -> id
              in
           let binder_to_term b =
             match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated (x,uu____20541) ->
-                let uu____20542 =
-                  let uu____20543 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____20543  in
-                let uu____20544 = FStar_Ident.range_of_id x  in
-                FStar_Parser_AST.mk_term uu____20542 uu____20544
+            | FStar_Parser_AST.Annotated (x,uu____20520) ->
+                let uu____20521 =
+                  let uu____20522 = FStar_Ident.lid_of_ids [x]  in
+                  FStar_Parser_AST.Var uu____20522  in
+                let uu____20523 = FStar_Ident.range_of_id x  in
+                FStar_Parser_AST.mk_term uu____20521 uu____20523
                   FStar_Parser_AST.Expr
             | FStar_Parser_AST.Variable x ->
-                let uu____20546 =
-                  let uu____20547 = FStar_Ident.lid_of_ids [x]  in
-                  FStar_Parser_AST.Var uu____20547  in
-                let uu____20548 = FStar_Ident.range_of_id x  in
-                FStar_Parser_AST.mk_term uu____20546 uu____20548
+                let uu____20525 =
+                  let uu____20526 = FStar_Ident.lid_of_ids [x]  in
+                  FStar_Parser_AST.Var uu____20526  in
+                let uu____20527 = FStar_Ident.range_of_id x  in
+                FStar_Parser_AST.mk_term uu____20525 uu____20527
                   FStar_Parser_AST.Expr
-            | FStar_Parser_AST.TAnnotated (a,uu____20550) ->
-                let uu____20551 = FStar_Ident.range_of_id a  in
+            | FStar_Parser_AST.TAnnotated (a,uu____20529) ->
+                let uu____20530 = FStar_Ident.range_of_id a  in
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  uu____20551 FStar_Parser_AST.Type_level
+                  uu____20530 FStar_Parser_AST.Type_level
             | FStar_Parser_AST.TVariable a ->
-                let uu____20553 = FStar_Ident.range_of_id a  in
+                let uu____20532 = FStar_Ident.range_of_id a  in
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  uu____20553 FStar_Parser_AST.Type_level
+                  uu____20532 FStar_Parser_AST.Type_level
             | FStar_Parser_AST.NoName t -> t  in
           let tot =
             FStar_Parser_AST.mk_term
@@ -5713,85 +5690,85 @@ let rec (desugar_tycon :
               match b.FStar_Parser_AST.aqual with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit ) ->
                   FStar_Parser_AST.Hash
-              | uu____20583 -> FStar_Parser_AST.Nothing  in
+              | uu____20562 -> FStar_Parser_AST.Nothing  in
             FStar_List.fold_left
               (fun out  ->
                  fun b  ->
-                   let uu____20591 =
-                     let uu____20592 =
-                       let uu____20599 = binder_to_term b  in
-                       (out, uu____20599, (imp_of_aqual b))  in
-                     FStar_Parser_AST.App uu____20592  in
-                   FStar_Parser_AST.mk_term uu____20591
+                   let uu____20570 =
+                     let uu____20571 =
+                       let uu____20578 = binder_to_term b  in
+                       (out, uu____20578, (imp_of_aqual b))  in
+                     FStar_Parser_AST.App uu____20571  in
+                   FStar_Parser_AST.mk_term uu____20570
                      out.FStar_Parser_AST.range out.FStar_Parser_AST.level) t
               binders
              in
-          let tycon_record_as_variant uu___18_20611 =
-            match uu___18_20611 with
+          let tycon_record_as_variant uu___18_20590 =
+            match uu___18_20590 with
             | FStar_Parser_AST.TyconRecord (id,parms,kopt,fields) ->
                 let constrName =
-                  let uu____20643 =
-                    let uu____20649 =
-                      let uu____20651 = FStar_Ident.text_of_id id  in
-                      Prims.op_Hat "Mk" uu____20651  in
-                    let uu____20654 = FStar_Ident.range_of_id id  in
-                    (uu____20649, uu____20654)  in
-                  FStar_Ident.mk_ident uu____20643  in
+                  let uu____20622 =
+                    let uu____20628 =
+                      let uu____20630 = FStar_Ident.text_of_id id  in
+                      Prims.op_Hat "Mk" uu____20630  in
+                    let uu____20633 = FStar_Ident.range_of_id id  in
+                    (uu____20628, uu____20633)  in
+                  FStar_Ident.mk_ident uu____20622  in
                 let mfields =
                   FStar_List.map
-                    (fun uu____20667  ->
-                       match uu____20667 with
+                    (fun uu____20646  ->
+                       match uu____20646 with
                        | (x,t) ->
-                           let uu____20674 = FStar_Ident.range_of_id x  in
+                           let uu____20653 = FStar_Ident.range_of_id x  in
                            FStar_Parser_AST.mk_binder
-                             (FStar_Parser_AST.Annotated (x, t)) uu____20674
+                             (FStar_Parser_AST.Annotated (x, t)) uu____20653
                              FStar_Parser_AST.Expr
                              FStar_Pervasives_Native.None) fields
                    in
                 let result =
-                  let uu____20676 =
-                    let uu____20677 =
-                      let uu____20678 = FStar_Ident.lid_of_ids [id]  in
-                      FStar_Parser_AST.Var uu____20678  in
-                    let uu____20679 = FStar_Ident.range_of_id id  in
-                    FStar_Parser_AST.mk_term uu____20677 uu____20679
+                  let uu____20655 =
+                    let uu____20656 =
+                      let uu____20657 = FStar_Ident.lid_of_ids [id]  in
+                      FStar_Parser_AST.Var uu____20657  in
+                    let uu____20658 = FStar_Ident.range_of_id id  in
+                    FStar_Parser_AST.mk_term uu____20656 uu____20658
                       FStar_Parser_AST.Type_level
                      in
-                  apply_binders uu____20676 parms  in
+                  apply_binders uu____20655 parms  in
                 let constrTyp =
-                  let uu____20681 = FStar_Ident.range_of_id id  in
+                  let uu____20660 = FStar_Ident.range_of_id id  in
                   FStar_Parser_AST.mk_term
                     (FStar_Parser_AST.Product
                        (mfields, (with_constructor_effect result)))
-                    uu____20681 FStar_Parser_AST.Type_level
+                    uu____20660 FStar_Parser_AST.Type_level
                    in
                 let names =
-                  let uu____20687 = binder_idents parms  in id :: uu____20687
+                  let uu____20666 = binder_idents parms  in id :: uu____20666
                    in
                 (FStar_List.iter
-                   (fun uu____20701  ->
-                      match uu____20701 with
-                      | (f,uu____20707) ->
-                          let uu____20708 =
+                   (fun uu____20680  ->
+                      match uu____20680 with
+                      | (f,uu____20686) ->
+                          let uu____20687 =
                             FStar_Util.for_some
                               (fun i  -> FStar_Ident.ident_equals f i) names
                              in
-                          if uu____20708
+                          if uu____20687
                           then
-                            let uu____20713 =
-                              let uu____20719 =
-                                let uu____20721 = FStar_Ident.text_of_id f
+                            let uu____20692 =
+                              let uu____20698 =
+                                let uu____20700 = FStar_Ident.text_of_id f
                                    in
                                 FStar_Util.format1
                                   "Field %s shadows the record's name or a parameter of it, please rename it"
-                                  uu____20721
+                                  uu____20700
                                  in
-                              (FStar_Errors.Error_FieldShadow, uu____20719)
+                              (FStar_Errors.Error_FieldShadow, uu____20698)
                                in
-                            let uu____20725 = FStar_Ident.range_of_id f  in
-                            FStar_Errors.raise_error uu____20713 uu____20725
+                            let uu____20704 = FStar_Ident.range_of_id f  in
+                            FStar_Errors.raise_error uu____20692 uu____20704
                           else ()) fields;
-                 (let uu____20728 =
+                 (let uu____20707 =
                     FStar_All.pipe_right fields
                       (FStar_List.map FStar_Pervasives_Native.fst)
                      in
@@ -5799,13 +5776,13 @@ let rec (desugar_tycon :
                       (id, parms, kopt,
                         [(constrName,
                            (FStar_Pervasives_Native.Some constrTyp), false)])),
-                    uu____20728)))
-            | uu____20782 -> failwith "impossible"  in
-          let desugar_abstract_tc quals1 _env mutuals uu___19_20822 =
-            match uu___19_20822 with
+                    uu____20707)))
+            | uu____20761 -> failwith "impossible"  in
+          let desugar_abstract_tc quals1 _env mutuals uu___19_20801 =
+            match uu___19_20801 with
             | FStar_Parser_AST.TyconAbstract (id,binders,kopt) ->
-                let uu____20846 = typars_of_binders _env binders  in
-                (match uu____20846 with
+                let uu____20825 = typars_of_binders _env binders  in
+                (match uu____20825 with
                  | (_env',typars) ->
                      let k =
                        match kopt with
@@ -5815,15 +5792,15 @@ let rec (desugar_tycon :
                            desugar_term _env' k
                         in
                      let tconstr =
-                       let uu____20882 =
-                         let uu____20883 =
-                           let uu____20884 = FStar_Ident.lid_of_ids [id]  in
-                           FStar_Parser_AST.Var uu____20884  in
-                         let uu____20885 = FStar_Ident.range_of_id id  in
-                         FStar_Parser_AST.mk_term uu____20883 uu____20885
+                       let uu____20861 =
+                         let uu____20862 =
+                           let uu____20863 = FStar_Ident.lid_of_ids [id]  in
+                           FStar_Parser_AST.Var uu____20863  in
+                         let uu____20864 = FStar_Ident.range_of_id id  in
+                         FStar_Parser_AST.mk_term uu____20862 uu____20864
                            FStar_Parser_AST.Type_level
                           in
-                       apply_binders uu____20882 binders  in
+                       apply_binders uu____20861 binders  in
                      let qlid = FStar_Syntax_DsEnv.qualify _env id  in
                      let typars1 = FStar_Syntax_Subst.close_binders typars
                         in
@@ -5841,55 +5818,55 @@ let rec (desugar_tycon :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        }  in
-                     let uu____20894 =
+                     let uu____20873 =
                        FStar_Syntax_DsEnv.push_top_level_rec_binding _env id
                          FStar_Syntax_Syntax.delta_constant
                         in
-                     (match uu____20894 with
-                      | (_env1,uu____20911) ->
-                          let uu____20918 =
+                     (match uu____20873 with
+                      | (_env1,uu____20890) ->
+                          let uu____20897 =
                             FStar_Syntax_DsEnv.push_top_level_rec_binding
                               _env' id FStar_Syntax_Syntax.delta_constant
                              in
-                          (match uu____20918 with
-                           | (_env2,uu____20935) ->
+                          (match uu____20897 with
+                           | (_env2,uu____20914) ->
                                (_env1, _env2, se, tconstr))))
-            | uu____20942 -> failwith "Unexpected tycon"  in
+            | uu____20921 -> failwith "Unexpected tycon"  in
           let push_tparams env1 bs =
-            let uu____20985 =
+            let uu____20964 =
               FStar_List.fold_left
-                (fun uu____21019  ->
-                   fun uu____21020  ->
-                     match (uu____21019, uu____21020) with
+                (fun uu____20998  ->
+                   fun uu____20999  ->
+                     match (uu____20998, uu____20999) with
                      | ((env2,tps),(x,imp)) ->
-                         let uu____21089 =
+                         let uu____21068 =
                            FStar_Syntax_DsEnv.push_bv env2
                              x.FStar_Syntax_Syntax.ppname
                             in
-                         (match uu____21089 with
+                         (match uu____21068 with
                           | (env3,y) -> (env3, ((y, imp) :: tps))))
                 (env1, []) bs
                in
-            match uu____20985 with
+            match uu____20964 with
             | (env2,bs1) -> (env2, (FStar_List.rev bs1))  in
           match tcs with
           | (FStar_Parser_AST.TyconAbstract (id,bs,kopt))::[] ->
               let kopt1 =
                 match kopt with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____21180 =
-                      let uu____21181 = FStar_Ident.range_of_id id  in
-                      tm_type_z uu____21181  in
-                    FStar_Pervasives_Native.Some uu____21180
-                | uu____21182 -> kopt  in
+                    let uu____21159 =
+                      let uu____21160 = FStar_Ident.range_of_id id  in
+                      tm_type_z uu____21160  in
+                    FStar_Pervasives_Native.Some uu____21159
+                | uu____21161 -> kopt  in
               let tc = FStar_Parser_AST.TyconAbstract (id, bs, kopt1)  in
-              let uu____21190 = desugar_abstract_tc quals env [] tc  in
-              (match uu____21190 with
-               | (uu____21203,uu____21204,se,uu____21206) ->
+              let uu____21169 = desugar_abstract_tc quals env [] tc  in
+              (match uu____21169 with
+               | (uu____21182,uu____21183,se,uu____21185) ->
                    let se1 =
                      match se.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,uu____21209,typars,k,[],[]) ->
+                         (l,uu____21188,typars,k,[],[]) ->
                          let quals1 = se.FStar_Syntax_Syntax.sigquals  in
                          let quals2 =
                            if
@@ -5897,25 +5874,25 @@ let rec (desugar_tycon :
                                FStar_Syntax_Syntax.Assumption quals1
                            then quals1
                            else
-                             ((let uu____21228 =
-                                 let uu____21230 = FStar_Options.ml_ish ()
+                             ((let uu____21207 =
+                                 let uu____21209 = FStar_Options.ml_ish ()
                                     in
-                                 Prims.op_Negation uu____21230  in
-                               if uu____21228
+                                 Prims.op_Negation uu____21209  in
+                               if uu____21207
                                then
-                                 let uu____21233 =
-                                   let uu____21239 =
-                                     let uu____21241 =
+                                 let uu____21212 =
+                                   let uu____21218 =
+                                     let uu____21220 =
                                        FStar_Syntax_Print.lid_to_string l  in
                                      FStar_Util.format1
                                        "Adding an implicit 'assume new' qualifier on %s"
-                                       uu____21241
+                                       uu____21220
                                       in
                                    (FStar_Errors.Warning_AddImplicitAssumeNewQualifier,
-                                     uu____21239)
+                                     uu____21218)
                                     in
                                  FStar_Errors.log_issue
-                                   se.FStar_Syntax_Syntax.sigrng uu____21233
+                                   se.FStar_Syntax_Syntax.sigrng uu____21212
                                else ());
                               FStar_Syntax_Syntax.Assumption
                               ::
@@ -5926,70 +5903,67 @@ let rec (desugar_tycon :
                          let t =
                            match typars with
                            | [] -> k
-                           | uu____21254 ->
-                               let uu____21255 =
-                                 let uu____21262 =
-                                   let uu____21263 =
-                                     let uu____21278 =
-                                       FStar_Syntax_Syntax.mk_Total k  in
-                                     (typars, uu____21278)  in
-                                   FStar_Syntax_Syntax.Tm_arrow uu____21263
-                                    in
-                                 FStar_Syntax_Syntax.mk uu____21262  in
-                               uu____21255 FStar_Pervasives_Native.None
+                           | uu____21233 ->
+                               let uu____21234 =
+                                 let uu____21235 =
+                                   let uu____21250 =
+                                     FStar_Syntax_Syntax.mk_Total k  in
+                                   (typars, uu____21250)  in
+                                 FStar_Syntax_Syntax.Tm_arrow uu____21235  in
+                               FStar_Syntax_Syntax.mk uu____21234
                                  se.FStar_Syntax_Syntax.sigrng
                             in
-                         let uu___2834_21291 = se  in
+                         let uu___2834_21263 = se  in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ (l, [], t));
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___2834_21291.FStar_Syntax_Syntax.sigrng);
+                             (uu___2834_21263.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals = quals2;
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___2834_21291.FStar_Syntax_Syntax.sigmeta);
+                             (uu___2834_21263.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___2834_21291.FStar_Syntax_Syntax.sigattrs);
+                             (uu___2834_21263.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___2834_21291.FStar_Syntax_Syntax.sigopts)
+                             (uu___2834_21263.FStar_Syntax_Syntax.sigopts)
                          }
-                     | uu____21292 -> failwith "Impossible"  in
+                     | uu____21264 -> failwith "Impossible"  in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se1  in
                    (env1, [se1]))
           | (FStar_Parser_AST.TyconAbbrev (id,binders,kopt,t))::[] ->
-              let uu____21307 = typars_of_binders env binders  in
-              (match uu____21307 with
+              let uu____21279 = typars_of_binders env binders  in
+              (match uu____21279 with
                | (env',typars) ->
                    let kopt1 =
                      match kopt with
                      | FStar_Pervasives_Native.None  ->
-                         let uu____21341 =
+                         let uu____21313 =
                            FStar_Util.for_some
-                             (fun uu___20_21344  ->
-                                match uu___20_21344 with
+                             (fun uu___20_21316  ->
+                                match uu___20_21316 with
                                 | FStar_Syntax_Syntax.Effect  -> true
-                                | uu____21347 -> false) quals
+                                | uu____21319 -> false) quals
                             in
-                         if uu____21341
+                         if uu____21313
                          then
                            FStar_Pervasives_Native.Some
                              FStar_Syntax_Syntax.teff
                          else FStar_Pervasives_Native.None
                      | FStar_Pervasives_Native.Some k ->
-                         let uu____21355 = desugar_term env' k  in
-                         FStar_Pervasives_Native.Some uu____21355
+                         let uu____21327 = desugar_term env' k  in
+                         FStar_Pervasives_Native.Some uu____21327
                       in
                    let t0 = t  in
                    let quals1 =
-                     let uu____21360 =
+                     let uu____21332 =
                        FStar_All.pipe_right quals
                          (FStar_Util.for_some
-                            (fun uu___21_21366  ->
-                               match uu___21_21366 with
+                            (fun uu___21_21338  ->
+                               match uu___21_21338 with
                                | FStar_Syntax_Syntax.Logic  -> true
-                               | uu____21369 -> false))
+                               | uu____21341 -> false))
                         in
-                     if uu____21360
+                     if uu____21332
                      then quals
                      else
                        if
@@ -5999,40 +5973,40 @@ let rec (desugar_tycon :
                       in
                    let qlid = FStar_Syntax_DsEnv.qualify env id  in
                    let se =
-                     let uu____21383 =
+                     let uu____21355 =
                        FStar_All.pipe_right quals1
                          (FStar_List.contains FStar_Syntax_Syntax.Effect)
                         in
-                     if uu____21383
+                     if uu____21355
                      then
-                       let uu____21389 =
-                         let uu____21396 =
-                           let uu____21397 = unparen t  in
-                           uu____21397.FStar_Parser_AST.tm  in
-                         match uu____21396 with
+                       let uu____21361 =
+                         let uu____21368 =
+                           let uu____21369 = unparen t  in
+                           uu____21369.FStar_Parser_AST.tm  in
+                         match uu____21368 with
                          | FStar_Parser_AST.Construct (head,args) ->
-                             let uu____21418 =
+                             let uu____21390 =
                                match FStar_List.rev args with
-                               | (last_arg,uu____21448)::args_rev ->
-                                   let uu____21460 =
-                                     let uu____21461 = unparen last_arg  in
-                                     uu____21461.FStar_Parser_AST.tm  in
-                                   (match uu____21460 with
+                               | (last_arg,uu____21420)::args_rev ->
+                                   let uu____21432 =
+                                     let uu____21433 = unparen last_arg  in
+                                     uu____21433.FStar_Parser_AST.tm  in
+                                   (match uu____21432 with
                                     | FStar_Parser_AST.Attributes ts ->
                                         (ts, (FStar_List.rev args_rev))
-                                    | uu____21489 -> ([], args))
-                               | uu____21498 -> ([], args)  in
-                             (match uu____21418 with
+                                    | uu____21461 -> ([], args))
+                               | uu____21470 -> ([], args)  in
+                             (match uu____21390 with
                               | (cattributes,args1) ->
-                                  let uu____21537 =
+                                  let uu____21509 =
                                     desugar_attributes env cattributes  in
                                   ((FStar_Parser_AST.mk_term
                                       (FStar_Parser_AST.Construct
                                          (head, args1))
                                       t.FStar_Parser_AST.range
-                                      t.FStar_Parser_AST.level), uu____21537))
-                         | uu____21548 -> (t, [])  in
-                       match uu____21389 with
+                                      t.FStar_Parser_AST.level), uu____21509))
+                         | uu____21520 -> (t, [])  in
+                       match uu____21361 with
                        | (t1,cattributes) ->
                            let c =
                              desugar_comp t1.FStar_Parser_AST.range false
@@ -6045,10 +6019,10 @@ let rec (desugar_tycon :
                            let quals2 =
                              FStar_All.pipe_right quals1
                                (FStar_List.filter
-                                  (fun uu___22_21571  ->
-                                     match uu___22_21571 with
+                                  (fun uu___22_21543  ->
+                                     match uu___22_21543 with
                                      | FStar_Syntax_Syntax.Effect  -> false
-                                     | uu____21574 -> true))
+                                     | uu____21546 -> true))
                               in
                            {
                              FStar_Syntax_Syntax.sigel =
@@ -6071,23 +6045,23 @@ let rec (desugar_tycon :
                       in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se  in
                    (env1, [se]))
-          | (FStar_Parser_AST.TyconRecord uu____21582)::[] ->
+          | (FStar_Parser_AST.TyconRecord uu____21554)::[] ->
               let trec = FStar_List.hd tcs  in
-              let uu____21602 = tycon_record_as_variant trec  in
-              (match uu____21602 with
+              let uu____21574 = tycon_record_as_variant trec  in
+              (match uu____21574 with
                | (t,fs) ->
-                   let uu____21619 =
-                     let uu____21622 =
-                       let uu____21623 =
-                         let uu____21632 =
-                           let uu____21635 =
+                   let uu____21591 =
+                     let uu____21594 =
+                       let uu____21595 =
+                         let uu____21604 =
+                           let uu____21607 =
                              FStar_Syntax_DsEnv.current_module env  in
-                           FStar_Ident.ids_of_lid uu____21635  in
-                         (uu____21632, fs)  in
-                       FStar_Syntax_Syntax.RecordType uu____21623  in
-                     uu____21622 :: quals  in
-                   desugar_tycon env d uu____21619 [t])
-          | uu____21640::uu____21641 ->
+                           FStar_Ident.ids_of_lid uu____21607  in
+                         (uu____21604, fs)  in
+                       FStar_Syntax_Syntax.RecordType uu____21595  in
+                     uu____21594 :: quals  in
+                   desugar_tycon env d uu____21591 [t])
+          | uu____21612::uu____21613 ->
               let env0 = env  in
               let mutuals =
                 FStar_List.map
@@ -6096,90 +6070,90 @@ let rec (desugar_tycon :
                        (tycon_id x)) tcs
                  in
               let rec collect_tcs quals1 et tc =
-                let uu____21799 = et  in
-                match uu____21799 with
+                let uu____21771 = et  in
+                match uu____21771 with
                 | (env1,tcs1) ->
                     (match tc with
-                     | FStar_Parser_AST.TyconRecord uu____22009 ->
+                     | FStar_Parser_AST.TyconRecord uu____21981 ->
                          let trec = tc  in
-                         let uu____22029 = tycon_record_as_variant trec  in
-                         (match uu____22029 with
+                         let uu____22001 = tycon_record_as_variant trec  in
+                         (match uu____22001 with
                           | (t,fs) ->
-                              let uu____22085 =
-                                let uu____22088 =
-                                  let uu____22089 =
-                                    let uu____22098 =
-                                      let uu____22101 =
+                              let uu____22057 =
+                                let uu____22060 =
+                                  let uu____22061 =
+                                    let uu____22070 =
+                                      let uu____22073 =
                                         FStar_Syntax_DsEnv.current_module
                                           env1
                                          in
-                                      FStar_Ident.ids_of_lid uu____22101  in
-                                    (uu____22098, fs)  in
-                                  FStar_Syntax_Syntax.RecordType uu____22089
+                                      FStar_Ident.ids_of_lid uu____22073  in
+                                    (uu____22070, fs)  in
+                                  FStar_Syntax_Syntax.RecordType uu____22061
                                    in
-                                uu____22088 :: quals1  in
-                              collect_tcs uu____22085 (env1, tcs1) t)
+                                uu____22060 :: quals1  in
+                              collect_tcs uu____22057 (env1, tcs1) t)
                      | FStar_Parser_AST.TyconVariant
                          (id,binders,kopt,constructors) ->
-                         let uu____22179 =
+                         let uu____22151 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt))
                             in
-                         (match uu____22179 with
-                          | (env2,uu____22236,se,tconstr) ->
+                         (match uu____22151 with
+                          | (env2,uu____22208,se,tconstr) ->
                               (env2,
                                 ((FStar_Util.Inl
                                     (se, constructors, tconstr, quals1)) ::
                                 tcs1)))
                      | FStar_Parser_AST.TyconAbbrev (id,binders,kopt,t) ->
-                         let uu____22373 =
+                         let uu____22345 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt))
                             in
-                         (match uu____22373 with
-                          | (env2,uu____22430,se,tconstr) ->
+                         (match uu____22345 with
+                          | (env2,uu____22402,se,tconstr) ->
                               (env2,
                                 ((FStar_Util.Inr (se, binders, t, quals1)) ::
                                 tcs1)))
-                     | uu____22546 ->
+                     | uu____22518 ->
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                              "Mutually defined type contains a non-inductive element")
                            rng)
                  in
-              let uu____22592 =
+              let uu____22564 =
                 FStar_List.fold_left (collect_tcs quals) (env, []) tcs  in
-              (match uu____22592 with
+              (match uu____22564 with
                | (env1,tcs1) ->
                    let tcs2 = FStar_List.rev tcs1  in
                    let tps_sigelts =
                      FStar_All.pipe_right tcs2
                        (FStar_List.collect
-                          (fun uu___24_23044  ->
-                             match uu___24_23044 with
+                          (fun uu___24_23016  ->
+                             match uu___24_23016 with
                              | FStar_Util.Inr
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (id,uvs,tpars,k,uu____23098,uu____23099);
-                                    FStar_Syntax_Syntax.sigrng = uu____23100;
+                                      (id,uvs,tpars,k,uu____23070,uu____23071);
+                                    FStar_Syntax_Syntax.sigrng = uu____23072;
                                     FStar_Syntax_Syntax.sigquals =
-                                      uu____23101;
-                                    FStar_Syntax_Syntax.sigmeta = uu____23102;
+                                      uu____23073;
+                                    FStar_Syntax_Syntax.sigmeta = uu____23074;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____23103;
-                                    FStar_Syntax_Syntax.sigopts = uu____23104;_},binders,t,quals1)
+                                      uu____23075;
+                                    FStar_Syntax_Syntax.sigopts = uu____23076;_},binders,t,quals1)
                                  ->
                                  let t1 =
-                                   let uu____23166 =
+                                   let uu____23138 =
                                      typars_of_binders env1 binders  in
-                                   match uu____23166 with
+                                   match uu____23138 with
                                    | (env2,tpars1) ->
-                                       let uu____23193 =
+                                       let uu____23165 =
                                          push_tparams env2 tpars1  in
-                                       (match uu____23193 with
+                                       (match uu____23165 with
                                         | (env_tps,tpars2) ->
                                             let t1 = desugar_typ env_tps t
                                                in
@@ -6190,26 +6164,26 @@ let rec (desugar_tycon :
                                             FStar_Syntax_Subst.close tpars3
                                               t1)
                                     in
-                                 let uu____23222 =
-                                   let uu____23233 =
+                                 let uu____23194 =
+                                   let uu____23205 =
                                      mk_typ_abbrev env1 d id uvs tpars
                                        (FStar_Pervasives_Native.Some k) t1
                                        [id] quals1 rng
                                       in
-                                   ([], uu____23233)  in
-                                 [uu____23222]
+                                   ([], uu____23205)  in
+                                 [uu____23194]
                              | FStar_Util.Inl
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,univs,tpars,k,mutuals1,uu____23269);
-                                    FStar_Syntax_Syntax.sigrng = uu____23270;
+                                      (tname,univs,tpars,k,mutuals1,uu____23241);
+                                    FStar_Syntax_Syntax.sigrng = uu____23242;
                                     FStar_Syntax_Syntax.sigquals =
                                       tname_quals;
-                                    FStar_Syntax_Syntax.sigmeta = uu____23272;
+                                    FStar_Syntax_Syntax.sigmeta = uu____23244;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____23273;
-                                    FStar_Syntax_Syntax.sigopts = uu____23274;_},constrs,tconstr,quals1)
+                                      uu____23245;
+                                    FStar_Syntax_Syntax.sigopts = uu____23246;_},constrs,tconstr,quals1)
                                  ->
                                  let mk_tot t =
                                    let tot1 =
@@ -6226,15 +6200,15 @@ let rec (desugar_tycon :
                                      t.FStar_Parser_AST.level
                                     in
                                  let tycon = (tname, tpars, k)  in
-                                 let uu____23365 = push_tparams env1 tpars
+                                 let uu____23337 = push_tparams env1 tpars
                                     in
-                                 (match uu____23365 with
+                                 (match uu____23337 with
                                   | (env_tps,tps) ->
                                       let data_tpars =
                                         FStar_List.map
-                                          (fun uu____23424  ->
-                                             match uu____23424 with
-                                             | (x,uu____23436) ->
+                                          (fun uu____23396  ->
+                                             match uu____23396 with
+                                             | (x,uu____23408) ->
                                                  (x,
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
@@ -6246,19 +6220,19 @@ let rec (desugar_tycon :
                                           d.FStar_Parser_AST.attrs
                                          in
                                       let val_attrs =
-                                        let uu____23447 =
+                                        let uu____23419 =
                                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                             env1 tname
                                            in
-                                        FStar_All.pipe_right uu____23447
+                                        FStar_All.pipe_right uu____23419
                                           FStar_Pervasives_Native.snd
                                          in
-                                      let uu____23470 =
-                                        let uu____23489 =
+                                      let uu____23442 =
+                                        let uu____23461 =
                                           FStar_All.pipe_right constrs
                                             (FStar_List.map
-                                               (fun uu____23566  ->
-                                                  match uu____23566 with
+                                               (fun uu____23538  ->
+                                                  match uu____23538 with
                                                   | (id,topt,of_notation) ->
                                                       let t =
                                                         if of_notation
@@ -6290,10 +6264,10 @@ let rec (desugar_tycon :
                                                                t -> t)
                                                          in
                                                       let t1 =
-                                                        let uu____23609 =
+                                                        let uu____23581 =
                                                           close env_tps t  in
                                                         desugar_term env_tps
-                                                          uu____23609
+                                                          uu____23581
                                                          in
                                                       let name =
                                                         FStar_Syntax_DsEnv.qualify
@@ -6304,54 +6278,54 @@ let rec (desugar_tycon :
                                                           tname_quals
                                                           (FStar_List.collect
                                                              (fun
-                                                                uu___23_23620
+                                                                uu___23_23592
                                                                  ->
-                                                                match uu___23_23620
+                                                                match uu___23_23592
                                                                 with
                                                                 | FStar_Syntax_Syntax.RecordType
                                                                     fns ->
                                                                     [
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
-                                                                | uu____23632
+                                                                | uu____23604
                                                                     -> []))
                                                          in
                                                       let ntps =
                                                         FStar_List.length
                                                           data_tpars
                                                          in
-                                                      let uu____23640 =
-                                                        let uu____23651 =
-                                                          let uu____23652 =
-                                                            let uu____23653 =
-                                                              let uu____23669
+                                                      let uu____23612 =
+                                                        let uu____23623 =
+                                                          let uu____23624 =
+                                                            let uu____23625 =
+                                                              let uu____23641
                                                                 =
-                                                                let uu____23670
+                                                                let uu____23642
                                                                   =
-                                                                  let uu____23673
+                                                                  let uu____23645
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Util.name_function_binders
                                                                      in
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                    uu____23673
+                                                                    uu____23645
                                                                    in
                                                                 FStar_Syntax_Util.arrow
                                                                   data_tpars
-                                                                  uu____23670
+                                                                  uu____23642
                                                                  in
                                                               (name, univs,
-                                                                uu____23669,
+                                                                uu____23641,
                                                                 tname, ntps,
                                                                 mutuals1)
                                                                in
                                                             FStar_Syntax_Syntax.Sig_datacon
-                                                              uu____23653
+                                                              uu____23625
                                                              in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
-                                                              = uu____23652;
+                                                              = uu____23624;
                                                             FStar_Syntax_Syntax.sigrng
                                                               = rng;
                                                             FStar_Syntax_Syntax.sigquals
@@ -6368,14 +6342,14 @@ let rec (desugar_tycon :
                                                               =
                                                               FStar_Pervasives_Native.None
                                                           }  in
-                                                        (tps, uu____23651)
+                                                        (tps, uu____23623)
                                                          in
-                                                      (name, uu____23640)))
+                                                      (name, uu____23612)))
                                            in
                                         FStar_All.pipe_left FStar_List.split
-                                          uu____23489
+                                          uu____23461
                                          in
-                                      (match uu____23470 with
+                                      (match uu____23442 with
                                        | (constrNames,constrs1) ->
                                            ([],
                                              {
@@ -6396,23 +6370,23 @@ let rec (desugar_tycon :
                                                  FStar_Pervasives_Native.None
                                              })
                                            :: constrs1))
-                             | uu____23805 -> failwith "impossible"))
+                             | uu____23777 -> failwith "impossible"))
                       in
                    let sigelts =
                      FStar_All.pipe_right tps_sigelts
                        (FStar_List.map
-                          (fun uu____23886  ->
-                             match uu____23886 with | (uu____23897,se) -> se))
+                          (fun uu____23858  ->
+                             match uu____23858 with | (uu____23869,se) -> se))
                       in
-                   let uu____23911 =
-                     let uu____23918 =
+                   let uu____23883 =
+                     let uu____23890 =
                        FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
                          sigelts
                         in
                      FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____23918 rng
+                       sigelts quals uu____23890 rng
                       in
-                   (match uu____23911 with
+                   (match uu____23883 with
                     | (bundle,abbrevs) ->
                         let env2 = FStar_Syntax_DsEnv.push_sigelt env0 bundle
                            in
@@ -6423,8 +6397,8 @@ let rec (desugar_tycon :
                         let data_ops =
                           FStar_All.pipe_right tps_sigelts
                             (FStar_List.collect
-                               (fun uu____23963  ->
-                                  match uu____23963 with
+                               (fun uu____23935  ->
+                                  match uu____23935 with
                                   | (tps,se) ->
                                       mk_data_projector_names quals env3 se))
                            in
@@ -6434,7 +6408,7 @@ let rec (desugar_tycon :
                                (fun se  ->
                                   match se.FStar_Syntax_Syntax.sigel with
                                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname,uu____24011,tps,k,uu____24014,constrs)
+                                      (tname,uu____23983,tps,k,uu____23986,constrs)
                                       ->
                                       let quals1 =
                                         se.FStar_Syntax_Syntax.sigquals  in
@@ -6451,13 +6425,13 @@ let rec (desugar_tycon :
                                         then FStar_Syntax_Syntax.Private ::
                                           quals1
                                         else quals1  in
-                                      let uu____24035 =
+                                      let uu____24007 =
                                         FStar_All.pipe_right constrs
                                           (FStar_List.filter
                                              (fun data_lid  ->
                                                 let data_quals =
                                                   let data_se =
-                                                    let uu____24050 =
+                                                    let uu____24022 =
                                                       FStar_All.pipe_right
                                                         sigelts
                                                         (FStar_List.find
@@ -6465,38 +6439,38 @@ let rec (desugar_tycon :
                                                               match se1.FStar_Syntax_Syntax.sigel
                                                               with
                                                               | FStar_Syntax_Syntax.Sig_datacon
-                                                                  (name,uu____24067,uu____24068,uu____24069,uu____24070,uu____24071)
+                                                                  (name,uu____24039,uu____24040,uu____24041,uu____24042,uu____24043)
                                                                   ->
                                                                   FStar_Ident.lid_equals
                                                                     name
                                                                     data_lid
-                                                              | uu____24078
+                                                              | uu____24050
                                                                   -> false))
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____24050
+                                                      uu____24022
                                                       FStar_Util.must
                                                      in
                                                   data_se.FStar_Syntax_Syntax.sigquals
                                                    in
-                                                let uu____24082 =
+                                                let uu____24054 =
                                                   FStar_All.pipe_right
                                                     data_quals
                                                     (FStar_List.existsb
-                                                       (fun uu___25_24089  ->
-                                                          match uu___25_24089
+                                                       (fun uu___25_24061  ->
+                                                          match uu___25_24061
                                                           with
                                                           | FStar_Syntax_Syntax.RecordConstructor
-                                                              uu____24091 ->
+                                                              uu____24063 ->
                                                               true
-                                                          | uu____24101 ->
+                                                          | uu____24073 ->
                                                               false))
                                                    in
-                                                Prims.op_Negation uu____24082))
+                                                Prims.op_Negation uu____24054))
                                          in
                                       mk_data_discriminators quals2 env3
-                                        uu____24035
-                                  | uu____24103 -> []))
+                                        uu____24007
+                                  | uu____24075 -> []))
                            in
                         let ops = FStar_List.append discs data_ops  in
                         let env4 =
@@ -6517,28 +6491,28 @@ let (desugar_binders :
   =
   fun env  ->
     fun binders  ->
-      let uu____24140 =
+      let uu____24112 =
         FStar_List.fold_left
-          (fun uu____24175  ->
+          (fun uu____24147  ->
              fun b  ->
-               match uu____24175 with
+               match uu____24147 with
                | (env1,binders1) ->
-                   let uu____24219 = desugar_binder env1 b  in
-                   (match uu____24219 with
+                   let uu____24191 = desugar_binder env1 b  in
+                   (match uu____24191 with
                     | (FStar_Pervasives_Native.Some a,k) ->
-                        let uu____24242 =
+                        let uu____24214 =
                           as_binder env1 b.FStar_Parser_AST.aqual
                             ((FStar_Pervasives_Native.Some a), k)
                            in
-                        (match uu____24242 with
+                        (match uu____24214 with
                          | (binder,env2) -> (env2, (binder :: binders1)))
-                    | uu____24295 ->
+                    | uu____24267 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_MissingNameInBinder,
                             "Missing name in binder")
                           b.FStar_Parser_AST.brange)) (env, []) binders
          in
-      match uu____24140 with
+      match uu____24112 with
       | (env1,binders1) -> (env1, (FStar_List.rev binders1))
   
 let (push_reflect_effect :
@@ -6550,22 +6524,22 @@ let (push_reflect_effect :
     fun quals  ->
       fun effect_name  ->
         fun range  ->
-          let uu____24399 =
+          let uu____24371 =
             FStar_All.pipe_right quals
               (FStar_Util.for_some
-                 (fun uu___26_24406  ->
-                    match uu___26_24406 with
-                    | FStar_Syntax_Syntax.Reflectable uu____24408 -> true
-                    | uu____24410 -> false))
+                 (fun uu___26_24378  ->
+                    match uu___26_24378 with
+                    | FStar_Syntax_Syntax.Reflectable uu____24380 -> true
+                    | uu____24382 -> false))
              in
-          if uu____24399
+          if uu____24371
           then
             let monad_env =
-              let uu____24414 = FStar_Ident.ident_of_lid effect_name  in
-              FStar_Syntax_DsEnv.enter_monad_scope env uu____24414  in
+              let uu____24386 = FStar_Ident.ident_of_lid effect_name  in
+              FStar_Syntax_DsEnv.enter_monad_scope env uu____24386  in
             let reflect_lid =
-              let uu____24416 = FStar_Ident.id_of_text "reflect"  in
-              FStar_All.pipe_right uu____24416
+              let uu____24388 = FStar_Ident.id_of_text "reflect"  in
+              FStar_All.pipe_right uu____24388
                 (FStar_Syntax_DsEnv.qualify monad_env)
                in
             let quals1 =
@@ -6595,52 +6569,52 @@ let (parse_attr_with_list :
   fun warn  ->
     fun at  ->
       fun head  ->
-        let warn1 uu____24467 =
+        let warn1 uu____24439 =
           if warn
           then
-            let uu____24469 =
-              let uu____24475 =
-                let uu____24477 = FStar_Ident.string_of_lid head  in
+            let uu____24441 =
+              let uu____24447 =
+                let uu____24449 = FStar_Ident.string_of_lid head  in
                 FStar_Util.format1
                   "Found ill-applied '%s', argument should be a non-empty list of integer literals"
-                  uu____24477
+                  uu____24449
                  in
-              (FStar_Errors.Warning_UnappliedFail, uu____24475)  in
-            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu____24469
+              (FStar_Errors.Warning_UnappliedFail, uu____24447)  in
+            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu____24441
           else ()  in
-        let uu____24483 = FStar_Syntax_Util.head_and_args at  in
-        match uu____24483 with
+        let uu____24455 = FStar_Syntax_Util.head_and_args at  in
+        match uu____24455 with
         | (hd,args) ->
-            let uu____24536 =
-              let uu____24537 = FStar_Syntax_Subst.compress hd  in
-              uu____24537.FStar_Syntax_Syntax.n  in
-            (match uu____24536 with
+            let uu____24508 =
+              let uu____24509 = FStar_Syntax_Subst.compress hd  in
+              uu____24509.FStar_Syntax_Syntax.n  in
+            (match uu____24508 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv head ->
                  (match args with
                   | [] -> ((FStar_Pervasives_Native.Some []), true)
-                  | (a1,uu____24581)::[] ->
-                      let uu____24606 =
-                        let uu____24611 =
-                          let uu____24620 =
+                  | (a1,uu____24553)::[] ->
+                      let uu____24578 =
+                        let uu____24583 =
+                          let uu____24592 =
                             FStar_Syntax_Embeddings.e_list
                               FStar_Syntax_Embeddings.e_int
                              in
-                          FStar_Syntax_Embeddings.unembed uu____24620 a1  in
-                        uu____24611 true FStar_Syntax_Embeddings.id_norm_cb
+                          FStar_Syntax_Embeddings.unembed uu____24592 a1  in
+                        uu____24583 true FStar_Syntax_Embeddings.id_norm_cb
                          in
-                      (match uu____24606 with
+                      (match uu____24578 with
                        | FStar_Pervasives_Native.Some es ->
-                           let uu____24643 =
-                             let uu____24649 =
+                           let uu____24615 =
+                             let uu____24621 =
                                FStar_List.map FStar_BigInt.to_int_fs es  in
-                             FStar_Pervasives_Native.Some uu____24649  in
-                           (uu____24643, true)
-                       | uu____24664 ->
+                             FStar_Pervasives_Native.Some uu____24621  in
+                           (uu____24615, true)
+                       | uu____24636 ->
                            (warn1 (); (FStar_Pervasives_Native.None, true)))
-                  | uu____24680 ->
+                  | uu____24652 ->
                       (warn1 (); (FStar_Pervasives_Native.None, true)))
-             | uu____24702 -> (FStar_Pervasives_Native.None, false))
+             | uu____24674 -> (FStar_Pervasives_Native.None, false))
   
 let (get_fail_attr1 :
   Prims.bool ->
@@ -6655,17 +6629,17 @@ let (get_fail_attr1 :
         | FStar_Pervasives_Native.Some l ->
             FStar_Pervasives_Native.Some (l, b)
          in
-      let uu____24819 =
+      let uu____24791 =
         parse_attr_with_list warn at FStar_Parser_Const.fail_attr  in
-      match uu____24819 with
+      match uu____24791 with
       | (res,matched) ->
           if matched
           then rebind res false
           else
-            (let uu____24868 =
+            (let uu____24840 =
                parse_attr_with_list warn at FStar_Parser_Const.fail_lax_attr
                 in
-             match uu____24868 with | (res1,uu____24890) -> rebind res1 true)
+             match uu____24840 with | (res1,uu____24862) -> rebind res1 true)
   
 let (get_fail_attr :
   Prims.bool ->
@@ -6684,12 +6658,12 @@ let (get_fail_attr :
             -> FStar_Pervasives_Native.Some (e, l)
         | (FStar_Pervasives_Native.None ,FStar_Pervasives_Native.Some (e,l))
             -> FStar_Pervasives_Native.Some (e, l)
-        | uu____25217 -> FStar_Pervasives_Native.None  in
+        | uu____25189 -> FStar_Pervasives_Native.None  in
       FStar_List.fold_right
         (fun at  ->
            fun acc  ->
-             let uu____25275 = get_fail_attr1 warn at  in
-             comb uu____25275 acc) ats FStar_Pervasives_Native.None
+             let uu____25247 = get_fail_attr1 warn at  in
+             comb uu____25247 acc) ats FStar_Pervasives_Native.None
   
 let (lookup_effect_lid :
   FStar_Syntax_DsEnv.env ->
@@ -6698,17 +6672,17 @@ let (lookup_effect_lid :
   fun env  ->
     fun l  ->
       fun r  ->
-        let uu____25310 = FStar_Syntax_DsEnv.try_lookup_effect_defn env l  in
-        match uu____25310 with
+        let uu____25282 = FStar_Syntax_DsEnv.try_lookup_effect_defn env l  in
+        match uu____25282 with
         | FStar_Pervasives_Native.None  ->
-            let uu____25313 =
-              let uu____25319 =
-                let uu____25321 =
-                  let uu____25323 = FStar_Syntax_Print.lid_to_string l  in
-                  Prims.op_Hat uu____25323 " not found"  in
-                Prims.op_Hat "Effect name " uu____25321  in
-              (FStar_Errors.Fatal_EffectNotFound, uu____25319)  in
-            FStar_Errors.raise_error uu____25313 r
+            let uu____25285 =
+              let uu____25291 =
+                let uu____25293 =
+                  let uu____25295 = FStar_Syntax_Print.lid_to_string l  in
+                  Prims.op_Hat uu____25295 " not found"  in
+                Prims.op_Hat "Effect name " uu____25293  in
+              (FStar_Errors.Fatal_EffectNotFound, uu____25291)  in
+            FStar_Errors.raise_error uu____25285 r
         | FStar_Pervasives_Native.Some l1 -> l1
   
 let rec (desugar_effect :
@@ -6736,32 +6710,32 @@ let rec (desugar_effect :
                     let env0 = env  in
                     let monad_env =
                       FStar_Syntax_DsEnv.enter_monad_scope env eff_name  in
-                    let uu____25479 = desugar_binders monad_env eff_binders
+                    let uu____25451 = desugar_binders monad_env eff_binders
                        in
-                    match uu____25479 with
+                    match uu____25451 with
                     | (env1,binders) ->
                         let eff_t = desugar_term env1 eff_typ  in
                         let num_indices =
-                          let uu____25518 =
-                            let uu____25527 =
+                          let uu____25490 =
+                            let uu____25499 =
                               FStar_Syntax_Util.arrow_formals eff_t  in
-                            FStar_Pervasives_Native.fst uu____25527  in
-                          FStar_List.length uu____25518  in
+                            FStar_Pervasives_Native.fst uu____25499  in
+                          FStar_List.length uu____25490  in
                         (if is_layered && (num_indices <= Prims.int_one)
                          then
-                           (let uu____25545 =
-                              let uu____25551 =
-                                let uu____25553 =
-                                  let uu____25555 =
+                           (let uu____25517 =
+                              let uu____25523 =
+                                let uu____25525 =
+                                  let uu____25527 =
                                     FStar_Ident.text_of_id eff_name  in
-                                  Prims.op_Hat uu____25555
+                                  Prims.op_Hat uu____25527
                                     "is defined as a layered effect but has no indices"
                                    in
-                                Prims.op_Hat "Effect " uu____25553  in
+                                Prims.op_Hat "Effect " uu____25525  in
                               (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                                uu____25551)
+                                uu____25523)
                                in
-                            FStar_Errors.raise_error uu____25545
+                            FStar_Errors.raise_error uu____25517
                               d.FStar_Parser_AST.drange)
                          else ();
                          (let for_free = num_indices = Prims.int_one  in
@@ -6787,41 +6761,41 @@ let rec (desugar_effect :
                           let name_of_eff_decl decl =
                             match decl.FStar_Parser_AST.d with
                             | FStar_Parser_AST.Tycon
-                                (uu____25623,uu____25624,(FStar_Parser_AST.TyconAbbrev
-                                 (name,uu____25626,uu____25627,uu____25628))::[])
+                                (uu____25595,uu____25596,(FStar_Parser_AST.TyconAbbrev
+                                 (name,uu____25598,uu____25599,uu____25600))::[])
                                 -> FStar_Ident.text_of_id name
-                            | uu____25643 ->
+                            | uu____25615 ->
                                 failwith
                                   "Malformed effect member declaration."
                              in
-                          let uu____25646 =
+                          let uu____25618 =
                             FStar_List.partition
                               (fun decl  ->
-                                 let uu____25658 = name_of_eff_decl decl  in
-                                 FStar_List.mem uu____25658 mandatory_members)
+                                 let uu____25630 = name_of_eff_decl decl  in
+                                 FStar_List.mem uu____25630 mandatory_members)
                               eff_decls
                              in
-                          match uu____25646 with
+                          match uu____25618 with
                           | (mandatory_members_decls,actions) ->
-                              let uu____25677 =
+                              let uu____25649 =
                                 FStar_All.pipe_right mandatory_members_decls
                                   (FStar_List.fold_left
-                                     (fun uu____25706  ->
+                                     (fun uu____25678  ->
                                         fun decl  ->
-                                          match uu____25706 with
+                                          match uu____25678 with
                                           | (env2,out) ->
-                                              let uu____25726 =
+                                              let uu____25698 =
                                                 desugar_decl env2 decl  in
-                                              (match uu____25726 with
+                                              (match uu____25698 with
                                                | (env3,ses) ->
-                                                   let uu____25739 =
-                                                     let uu____25742 =
+                                                   let uu____25711 =
+                                                     let uu____25714 =
                                                        FStar_List.hd ses  in
-                                                     uu____25742 :: out  in
-                                                   (env3, uu____25739)))
+                                                     uu____25714 :: out  in
+                                                   (env3, uu____25711)))
                                      (env1, []))
                                  in
-                              (match uu____25677 with
+                              (match uu____25649 with
                                | (env2,decls) ->
                                    let binders1 =
                                      FStar_Syntax_Subst.close_binders binders
@@ -6832,36 +6806,36 @@ let rec (desugar_effect :
                                           (fun d1  ->
                                              match d1.FStar_Parser_AST.d with
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____25788,uu____25789,(FStar_Parser_AST.TyconAbbrev
-                                                  (name,action_params,uu____25792,
+                                                 (uu____25760,uu____25761,(FStar_Parser_AST.TyconAbbrev
+                                                  (name,action_params,uu____25764,
                                                    {
                                                      FStar_Parser_AST.tm =
                                                        FStar_Parser_AST.Construct
-                                                       (uu____25793,(def,uu____25795)::
-                                                        (cps_type,uu____25797)::[]);
+                                                       (uu____25765,(def,uu____25767)::
+                                                        (cps_type,uu____25769)::[]);
                                                      FStar_Parser_AST.range =
-                                                       uu____25798;
+                                                       uu____25770;
                                                      FStar_Parser_AST.level =
-                                                       uu____25799;_}))::[])
+                                                       uu____25771;_}))::[])
                                                  when
                                                  Prims.op_Negation for_free
                                                  ->
-                                                 let uu____25832 =
+                                                 let uu____25804 =
                                                    desugar_binders env2
                                                      action_params
                                                     in
-                                                 (match uu____25832 with
+                                                 (match uu____25804 with
                                                   | (env3,action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1
                                                          in
-                                                      let uu____25864 =
+                                                      let uu____25836 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name
                                                          in
-                                                      let uu____25865 =
-                                                        let uu____25866 =
+                                                      let uu____25837 =
+                                                        let uu____25838 =
                                                           desugar_term env3
                                                             def
                                                            in
@@ -6869,10 +6843,10 @@ let rec (desugar_effect :
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____25866
+                                                          uu____25838
                                                          in
-                                                      let uu____25873 =
-                                                        let uu____25874 =
+                                                      let uu____25845 =
+                                                        let uu____25846 =
                                                           desugar_typ env3
                                                             cps_type
                                                            in
@@ -6880,11 +6854,11 @@ let rec (desugar_effect :
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____25874
+                                                          uu____25846
                                                          in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____25864;
+                                                          = uu____25836;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6892,31 +6866,31 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____25865;
+                                                          = uu____25837;
                                                         FStar_Syntax_Syntax.action_typ
-                                                          = uu____25873
+                                                          = uu____25845
                                                       })
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____25881,uu____25882,(FStar_Parser_AST.TyconAbbrev
-                                                  (name,action_params,uu____25885,defn))::[])
+                                                 (uu____25853,uu____25854,(FStar_Parser_AST.TyconAbbrev
+                                                  (name,action_params,uu____25857,defn))::[])
                                                  when for_free || is_layered
                                                  ->
-                                                 let uu____25901 =
+                                                 let uu____25873 =
                                                    desugar_binders env2
                                                      action_params
                                                     in
-                                                 (match uu____25901 with
+                                                 (match uu____25873 with
                                                   | (env3,action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1
                                                          in
-                                                      let uu____25933 =
+                                                      let uu____25905 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name
                                                          in
-                                                      let uu____25934 =
-                                                        let uu____25935 =
+                                                      let uu____25906 =
+                                                        let uu____25907 =
                                                           desugar_term env3
                                                             defn
                                                            in
@@ -6924,11 +6898,11 @@ let rec (desugar_effect :
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____25935
+                                                          uu____25907
                                                          in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____25933;
+                                                          = uu____25905;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6936,12 +6910,12 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____25934;
+                                                          = uu____25906;
                                                         FStar_Syntax_Syntax.action_typ
                                                           =
                                                           FStar_Syntax_Syntax.tun
                                                       })
-                                             | uu____25942 ->
+                                             | uu____25914 ->
                                                  FStar_Errors.raise_error
                                                    (FStar_Errors.Fatal_MalformedActionDeclaration,
                                                      "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
@@ -6952,24 +6926,24 @@ let rec (desugar_effect :
                                       in
                                    let lookup s =
                                      let l =
-                                       let uu____25961 =
+                                       let uu____25933 =
                                          FStar_Ident.mk_ident
                                            (s, (d.FStar_Parser_AST.drange))
                                           in
                                        FStar_Syntax_DsEnv.qualify env2
-                                         uu____25961
+                                         uu____25933
                                         in
-                                     let uu____25963 =
-                                       let uu____25964 =
+                                     let uu____25935 =
+                                       let uu____25936 =
                                          FStar_Syntax_DsEnv.fail_or env2
                                            (FStar_Syntax_DsEnv.try_lookup_definition
                                               env2) l
                                           in
                                        FStar_All.pipe_left
                                          (FStar_Syntax_Subst.close binders1)
-                                         uu____25964
+                                         uu____25936
                                         in
-                                     ([], uu____25963)  in
+                                     ([], uu____25935)  in
                                    let mname =
                                      FStar_Syntax_DsEnv.qualify env0 eff_name
                                       in
@@ -6984,24 +6958,24 @@ let rec (desugar_effect :
                                    let combinators =
                                      if for_free
                                      then
-                                       let uu____25986 =
-                                         let uu____25987 =
-                                           let uu____25990 = lookup "repr"
+                                       let uu____25958 =
+                                         let uu____25959 =
+                                           let uu____25962 = lookup "repr"
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____25990
+                                             uu____25962
                                             in
-                                         let uu____25992 =
-                                           let uu____25995 = lookup "return"
+                                         let uu____25964 =
+                                           let uu____25967 = lookup "return"
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____25995
+                                             uu____25967
                                             in
-                                         let uu____25997 =
-                                           let uu____26000 = lookup "bind"
+                                         let uu____25969 =
+                                           let uu____25972 = lookup "bind"
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____26000
+                                             uu____25972
                                             in
                                          {
                                            FStar_Syntax_Syntax.ret_wp =
@@ -7019,156 +6993,156 @@ let rec (desugar_effect :
                                            FStar_Syntax_Syntax.trivial =
                                              dummy_tscheme;
                                            FStar_Syntax_Syntax.repr =
-                                             uu____25987;
+                                             uu____25959;
                                            FStar_Syntax_Syntax.return_repr =
-                                             uu____25992;
+                                             uu____25964;
                                            FStar_Syntax_Syntax.bind_repr =
-                                             uu____25997
+                                             uu____25969
                                          }  in
                                        FStar_Syntax_Syntax.DM4F_eff
-                                         uu____25986
+                                         uu____25958
                                      else
                                        if is_layered
                                        then
-                                         (let to_comb uu____26034 =
-                                            match uu____26034 with
+                                         (let to_comb uu____26006 =
+                                            match uu____26006 with
                                             | (us,t) ->
                                                 ((us, t), dummy_tscheme)
                                              in
-                                          let uu____26081 =
-                                            let uu____26082 =
+                                          let uu____26053 =
+                                            let uu____26054 =
                                               FStar_Ident.lid_of_str ""  in
-                                            let uu____26084 =
-                                              let uu____26089 = lookup "repr"
+                                            let uu____26056 =
+                                              let uu____26061 = lookup "repr"
                                                  in
                                               FStar_All.pipe_right
-                                                uu____26089 to_comb
+                                                uu____26061 to_comb
                                                in
-                                            let uu____26107 =
-                                              let uu____26112 =
+                                            let uu____26079 =
+                                              let uu____26084 =
                                                 lookup "return"  in
                                               FStar_All.pipe_right
-                                                uu____26112 to_comb
+                                                uu____26084 to_comb
                                                in
-                                            let uu____26130 =
-                                              let uu____26135 = lookup "bind"
+                                            let uu____26102 =
+                                              let uu____26107 = lookup "bind"
                                                  in
                                               FStar_All.pipe_right
-                                                uu____26135 to_comb
+                                                uu____26107 to_comb
                                                in
-                                            let uu____26153 =
-                                              let uu____26158 =
+                                            let uu____26125 =
+                                              let uu____26130 =
                                                 lookup "subcomp"  in
                                               FStar_All.pipe_right
-                                                uu____26158 to_comb
+                                                uu____26130 to_comb
                                                in
-                                            let uu____26176 =
-                                              let uu____26181 =
+                                            let uu____26148 =
+                                              let uu____26153 =
                                                 lookup "if_then_else"  in
                                               FStar_All.pipe_right
-                                                uu____26181 to_comb
+                                                uu____26153 to_comb
                                                in
                                             {
                                               FStar_Syntax_Syntax.l_base_effect
-                                                = uu____26082;
+                                                = uu____26054;
                                               FStar_Syntax_Syntax.l_repr =
-                                                uu____26084;
+                                                uu____26056;
                                               FStar_Syntax_Syntax.l_return =
-                                                uu____26107;
+                                                uu____26079;
                                               FStar_Syntax_Syntax.l_bind =
-                                                uu____26130;
+                                                uu____26102;
                                               FStar_Syntax_Syntax.l_subcomp =
-                                                uu____26153;
+                                                uu____26125;
                                               FStar_Syntax_Syntax.l_if_then_else
-                                                = uu____26176
+                                                = uu____26148
                                             }  in
                                           FStar_Syntax_Syntax.Layered_eff
-                                            uu____26081)
+                                            uu____26053)
                                        else
                                          (let rr =
                                             FStar_Util.for_some
-                                              (fun uu___27_26204  ->
-                                                 match uu___27_26204 with
+                                              (fun uu___27_26176  ->
+                                                 match uu___27_26176 with
                                                  | FStar_Syntax_Syntax.Reifiable
                                                       -> true
                                                  | FStar_Syntax_Syntax.Reflectable
-                                                     uu____26207 -> true
-                                                 | uu____26209 -> false)
+                                                     uu____26179 -> true
+                                                 | uu____26181 -> false)
                                               qualifiers
                                              in
-                                          let uu____26211 =
-                                            let uu____26212 =
+                                          let uu____26183 =
+                                            let uu____26184 =
                                               lookup "return_wp"  in
-                                            let uu____26214 =
+                                            let uu____26186 =
                                               lookup "bind_wp"  in
-                                            let uu____26216 =
+                                            let uu____26188 =
                                               lookup "stronger"  in
-                                            let uu____26218 =
+                                            let uu____26190 =
                                               lookup "if_then_else"  in
-                                            let uu____26220 = lookup "ite_wp"
+                                            let uu____26192 = lookup "ite_wp"
                                                in
-                                            let uu____26222 =
+                                            let uu____26194 =
                                               lookup "close_wp"  in
-                                            let uu____26224 =
+                                            let uu____26196 =
                                               lookup "trivial"  in
-                                            let uu____26226 =
+                                            let uu____26198 =
                                               if rr
                                               then
-                                                let uu____26232 =
+                                                let uu____26204 =
                                                   lookup "repr"  in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26232
+                                                  uu____26204
                                               else
                                                 FStar_Pervasives_Native.None
                                                in
-                                            let uu____26236 =
+                                            let uu____26208 =
                                               if rr
                                               then
-                                                let uu____26242 =
+                                                let uu____26214 =
                                                   lookup "return"  in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26242
+                                                  uu____26214
                                               else
                                                 FStar_Pervasives_Native.None
                                                in
-                                            let uu____26246 =
+                                            let uu____26218 =
                                               if rr
                                               then
-                                                let uu____26252 =
+                                                let uu____26224 =
                                                   lookup "bind"  in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26252
+                                                  uu____26224
                                               else
                                                 FStar_Pervasives_Native.None
                                                in
                                             {
                                               FStar_Syntax_Syntax.ret_wp =
-                                                uu____26212;
+                                                uu____26184;
                                               FStar_Syntax_Syntax.bind_wp =
-                                                uu____26214;
+                                                uu____26186;
                                               FStar_Syntax_Syntax.stronger =
-                                                uu____26216;
+                                                uu____26188;
                                               FStar_Syntax_Syntax.if_then_else
-                                                = uu____26218;
+                                                = uu____26190;
                                               FStar_Syntax_Syntax.ite_wp =
-                                                uu____26220;
+                                                uu____26192;
                                               FStar_Syntax_Syntax.close_wp =
-                                                uu____26222;
+                                                uu____26194;
                                               FStar_Syntax_Syntax.trivial =
-                                                uu____26224;
+                                                uu____26196;
                                               FStar_Syntax_Syntax.repr =
-                                                uu____26226;
+                                                uu____26198;
                                               FStar_Syntax_Syntax.return_repr
-                                                = uu____26236;
+                                                = uu____26208;
                                               FStar_Syntax_Syntax.bind_repr =
-                                                uu____26246
+                                                uu____26218
                                             }  in
                                           FStar_Syntax_Syntax.Primitive_eff
-                                            uu____26211)
+                                            uu____26183)
                                       in
                                    let sigel =
-                                     let uu____26257 =
-                                       let uu____26258 =
+                                     let uu____26229 =
+                                       let uu____26230 =
                                          FStar_List.map (desugar_term env2)
                                            attrs
                                           in
@@ -7185,10 +7159,10 @@ let rec (desugar_effect :
                                          FStar_Syntax_Syntax.actions =
                                            actions1;
                                          FStar_Syntax_Syntax.eff_attrs =
-                                           uu____26258
+                                           uu____26230
                                        }  in
                                      FStar_Syntax_Syntax.Sig_new_effect
-                                       uu____26257
+                                       uu____26229
                                       in
                                    let se =
                                      {
@@ -7211,13 +7185,13 @@ let rec (desugar_effect :
                                        (FStar_List.fold_left
                                           (fun env4  ->
                                              fun a  ->
-                                               let uu____26275 =
+                                               let uu____26247 =
                                                  FStar_Syntax_Util.action_as_lb
                                                    mname a
                                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                                   in
                                                FStar_Syntax_DsEnv.push_sigelt
-                                                 env4 uu____26275) env3)
+                                                 env4 uu____26247) env3)
                                       in
                                    let env5 =
                                      push_reflect_effect env4 qualifiers
@@ -7248,30 +7222,30 @@ and (desugar_redefine_effect :
                 let env0 = env  in
                 let env1 = FStar_Syntax_DsEnv.enter_monad_scope env eff_name
                    in
-                let uu____26298 = desugar_binders env1 eff_binders  in
-                match uu____26298 with
+                let uu____26270 = desugar_binders env1 eff_binders  in
+                match uu____26270 with
                 | (env2,binders) ->
-                    let uu____26335 =
-                      let uu____26346 = head_and_args defn  in
-                      match uu____26346 with
+                    let uu____26307 =
+                      let uu____26318 = head_and_args defn  in
+                      match uu____26318 with
                       | (head,args) ->
                           let lid =
                             match head.FStar_Parser_AST.tm with
                             | FStar_Parser_AST.Name l -> l
-                            | uu____26383 ->
-                                let uu____26384 =
-                                  let uu____26390 =
-                                    let uu____26392 =
-                                      let uu____26394 =
+                            | uu____26355 ->
+                                let uu____26356 =
+                                  let uu____26362 =
+                                    let uu____26364 =
+                                      let uu____26366 =
                                         FStar_Parser_AST.term_to_string head
                                          in
-                                      Prims.op_Hat uu____26394 " not found"
+                                      Prims.op_Hat uu____26366 " not found"
                                        in
-                                    Prims.op_Hat "Effect " uu____26392  in
+                                    Prims.op_Hat "Effect " uu____26364  in
                                   (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____26390)
+                                    uu____26362)
                                    in
-                                FStar_Errors.raise_error uu____26384
+                                FStar_Errors.raise_error uu____26356
                                   d.FStar_Parser_AST.drange
                              in
                           let ed =
@@ -7279,25 +7253,25 @@ and (desugar_redefine_effect :
                               (FStar_Syntax_DsEnv.try_lookup_effect_defn env2)
                               lid
                              in
-                          let uu____26400 =
+                          let uu____26372 =
                             match FStar_List.rev args with
-                            | (last_arg,uu____26430)::args_rev ->
-                                let uu____26442 =
-                                  let uu____26443 = unparen last_arg  in
-                                  uu____26443.FStar_Parser_AST.tm  in
-                                (match uu____26442 with
+                            | (last_arg,uu____26402)::args_rev ->
+                                let uu____26414 =
+                                  let uu____26415 = unparen last_arg  in
+                                  uu____26415.FStar_Parser_AST.tm  in
+                                (match uu____26414 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
-                                 | uu____26471 -> ([], args))
-                            | uu____26480 -> ([], args)  in
-                          (match uu____26400 with
+                                 | uu____26443 -> ([], args))
+                            | uu____26452 -> ([], args)  in
+                          (match uu____26372 with
                            | (cattributes,args1) ->
-                               let uu____26523 = desugar_args env2 args1  in
-                               let uu____26524 =
+                               let uu____26495 = desugar_args env2 args1  in
+                               let uu____26496 =
                                  desugar_attributes env2 cattributes  in
-                               (lid, ed, uu____26523, uu____26524))
+                               (lid, ed, uu____26495, uu____26496))
                        in
-                    (match uu____26335 with
+                    (match uu____26307 with
                      | (ed_lid,ed,args,cattributes) ->
                          let binders1 =
                            FStar_Syntax_Subst.close_binders binders  in
@@ -7311,77 +7285,77 @@ and (desugar_redefine_effect :
                                 "Unexpected number of arguments to effect constructor")
                               defn.FStar_Parser_AST.range
                           else ();
-                          (let uu____26564 =
+                          (let uu____26536 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
                                FStar_Syntax_Syntax.t_unit
                               in
-                           match uu____26564 with
-                           | (ed_binders,uu____26578,ed_binders_opening) ->
-                               let sub' shift_n uu____26597 =
-                                 match uu____26597 with
+                           match uu____26536 with
+                           | (ed_binders,uu____26550,ed_binders_opening) ->
+                               let sub' shift_n uu____26569 =
+                                 match uu____26569 with
                                  | (us,x) ->
                                      let x1 =
-                                       let uu____26612 =
+                                       let uu____26584 =
                                          FStar_Syntax_Subst.shift_subst
                                            (shift_n + (FStar_List.length us))
                                            ed_binders_opening
                                           in
-                                       FStar_Syntax_Subst.subst uu____26612 x
+                                       FStar_Syntax_Subst.subst uu____26584 x
                                         in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
                                          ed_binders args
                                         in
-                                     let uu____26616 =
-                                       let uu____26617 =
+                                     let uu____26588 =
+                                       let uu____26589 =
                                          FStar_Syntax_Subst.subst s x1  in
-                                       (us, uu____26617)  in
+                                       (us, uu____26589)  in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____26616
+                                       binders1 uu____26588
                                   in
                                let sub = sub' Prims.int_zero  in
                                let mname =
                                  FStar_Syntax_DsEnv.qualify env0 eff_name  in
                                let ed1 =
-                                 let uu____26638 =
+                                 let uu____26610 =
                                    sub ed.FStar_Syntax_Syntax.signature  in
-                                 let uu____26639 =
+                                 let uu____26611 =
                                    FStar_Syntax_Util.apply_eff_combinators
                                      sub ed.FStar_Syntax_Syntax.combinators
                                     in
-                                 let uu____26640 =
+                                 let uu____26612 =
                                    FStar_List.map
                                      (fun action  ->
                                         let nparam =
                                           FStar_List.length
                                             action.FStar_Syntax_Syntax.action_params
                                            in
-                                        let uu____26656 =
+                                        let uu____26628 =
                                           FStar_Syntax_DsEnv.qualify env2
                                             action.FStar_Syntax_Syntax.action_unqualified_name
                                            in
-                                        let uu____26657 =
-                                          let uu____26658 =
+                                        let uu____26629 =
+                                          let uu____26630 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_defn))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____26658
+                                            uu____26630
                                            in
-                                        let uu____26673 =
-                                          let uu____26674 =
+                                        let uu____26645 =
+                                          let uu____26646 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_typ))
                                              in
                                           FStar_Pervasives_Native.snd
-                                            uu____26674
+                                            uu____26646
                                            in
                                         {
                                           FStar_Syntax_Syntax.action_name =
-                                            uu____26656;
+                                            uu____26628;
                                           FStar_Syntax_Syntax.action_unqualified_name
                                             =
                                             (action.FStar_Syntax_Syntax.action_unqualified_name);
@@ -7390,9 +7364,9 @@ and (desugar_redefine_effect :
                                           FStar_Syntax_Syntax.action_params =
                                             (action.FStar_Syntax_Syntax.action_params);
                                           FStar_Syntax_Syntax.action_defn =
-                                            uu____26657;
+                                            uu____26629;
                                           FStar_Syntax_Syntax.action_typ =
-                                            uu____26673
+                                            uu____26645
                                         }) ed.FStar_Syntax_Syntax.actions
                                     in
                                  {
@@ -7403,26 +7377,26 @@ and (desugar_redefine_effect :
                                      (ed.FStar_Syntax_Syntax.univs);
                                    FStar_Syntax_Syntax.binders = binders1;
                                    FStar_Syntax_Syntax.signature =
-                                     uu____26638;
+                                     uu____26610;
                                    FStar_Syntax_Syntax.combinators =
-                                     uu____26639;
-                                   FStar_Syntax_Syntax.actions = uu____26640;
+                                     uu____26611;
+                                   FStar_Syntax_Syntax.actions = uu____26612;
                                    FStar_Syntax_Syntax.eff_attrs =
                                      (ed.FStar_Syntax_Syntax.eff_attrs)
                                  }  in
                                let se =
-                                 let uu____26690 =
-                                   let uu____26693 =
+                                 let uu____26662 =
+                                   let uu____26665 =
                                      trans_qual1
                                        (FStar_Pervasives_Native.Some mname)
                                       in
-                                   FStar_List.map uu____26693 quals  in
+                                   FStar_List.map uu____26665 quals  in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ed1);
                                    FStar_Syntax_Syntax.sigrng =
                                      (d.FStar_Parser_AST.drange);
-                                   FStar_Syntax_Syntax.sigquals = uu____26690;
+                                   FStar_Syntax_Syntax.sigquals = uu____26662;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = [];
@@ -7438,26 +7412,26 @@ and (desugar_redefine_effect :
                                    (FStar_List.fold_left
                                       (fun env4  ->
                                          fun a  ->
-                                           let uu____26708 =
+                                           let uu____26680 =
                                              FStar_Syntax_Util.action_as_lb
                                                mname a
                                                (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                               in
                                            FStar_Syntax_DsEnv.push_sigelt
-                                             env4 uu____26708) env3)
+                                             env4 uu____26680) env3)
                                   in
                                let env5 =
-                                 let uu____26710 =
+                                 let uu____26682 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
                                         FStar_Parser_AST.Reflectable)
                                     in
-                                 if uu____26710
+                                 if uu____26682
                                  then
                                    let reflect_lid =
-                                     let uu____26717 =
+                                     let uu____26689 =
                                        FStar_Ident.id_of_text "reflect"  in
-                                     FStar_All.pipe_right uu____26717
+                                     FStar_All.pipe_right uu____26689
                                        (FStar_Syntax_DsEnv.qualify monad_env)
                                       in
                                    let quals1 =
@@ -7493,55 +7467,55 @@ and (desugar_decl_aux :
       let no_fail_attrs ats =
         FStar_List.filter
           (fun at  ->
-             let uu____26750 = get_fail_attr1 false at  in
-             FStar_Option.isNone uu____26750) ats
+             let uu____26722 = get_fail_attr1 false at  in
+             FStar_Option.isNone uu____26722) ats
          in
       let env0 =
-        let uu____26771 = FStar_Syntax_DsEnv.snapshot env  in
-        FStar_All.pipe_right uu____26771 FStar_Pervasives_Native.snd  in
+        let uu____26743 = FStar_Syntax_DsEnv.snapshot env  in
+        FStar_All.pipe_right uu____26743 FStar_Pervasives_Native.snd  in
       let attrs = FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs
          in
-      let uu____26786 =
-        let uu____26793 = get_fail_attr false attrs  in
-        match uu____26793 with
+      let uu____26758 =
+        let uu____26765 = get_fail_attr false attrs  in
+        match uu____26765 with
         | FStar_Pervasives_Native.Some (expected_errs,lax) ->
             let d1 =
-              let uu___3389_26830 = d  in
+              let uu___3389_26802 = d  in
               {
-                FStar_Parser_AST.d = (uu___3389_26830.FStar_Parser_AST.d);
+                FStar_Parser_AST.d = (uu___3389_26802.FStar_Parser_AST.d);
                 FStar_Parser_AST.drange =
-                  (uu___3389_26830.FStar_Parser_AST.drange);
+                  (uu___3389_26802.FStar_Parser_AST.drange);
                 FStar_Parser_AST.quals =
-                  (uu___3389_26830.FStar_Parser_AST.quals);
+                  (uu___3389_26802.FStar_Parser_AST.quals);
                 FStar_Parser_AST.attrs = []
               }  in
-            let uu____26831 =
+            let uu____26803 =
               FStar_Errors.catch_errors
-                (fun uu____26849  ->
+                (fun uu____26821  ->
                    FStar_Options.with_saved_options
-                     (fun uu____26855  -> desugar_decl_noattrs env d1))
+                     (fun uu____26827  -> desugar_decl_noattrs env d1))
                in
-            (match uu____26831 with
+            (match uu____26803 with
              | (errs,r) ->
                  (match (errs, r) with
                   | ([],FStar_Pervasives_Native.Some (env1,ses)) ->
                       let ses1 =
                         FStar_List.map
                           (fun se  ->
-                             let uu___3404_26915 = se  in
-                             let uu____26916 = no_fail_attrs attrs  in
+                             let uu___3404_26887 = se  in
+                             let uu____26888 = no_fail_attrs attrs  in
                              {
                                FStar_Syntax_Syntax.sigel =
-                                 (uu___3404_26915.FStar_Syntax_Syntax.sigel);
+                                 (uu___3404_26887.FStar_Syntax_Syntax.sigel);
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___3404_26915.FStar_Syntax_Syntax.sigrng);
+                                 (uu___3404_26887.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___3404_26915.FStar_Syntax_Syntax.sigquals);
+                                 (uu___3404_26887.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___3404_26915.FStar_Syntax_Syntax.sigmeta);
-                               FStar_Syntax_Syntax.sigattrs = uu____26916;
+                                 (uu___3404_26887.FStar_Syntax_Syntax.sigmeta);
+                               FStar_Syntax_Syntax.sigattrs = uu____26888;
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___3404_26915.FStar_Syntax_Syntax.sigopts)
+                                 (uu___3404_26887.FStar_Syntax_Syntax.sigopts)
                              }) ses
                          in
                       let se =
@@ -7569,128 +7543,128 @@ and (desugar_decl_aux :
                       if expected_errs = []
                       then (env0, [])
                       else
-                        (let uu____26969 =
+                        (let uu____26941 =
                            FStar_Errors.find_multiset_discrepancy
                              expected_errs errnos
                             in
-                         match uu____26969 with
+                         match uu____26941 with
                          | FStar_Pervasives_Native.None  -> (env0, [])
                          | FStar_Pervasives_Native.Some (e,n1,n2) ->
                              (FStar_List.iter FStar_Errors.print_issue errs1;
-                              (let uu____27018 =
-                                 let uu____27024 =
-                                   let uu____27026 =
+                              (let uu____26990 =
+                                 let uu____26996 =
+                                   let uu____26998 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int expected_errs
                                       in
-                                   let uu____27029 =
+                                   let uu____27001 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int errnos
                                       in
-                                   let uu____27032 =
+                                   let uu____27004 =
                                      FStar_Util.string_of_int e  in
-                                   let uu____27034 =
+                                   let uu____27006 =
                                      FStar_Util.string_of_int n2  in
-                                   let uu____27036 =
+                                   let uu____27008 =
                                      FStar_Util.string_of_int n1  in
                                    FStar_Util.format5
                                      "This top-level definition was expected to raise error codes %s, but it raised %s (at desugaring time). Error #%s was raised %s times, instead of %s."
-                                     uu____27026 uu____27029 uu____27032
-                                     uu____27034 uu____27036
+                                     uu____26998 uu____27001 uu____27004
+                                     uu____27006 uu____27008
                                     in
-                                 (FStar_Errors.Error_DidNotFail, uu____27024)
+                                 (FStar_Errors.Error_DidNotFail, uu____26996)
                                   in
                                FStar_Errors.log_issue
-                                 d1.FStar_Parser_AST.drange uu____27018);
+                                 d1.FStar_Parser_AST.drange uu____26990);
                               (env0, [])))))
         | FStar_Pervasives_Native.None  -> desugar_decl_noattrs env d  in
-      match uu____26786 with
+      match uu____26758 with
       | (env1,sigelts) ->
           let rec val_attrs ses =
             match ses with
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-                  uu____27074;
-                FStar_Syntax_Syntax.sigrng = uu____27075;
-                FStar_Syntax_Syntax.sigquals = uu____27076;
-                FStar_Syntax_Syntax.sigmeta = uu____27077;
-                FStar_Syntax_Syntax.sigattrs = uu____27078;
-                FStar_Syntax_Syntax.sigopts = uu____27079;_}::[] ->
-                let uu____27092 =
-                  let uu____27095 = FStar_List.hd sigelts  in
-                  FStar_Syntax_Util.lids_of_sigelt uu____27095  in
-                FStar_All.pipe_right uu____27092
+                  uu____27046;
+                FStar_Syntax_Syntax.sigrng = uu____27047;
+                FStar_Syntax_Syntax.sigquals = uu____27048;
+                FStar_Syntax_Syntax.sigmeta = uu____27049;
+                FStar_Syntax_Syntax.sigattrs = uu____27050;
+                FStar_Syntax_Syntax.sigopts = uu____27051;_}::[] ->
+                let uu____27064 =
+                  let uu____27067 = FStar_List.hd sigelts  in
+                  FStar_Syntax_Util.lids_of_sigelt uu____27067  in
+                FStar_All.pipe_right uu____27064
                   (FStar_List.collect
                      (fun nm  ->
-                        let uu____27103 =
+                        let uu____27075 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm
                            in
-                        FStar_Pervasives_Native.snd uu____27103))
+                        FStar_Pervasives_Native.snd uu____27075))
             | {
                 FStar_Syntax_Syntax.sigel =
-                  FStar_Syntax_Syntax.Sig_inductive_typ uu____27116;
-                FStar_Syntax_Syntax.sigrng = uu____27117;
-                FStar_Syntax_Syntax.sigquals = uu____27118;
-                FStar_Syntax_Syntax.sigmeta = uu____27119;
-                FStar_Syntax_Syntax.sigattrs = uu____27120;
-                FStar_Syntax_Syntax.sigopts = uu____27121;_}::uu____27122 ->
-                let uu____27147 =
-                  let uu____27150 = FStar_List.hd sigelts  in
-                  FStar_Syntax_Util.lids_of_sigelt uu____27150  in
-                FStar_All.pipe_right uu____27147
+                  FStar_Syntax_Syntax.Sig_inductive_typ uu____27088;
+                FStar_Syntax_Syntax.sigrng = uu____27089;
+                FStar_Syntax_Syntax.sigquals = uu____27090;
+                FStar_Syntax_Syntax.sigmeta = uu____27091;
+                FStar_Syntax_Syntax.sigattrs = uu____27092;
+                FStar_Syntax_Syntax.sigopts = uu____27093;_}::uu____27094 ->
+                let uu____27119 =
+                  let uu____27122 = FStar_List.hd sigelts  in
+                  FStar_Syntax_Util.lids_of_sigelt uu____27122  in
+                FStar_All.pipe_right uu____27119
                   (FStar_List.collect
                      (fun nm  ->
-                        let uu____27158 =
+                        let uu____27130 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm
                            in
-                        FStar_Pervasives_Native.snd uu____27158))
+                        FStar_Pervasives_Native.snd uu____27130))
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_fail
                   (_errs,_lax,ses1);
-                FStar_Syntax_Syntax.sigrng = uu____27174;
-                FStar_Syntax_Syntax.sigquals = uu____27175;
-                FStar_Syntax_Syntax.sigmeta = uu____27176;
-                FStar_Syntax_Syntax.sigattrs = uu____27177;
-                FStar_Syntax_Syntax.sigopts = uu____27178;_}::[] ->
+                FStar_Syntax_Syntax.sigrng = uu____27146;
+                FStar_Syntax_Syntax.sigquals = uu____27147;
+                FStar_Syntax_Syntax.sigmeta = uu____27148;
+                FStar_Syntax_Syntax.sigattrs = uu____27149;
+                FStar_Syntax_Syntax.sigopts = uu____27150;_}::[] ->
                 FStar_List.collect (fun se  -> val_attrs [se]) ses1
-            | uu____27199 -> []  in
+            | uu____27171 -> []  in
           let attrs1 =
-            let uu____27205 = val_attrs sigelts  in
-            FStar_List.append attrs uu____27205  in
-          let uu____27208 =
+            let uu____27177 = val_attrs sigelts  in
+            FStar_List.append attrs uu____27177  in
+          let uu____27180 =
             FStar_List.map
               (fun sigelt  ->
-                 let uu___3464_27212 = sigelt  in
+                 let uu___3464_27184 = sigelt  in
                  {
                    FStar_Syntax_Syntax.sigel =
-                     (uu___3464_27212.FStar_Syntax_Syntax.sigel);
+                     (uu___3464_27184.FStar_Syntax_Syntax.sigel);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___3464_27212.FStar_Syntax_Syntax.sigrng);
+                     (uu___3464_27184.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___3464_27212.FStar_Syntax_Syntax.sigquals);
+                     (uu___3464_27184.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___3464_27212.FStar_Syntax_Syntax.sigmeta);
+                     (uu___3464_27184.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs = attrs1;
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___3464_27212.FStar_Syntax_Syntax.sigopts)
+                     (uu___3464_27184.FStar_Syntax_Syntax.sigopts)
                  }) sigelts
              in
-          (env1, uu____27208)
+          (env1, uu____27180)
 
 and (desugar_decl :
   env_t -> FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts)) =
   fun env  ->
     fun d  ->
-      let uu____27219 = desugar_decl_aux env d  in
-      match uu____27219 with
+      let uu____27191 = desugar_decl_aux env d  in
+      match uu____27191 with
       | (env1,ses) ->
-          let uu____27230 =
+          let uu____27202 =
             FStar_All.pipe_right ses
               (FStar_List.map generalize_annotated_univs)
              in
-          (env1, uu____27230)
+          (env1, uu____27202)
 
 and (desugar_decl_noattrs :
   FStar_Syntax_DsEnv.env ->
@@ -7719,49 +7693,49 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Open lid ->
           let env1 = FStar_Syntax_DsEnv.push_namespace env lid  in (env1, [])
       | FStar_Parser_AST.Friend lid ->
-          let uu____27262 = FStar_Syntax_DsEnv.iface env  in
-          if uu____27262
+          let uu____27234 = FStar_Syntax_DsEnv.iface env  in
+          if uu____27234
           then
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FriendInterface,
                 "'friend' declarations are not allowed in interfaces")
               d.FStar_Parser_AST.drange
           else
-            (let uu____27277 =
-               let uu____27279 =
-                 let uu____27281 = FStar_Syntax_DsEnv.dep_graph env  in
-                 let uu____27282 = FStar_Syntax_DsEnv.current_module env  in
-                 FStar_Parser_Dep.module_has_interface uu____27281
-                   uu____27282
+            (let uu____27249 =
+               let uu____27251 =
+                 let uu____27253 = FStar_Syntax_DsEnv.dep_graph env  in
+                 let uu____27254 = FStar_Syntax_DsEnv.current_module env  in
+                 FStar_Parser_Dep.module_has_interface uu____27253
+                   uu____27254
                   in
-               Prims.op_Negation uu____27279  in
-             if uu____27277
+               Prims.op_Negation uu____27251  in
+             if uu____27249
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_FriendInterface,
                    "'friend' declarations are not allowed in modules that lack interfaces")
                  d.FStar_Parser_AST.drange
              else
-               (let uu____27296 =
-                  let uu____27298 =
-                    let uu____27300 = FStar_Syntax_DsEnv.dep_graph env  in
-                    FStar_Parser_Dep.module_has_interface uu____27300 lid  in
-                  Prims.op_Negation uu____27298  in
-                if uu____27296
+               (let uu____27268 =
+                  let uu____27270 =
+                    let uu____27272 = FStar_Syntax_DsEnv.dep_graph env  in
+                    FStar_Parser_Dep.module_has_interface uu____27272 lid  in
+                  Prims.op_Negation uu____27270  in
+                if uu____27268
                 then
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_FriendInterface,
                       "'friend' declarations cannot refer to modules that lack interfaces")
                     d.FStar_Parser_AST.drange
                 else
-                  (let uu____27314 =
-                     let uu____27316 =
-                       let uu____27318 = FStar_Syntax_DsEnv.dep_graph env  in
-                       FStar_Parser_Dep.deps_has_implementation uu____27318
+                  (let uu____27286 =
+                     let uu____27288 =
+                       let uu____27290 = FStar_Syntax_DsEnv.dep_graph env  in
+                       FStar_Parser_Dep.deps_has_implementation uu____27290
                          lid
                         in
-                     Prims.op_Negation uu____27316  in
-                   if uu____27314
+                     Prims.op_Negation uu____27288  in
+                   if uu____27286
                    then
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FriendInterface,
@@ -7771,8 +7745,8 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Include lid ->
           let env1 = FStar_Syntax_DsEnv.push_include env lid  in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x,l) ->
-          let uu____27336 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
-          (uu____27336, [])
+          let uu____27308 = FStar_Syntax_DsEnv.push_module_abbrev env x l  in
+          (uu____27308, [])
       | FStar_Parser_AST.Tycon (is_effect,typeclass,tcs) ->
           let quals = d.FStar_Parser_AST.quals  in
           let quals1 =
@@ -7783,80 +7757,80 @@ and (desugar_decl_noattrs :
             if typeclass
             then
               match tcs with
-              | (FStar_Parser_AST.TyconRecord uu____27365)::[] ->
+              | (FStar_Parser_AST.TyconRecord uu____27337)::[] ->
                   FStar_Parser_AST.Noeq :: quals1
-              | uu____27384 ->
+              | uu____27356 ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Error_BadClassDecl,
                       "Ill-formed `class` declaration: definition must be a record type")
                     d.FStar_Parser_AST.drange
             else quals1  in
-          let uu____27393 =
-            let uu____27398 =
+          let uu____27365 =
+            let uu____27370 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals2
                in
-            desugar_tycon env d uu____27398 tcs  in
-          (match uu____27393 with
+            desugar_tycon env d uu____27370 tcs  in
+          (match uu____27365 with
            | (env1,ses) ->
                let mkclass lid =
                  let r = FStar_Ident.range_of_lid lid  in
-                 let uu____27416 =
-                   let uu____27417 =
-                     let uu____27424 =
-                       let uu____27425 = tun_r r  in
+                 let uu____27388 =
+                   let uu____27389 =
+                     let uu____27396 =
+                       let uu____27397 = tun_r r  in
                        FStar_Syntax_Syntax.new_bv
-                         (FStar_Pervasives_Native.Some r) uu____27425
+                         (FStar_Pervasives_Native.Some r) uu____27397
                         in
-                     FStar_Syntax_Syntax.mk_binder uu____27424  in
-                   [uu____27417]  in
-                 let uu____27438 =
-                   let uu____27441 =
+                     FStar_Syntax_Syntax.mk_binder uu____27396  in
+                   [uu____27389]  in
+                 let uu____27410 =
+                   let uu____27413 =
                      FStar_Syntax_Syntax.tabbrev
                        FStar_Parser_Const.mk_class_lid
                       in
-                   let uu____27444 =
-                     let uu____27455 =
-                       let uu____27464 =
-                         let uu____27465 = FStar_Ident.string_of_lid lid  in
-                         FStar_Syntax_Util.exp_string uu____27465  in
-                       FStar_Syntax_Syntax.as_arg uu____27464  in
-                     [uu____27455]  in
-                   FStar_Syntax_Util.mk_app uu____27441 uu____27444  in
-                 FStar_Syntax_Util.abs uu____27416 uu____27438
+                   let uu____27416 =
+                     let uu____27427 =
+                       let uu____27436 =
+                         let uu____27437 = FStar_Ident.string_of_lid lid  in
+                         FStar_Syntax_Util.exp_string uu____27437  in
+                       FStar_Syntax_Syntax.as_arg uu____27436  in
+                     [uu____27427]  in
+                   FStar_Syntax_Util.mk_app uu____27413 uu____27416  in
+                 FStar_Syntax_Util.abs uu____27388 uu____27410
                    FStar_Pervasives_Native.None
                   in
                let get_meths se =
                  let rec get_fname quals3 =
                    match quals3 with
                    | (FStar_Syntax_Syntax.Projector
-                       (uu____27505,id))::uu____27507 ->
+                       (uu____27477,id))::uu____27479 ->
                        FStar_Pervasives_Native.Some id
-                   | uu____27510::quals4 -> get_fname quals4
+                   | uu____27482::quals4 -> get_fname quals4
                    | [] -> FStar_Pervasives_Native.None  in
-                 let uu____27514 = get_fname se.FStar_Syntax_Syntax.sigquals
+                 let uu____27486 = get_fname se.FStar_Syntax_Syntax.sigquals
                     in
-                 match uu____27514 with
+                 match uu____27486 with
                  | FStar_Pervasives_Native.None  -> []
                  | FStar_Pervasives_Native.Some id ->
-                     let uu____27520 = FStar_Syntax_DsEnv.qualify env1 id  in
-                     [uu____27520]
+                     let uu____27492 = FStar_Syntax_DsEnv.qualify env1 id  in
+                     [uu____27492]
                   in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____27541) ->
+                 | FStar_Syntax_Syntax.Sig_bundle (ses1,uu____27513) ->
                      FStar_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid,uu____27551,uu____27552,uu____27553,uu____27554,uu____27555)
+                     (lid,uu____27523,uu____27524,uu____27525,uu____27526,uu____27527)
                      ->
-                     let uu____27564 =
-                       let uu____27565 =
-                         let uu____27566 =
-                           let uu____27573 = mkclass lid  in
-                           (meths, uu____27573)  in
-                         FStar_Syntax_Syntax.Sig_splice uu____27566  in
+                     let uu____27536 =
+                       let uu____27537 =
+                         let uu____27538 =
+                           let uu____27545 = mkclass lid  in
+                           (meths, uu____27545)  in
+                         FStar_Syntax_Syntax.Sig_splice uu____27538  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____27565;
+                         FStar_Syntax_Syntax.sigel = uu____27537;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
@@ -7866,8 +7840,8 @@ and (desugar_decl_noattrs :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        }  in
-                     [uu____27564]
-                 | uu____27576 -> []  in
+                     [uu____27536]
+                 | uu____27548 -> []  in
                let extra =
                  if typeclass
                  then
@@ -7885,34 +7859,34 @@ and (desugar_decl_noattrs :
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
                | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27610;
-                    FStar_Parser_AST.prange = uu____27611;_},uu____27612)::[]
+                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27582;
+                    FStar_Parser_AST.prange = uu____27583;_},uu____27584)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                      uu____27622;
-                    FStar_Parser_AST.prange = uu____27623;_},uu____27624)::[]
+                      uu____27594;
+                    FStar_Parser_AST.prange = uu____27595;_},uu____27596)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatOp
-                           uu____27640;
-                         FStar_Parser_AST.prange = uu____27641;_},uu____27642);
-                    FStar_Parser_AST.prange = uu____27643;_},uu____27644)::[]
+                           uu____27612;
+                         FStar_Parser_AST.prange = uu____27613;_},uu____27614);
+                    FStar_Parser_AST.prange = uu____27615;_},uu____27616)::[]
                    -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           uu____27666;
-                         FStar_Parser_AST.prange = uu____27667;_},uu____27668);
-                    FStar_Parser_AST.prange = uu____27669;_},uu____27670)::[]
+                           uu____27638;
+                         FStar_Parser_AST.prange = uu____27639;_},uu____27640);
+                    FStar_Parser_AST.prange = uu____27641;_},uu____27642)::[]
                    -> false
-               | (p,uu____27699)::[] ->
-                   let uu____27708 = is_app_pattern p  in
-                   Prims.op_Negation uu____27708
-               | uu____27710 -> false)
+               | (p,uu____27671)::[] ->
+                   let uu____27680 = is_app_pattern p  in
+                   Prims.op_Negation uu____27680
+               | uu____27682 -> false)
              in
           if Prims.op_Negation expand_toplevel_pattern
           then
@@ -7929,19 +7903,19 @@ and (desugar_decl_noattrs :
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
                 d.FStar_Parser_AST.drange FStar_Parser_AST.Expr
                in
-            let uu____27785 = desugar_term_maybe_top true env as_inner_let
+            let uu____27757 = desugar_term_maybe_top true env as_inner_let
                in
-            (match uu____27785 with
+            (match uu____27757 with
              | (ds_lets,aq) ->
                  (check_no_aq aq;
-                  (let uu____27798 =
-                     let uu____27799 =
+                  (let uu____27770 =
+                     let uu____27771 =
                        FStar_All.pipe_left FStar_Syntax_Subst.compress
                          ds_lets
                         in
-                     uu____27799.FStar_Syntax_Syntax.n  in
-                   match uu____27798 with
-                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27809) ->
+                     uu____27771.FStar_Syntax_Syntax.n  in
+                   match uu____27770 with
+                   | FStar_Syntax_Syntax.Tm_let (lbs,uu____27781) ->
                        let fvs =
                          FStar_All.pipe_right
                            (FStar_Pervasives_Native.snd lbs)
@@ -7950,54 +7924,54 @@ and (desugar_decl_noattrs :
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname))
                           in
-                       let uu____27840 =
+                       let uu____27812 =
                          FStar_List.fold_right
                            (fun fv  ->
-                              fun uu____27865  ->
-                                match uu____27865 with
+                              fun uu____27837  ->
+                                match uu____27837 with
                                 | (qs,ats) ->
-                                    let uu____27892 =
+                                    let uu____27864 =
                                       FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                         env
                                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                        in
-                                    (match uu____27892 with
+                                    (match uu____27864 with
                                      | (qs',ats') ->
                                          ((FStar_List.append qs' qs),
                                            (FStar_List.append ats' ats))))
                            fvs ([], [])
                           in
-                       (match uu____27840 with
+                       (match uu____27812 with
                         | (val_quals,val_attrs) ->
                             let quals1 =
                               match quals with
-                              | uu____27946::uu____27947 ->
+                              | uu____27918::uu____27919 ->
                                   FStar_List.map
                                     (trans_qual1 FStar_Pervasives_Native.None)
                                     quals
-                              | uu____27950 -> val_quals  in
+                              | uu____27922 -> val_quals  in
                             let quals2 =
-                              let uu____27954 =
+                              let uu____27926 =
                                 FStar_All.pipe_right lets1
                                   (FStar_Util.for_some
-                                     (fun uu____27987  ->
-                                        match uu____27987 with
-                                        | (uu____28001,(uu____28002,t)) ->
+                                     (fun uu____27959  ->
+                                        match uu____27959 with
+                                        | (uu____27973,(uu____27974,t)) ->
                                             t.FStar_Parser_AST.level =
                                               FStar_Parser_AST.Formula))
                                  in
-                              if uu____27954
+                              if uu____27926
                               then FStar_Syntax_Syntax.Logic :: quals1
                               else quals1  in
                             let lbs1 =
-                              let uu____28022 =
+                              let uu____27994 =
                                 FStar_All.pipe_right quals2
                                   (FStar_List.contains
                                      FStar_Syntax_Syntax.Abstract)
                                  in
-                              if uu____28022
+                              if uu____27994
                               then
-                                let uu____28028 =
+                                let uu____28000 =
                                   FStar_All.pipe_right
                                     (FStar_Pervasives_Native.snd lbs)
                                     (FStar_List.map
@@ -8006,40 +7980,40 @@ and (desugar_decl_noattrs :
                                             FStar_Util.right
                                               lb.FStar_Syntax_Syntax.lbname
                                              in
-                                          let uu___3642_28043 = lb  in
+                                          let uu___3642_28015 = lb  in
                                           {
                                             FStar_Syntax_Syntax.lbname =
                                               (FStar_Util.Inr
-                                                 (let uu___3644_28045 = fv
+                                                 (let uu___3644_28017 = fv
                                                      in
                                                   {
                                                     FStar_Syntax_Syntax.fv_name
                                                       =
-                                                      (uu___3644_28045.FStar_Syntax_Syntax.fv_name);
+                                                      (uu___3644_28017.FStar_Syntax_Syntax.fv_name);
                                                     FStar_Syntax_Syntax.fv_delta
                                                       =
                                                       (FStar_Syntax_Syntax.Delta_abstract
                                                          (fv.FStar_Syntax_Syntax.fv_delta));
                                                     FStar_Syntax_Syntax.fv_qual
                                                       =
-                                                      (uu___3644_28045.FStar_Syntax_Syntax.fv_qual)
+                                                      (uu___3644_28017.FStar_Syntax_Syntax.fv_qual)
                                                   }));
                                             FStar_Syntax_Syntax.lbunivs =
-                                              (uu___3642_28043.FStar_Syntax_Syntax.lbunivs);
+                                              (uu___3642_28015.FStar_Syntax_Syntax.lbunivs);
                                             FStar_Syntax_Syntax.lbtyp =
-                                              (uu___3642_28043.FStar_Syntax_Syntax.lbtyp);
+                                              (uu___3642_28015.FStar_Syntax_Syntax.lbtyp);
                                             FStar_Syntax_Syntax.lbeff =
-                                              (uu___3642_28043.FStar_Syntax_Syntax.lbeff);
+                                              (uu___3642_28015.FStar_Syntax_Syntax.lbeff);
                                             FStar_Syntax_Syntax.lbdef =
-                                              (uu___3642_28043.FStar_Syntax_Syntax.lbdef);
+                                              (uu___3642_28015.FStar_Syntax_Syntax.lbdef);
                                             FStar_Syntax_Syntax.lbattrs =
-                                              (uu___3642_28043.FStar_Syntax_Syntax.lbattrs);
+                                              (uu___3642_28015.FStar_Syntax_Syntax.lbattrs);
                                             FStar_Syntax_Syntax.lbpos =
-                                              (uu___3642_28043.FStar_Syntax_Syntax.lbpos)
+                                              (uu___3642_28015.FStar_Syntax_Syntax.lbpos)
                                           }))
                                    in
                                 ((FStar_Pervasives_Native.fst lbs),
-                                  uu____28028)
+                                  uu____28000)
                               else lbs  in
                             let names =
                               FStar_All.pipe_right fvs
@@ -8068,17 +8042,17 @@ and (desugar_decl_noattrs :
                             let env1 = FStar_Syntax_DsEnv.push_sigelt env s
                                in
                             (env1, [s]))
-                   | uu____28070 ->
+                   | uu____28042 ->
                        failwith "Desugaring a let did not produce a let")))
           else
-            (let uu____28078 =
+            (let uu____28050 =
                match lets with
                | (pat,body)::[] -> (pat, body)
-               | uu____28097 ->
+               | uu____28069 ->
                    failwith
                      "expand_toplevel_pattern should only allow single definition lets"
                 in
-             match uu____28078 with
+             match uu____28050 with
              | (pat,body) ->
                  let fresh_toplevel_name =
                    FStar_Ident.gen FStar_Range.dummyRange  in
@@ -8091,14 +8065,14 @@ and (desugar_decl_noattrs :
                       in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1,ty) ->
-                       let uu___3667_28134 = pat1  in
+                       let uu___3667_28106 = pat1  in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
-                           (uu___3667_28134.FStar_Parser_AST.prange)
+                           (uu___3667_28106.FStar_Parser_AST.prange)
                        }
-                   | uu____28141 -> var_pat  in
+                   | uu____28113 -> var_pat  in
                  let main_let =
                    let quals1 =
                      if
@@ -8109,47 +8083,47 @@ and (desugar_decl_noattrs :
                        (d.FStar_Parser_AST.quals)
                       in
                    desugar_decl env
-                     (let uu___3673_28152 = d  in
+                     (let uu___3673_28124 = d  in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
                              (isrec, [(fresh_pat, body)]));
                         FStar_Parser_AST.drange =
-                          (uu___3673_28152.FStar_Parser_AST.drange);
+                          (uu___3673_28124.FStar_Parser_AST.drange);
                         FStar_Parser_AST.quals = quals1;
                         FStar_Parser_AST.attrs =
-                          (uu___3673_28152.FStar_Parser_AST.attrs)
+                          (uu___3673_28124.FStar_Parser_AST.attrs)
                       })
                     in
                  let main =
-                   let uu____28168 =
-                     let uu____28169 =
+                   let uu____28140 =
+                     let uu____28141 =
                        FStar_Ident.lid_of_ids [fresh_toplevel_name]  in
-                     FStar_Parser_AST.Var uu____28169  in
-                   FStar_Parser_AST.mk_term uu____28168
+                     FStar_Parser_AST.Var uu____28141  in
+                   FStar_Parser_AST.mk_term uu____28140
                      pat.FStar_Parser_AST.prange FStar_Parser_AST.Expr
                     in
-                 let build_generic_projection uu____28193 id_opt =
-                   match uu____28193 with
+                 let build_generic_projection uu____28165 id_opt =
+                   match uu____28165 with
                    | (env1,ses) ->
-                       let uu____28215 =
+                       let uu____28187 =
                          match id_opt with
                          | FStar_Pervasives_Native.Some id ->
                              let lid = FStar_Ident.lid_of_ids [id]  in
                              let branch =
-                               let uu____28227 = FStar_Ident.range_of_lid lid
+                               let uu____28199 = FStar_Ident.range_of_lid lid
                                   in
                                FStar_Parser_AST.mk_term
-                                 (FStar_Parser_AST.Var lid) uu____28227
+                                 (FStar_Parser_AST.Var lid) uu____28199
                                  FStar_Parser_AST.Expr
                                 in
                              let bv_pat =
-                               let uu____28229 = FStar_Ident.range_of_id id
+                               let uu____28201 = FStar_Ident.range_of_id id
                                   in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____28229
+                                 uu____28201
                                 in
                              (bv_pat, branch)
                          | FStar_Pervasives_Native.None  ->
@@ -8162,34 +8136,34 @@ and (desugar_decl_noattrs :
                                  FStar_Range.dummyRange FStar_Parser_AST.Expr
                                 in
                              let bv_pat =
-                               let uu____28235 = FStar_Ident.range_of_id id
+                               let uu____28207 = FStar_Ident.range_of_id id
                                   in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____28235
+                                 uu____28207
                                 in
                              let bv_pat1 =
-                               let uu____28239 =
-                                 let uu____28240 =
-                                   let uu____28251 =
-                                     let uu____28258 =
-                                       let uu____28259 =
+                               let uu____28211 =
+                                 let uu____28212 =
+                                   let uu____28223 =
+                                     let uu____28230 =
+                                       let uu____28231 =
                                          FStar_Ident.range_of_id id  in
-                                       unit_ty uu____28259  in
-                                     (uu____28258,
+                                       unit_ty uu____28231  in
+                                     (uu____28230,
                                        FStar_Pervasives_Native.None)
                                       in
-                                   (bv_pat, uu____28251)  in
-                                 FStar_Parser_AST.PatAscribed uu____28240  in
-                               let uu____28268 = FStar_Ident.range_of_id id
+                                   (bv_pat, uu____28223)  in
+                                 FStar_Parser_AST.PatAscribed uu____28212  in
+                               let uu____28240 = FStar_Ident.range_of_id id
                                   in
-                               FStar_Parser_AST.mk_pattern uu____28239
-                                 uu____28268
+                               FStar_Parser_AST.mk_pattern uu____28211
+                                 uu____28240
                                 in
                              (bv_pat1, branch)
                           in
-                       (match uu____28215 with
+                       (match uu____28187 with
                         | (bv_pat,branch) ->
                             let body1 =
                               FStar_Parser_AST.mk_term
@@ -8208,44 +8182,44 @@ and (desugar_decl_noattrs :
                                 FStar_Range.dummyRange []
                                in
                             let id_decl1 =
-                              let uu___3697_28322 = id_decl  in
+                              let uu___3697_28294 = id_decl  in
                               {
                                 FStar_Parser_AST.d =
-                                  (uu___3697_28322.FStar_Parser_AST.d);
+                                  (uu___3697_28294.FStar_Parser_AST.d);
                                 FStar_Parser_AST.drange =
-                                  (uu___3697_28322.FStar_Parser_AST.drange);
+                                  (uu___3697_28294.FStar_Parser_AST.drange);
                                 FStar_Parser_AST.quals =
                                   (d.FStar_Parser_AST.quals);
                                 FStar_Parser_AST.attrs =
-                                  (uu___3697_28322.FStar_Parser_AST.attrs)
+                                  (uu___3697_28294.FStar_Parser_AST.attrs)
                               }  in
-                            let uu____28323 = desugar_decl env1 id_decl1  in
-                            (match uu____28323 with
+                            let uu____28295 = desugar_decl env1 id_decl1  in
+                            (match uu____28295 with
                              | (env2,ses') ->
                                  (env2, (FStar_List.append ses ses'))))
                     in
-                 let build_projection uu____28359 id =
-                   match uu____28359 with
+                 let build_projection uu____28331 id =
+                   match uu____28331 with
                    | (env1,ses) ->
                        build_generic_projection (env1, ses)
                          (FStar_Pervasives_Native.Some id)
                     in
-                 let build_coverage_check uu____28398 =
-                   match uu____28398 with
+                 let build_coverage_check uu____28370 =
+                   match uu____28370 with
                    | (env1,ses) ->
                        build_generic_projection (env1, ses)
                          FStar_Pervasives_Native.None
                     in
                  let bvs =
-                   let uu____28422 = gather_pattern_bound_vars pat  in
-                   FStar_All.pipe_right uu____28422 FStar_Util.set_elements
+                   let uu____28394 = gather_pattern_bound_vars pat  in
+                   FStar_All.pipe_right uu____28394 FStar_Util.set_elements
                     in
-                 let uu____28429 =
+                 let uu____28401 =
                    (FStar_List.isEmpty bvs) &&
-                     (let uu____28432 = is_var_pattern pat  in
-                      Prims.op_Negation uu____28432)
+                     (let uu____28404 = is_var_pattern pat  in
+                      Prims.op_Negation uu____28404)
                     in
-                 if uu____28429
+                 if uu____28401
                  then build_coverage_check main_let
                  else FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Assume (id,t) ->
@@ -8266,21 +8240,21 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Val (id,t) ->
           let quals = d.FStar_Parser_AST.quals  in
           let t1 =
-            let uu____28455 = close_fun env t  in
-            desugar_term env uu____28455  in
+            let uu____28427 = close_fun env t  in
+            desugar_term env uu____28427  in
           let quals1 =
-            let uu____28459 =
+            let uu____28431 =
               (FStar_Syntax_DsEnv.iface env) &&
                 (FStar_Syntax_DsEnv.admitted_iface env)
                in
-            if uu____28459
+            if uu____28431
             then FStar_Parser_AST.Assumption :: quals
             else quals  in
           let lid = FStar_Syntax_DsEnv.qualify env id  in
           let attrs =
             FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs  in
           let se =
-            let uu____28471 =
+            let uu____28443 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals1
                in
@@ -8288,7 +8262,7 @@ and (desugar_decl_noattrs :
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-              FStar_Syntax_Syntax.sigquals = uu____28471;
+              FStar_Syntax_Syntax.sigquals = uu____28443;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = attrs;
@@ -8304,19 +8278,19 @@ and (desugar_decl_noattrs :
                   FStar_Parser_Const.exn_lid
             | FStar_Pervasives_Native.Some term ->
                 let t = desugar_term env term  in
+                let uu____28456 =
+                  let uu____28465 = FStar_Syntax_Syntax.null_binder t  in
+                  [uu____28465]  in
                 let uu____28484 =
-                  let uu____28493 = FStar_Syntax_Syntax.null_binder t  in
-                  [uu____28493]  in
-                let uu____28512 =
-                  let uu____28515 =
+                  let uu____28487 =
                     FStar_Syntax_DsEnv.fail_or env
                       (FStar_Syntax_DsEnv.try_lookup_lid env)
                       FStar_Parser_Const.exn_lid
                      in
                   FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total
-                    uu____28515
+                    uu____28487
                    in
-                FStar_Syntax_Util.arrow uu____28484 uu____28512
+                FStar_Syntax_Util.arrow uu____28456 uu____28484
              in
           let l = FStar_Syntax_DsEnv.qualify env id  in
           let qual = [FStar_Syntax_Syntax.ExceptionConstructor]  in
@@ -8370,7 +8344,7 @@ and (desugar_decl_noattrs :
           desugar_effect env d quals true eff_name eff_binders eff_typ
             eff_decls attrs
       | FStar_Parser_AST.LayeredEffect (FStar_Parser_AST.RedefineEffect
-          uu____28578) ->
+          uu____28550) ->
           failwith
             "Impossible: LayeredEffect (RedefineEffect _) (should not be parseable)"
       | FStar_Parser_AST.SubEffect l ->
@@ -8382,44 +8356,44 @@ and (desugar_decl_noattrs :
             lookup_effect_lid env l.FStar_Parser_AST.mdest
               d.FStar_Parser_AST.drange
              in
-          let uu____28595 =
-            let uu____28597 =
+          let uu____28567 =
+            let uu____28569 =
               (FStar_Syntax_Util.is_layered src_ed) ||
                 (FStar_Syntax_Util.is_layered dst_ed)
                in
-            Prims.op_Negation uu____28597  in
-          if uu____28595
+            Prims.op_Negation uu____28569  in
+          if uu____28567
           then
-            let uu____28604 =
+            let uu____28576 =
               match l.FStar_Parser_AST.lift_op with
               | FStar_Parser_AST.NonReifiableLift t ->
+                  let uu____28594 =
+                    let uu____28597 =
+                      let uu____28598 = desugar_term env t  in
+                      ([], uu____28598)  in
+                    FStar_Pervasives_Native.Some uu____28597  in
+                  (uu____28594, FStar_Pervasives_Native.None)
+              | FStar_Parser_AST.ReifiableLift (wp,t) ->
+                  let uu____28611 =
+                    let uu____28614 =
+                      let uu____28615 = desugar_term env wp  in
+                      ([], uu____28615)  in
+                    FStar_Pervasives_Native.Some uu____28614  in
                   let uu____28622 =
                     let uu____28625 =
                       let uu____28626 = desugar_term env t  in
                       ([], uu____28626)  in
                     FStar_Pervasives_Native.Some uu____28625  in
-                  (uu____28622, FStar_Pervasives_Native.None)
-              | FStar_Parser_AST.ReifiableLift (wp,t) ->
-                  let uu____28639 =
-                    let uu____28642 =
-                      let uu____28643 = desugar_term env wp  in
-                      ([], uu____28643)  in
-                    FStar_Pervasives_Native.Some uu____28642  in
-                  let uu____28650 =
-                    let uu____28653 =
-                      let uu____28654 = desugar_term env t  in
-                      ([], uu____28654)  in
-                    FStar_Pervasives_Native.Some uu____28653  in
-                  (uu____28639, uu____28650)
+                  (uu____28611, uu____28622)
               | FStar_Parser_AST.LiftForFree t ->
-                  let uu____28666 =
-                    let uu____28669 =
-                      let uu____28670 = desugar_term env t  in
-                      ([], uu____28670)  in
-                    FStar_Pervasives_Native.Some uu____28669  in
-                  (FStar_Pervasives_Native.None, uu____28666)
+                  let uu____28638 =
+                    let uu____28641 =
+                      let uu____28642 = desugar_term env t  in
+                      ([], uu____28642)  in
+                    FStar_Pervasives_Native.Some uu____28641  in
+                  (FStar_Pervasives_Native.None, uu____28638)
                in
-            (match uu____28604 with
+            (match uu____28576 with
              | (lift_wp,lift) ->
                  let se =
                    {
@@ -8446,11 +8420,11 @@ and (desugar_decl_noattrs :
             (match l.FStar_Parser_AST.lift_op with
              | FStar_Parser_AST.NonReifiableLift t ->
                  let sub_eff =
-                   let uu____28704 =
-                     let uu____28707 =
-                       let uu____28708 = desugar_term env t  in
-                       ([], uu____28708)  in
-                     FStar_Pervasives_Native.Some uu____28707  in
+                   let uu____28676 =
+                     let uu____28679 =
+                       let uu____28680 = desugar_term env t  in
+                       ([], uu____28680)  in
+                     FStar_Pervasives_Native.Some uu____28679  in
                    {
                      FStar_Syntax_Syntax.source =
                        (src_ed.FStar_Syntax_Syntax.mname);
@@ -8458,7 +8432,7 @@ and (desugar_decl_noattrs :
                        (dst_ed.FStar_Syntax_Syntax.mname);
                      FStar_Syntax_Syntax.lift_wp =
                        FStar_Pervasives_Native.None;
-                     FStar_Syntax_Syntax.lift = uu____28704
+                     FStar_Syntax_Syntax.lift = uu____28676
                    }  in
                  (env,
                    [{
@@ -8473,28 +8447,28 @@ and (desugar_decl_noattrs :
                       FStar_Syntax_Syntax.sigopts =
                         FStar_Pervasives_Native.None
                     }])
-             | uu____28715 ->
+             | uu____28687 ->
                  failwith
                    "Impossible! unexpected lift_op for lift to a layered effect")
       | FStar_Parser_AST.Polymonadic_bind (m_eff,n_eff,p_eff,bind) ->
           let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange  in
           let n = lookup_effect_lid env n_eff d.FStar_Parser_AST.drange  in
           let p = lookup_effect_lid env p_eff d.FStar_Parser_AST.drange  in
-          let uu____28728 =
-            let uu____28729 =
-              let uu____28730 =
-                let uu____28731 =
-                  let uu____28742 =
-                    let uu____28743 = desugar_term env bind  in
-                    ([], uu____28743)  in
+          let uu____28700 =
+            let uu____28701 =
+              let uu____28702 =
+                let uu____28703 =
+                  let uu____28714 =
+                    let uu____28715 = desugar_term env bind  in
+                    ([], uu____28715)  in
                   ((m.FStar_Syntax_Syntax.mname),
                     (n.FStar_Syntax_Syntax.mname),
-                    (p.FStar_Syntax_Syntax.mname), uu____28742,
+                    (p.FStar_Syntax_Syntax.mname), uu____28714,
                     ([], FStar_Syntax_Syntax.tun))
                    in
-                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____28731  in
+                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____28703  in
               {
-                FStar_Syntax_Syntax.sigel = uu____28730;
+                FStar_Syntax_Syntax.sigel = uu____28702;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
@@ -8502,19 +8476,19 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = [];
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               }  in
-            [uu____28729]  in
-          (env, uu____28728)
+            [uu____28701]  in
+          (env, uu____28700)
       | FStar_Parser_AST.Splice (ids,t) ->
           let t1 = desugar_term env t  in
           let se =
-            let uu____28762 =
-              let uu____28763 =
-                let uu____28770 =
+            let uu____28734 =
+              let uu____28735 =
+                let uu____28742 =
                   FStar_List.map (FStar_Syntax_DsEnv.qualify env) ids  in
-                (uu____28770, t1)  in
-              FStar_Syntax_Syntax.Sig_splice uu____28763  in
+                (uu____28742, t1)  in
+              FStar_Syntax_Syntax.Sig_splice uu____28735  in
             {
-              FStar_Syntax_Syntax.sigel = uu____28762;
+              FStar_Syntax_Syntax.sigel = uu____28734;
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
@@ -8531,18 +8505,18 @@ let (desugar_decls :
   =
   fun env  ->
     fun decls  ->
-      let uu____28797 =
+      let uu____28769 =
         FStar_List.fold_left
-          (fun uu____28817  ->
+          (fun uu____28789  ->
              fun d  ->
-               match uu____28817 with
+               match uu____28789 with
                | (env1,sigelts) ->
-                   let uu____28837 = desugar_decl env1 d  in
-                   (match uu____28837 with
+                   let uu____28809 = desugar_decl env1 d  in
+                   (match uu____28809 with
                     | (env2,se) -> (env2, (FStar_List.append sigelts se))))
           (env, []) decls
          in
-      match uu____28797 with | (env1,sigelts) -> (env1, sigelts)
+      match uu____28769 with | (env1,sigelts) -> (env1, sigelts)
   
 let (open_prims_all :
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
@@ -8565,41 +8539,41 @@ let (desugar_modul_common :
       fun m  ->
         let env1 =
           match (curmod, m) with
-          | (FStar_Pervasives_Native.None ,uu____28928) -> env
+          | (FStar_Pervasives_Native.None ,uu____28900) -> env
           | (FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____28932;
-               FStar_Syntax_Syntax.exports = uu____28933;
-               FStar_Syntax_Syntax.is_interface = uu____28934;_},FStar_Parser_AST.Module
-             (current_lid,uu____28936)) when
+               FStar_Syntax_Syntax.declarations = uu____28904;
+               FStar_Syntax_Syntax.exports = uu____28905;
+               FStar_Syntax_Syntax.is_interface = uu____28906;_},FStar_Parser_AST.Module
+             (current_lid,uu____28908)) when
               (FStar_Ident.lid_equals prev_lid current_lid) &&
                 (FStar_Options.interactive ())
               -> env
-          | (FStar_Pervasives_Native.Some prev_mod,uu____28945) ->
-              let uu____28948 =
+          | (FStar_Pervasives_Native.Some prev_mod,uu____28917) ->
+              let uu____28920 =
                 FStar_Syntax_DsEnv.finish_module_or_interface env prev_mod
                  in
-              FStar_Pervasives_Native.fst uu____28948
+              FStar_Pervasives_Native.fst uu____28920
            in
-        let uu____28953 =
+        let uu____28925 =
           match m with
           | FStar_Parser_AST.Interface (mname,decls,admitted) ->
-              let uu____28995 =
+              let uu____28967 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface true admitted
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____28995, mname, decls, true)
+              (uu____28967, mname, decls, true)
           | FStar_Parser_AST.Module (mname,decls) ->
-              let uu____29017 =
+              let uu____28989 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface false false
                   env1 mname FStar_Syntax_DsEnv.default_mii
                  in
-              (uu____29017, mname, decls, false)
+              (uu____28989, mname, decls, false)
            in
-        match uu____28953 with
+        match uu____28925 with
         | ((env2,pop_when_done),mname,decls,intf) ->
-            let uu____29059 = desugar_decls env2 decls  in
-            (match uu____29059 with
+            let uu____29031 = desugar_decls env2 decls  in
+            (match uu____29031 with
              | (env3,sigelts) ->
                  let modul =
                    {
@@ -8625,23 +8599,23 @@ let (desugar_partial_modul :
     fun env  ->
       fun m  ->
         let m1 =
-          let uu____29127 =
+          let uu____29099 =
             (FStar_Options.interactive ()) &&
-              (let uu____29130 =
-                 let uu____29132 =
-                   let uu____29134 = FStar_Options.file_list ()  in
-                   FStar_List.hd uu____29134  in
-                 FStar_Util.get_file_extension uu____29132  in
-               FStar_List.mem uu____29130 ["fsti"; "fsi"])
+              (let uu____29102 =
+                 let uu____29104 =
+                   let uu____29106 = FStar_Options.file_list ()  in
+                   FStar_List.hd uu____29106  in
+                 FStar_Util.get_file_extension uu____29104  in
+               FStar_List.mem uu____29102 ["fsti"; "fsi"])
              in
-          if uu____29127 then as_interface m else m  in
-        let uu____29148 = desugar_modul_common curmod env m1  in
-        match uu____29148 with
+          if uu____29099 then as_interface m else m  in
+        let uu____29120 = desugar_modul_common curmod env m1  in
+        match uu____29120 with
         | (env1,modul,pop_when_done) ->
             if pop_when_done
             then
-              let uu____29170 = FStar_Syntax_DsEnv.pop ()  in
-              (uu____29170, modul)
+              let uu____29142 = FStar_Syntax_DsEnv.pop ()  in
+              (uu____29142, modul)
             else (env1, modul)
   
 let (desugar_modul :
@@ -8650,34 +8624,34 @@ let (desugar_modul :
   =
   fun env  ->
     fun m  ->
-      let uu____29192 =
+      let uu____29164 =
         desugar_modul_common FStar_Pervasives_Native.None env m  in
-      match uu____29192 with
+      match uu____29164 with
       | (env1,modul,pop_when_done) ->
-          let uu____29209 =
+          let uu____29181 =
             FStar_Syntax_DsEnv.finish_module_or_interface env1 modul  in
-          (match uu____29209 with
+          (match uu____29181 with
            | (env2,modul1) ->
-               ((let uu____29221 =
-                   let uu____29223 =
+               ((let uu____29193 =
+                   let uu____29195 =
                      FStar_Ident.string_of_lid
                        modul1.FStar_Syntax_Syntax.name
                       in
-                   FStar_Options.dump_module uu____29223  in
-                 if uu____29221
+                   FStar_Options.dump_module uu____29195  in
+                 if uu____29193
                  then
-                   let uu____29226 =
+                   let uu____29198 =
                      FStar_Syntax_Print.modul_to_string modul1  in
                    FStar_Util.print1 "Module after desugaring:\n%s\n"
-                     uu____29226
+                     uu____29198
                  else ());
-                (let uu____29231 =
+                (let uu____29203 =
                    if pop_when_done
                    then
                      FStar_Syntax_DsEnv.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
                    else env2  in
-                 (uu____29231, modul1))))
+                 (uu____29203, modul1))))
   
 let with_options : 'a . (unit -> 'a) -> 'a =
   fun f  ->
@@ -8695,9 +8669,9 @@ let (ast_modul_to_modul :
   fun modul  ->
     fun env  ->
       with_options
-        (fun uu____29281  ->
-           let uu____29282 = desugar_modul env modul  in
-           match uu____29282 with | (e,m) -> (m, e))
+        (fun uu____29253  ->
+           let uu____29254 = desugar_modul env modul  in
+           match uu____29254 with | (e,m) -> (m, e))
   
 let (decls_to_sigelts :
   FStar_Parser_AST.decl Prims.list ->
@@ -8706,9 +8680,9 @@ let (decls_to_sigelts :
   fun decls  ->
     fun env  ->
       with_options
-        (fun uu____29320  ->
-           let uu____29321 = desugar_decls env decls  in
-           match uu____29321 with | (env1,sigelts) -> (sigelts, env1))
+        (fun uu____29292  ->
+           let uu____29293 = desugar_decls env decls  in
+           match uu____29293 with | (env1,sigelts) -> (sigelts, env1))
   
 let (partial_ast_modul_to_modul :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
@@ -8719,9 +8693,9 @@ let (partial_ast_modul_to_modul :
     fun a_modul  ->
       fun env  ->
         with_options
-          (fun uu____29372  ->
-             let uu____29373 = desugar_partial_modul modul env a_modul  in
-             match uu____29373 with | (env1,modul1) -> (modul1, env1))
+          (fun uu____29344  ->
+             let uu____29345 = desugar_partial_modul modul env a_modul  in
+             match uu____29345 with | (env1,modul1) -> (modul1, env1))
   
 let (add_modul_to_env :
   FStar_Syntax_Syntax.modul ->
@@ -8737,51 +8711,51 @@ let (add_modul_to_env :
             let erase_binders bs =
               match bs with
               | [] -> []
-              | uu____29468 ->
+              | uu____29440 ->
                   let t =
-                    let uu____29478 =
+                    let uu____29450 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
-                        FStar_Pervasives_Native.None FStar_Range.dummyRange
+                        FStar_Range.dummyRange
                        in
-                    erase_univs uu____29478  in
-                  let uu____29491 =
-                    let uu____29492 = FStar_Syntax_Subst.compress t  in
-                    uu____29492.FStar_Syntax_Syntax.n  in
-                  (match uu____29491 with
-                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____29504,uu____29505)
+                    erase_univs uu____29450  in
+                  let uu____29463 =
+                    let uu____29464 = FStar_Syntax_Subst.compress t  in
+                    uu____29464.FStar_Syntax_Syntax.n  in
+                  (match uu____29463 with
+                   | FStar_Syntax_Syntax.Tm_abs (bs1,uu____29476,uu____29477)
                        -> bs1
-                   | uu____29530 -> failwith "Impossible")
+                   | uu____29502 -> failwith "Impossible")
                in
-            let uu____29540 =
-              let uu____29547 = erase_binders ed.FStar_Syntax_Syntax.binders
+            let uu____29512 =
+              let uu____29519 = erase_binders ed.FStar_Syntax_Syntax.binders
                  in
-              FStar_Syntax_Subst.open_term' uu____29547
+              FStar_Syntax_Subst.open_term' uu____29519
                 FStar_Syntax_Syntax.t_unit
                in
-            match uu____29540 with
-            | (binders,uu____29549,binders_opening) ->
+            match uu____29512 with
+            | (binders,uu____29521,binders_opening) ->
                 let erase_term t =
-                  let uu____29557 =
-                    let uu____29558 =
+                  let uu____29529 =
+                    let uu____29530 =
                       FStar_Syntax_Subst.subst binders_opening t  in
-                    erase_univs uu____29558  in
-                  FStar_Syntax_Subst.close binders uu____29557  in
-                let erase_tscheme uu____29576 =
-                  match uu____29576 with
+                    erase_univs uu____29530  in
+                  FStar_Syntax_Subst.close binders uu____29529  in
+                let erase_tscheme uu____29548 =
+                  match uu____29548 with
                   | (us,t) ->
                       let t1 =
-                        let uu____29596 =
+                        let uu____29568 =
                           FStar_Syntax_Subst.shift_subst
                             (FStar_List.length us) binders_opening
                            in
-                        FStar_Syntax_Subst.subst uu____29596 t  in
-                      let uu____29599 =
-                        let uu____29600 = erase_univs t1  in
-                        FStar_Syntax_Subst.close binders uu____29600  in
-                      ([], uu____29599)
+                        FStar_Syntax_Subst.subst uu____29568 t  in
+                      let uu____29571 =
+                        let uu____29572 = erase_univs t1  in
+                        FStar_Syntax_Subst.close binders uu____29572  in
+                      ([], uu____29571)
                    in
                 let erase_action action =
                   let opening =
@@ -8793,124 +8767,123 @@ let (add_modul_to_env :
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
-                    | uu____29623 ->
+                    | uu____29595 ->
                         let bs =
-                          let uu____29633 =
+                          let uu____29605 =
                             FStar_Syntax_Subst.subst_binders opening
                               action.FStar_Syntax_Syntax.action_params
                              in
-                          FStar_All.pipe_left erase_binders uu____29633  in
+                          FStar_All.pipe_left erase_binders uu____29605  in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
                                (bs, FStar_Syntax_Syntax.t_unit,
                                  FStar_Pervasives_Native.None))
-                            FStar_Pervasives_Native.None
                             FStar_Range.dummyRange
                            in
-                        let uu____29673 =
-                          let uu____29674 =
-                            let uu____29677 =
+                        let uu____29645 =
+                          let uu____29646 =
+                            let uu____29649 =
                               FStar_Syntax_Subst.close binders t  in
-                            FStar_Syntax_Subst.compress uu____29677  in
-                          uu____29674.FStar_Syntax_Syntax.n  in
-                        (match uu____29673 with
+                            FStar_Syntax_Subst.compress uu____29649  in
+                          uu____29646.FStar_Syntax_Syntax.n  in
+                        (match uu____29645 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (bs1,uu____29679,uu____29680) -> bs1
-                         | uu____29705 -> failwith "Impossible")
+                             (bs1,uu____29651,uu____29652) -> bs1
+                         | uu____29677 -> failwith "Impossible")
                      in
                   let erase_term1 t =
-                    let uu____29713 =
-                      let uu____29714 = FStar_Syntax_Subst.subst opening t
+                    let uu____29685 =
+                      let uu____29686 = FStar_Syntax_Subst.subst opening t
                          in
-                      erase_univs uu____29714  in
-                    FStar_Syntax_Subst.close binders uu____29713  in
-                  let uu___3968_29715 = action  in
-                  let uu____29716 =
+                      erase_univs uu____29686  in
+                    FStar_Syntax_Subst.close binders uu____29685  in
+                  let uu___3968_29687 = action  in
+                  let uu____29688 =
                     erase_term1 action.FStar_Syntax_Syntax.action_defn  in
-                  let uu____29717 =
+                  let uu____29689 =
                     erase_term1 action.FStar_Syntax_Syntax.action_typ  in
                   {
                     FStar_Syntax_Syntax.action_name =
-                      (uu___3968_29715.FStar_Syntax_Syntax.action_name);
+                      (uu___3968_29687.FStar_Syntax_Syntax.action_name);
                     FStar_Syntax_Syntax.action_unqualified_name =
-                      (uu___3968_29715.FStar_Syntax_Syntax.action_unqualified_name);
+                      (uu___3968_29687.FStar_Syntax_Syntax.action_unqualified_name);
                     FStar_Syntax_Syntax.action_univs = [];
                     FStar_Syntax_Syntax.action_params = erased_action_params;
-                    FStar_Syntax_Syntax.action_defn = uu____29716;
-                    FStar_Syntax_Syntax.action_typ = uu____29717
+                    FStar_Syntax_Syntax.action_defn = uu____29688;
+                    FStar_Syntax_Syntax.action_typ = uu____29689
                   }  in
-                let uu___3970_29718 = ed  in
-                let uu____29719 = FStar_Syntax_Subst.close_binders binders
+                let uu___3970_29690 = ed  in
+                let uu____29691 = FStar_Syntax_Subst.close_binders binders
                    in
-                let uu____29720 =
+                let uu____29692 =
                   erase_tscheme ed.FStar_Syntax_Syntax.signature  in
-                let uu____29721 =
+                let uu____29693 =
                   FStar_Syntax_Util.apply_eff_combinators erase_tscheme
                     ed.FStar_Syntax_Syntax.combinators
                    in
-                let uu____29722 =
+                let uu____29694 =
                   FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions
                    in
                 {
                   FStar_Syntax_Syntax.mname =
-                    (uu___3970_29718.FStar_Syntax_Syntax.mname);
+                    (uu___3970_29690.FStar_Syntax_Syntax.mname);
                   FStar_Syntax_Syntax.cattributes =
-                    (uu___3970_29718.FStar_Syntax_Syntax.cattributes);
+                    (uu___3970_29690.FStar_Syntax_Syntax.cattributes);
                   FStar_Syntax_Syntax.univs = [];
-                  FStar_Syntax_Syntax.binders = uu____29719;
-                  FStar_Syntax_Syntax.signature = uu____29720;
-                  FStar_Syntax_Syntax.combinators = uu____29721;
-                  FStar_Syntax_Syntax.actions = uu____29722;
+                  FStar_Syntax_Syntax.binders = uu____29691;
+                  FStar_Syntax_Syntax.signature = uu____29692;
+                  FStar_Syntax_Syntax.combinators = uu____29693;
+                  FStar_Syntax_Syntax.actions = uu____29694;
                   FStar_Syntax_Syntax.eff_attrs =
-                    (uu___3970_29718.FStar_Syntax_Syntax.eff_attrs)
+                    (uu___3970_29690.FStar_Syntax_Syntax.eff_attrs)
                 }
              in
           let push_sigelt env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___3977_29738 = se  in
-                  let uu____29739 =
-                    let uu____29740 = erase_univs_ed ed  in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____29740  in
+                  let uu___3977_29710 = se  in
+                  let uu____29711 =
+                    let uu____29712 = erase_univs_ed ed  in
+                    FStar_Syntax_Syntax.Sig_new_effect uu____29712  in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____29739;
+                    FStar_Syntax_Syntax.sigel = uu____29711;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3977_29738.FStar_Syntax_Syntax.sigrng);
+                      (uu___3977_29710.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3977_29738.FStar_Syntax_Syntax.sigquals);
+                      (uu___3977_29710.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3977_29738.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3977_29710.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3977_29738.FStar_Syntax_Syntax.sigattrs);
+                      (uu___3977_29710.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___3977_29738.FStar_Syntax_Syntax.sigopts)
+                      (uu___3977_29710.FStar_Syntax_Syntax.sigopts)
                   }  in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se'  in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____29742 -> FStar_Syntax_DsEnv.push_sigelt env se  in
-          let uu____29743 =
+            | uu____29714 -> FStar_Syntax_DsEnv.push_sigelt env se  in
+          let uu____29715 =
             FStar_Syntax_DsEnv.prepare_module_or_interface false false en
               m.FStar_Syntax_Syntax.name mii
              in
-          match uu____29743 with
+          match uu____29715 with
           | (en1,pop_when_done) ->
               let en2 =
-                let uu____29760 =
+                let uu____29732 =
                   FStar_Syntax_DsEnv.set_current_module en1
                     m.FStar_Syntax_Syntax.name
                    in
-                FStar_List.fold_left push_sigelt uu____29760
+                FStar_List.fold_left push_sigelt uu____29732
                   m.FStar_Syntax_Syntax.exports
                  in
               let env = FStar_Syntax_DsEnv.finish en2 m  in
-              let uu____29762 =
+              let uu____29734 =
                 if pop_when_done
                 then
                   FStar_Syntax_DsEnv.export_interface
                     m.FStar_Syntax_Syntax.name env
                 else env  in
-              ((), uu____29762)
+              ((), uu____29734)
   

--- a/src/ocaml-output/FStar_TypeChecker_Cfg.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Cfg.ml
@@ -1780,12 +1780,6 @@ let try_unembed_simple :
       let uu____4081 = FStar_Syntax_Embeddings.unembed emb x  in
       uu____4081 false FStar_Syntax_Embeddings.id_norm_cb
   
-let mk :
-  'uuuuuu4096 .
-    'uuuuuu4096 ->
-      FStar_Range.range -> 'uuuuuu4096 FStar_Syntax_Syntax.syntax
-  =
-  fun t  -> fun r  -> FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None r 
 let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
   let arg_as_int a =
     FStar_All.pipe_right (FStar_Pervasives_Native.fst a)
@@ -1804,63 +1798,63 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
       (try_unembed_simple FStar_Syntax_Embeddings.e_string)
      in
   let arg_as_list e a1 =
-    let uu____4215 =
-      let uu____4224 = FStar_Syntax_Embeddings.e_list e  in
-      try_unembed_simple uu____4224  in
-    FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu____4215  in
-  let arg_as_bounded_int uu____4254 =
-    match uu____4254 with
-    | (a,uu____4268) ->
-        let uu____4279 = FStar_Syntax_Util.head_and_args' a  in
-        (match uu____4279 with
+    let uu____4195 =
+      let uu____4204 = FStar_Syntax_Embeddings.e_list e  in
+      try_unembed_simple uu____4204  in
+    FStar_All.pipe_right (FStar_Pervasives_Native.fst a1) uu____4195  in
+  let arg_as_bounded_int uu____4234 =
+    match uu____4234 with
+    | (a,uu____4248) ->
+        let uu____4259 = FStar_Syntax_Util.head_and_args' a  in
+        (match uu____4259 with
          | (hd,args) ->
              let a1 = FStar_Syntax_Util.unlazy_emb a  in
-             let uu____4323 =
-               let uu____4338 =
-                 let uu____4339 = FStar_Syntax_Subst.compress hd  in
-                 uu____4339.FStar_Syntax_Syntax.n  in
-               (uu____4338, args)  in
-             (match uu____4323 with
-              | (FStar_Syntax_Syntax.Tm_fvar fv1,(arg,uu____4360)::[]) when
-                  let uu____4395 =
+             let uu____4303 =
+               let uu____4318 =
+                 let uu____4319 = FStar_Syntax_Subst.compress hd  in
+                 uu____4319.FStar_Syntax_Syntax.n  in
+               (uu____4318, args)  in
+             (match uu____4303 with
+              | (FStar_Syntax_Syntax.Tm_fvar fv1,(arg,uu____4340)::[]) when
+                  let uu____4375 =
                     FStar_Ident.string_of_lid
                       (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                      in
-                  FStar_Util.ends_with uu____4395 "int_to_t" ->
+                  FStar_Util.ends_with uu____4375 "int_to_t" ->
                   let arg1 = FStar_Syntax_Util.unlazy_emb arg  in
-                  let uu____4399 =
-                    let uu____4400 = FStar_Syntax_Subst.compress arg1  in
-                    uu____4400.FStar_Syntax_Syntax.n  in
-                  (match uu____4399 with
+                  let uu____4379 =
+                    let uu____4380 = FStar_Syntax_Subst.compress arg1  in
+                    uu____4380.FStar_Syntax_Syntax.n  in
+                  (match uu____4379 with
                    | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
                        (i,FStar_Pervasives_Native.None )) ->
-                       let uu____4422 =
-                         let uu____4427 = FStar_BigInt.big_int_of_string i
+                       let uu____4402 =
+                         let uu____4407 = FStar_BigInt.big_int_of_string i
                             in
-                         (fv1, uu____4427)  in
-                       FStar_Pervasives_Native.Some uu____4422
-                   | uu____4432 -> FStar_Pervasives_Native.None)
-              | uu____4437 -> FStar_Pervasives_Native.None))
+                         (fv1, uu____4407)  in
+                       FStar_Pervasives_Native.Some uu____4402
+                   | uu____4412 -> FStar_Pervasives_Native.None)
+              | uu____4417 -> FStar_Pervasives_Native.None))
      in
   let lift_unary f aopts =
     match aopts with
     | (FStar_Pervasives_Native.Some a1)::[] ->
-        let uu____4499 = f a1  in FStar_Pervasives_Native.Some uu____4499
-    | uu____4500 -> FStar_Pervasives_Native.None  in
+        let uu____4479 = f a1  in FStar_Pervasives_Native.Some uu____4479
+    | uu____4480 -> FStar_Pervasives_Native.None  in
   let lift_binary f aopts =
     match aopts with
     | (FStar_Pervasives_Native.Some a0)::(FStar_Pervasives_Native.Some
         a1)::[] ->
-        let uu____4556 = f a0 a1  in FStar_Pervasives_Native.Some uu____4556
-    | uu____4557 -> FStar_Pervasives_Native.None  in
+        let uu____4536 = f a0 a1  in FStar_Pervasives_Native.Some uu____4536
+    | uu____4537 -> FStar_Pervasives_Native.None  in
   let unary_op as_a f res norm_cb args =
-    let uu____4624 = FStar_List.map as_a args  in
-    lift_unary (f res.psc_range) uu____4624  in
+    let uu____4604 = FStar_List.map as_a args  in
+    lift_unary (f res.psc_range) uu____4604  in
   let binary_op as_a f res n args =
-    let uu____4706 = FStar_List.map as_a args  in
-    lift_binary (f res.psc_range) uu____4706  in
-  let as_primitive_step is_strong uu____4761 =
-    match uu____4761 with
+    let uu____4686 = FStar_List.map as_a args  in
+    lift_binary (f res.psc_range) uu____4686  in
+  let as_primitive_step is_strong uu____4741 =
+    match uu____4741 with
     | (l,arity,u_arity,f,f_nbe) ->
         {
           name = l;
@@ -1877,148 +1871,150 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
     unary_op arg_as_int
       (fun r  ->
          fun x  ->
-           let uu____4869 = f x  in
-           embed_simple FStar_Syntax_Embeddings.e_int r uu____4869)
+           let uu____4849 = f x  in
+           embed_simple FStar_Syntax_Embeddings.e_int r uu____4849)
      in
   let binary_int_op f =
     binary_op arg_as_int
       (fun r  ->
          fun x  ->
            fun y  ->
-             let uu____4911 = f x y  in
-             embed_simple FStar_Syntax_Embeddings.e_int r uu____4911)
+             let uu____4891 = f x y  in
+             embed_simple FStar_Syntax_Embeddings.e_int r uu____4891)
      in
   let unary_bool_op f =
     unary_op arg_as_bool
       (fun r  ->
          fun x  ->
-           let uu____4952 = f x  in
-           embed_simple FStar_Syntax_Embeddings.e_bool r uu____4952)
+           let uu____4932 = f x  in
+           embed_simple FStar_Syntax_Embeddings.e_bool r uu____4932)
      in
   let binary_bool_op f =
     binary_op arg_as_bool
       (fun r  ->
          fun x  ->
            fun y  ->
-             let uu____5005 = f x y  in
-             embed_simple FStar_Syntax_Embeddings.e_bool r uu____5005)
+             let uu____4985 = f x y  in
+             embed_simple FStar_Syntax_Embeddings.e_bool r uu____4985)
      in
   let binary_string_op f =
     binary_op arg_as_string
       (fun r  ->
          fun x  ->
            fun y  ->
-             let uu____5058 = f x y  in
-             embed_simple FStar_Syntax_Embeddings.e_string r uu____5058)
+             let uu____5038 = f x y  in
+             embed_simple FStar_Syntax_Embeddings.e_string r uu____5038)
      in
   let mixed_binary_op as_a as_b embed_c f res _norm_cb args =
     match args with
     | a1::b1::[] ->
-        let uu____5211 =
-          let uu____5220 = as_a a1  in
-          let uu____5223 = as_b b1  in (uu____5220, uu____5223)  in
-        (match uu____5211 with
+        let uu____5191 =
+          let uu____5200 = as_a a1  in
+          let uu____5203 = as_b b1  in (uu____5200, uu____5203)  in
+        (match uu____5191 with
          | (FStar_Pervasives_Native.Some a2,FStar_Pervasives_Native.Some b2)
              ->
-             let uu____5238 =
-               let uu____5239 = f res.psc_range a2 b2  in
-               embed_c res.psc_range uu____5239  in
-             FStar_Pervasives_Native.Some uu____5238
-         | uu____5240 -> FStar_Pervasives_Native.None)
-    | uu____5249 -> FStar_Pervasives_Native.None  in
+             let uu____5218 =
+               let uu____5219 = f res.psc_range a2 b2  in
+               embed_c res.psc_range uu____5219  in
+             FStar_Pervasives_Native.Some uu____5218
+         | uu____5220 -> FStar_Pervasives_Native.None)
+    | uu____5229 -> FStar_Pervasives_Native.None  in
   let list_of_string' rng s =
     let name l =
-      let uu____5271 =
-        let uu____5272 =
+      let uu____5251 =
+        let uu____5252 =
           FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
             FStar_Pervasives_Native.None
            in
-        FStar_Syntax_Syntax.Tm_fvar uu____5272  in
-      mk uu____5271 rng  in
+        FStar_Syntax_Syntax.Tm_fvar uu____5252  in
+      FStar_Syntax_Syntax.mk uu____5251 rng  in
     let char_t = name FStar_Parser_Const.char_lid  in
     let charterm c =
-      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c)) rng  in
-    let uu____5286 =
-      let uu____5289 = FStar_String.list_of_string s  in
-      FStar_List.map charterm uu____5289  in
-    FStar_All.pipe_left (FStar_Syntax_Util.mk_list char_t rng) uu____5286  in
+      FStar_Syntax_Syntax.mk
+        (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c)) rng
+       in
+    let uu____5266 =
+      let uu____5269 = FStar_String.list_of_string s  in
+      FStar_List.map charterm uu____5269  in
+    FStar_All.pipe_left (FStar_Syntax_Util.mk_list char_t rng) uu____5266  in
   let string_of_list' rng l =
     let s = FStar_String.string_of_list l  in FStar_Syntax_Util.exp_string s
      in
   let string_compare' rng s1 s2 =
     let r = FStar_String.compare s1 s2  in
-    let uu____5337 =
-      let uu____5338 = FStar_Util.string_of_int r  in
-      FStar_BigInt.big_int_of_string uu____5338  in
-    embed_simple FStar_Syntax_Embeddings.e_int rng uu____5337  in
+    let uu____5317 =
+      let uu____5318 = FStar_Util.string_of_int r  in
+      FStar_BigInt.big_int_of_string uu____5318  in
+    embed_simple FStar_Syntax_Embeddings.e_int rng uu____5317  in
   let string_concat' psc1 _n args =
     match args with
     | a1::a2::[] ->
-        let uu____5424 = arg_as_string a1  in
-        (match uu____5424 with
+        let uu____5404 = arg_as_string a1  in
+        (match uu____5404 with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____5433 = arg_as_list FStar_Syntax_Embeddings.e_string a2
+             let uu____5413 = arg_as_list FStar_Syntax_Embeddings.e_string a2
                 in
-             (match uu____5433 with
+             (match uu____5413 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.concat s1 s2  in
-                  let uu____5451 =
+                  let uu____5431 =
                     embed_simple FStar_Syntax_Embeddings.e_string
                       psc1.psc_range r
                      in
-                  FStar_Pervasives_Native.Some uu____5451
-              | uu____5453 -> FStar_Pervasives_Native.None)
-         | uu____5459 -> FStar_Pervasives_Native.None)
-    | uu____5463 -> FStar_Pervasives_Native.None  in
+                  FStar_Pervasives_Native.Some uu____5431
+              | uu____5433 -> FStar_Pervasives_Native.None)
+         | uu____5439 -> FStar_Pervasives_Native.None)
+    | uu____5443 -> FStar_Pervasives_Native.None  in
   let string_split' psc1 _norm_cb args =
     match args with
     | a1::a2::[] ->
-        let uu____5544 = arg_as_list FStar_Syntax_Embeddings.e_char a1  in
-        (match uu____5544 with
+        let uu____5524 = arg_as_list FStar_Syntax_Embeddings.e_char a1  in
+        (match uu____5524 with
          | FStar_Pervasives_Native.Some s1 ->
-             let uu____5560 = arg_as_string a2  in
-             (match uu____5560 with
+             let uu____5540 = arg_as_string a2  in
+             (match uu____5540 with
               | FStar_Pervasives_Native.Some s2 ->
                   let r = FStar_String.split s1 s2  in
-                  let uu____5573 =
-                    let uu____5574 =
+                  let uu____5553 =
+                    let uu____5554 =
                       FStar_Syntax_Embeddings.e_list
                         FStar_Syntax_Embeddings.e_string
                        in
-                    embed_simple uu____5574 psc1.psc_range r  in
-                  FStar_Pervasives_Native.Some uu____5573
-              | uu____5584 -> FStar_Pervasives_Native.None)
-         | uu____5588 -> FStar_Pervasives_Native.None)
-    | uu____5594 -> FStar_Pervasives_Native.None  in
+                    embed_simple uu____5554 psc1.psc_range r  in
+                  FStar_Pervasives_Native.Some uu____5553
+              | uu____5564 -> FStar_Pervasives_Native.None)
+         | uu____5568 -> FStar_Pervasives_Native.None)
+    | uu____5574 -> FStar_Pervasives_Native.None  in
   let string_substring' psc1 _norm_cb args =
     match args with
     | a1::a2::a3::[] ->
-        let uu____5632 =
-          let uu____5646 = arg_as_string a1  in
-          let uu____5650 = arg_as_int a2  in
-          let uu____5653 = arg_as_int a3  in
-          (uu____5646, uu____5650, uu____5653)  in
-        (match uu____5632 with
+        let uu____5612 =
+          let uu____5626 = arg_as_string a1  in
+          let uu____5630 = arg_as_int a2  in
+          let uu____5633 = arg_as_int a3  in
+          (uu____5626, uu____5630, uu____5633)  in
+        (match uu____5612 with
          | (FStar_Pervasives_Native.Some s1,FStar_Pervasives_Native.Some
             n1,FStar_Pervasives_Native.Some n2) ->
              let n11 = FStar_BigInt.to_int_fs n1  in
              let n21 = FStar_BigInt.to_int_fs n2  in
              (try
-                (fun uu___512_5686  ->
+                (fun uu___510_5666  ->
                    match () with
                    | () ->
                        let r = FStar_String.substring s1 n11 n21  in
-                       let uu____5691 =
+                       let uu____5671 =
                          embed_simple FStar_Syntax_Embeddings.e_string
                            psc1.psc_range r
                           in
-                       FStar_Pervasives_Native.Some uu____5691) ()
-              with | uu___511_5694 -> FStar_Pervasives_Native.None)
-         | uu____5697 -> FStar_Pervasives_Native.None)
-    | uu____5711 -> FStar_Pervasives_Native.None  in
+                       FStar_Pervasives_Native.Some uu____5671) ()
+              with | uu___509_5674 -> FStar_Pervasives_Native.None)
+         | uu____5677 -> FStar_Pervasives_Native.None)
+    | uu____5691 -> FStar_Pervasives_Native.None  in
   let string_of_int rng i =
-    let uu____5725 = FStar_BigInt.string_of_big_int i  in
-    embed_simple FStar_Syntax_Embeddings.e_string rng uu____5725  in
+    let uu____5705 = FStar_BigInt.string_of_big_int i  in
+    embed_simple FStar_Syntax_Embeddings.e_string rng uu____5705  in
   let string_of_bool rng b =
     embed_simple FStar_Syntax_Embeddings.e_string rng
       (if b then "true" else "false")
@@ -2034,146 +2030,148 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
   let string_index psc1 _norm_cb args =
     match args with
     | a1::a2::[] ->
-        let uu____5804 =
-          let uu____5814 = arg_as_string a1  in
-          let uu____5818 = arg_as_int a2  in (uu____5814, uu____5818)  in
-        (match uu____5804 with
+        let uu____5784 =
+          let uu____5794 = arg_as_string a1  in
+          let uu____5798 = arg_as_int a2  in (uu____5794, uu____5798)  in
+        (match uu____5784 with
          | (FStar_Pervasives_Native.Some s,FStar_Pervasives_Native.Some i) ->
              (try
-                (fun uu___546_5842  ->
+                (fun uu___544_5822  ->
                    match () with
                    | () ->
                        let r = FStar_String.index s i  in
-                       let uu____5847 =
+                       let uu____5827 =
                          embed_simple FStar_Syntax_Embeddings.e_char
                            psc1.psc_range r
                           in
-                       FStar_Pervasives_Native.Some uu____5847) ()
-              with | uu___545_5850 -> FStar_Pervasives_Native.None)
-         | uu____5853 -> FStar_Pervasives_Native.None)
-    | uu____5863 -> FStar_Pervasives_Native.None  in
+                       FStar_Pervasives_Native.Some uu____5827) ()
+              with | uu___543_5830 -> FStar_Pervasives_Native.None)
+         | uu____5833 -> FStar_Pervasives_Native.None)
+    | uu____5843 -> FStar_Pervasives_Native.None  in
   let string_index_of psc1 _norm_cb args =
     match args with
     | a1::a2::[] ->
-        let uu____5894 =
-          let uu____5905 = arg_as_string a1  in
-          let uu____5909 = arg_as_char a2  in (uu____5905, uu____5909)  in
-        (match uu____5894 with
+        let uu____5874 =
+          let uu____5885 = arg_as_string a1  in
+          let uu____5889 = arg_as_char a2  in (uu____5885, uu____5889)  in
+        (match uu____5874 with
          | (FStar_Pervasives_Native.Some s,FStar_Pervasives_Native.Some c) ->
              (try
-                (fun uu___567_5938  ->
+                (fun uu___565_5918  ->
                    match () with
                    | () ->
                        let r = FStar_String.index_of s c  in
-                       let uu____5942 =
+                       let uu____5922 =
                          embed_simple FStar_Syntax_Embeddings.e_int
                            psc1.psc_range r
                           in
-                       FStar_Pervasives_Native.Some uu____5942) ()
-              with | uu___566_5944 -> FStar_Pervasives_Native.None)
-         | uu____5947 -> FStar_Pervasives_Native.None)
-    | uu____5958 -> FStar_Pervasives_Native.None  in
+                       FStar_Pervasives_Native.Some uu____5922) ()
+              with | uu___564_5924 -> FStar_Pervasives_Native.None)
+         | uu____5927 -> FStar_Pervasives_Native.None)
+    | uu____5938 -> FStar_Pervasives_Native.None  in
   let mk_range psc1 _norm_cb args =
     match args with
     | fn::from_line::from_col::to_line::to_col::[] ->
-        let uu____5992 =
-          let uu____6014 = arg_as_string fn  in
-          let uu____6018 = arg_as_int from_line  in
-          let uu____6021 = arg_as_int from_col  in
-          let uu____6024 = arg_as_int to_line  in
-          let uu____6027 = arg_as_int to_col  in
-          (uu____6014, uu____6018, uu____6021, uu____6024, uu____6027)  in
-        (match uu____5992 with
+        let uu____5972 =
+          let uu____5994 = arg_as_string fn  in
+          let uu____5998 = arg_as_int from_line  in
+          let uu____6001 = arg_as_int from_col  in
+          let uu____6004 = arg_as_int to_line  in
+          let uu____6007 = arg_as_int to_col  in
+          (uu____5994, uu____5998, uu____6001, uu____6004, uu____6007)  in
+        (match uu____5972 with
          | (FStar_Pervasives_Native.Some fn1,FStar_Pervasives_Native.Some
             from_l,FStar_Pervasives_Native.Some
             from_c,FStar_Pervasives_Native.Some
             to_l,FStar_Pervasives_Native.Some to_c) ->
              let r =
-               let uu____6062 =
-                 let uu____6063 = FStar_BigInt.to_int_fs from_l  in
-                 let uu____6065 = FStar_BigInt.to_int_fs from_c  in
-                 FStar_Range.mk_pos uu____6063 uu____6065  in
-               let uu____6067 =
-                 let uu____6068 = FStar_BigInt.to_int_fs to_l  in
-                 let uu____6070 = FStar_BigInt.to_int_fs to_c  in
-                 FStar_Range.mk_pos uu____6068 uu____6070  in
-               FStar_Range.mk_range fn1 uu____6062 uu____6067  in
-             let uu____6072 =
+               let uu____6042 =
+                 let uu____6043 = FStar_BigInt.to_int_fs from_l  in
+                 let uu____6045 = FStar_BigInt.to_int_fs from_c  in
+                 FStar_Range.mk_pos uu____6043 uu____6045  in
+               let uu____6047 =
+                 let uu____6048 = FStar_BigInt.to_int_fs to_l  in
+                 let uu____6050 = FStar_BigInt.to_int_fs to_c  in
+                 FStar_Range.mk_pos uu____6048 uu____6050  in
+               FStar_Range.mk_range fn1 uu____6042 uu____6047  in
+             let uu____6052 =
                embed_simple FStar_Syntax_Embeddings.e_range psc1.psc_range r
                 in
-             FStar_Pervasives_Native.Some uu____6072
-         | uu____6073 -> FStar_Pervasives_Native.None)
-    | uu____6095 -> FStar_Pervasives_Native.None  in
+             FStar_Pervasives_Native.Some uu____6052
+         | uu____6053 -> FStar_Pervasives_Native.None)
+    | uu____6075 -> FStar_Pervasives_Native.None  in
   let decidable_eq neg psc1 _norm_cb args =
     let r = psc1.psc_range  in
     let tru =
-      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true)) r
+      FStar_Syntax_Syntax.mk
+        (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true)) r
        in
     let fal =
-      mk (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false)) r
+      FStar_Syntax_Syntax.mk
+        (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false)) r
        in
     match args with
-    | (_typ,uu____6139)::(a1,uu____6141)::(a2,uu____6143)::[] ->
-        let uu____6200 = FStar_Syntax_Util.eq_tm a1 a2  in
-        (match uu____6200 with
+    | (_typ,uu____6119)::(a1,uu____6121)::(a2,uu____6123)::[] ->
+        let uu____6180 = FStar_Syntax_Util.eq_tm a1 a2  in
+        (match uu____6180 with
          | FStar_Syntax_Util.Equal  ->
              FStar_Pervasives_Native.Some (if neg then fal else tru)
          | FStar_Syntax_Util.NotEqual  ->
              FStar_Pervasives_Native.Some (if neg then tru else fal)
-         | uu____6209 -> FStar_Pervasives_Native.None)
-    | uu____6210 -> failwith "Unexpected number of arguments"  in
+         | uu____6189 -> FStar_Pervasives_Native.None)
+    | uu____6190 -> failwith "Unexpected number of arguments"  in
   let prims_to_fstar_range_step psc1 _norm_cb args =
     match args with
-    | (a1,uu____6253)::[] ->
-        let uu____6270 =
+    | (a1,uu____6233)::[] ->
+        let uu____6250 =
           try_unembed_simple FStar_Syntax_Embeddings.e_range a1  in
-        (match uu____6270 with
+        (match uu____6250 with
          | FStar_Pervasives_Native.Some r ->
-             let uu____6276 =
+             let uu____6256 =
                embed_simple FStar_Syntax_Embeddings.e_range psc1.psc_range r
                 in
-             FStar_Pervasives_Native.Some uu____6276
+             FStar_Pervasives_Native.Some uu____6256
          | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None)
-    | uu____6277 -> failwith "Unexpected number of arguments"  in
+    | uu____6257 -> failwith "Unexpected number of arguments"  in
   let bogus_cbs =
     {
       FStar_TypeChecker_NBETerm.iapp = (fun h  -> fun _args  -> h);
       FStar_TypeChecker_NBETerm.translate =
-        (fun uu____6297  -> failwith "bogus_cbs translate")
+        (fun uu____6277  -> failwith "bogus_cbs translate")
     }  in
   let basic_ops =
-    let uu____6331 =
-      let uu____6361 =
+    let uu____6311 =
+      let uu____6341 =
         FStar_TypeChecker_NBETerm.unary_int_op
           (fun x  -> FStar_BigInt.minus_big_int x)
          in
       (FStar_Parser_Const.op_Minus, Prims.int_one, Prims.int_zero,
-        (unary_int_op (fun x  -> FStar_BigInt.minus_big_int x)), uu____6361)
+        (unary_int_op (fun x  -> FStar_BigInt.minus_big_int x)), uu____6341)
        in
-    let uu____6395 =
-      let uu____6427 =
-        let uu____6457 =
+    let uu____6375 =
+      let uu____6407 =
+        let uu____6437 =
           FStar_TypeChecker_NBETerm.binary_int_op
             (fun x  -> fun y  -> FStar_BigInt.add_big_int x y)
            in
         (FStar_Parser_Const.op_Addition, (Prims.of_int (2)), Prims.int_zero,
           (binary_int_op (fun x  -> fun y  -> FStar_BigInt.add_big_int x y)),
-          uu____6457)
+          uu____6437)
          in
-      let uu____6497 =
-        let uu____6529 =
-          let uu____6559 =
+      let uu____6477 =
+        let uu____6509 =
+          let uu____6539 =
             FStar_TypeChecker_NBETerm.binary_int_op
               (fun x  -> fun y  -> FStar_BigInt.sub_big_int x y)
              in
           (FStar_Parser_Const.op_Subtraction, (Prims.of_int (2)),
             Prims.int_zero,
             (binary_int_op (fun x  -> fun y  -> FStar_BigInt.sub_big_int x y)),
-            uu____6559)
+            uu____6539)
            in
-        let uu____6599 =
-          let uu____6631 =
-            let uu____6661 =
+        let uu____6579 =
+          let uu____6611 =
+            let uu____6641 =
               FStar_TypeChecker_NBETerm.binary_int_op
                 (fun x  -> fun y  -> FStar_BigInt.mult_big_int x y)
                in
@@ -2181,11 +2179,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
               Prims.int_zero,
               (binary_int_op
                  (fun x  -> fun y  -> FStar_BigInt.mult_big_int x y)),
-              uu____6661)
+              uu____6641)
              in
-          let uu____6701 =
-            let uu____6733 =
-              let uu____6763 =
+          let uu____6681 =
+            let uu____6713 =
+              let uu____6743 =
                 FStar_TypeChecker_NBETerm.binary_int_op
                   (fun x  -> fun y  -> FStar_BigInt.div_big_int x y)
                  in
@@ -2193,19 +2191,19 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                 Prims.int_zero,
                 (binary_int_op
                    (fun x  -> fun y  -> FStar_BigInt.div_big_int x y)),
-                uu____6763)
+                uu____6743)
                in
-            let uu____6803 =
-              let uu____6835 =
-                let uu____6865 =
+            let uu____6783 =
+              let uu____6815 =
+                let uu____6845 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_int
                     (fun x  ->
                        fun y  ->
-                         let uu____6877 = FStar_BigInt.lt_big_int x y  in
+                         let uu____6857 = FStar_BigInt.lt_big_int x y  in
                          FStar_TypeChecker_NBETerm.embed
                            FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                           uu____6877)
+                           uu____6857)
                    in
                 (FStar_Parser_Const.op_LT, (Prims.of_int (2)),
                   Prims.int_zero,
@@ -2213,21 +2211,21 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                      (fun r  ->
                         fun x  ->
                           fun y  ->
-                            let uu____6908 = FStar_BigInt.lt_big_int x y  in
+                            let uu____6888 = FStar_BigInt.lt_big_int x y  in
                             embed_simple FStar_Syntax_Embeddings.e_bool r
-                              uu____6908)), uu____6865)
+                              uu____6888)), uu____6845)
                  in
-              let uu____6911 =
-                let uu____6943 =
-                  let uu____6973 =
+              let uu____6891 =
+                let uu____6923 =
+                  let uu____6953 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_int
                       (fun x  ->
                          fun y  ->
-                           let uu____6985 = FStar_BigInt.le_big_int x y  in
+                           let uu____6965 = FStar_BigInt.le_big_int x y  in
                            FStar_TypeChecker_NBETerm.embed
                              FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                             uu____6985)
+                             uu____6965)
                      in
                   (FStar_Parser_Const.op_LTE, (Prims.of_int (2)),
                     Prims.int_zero,
@@ -2235,22 +2233,22 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                        (fun r  ->
                           fun x  ->
                             fun y  ->
-                              let uu____7016 = FStar_BigInt.le_big_int x y
+                              let uu____6996 = FStar_BigInt.le_big_int x y
                                  in
                               embed_simple FStar_Syntax_Embeddings.e_bool r
-                                uu____7016)), uu____6973)
+                                uu____6996)), uu____6953)
                    in
-                let uu____7019 =
-                  let uu____7051 =
-                    let uu____7081 =
+                let uu____6999 =
+                  let uu____7031 =
+                    let uu____7061 =
                       FStar_TypeChecker_NBETerm.binary_op
                         FStar_TypeChecker_NBETerm.arg_as_int
                         (fun x  ->
                            fun y  ->
-                             let uu____7093 = FStar_BigInt.gt_big_int x y  in
+                             let uu____7073 = FStar_BigInt.gt_big_int x y  in
                              FStar_TypeChecker_NBETerm.embed
                                FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                               uu____7093)
+                               uu____7073)
                        in
                     (FStar_Parser_Const.op_GT, (Prims.of_int (2)),
                       Prims.int_zero,
@@ -2258,23 +2256,23 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                          (fun r  ->
                             fun x  ->
                               fun y  ->
-                                let uu____7124 = FStar_BigInt.gt_big_int x y
+                                let uu____7104 = FStar_BigInt.gt_big_int x y
                                    in
                                 embed_simple FStar_Syntax_Embeddings.e_bool r
-                                  uu____7124)), uu____7081)
+                                  uu____7104)), uu____7061)
                      in
-                  let uu____7127 =
-                    let uu____7159 =
-                      let uu____7189 =
+                  let uu____7107 =
+                    let uu____7139 =
+                      let uu____7169 =
                         FStar_TypeChecker_NBETerm.binary_op
                           FStar_TypeChecker_NBETerm.arg_as_int
                           (fun x  ->
                              fun y  ->
-                               let uu____7201 = FStar_BigInt.ge_big_int x y
+                               let uu____7181 = FStar_BigInt.ge_big_int x y
                                   in
                                FStar_TypeChecker_NBETerm.embed
                                  FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                                 uu____7201)
+                                 uu____7181)
                          in
                       (FStar_Parser_Const.op_GTE, (Prims.of_int (2)),
                         Prims.int_zero,
@@ -2282,14 +2280,14 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                            (fun r  ->
                               fun x  ->
                                 fun y  ->
-                                  let uu____7232 =
+                                  let uu____7212 =
                                     FStar_BigInt.ge_big_int x y  in
                                   embed_simple FStar_Syntax_Embeddings.e_bool
-                                    r uu____7232)), uu____7189)
+                                    r uu____7212)), uu____7169)
                        in
-                    let uu____7235 =
-                      let uu____7267 =
-                        let uu____7297 =
+                    let uu____7215 =
+                      let uu____7247 =
+                        let uu____7277 =
                           FStar_TypeChecker_NBETerm.binary_int_op
                             (fun x  -> fun y  -> FStar_BigInt.mod_big_int x y)
                            in
@@ -2298,44 +2296,44 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                           (binary_int_op
                              (fun x  ->
                                 fun y  -> FStar_BigInt.mod_big_int x y)),
-                          uu____7297)
+                          uu____7277)
                          in
-                      let uu____7337 =
-                        let uu____7369 =
-                          let uu____7399 =
+                      let uu____7317 =
+                        let uu____7349 =
+                          let uu____7379 =
                             FStar_TypeChecker_NBETerm.unary_bool_op
                               (fun x  -> Prims.op_Negation x)
                              in
                           (FStar_Parser_Const.op_Negation, Prims.int_one,
                             Prims.int_zero,
                             (unary_bool_op (fun x  -> Prims.op_Negation x)),
-                            uu____7399)
+                            uu____7379)
                            in
-                        let uu____7435 =
-                          let uu____7467 =
-                            let uu____7497 =
+                        let uu____7415 =
+                          let uu____7447 =
+                            let uu____7477 =
                               FStar_TypeChecker_NBETerm.binary_bool_op
                                 (fun x  -> fun y  -> x && y)
                                in
                             (FStar_Parser_Const.op_And, (Prims.of_int (2)),
                               Prims.int_zero,
                               (binary_bool_op (fun x  -> fun y  -> x && y)),
-                              uu____7497)
+                              uu____7477)
                              in
-                          let uu____7541 =
-                            let uu____7573 =
-                              let uu____7603 =
+                          let uu____7521 =
+                            let uu____7553 =
+                              let uu____7583 =
                                 FStar_TypeChecker_NBETerm.binary_bool_op
                                   (fun x  -> fun y  -> x || y)
                                  in
                               (FStar_Parser_Const.op_Or, (Prims.of_int (2)),
                                 Prims.int_zero,
                                 (binary_bool_op (fun x  -> fun y  -> x || y)),
-                                uu____7603)
+                                uu____7583)
                                in
-                            let uu____7647 =
-                              let uu____7679 =
-                                let uu____7709 =
+                            let uu____7627 =
+                              let uu____7659 =
+                                let uu____7689 =
                                   FStar_TypeChecker_NBETerm.unary_op
                                     FStar_TypeChecker_NBETerm.arg_as_int
                                     FStar_TypeChecker_NBETerm.string_of_int
@@ -2343,11 +2341,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                 (FStar_Parser_Const.string_of_int_lid,
                                   Prims.int_one, Prims.int_zero,
                                   (unary_op arg_as_int string_of_int),
-                                  uu____7709)
+                                  uu____7689)
                                  in
-                              let uu____7737 =
-                                let uu____7769 =
-                                  let uu____7799 =
+                              let uu____7717 =
+                                let uu____7749 =
+                                  let uu____7779 =
                                     FStar_TypeChecker_NBETerm.unary_op
                                       FStar_TypeChecker_NBETerm.arg_as_bool
                                       FStar_TypeChecker_NBETerm.string_of_bool
@@ -2355,11 +2353,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                   (FStar_Parser_Const.string_of_bool_lid,
                                     Prims.int_one, Prims.int_zero,
                                     (unary_op arg_as_bool string_of_bool),
-                                    uu____7799)
+                                    uu____7779)
                                    in
-                                let uu____7829 =
-                                  let uu____7861 =
-                                    let uu____7891 =
+                                let uu____7809 =
+                                  let uu____7841 =
+                                    let uu____7871 =
                                       FStar_TypeChecker_NBETerm.unary_op
                                         FStar_TypeChecker_NBETerm.arg_as_string
                                         FStar_TypeChecker_NBETerm.list_of_string'
@@ -2367,11 +2365,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                     (FStar_Parser_Const.string_list_of_string_lid,
                                       Prims.int_one, Prims.int_zero,
                                       (unary_op arg_as_string list_of_string'),
-                                      uu____7891)
+                                      uu____7871)
                                      in
-                                  let uu____7921 =
-                                    let uu____7953 =
-                                      let uu____7983 =
+                                  let uu____7901 =
+                                    let uu____7933 =
+                                      let uu____7963 =
                                         FStar_TypeChecker_NBETerm.unary_op
                                           (FStar_TypeChecker_NBETerm.arg_as_list
                                              FStar_TypeChecker_NBETerm.e_char)
@@ -2382,13 +2380,13 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                         (unary_op
                                            (arg_as_list
                                               FStar_Syntax_Embeddings.e_char)
-                                           string_of_list'), uu____7983)
+                                           string_of_list'), uu____7963)
                                        in
-                                    let uu____8019 =
-                                      let uu____8051 =
-                                        let uu____8083 =
-                                          let uu____8115 =
-                                            let uu____8145 =
+                                    let uu____7999 =
+                                      let uu____8031 =
+                                        let uu____8063 =
+                                          let uu____8095 =
+                                            let uu____8125 =
                                               FStar_TypeChecker_NBETerm.binary_string_op
                                                 (fun x  ->
                                                    fun y  ->
@@ -2401,12 +2399,12 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                  (fun x  ->
                                                     fun y  ->
                                                       FStar_String.op_Hat x y)),
-                                              uu____8145)
+                                              uu____8125)
                                              in
-                                          let uu____8189 =
-                                            let uu____8221 =
-                                              let uu____8253 =
-                                                let uu____8283 =
+                                          let uu____8169 =
+                                            let uu____8201 =
+                                              let uu____8233 =
+                                                let uu____8263 =
                                                   FStar_TypeChecker_NBETerm.binary_op
                                                     FStar_TypeChecker_NBETerm.arg_as_string
                                                     FStar_TypeChecker_NBETerm.string_compare'
@@ -2416,11 +2414,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                   Prims.int_zero,
                                                   (binary_op arg_as_string
                                                      string_compare'),
-                                                  uu____8283)
+                                                  uu____8263)
                                                  in
-                                              let uu____8313 =
-                                                let uu____8345 =
-                                                  let uu____8375 =
+                                              let uu____8293 =
+                                                let uu____8325 =
+                                                  let uu____8355 =
                                                     FStar_TypeChecker_NBETerm.unary_op
                                                       FStar_TypeChecker_NBETerm.arg_as_string
                                                       FStar_TypeChecker_NBETerm.string_lowercase
@@ -2430,11 +2428,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                     Prims.int_zero,
                                                     (unary_op arg_as_string
                                                        lowercase),
-                                                    uu____8375)
+                                                    uu____8355)
                                                    in
-                                                let uu____8405 =
-                                                  let uu____8437 =
-                                                    let uu____8467 =
+                                                let uu____8385 =
+                                                  let uu____8417 =
+                                                    let uu____8447 =
                                                       FStar_TypeChecker_NBETerm.unary_op
                                                         FStar_TypeChecker_NBETerm.arg_as_string
                                                         FStar_TypeChecker_NBETerm.string_uppercase
@@ -2444,49 +2442,49 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                       Prims.int_zero,
                                                       (unary_op arg_as_string
                                                          uppercase),
-                                                      uu____8467)
+                                                      uu____8447)
                                                      in
-                                                  let uu____8497 =
-                                                    let uu____8529 =
-                                                      let uu____8561 =
-                                                        let uu____8593 =
-                                                          let uu____8625 =
-                                                            let uu____8657 =
-                                                              let uu____8689
+                                                  let uu____8477 =
+                                                    let uu____8509 =
+                                                      let uu____8541 =
+                                                        let uu____8573 =
+                                                          let uu____8605 =
+                                                            let uu____8637 =
+                                                              let uu____8669
                                                                 =
-                                                                let uu____8719
+                                                                let uu____8699
                                                                   =
                                                                   FStar_Parser_Const.p2l
                                                                     ["Prims";
                                                                     "mk_range"]
                                                                    in
-                                                                (uu____8719,
+                                                                (uu____8699,
                                                                   (Prims.of_int (5)),
                                                                   Prims.int_zero,
                                                                   mk_range,
                                                                   FStar_TypeChecker_NBETerm.mk_range)
                                                                  in
-                                                              let uu____8746
+                                                              let uu____8726
                                                                 =
-                                                                let uu____8778
+                                                                let uu____8758
                                                                   =
-                                                                  let uu____8808
+                                                                  let uu____8788
                                                                     =
                                                                     FStar_Parser_Const.p2l
                                                                     ["FStar";
                                                                     "Range";
                                                                     "prims_to_fstar_range"]
                                                                      in
-                                                                  (uu____8808,
+                                                                  (uu____8788,
                                                                     Prims.int_one,
                                                                     Prims.int_zero,
                                                                     prims_to_fstar_range_step,
                                                                     FStar_TypeChecker_NBETerm.prims_to_fstar_range_step)
                                                                    in
-                                                                [uu____8778]
+                                                                [uu____8758]
                                                                  in
-                                                              uu____8689 ::
-                                                                uu____8746
+                                                              uu____8669 ::
+                                                                uu____8726
                                                                in
                                                             (FStar_Parser_Const.op_notEq,
                                                               (Prims.of_int (3)),
@@ -2495,7 +2493,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                                  true),
                                                               (FStar_TypeChecker_NBETerm.decidable_eq
                                                                  true))
-                                                              :: uu____8657
+                                                              :: uu____8637
                                                              in
                                                           (FStar_Parser_Const.op_Eq,
                                                             (Prims.of_int (3)),
@@ -2504,45 +2502,45 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                                                false),
                                                             (FStar_TypeChecker_NBETerm.decidable_eq
                                                                false))
-                                                            :: uu____8625
+                                                            :: uu____8605
                                                            in
                                                         (FStar_Parser_Const.string_sub_lid,
                                                           (Prims.of_int (3)),
                                                           Prims.int_zero,
                                                           string_substring',
                                                           FStar_TypeChecker_NBETerm.string_substring')
-                                                          :: uu____8593
+                                                          :: uu____8573
                                                          in
                                                       (FStar_Parser_Const.string_index_of_lid,
                                                         (Prims.of_int (2)),
                                                         Prims.int_zero,
                                                         string_index_of,
                                                         FStar_TypeChecker_NBETerm.string_index_of)
-                                                        :: uu____8561
+                                                        :: uu____8541
                                                        in
                                                     (FStar_Parser_Const.string_index_lid,
                                                       (Prims.of_int (2)),
                                                       Prims.int_zero,
                                                       string_index,
                                                       FStar_TypeChecker_NBETerm.string_index)
-                                                      :: uu____8529
+                                                      :: uu____8509
                                                      in
-                                                  uu____8437 :: uu____8497
+                                                  uu____8417 :: uu____8477
                                                    in
-                                                uu____8345 :: uu____8405  in
-                                              uu____8253 :: uu____8313  in
+                                                uu____8325 :: uu____8385  in
+                                              uu____8233 :: uu____8293  in
                                             (FStar_Parser_Const.string_concat_lid,
                                               (Prims.of_int (2)),
                                               Prims.int_zero, string_concat',
                                               FStar_TypeChecker_NBETerm.string_concat')
-                                              :: uu____8221
+                                              :: uu____8201
                                              in
-                                          uu____8115 :: uu____8189  in
+                                          uu____8095 :: uu____8169  in
                                         (FStar_Parser_Const.string_split_lid,
                                           (Prims.of_int (2)), Prims.int_zero,
                                           string_split',
                                           FStar_TypeChecker_NBETerm.string_split')
-                                          :: uu____8083
+                                          :: uu____8063
                                          in
                                       (FStar_Parser_Const.string_make_lid,
                                         (Prims.of_int (2)), Prims.int_zero,
@@ -2553,11 +2551,11 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                            (fun r  ->
                                               fun x  ->
                                                 fun y  ->
-                                                  let uu____9455 =
+                                                  let uu____9435 =
                                                     FStar_BigInt.to_int_fs x
                                                      in
                                                   FStar_String.make
-                                                    uu____9455 y)),
+                                                    uu____9435 y)),
                                         (FStar_TypeChecker_NBETerm.mixed_binary_op
                                            FStar_TypeChecker_NBETerm.arg_as_int
                                            FStar_TypeChecker_NBETerm.arg_as_char
@@ -2566,30 +2564,30 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
                                               bogus_cbs)
                                            (fun x  ->
                                               fun y  ->
-                                                let uu____9466 =
+                                                let uu____9446 =
                                                   FStar_BigInt.to_int_fs x
                                                    in
-                                                FStar_String.make uu____9466
+                                                FStar_String.make uu____9446
                                                   y)))
-                                        :: uu____8051
+                                        :: uu____8031
                                        in
-                                    uu____7953 :: uu____8019  in
-                                  uu____7861 :: uu____7921  in
-                                uu____7769 :: uu____7829  in
-                              uu____7679 :: uu____7737  in
-                            uu____7573 :: uu____7647  in
-                          uu____7467 :: uu____7541  in
-                        uu____7369 :: uu____7435  in
-                      uu____7267 :: uu____7337  in
-                    uu____7159 :: uu____7235  in
-                  uu____7051 :: uu____7127  in
-                uu____6943 :: uu____7019  in
-              uu____6835 :: uu____6911  in
-            uu____6733 :: uu____6803  in
-          uu____6631 :: uu____6701  in
-        uu____6529 :: uu____6599  in
-      uu____6427 :: uu____6497  in
-    uu____6331 :: uu____6395  in
+                                    uu____7933 :: uu____7999  in
+                                  uu____7841 :: uu____7901  in
+                                uu____7749 :: uu____7809  in
+                              uu____7659 :: uu____7717  in
+                            uu____7553 :: uu____7627  in
+                          uu____7447 :: uu____7521  in
+                        uu____7349 :: uu____7415  in
+                      uu____7247 :: uu____7317  in
+                    uu____7139 :: uu____7215  in
+                  uu____7031 :: uu____7107  in
+                uu____6923 :: uu____6999  in
+              uu____6815 :: uu____6891  in
+            uu____6713 :: uu____6783  in
+          uu____6611 :: uu____6681  in
+        uu____6509 :: uu____6579  in
+      uu____6407 :: uu____6477  in
+    uu____6311 :: uu____6375  in
   let weak_ops = []  in
   let bounded_arith_ops =
     let bounded_signed_int_types = ["Int8"; "Int16"; "Int32"; "Int64"]  in
@@ -2598,191 +2596,188 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
     let int_as_bounded r int_to_t n =
       let c = embed_simple FStar_Syntax_Embeddings.e_int r n  in
       let int_to_t1 = FStar_Syntax_Syntax.fv_to_tm int_to_t  in
-      let uu____10102 =
-        let uu____10107 =
-          let uu____10108 = FStar_Syntax_Syntax.as_arg c  in [uu____10108]
-           in
-        FStar_Syntax_Syntax.mk_Tm_app int_to_t1 uu____10107  in
-      uu____10102 FStar_Pervasives_Native.None r  in
+      let uu____10080 =
+        let uu____10081 = FStar_Syntax_Syntax.as_arg c  in [uu____10081]  in
+      FStar_Syntax_Syntax.mk_Tm_app int_to_t1 uu____10080 r  in
     let add_sub_mul_v =
       FStar_All.pipe_right
         (FStar_List.append bounded_signed_int_types
            bounded_unsigned_int_types)
         (FStar_List.collect
            (fun m  ->
-              let uu____10235 =
-                let uu____10265 = FStar_Parser_Const.p2l ["FStar"; m; "add"]
+              let uu____10208 =
+                let uu____10238 = FStar_Parser_Const.p2l ["FStar"; m; "add"]
                    in
-                let uu____10272 =
+                let uu____10245 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                    (fun uu____10290  ->
-                       fun uu____10291  ->
-                         match (uu____10290, uu____10291) with
-                         | ((int_to_t,x),(uu____10310,y)) ->
-                             let uu____10320 = FStar_BigInt.add_big_int x y
+                    (fun uu____10263  ->
+                       fun uu____10264  ->
+                         match (uu____10263, uu____10264) with
+                         | ((int_to_t,x),(uu____10283,y)) ->
+                             let uu____10293 = FStar_BigInt.add_big_int x y
                                 in
                              FStar_TypeChecker_NBETerm.int_as_bounded
-                               int_to_t uu____10320)
+                               int_to_t uu____10293)
                    in
-                (uu____10265, (Prims.of_int (2)), Prims.int_zero,
+                (uu____10238, (Prims.of_int (2)), Prims.int_zero,
                   (binary_op arg_as_bounded_int
                      (fun r  ->
-                        fun uu____10355  ->
-                          fun uu____10356  ->
-                            match (uu____10355, uu____10356) with
-                            | ((int_to_t,x),(uu____10375,y)) ->
-                                let uu____10385 =
+                        fun uu____10328  ->
+                          fun uu____10329  ->
+                            match (uu____10328, uu____10329) with
+                            | ((int_to_t,x),(uu____10348,y)) ->
+                                let uu____10358 =
                                   FStar_BigInt.add_big_int x y  in
-                                int_as_bounded r int_to_t uu____10385)),
-                  uu____10272)
+                                int_as_bounded r int_to_t uu____10358)),
+                  uu____10245)
                  in
-              let uu____10386 =
-                let uu____10418 =
-                  let uu____10448 =
+              let uu____10359 =
+                let uu____10391 =
+                  let uu____10421 =
                     FStar_Parser_Const.p2l ["FStar"; m; "sub"]  in
-                  let uu____10455 =
+                  let uu____10428 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                      (fun uu____10473  ->
-                         fun uu____10474  ->
-                           match (uu____10473, uu____10474) with
-                           | ((int_to_t,x),(uu____10493,y)) ->
-                               let uu____10503 = FStar_BigInt.sub_big_int x y
+                      (fun uu____10446  ->
+                         fun uu____10447  ->
+                           match (uu____10446, uu____10447) with
+                           | ((int_to_t,x),(uu____10466,y)) ->
+                               let uu____10476 = FStar_BigInt.sub_big_int x y
                                   in
                                FStar_TypeChecker_NBETerm.int_as_bounded
-                                 int_to_t uu____10503)
+                                 int_to_t uu____10476)
                      in
-                  (uu____10448, (Prims.of_int (2)), Prims.int_zero,
+                  (uu____10421, (Prims.of_int (2)), Prims.int_zero,
                     (binary_op arg_as_bounded_int
                        (fun r  ->
-                          fun uu____10538  ->
-                            fun uu____10539  ->
-                              match (uu____10538, uu____10539) with
-                              | ((int_to_t,x),(uu____10558,y)) ->
-                                  let uu____10568 =
+                          fun uu____10511  ->
+                            fun uu____10512  ->
+                              match (uu____10511, uu____10512) with
+                              | ((int_to_t,x),(uu____10531,y)) ->
+                                  let uu____10541 =
                                     FStar_BigInt.sub_big_int x y  in
-                                  int_as_bounded r int_to_t uu____10568)),
-                    uu____10455)
+                                  int_as_bounded r int_to_t uu____10541)),
+                    uu____10428)
                    in
-                let uu____10569 =
-                  let uu____10601 =
-                    let uu____10631 =
+                let uu____10542 =
+                  let uu____10574 =
+                    let uu____10604 =
                       FStar_Parser_Const.p2l ["FStar"; m; "mul"]  in
-                    let uu____10638 =
+                    let uu____10611 =
                       FStar_TypeChecker_NBETerm.binary_op
                         FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                        (fun uu____10656  ->
-                           fun uu____10657  ->
-                             match (uu____10656, uu____10657) with
-                             | ((int_to_t,x),(uu____10676,y)) ->
-                                 let uu____10686 =
+                        (fun uu____10629  ->
+                           fun uu____10630  ->
+                             match (uu____10629, uu____10630) with
+                             | ((int_to_t,x),(uu____10649,y)) ->
+                                 let uu____10659 =
                                    FStar_BigInt.mult_big_int x y  in
                                  FStar_TypeChecker_NBETerm.int_as_bounded
-                                   int_to_t uu____10686)
+                                   int_to_t uu____10659)
                        in
-                    (uu____10631, (Prims.of_int (2)), Prims.int_zero,
+                    (uu____10604, (Prims.of_int (2)), Prims.int_zero,
                       (binary_op arg_as_bounded_int
                          (fun r  ->
-                            fun uu____10721  ->
-                              fun uu____10722  ->
-                                match (uu____10721, uu____10722) with
-                                | ((int_to_t,x),(uu____10741,y)) ->
-                                    let uu____10751 =
+                            fun uu____10694  ->
+                              fun uu____10695  ->
+                                match (uu____10694, uu____10695) with
+                                | ((int_to_t,x),(uu____10714,y)) ->
+                                    let uu____10724 =
                                       FStar_BigInt.mult_big_int x y  in
-                                    int_as_bounded r int_to_t uu____10751)),
-                      uu____10638)
+                                    int_as_bounded r int_to_t uu____10724)),
+                      uu____10611)
                      in
-                  let uu____10752 =
-                    let uu____10784 =
-                      let uu____10814 =
+                  let uu____10725 =
+                    let uu____10757 =
+                      let uu____10787 =
                         FStar_Parser_Const.p2l ["FStar"; m; "v"]  in
-                      let uu____10821 =
+                      let uu____10794 =
                         FStar_TypeChecker_NBETerm.unary_op
                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                          (fun uu____10835  ->
-                             match uu____10835 with
+                          (fun uu____10808  ->
+                             match uu____10808 with
                              | (int_to_t,x) ->
                                  FStar_TypeChecker_NBETerm.embed
                                    FStar_TypeChecker_NBETerm.e_int bogus_cbs
                                    x)
                          in
-                      (uu____10814, Prims.int_one, Prims.int_zero,
+                      (uu____10787, Prims.int_one, Prims.int_zero,
                         (unary_op arg_as_bounded_int
                            (fun r  ->
-                              fun uu____10872  ->
-                                match uu____10872 with
+                              fun uu____10845  ->
+                                match uu____10845 with
                                 | (int_to_t,x) ->
                                     embed_simple
                                       FStar_Syntax_Embeddings.e_int r x)),
-                        uu____10821)
+                        uu____10794)
                        in
-                    [uu____10784]  in
-                  uu____10601 :: uu____10752  in
-                uu____10418 :: uu____10569  in
-              uu____10235 :: uu____10386))
+                    [uu____10757]  in
+                  uu____10574 :: uu____10725  in
+                uu____10391 :: uu____10542  in
+              uu____10208 :: uu____10359))
        in
     let div_mod_unsigned =
       FStar_All.pipe_right bounded_unsigned_int_types
         (FStar_List.collect
            (fun m  ->
-              let uu____11125 =
-                let uu____11155 = FStar_Parser_Const.p2l ["FStar"; m; "div"]
+              let uu____11098 =
+                let uu____11128 = FStar_Parser_Const.p2l ["FStar"; m; "div"]
                    in
-                let uu____11162 =
+                let uu____11135 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                    (fun uu____11180  ->
-                       fun uu____11181  ->
-                         match (uu____11180, uu____11181) with
-                         | ((int_to_t,x),(uu____11200,y)) ->
-                             let uu____11210 = FStar_BigInt.div_big_int x y
+                    (fun uu____11153  ->
+                       fun uu____11154  ->
+                         match (uu____11153, uu____11154) with
+                         | ((int_to_t,x),(uu____11173,y)) ->
+                             let uu____11183 = FStar_BigInt.div_big_int x y
                                 in
                              FStar_TypeChecker_NBETerm.int_as_bounded
-                               int_to_t uu____11210)
+                               int_to_t uu____11183)
                    in
-                (uu____11155, (Prims.of_int (2)), Prims.int_zero,
+                (uu____11128, (Prims.of_int (2)), Prims.int_zero,
                   (binary_op arg_as_bounded_int
                      (fun r  ->
-                        fun uu____11245  ->
-                          fun uu____11246  ->
-                            match (uu____11245, uu____11246) with
-                            | ((int_to_t,x),(uu____11265,y)) ->
-                                let uu____11275 =
+                        fun uu____11218  ->
+                          fun uu____11219  ->
+                            match (uu____11218, uu____11219) with
+                            | ((int_to_t,x),(uu____11238,y)) ->
+                                let uu____11248 =
                                   FStar_BigInt.div_big_int x y  in
-                                int_as_bounded r int_to_t uu____11275)),
-                  uu____11162)
+                                int_as_bounded r int_to_t uu____11248)),
+                  uu____11135)
                  in
-              let uu____11276 =
-                let uu____11308 =
-                  let uu____11338 =
+              let uu____11249 =
+                let uu____11281 =
+                  let uu____11311 =
                     FStar_Parser_Const.p2l ["FStar"; m; "rem"]  in
-                  let uu____11345 =
+                  let uu____11318 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                      (fun uu____11363  ->
-                         fun uu____11364  ->
-                           match (uu____11363, uu____11364) with
-                           | ((int_to_t,x),(uu____11383,y)) ->
-                               let uu____11393 = FStar_BigInt.mod_big_int x y
+                      (fun uu____11336  ->
+                         fun uu____11337  ->
+                           match (uu____11336, uu____11337) with
+                           | ((int_to_t,x),(uu____11356,y)) ->
+                               let uu____11366 = FStar_BigInt.mod_big_int x y
                                   in
                                FStar_TypeChecker_NBETerm.int_as_bounded
-                                 int_to_t uu____11393)
+                                 int_to_t uu____11366)
                      in
-                  (uu____11338, (Prims.of_int (2)), Prims.int_zero,
+                  (uu____11311, (Prims.of_int (2)), Prims.int_zero,
                     (binary_op arg_as_bounded_int
                        (fun r  ->
-                          fun uu____11428  ->
-                            fun uu____11429  ->
-                              match (uu____11428, uu____11429) with
-                              | ((int_to_t,x),(uu____11448,y)) ->
-                                  let uu____11458 =
+                          fun uu____11401  ->
+                            fun uu____11402  ->
+                              match (uu____11401, uu____11402) with
+                              | ((int_to_t,x),(uu____11421,y)) ->
+                                  let uu____11431 =
                                     FStar_BigInt.mod_big_int x y  in
-                                  int_as_bounded r int_to_t uu____11458)),
-                    uu____11345)
+                                  int_as_bounded r int_to_t uu____11431)),
+                    uu____11318)
                    in
-                [uu____11308]  in
-              uu____11125 :: uu____11276))
+                [uu____11281]  in
+              uu____11098 :: uu____11249))
        in
     let mask m =
       match m with
@@ -2791,215 +2786,215 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
       | "UInt32" -> FStar_BigInt.of_hex "ffffffff"
       | "UInt64" -> FStar_BigInt.of_hex "ffffffffffffffff"
       | "UInt128" -> FStar_BigInt.of_hex "ffffffffffffffffffffffffffffffff"
-      | uu____11564 ->
-          let uu____11566 =
+      | uu____11537 ->
+          let uu____11539 =
             FStar_Util.format1 "Impossible: bad string on mask: %s\n" m  in
-          failwith uu____11566
+          failwith uu____11539
        in
     let bitwise =
       FStar_All.pipe_right bounded_unsigned_int_types
         (FStar_List.collect
            (fun m  ->
-              let uu____11670 =
-                let uu____11700 =
+              let uu____11643 =
+                let uu____11673 =
                   FStar_Parser_Const.p2l ["FStar"; m; "logor"]  in
-                let uu____11707 =
+                let uu____11680 =
                   FStar_TypeChecker_NBETerm.binary_op
                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                    (fun uu____11725  ->
-                       fun uu____11726  ->
-                         match (uu____11725, uu____11726) with
-                         | ((int_to_t,x),(uu____11745,y)) ->
-                             let uu____11755 = FStar_BigInt.logor_big_int x y
+                    (fun uu____11698  ->
+                       fun uu____11699  ->
+                         match (uu____11698, uu____11699) with
+                         | ((int_to_t,x),(uu____11718,y)) ->
+                             let uu____11728 = FStar_BigInt.logor_big_int x y
                                 in
                              FStar_TypeChecker_NBETerm.int_as_bounded
-                               int_to_t uu____11755)
+                               int_to_t uu____11728)
                    in
-                (uu____11700, (Prims.of_int (2)), Prims.int_zero,
+                (uu____11673, (Prims.of_int (2)), Prims.int_zero,
                   (binary_op arg_as_bounded_int
                      (fun r  ->
-                        fun uu____11790  ->
-                          fun uu____11791  ->
-                            match (uu____11790, uu____11791) with
-                            | ((int_to_t,x),(uu____11810,y)) ->
-                                let uu____11820 =
+                        fun uu____11763  ->
+                          fun uu____11764  ->
+                            match (uu____11763, uu____11764) with
+                            | ((int_to_t,x),(uu____11783,y)) ->
+                                let uu____11793 =
                                   FStar_BigInt.logor_big_int x y  in
-                                int_as_bounded r int_to_t uu____11820)),
-                  uu____11707)
+                                int_as_bounded r int_to_t uu____11793)),
+                  uu____11680)
                  in
-              let uu____11821 =
-                let uu____11853 =
-                  let uu____11883 =
+              let uu____11794 =
+                let uu____11826 =
+                  let uu____11856 =
                     FStar_Parser_Const.p2l ["FStar"; m; "logand"]  in
-                  let uu____11890 =
+                  let uu____11863 =
                     FStar_TypeChecker_NBETerm.binary_op
                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                      (fun uu____11908  ->
-                         fun uu____11909  ->
-                           match (uu____11908, uu____11909) with
-                           | ((int_to_t,x),(uu____11928,y)) ->
-                               let uu____11938 =
+                      (fun uu____11881  ->
+                         fun uu____11882  ->
+                           match (uu____11881, uu____11882) with
+                           | ((int_to_t,x),(uu____11901,y)) ->
+                               let uu____11911 =
                                  FStar_BigInt.logand_big_int x y  in
                                FStar_TypeChecker_NBETerm.int_as_bounded
-                                 int_to_t uu____11938)
+                                 int_to_t uu____11911)
                      in
-                  (uu____11883, (Prims.of_int (2)), Prims.int_zero,
+                  (uu____11856, (Prims.of_int (2)), Prims.int_zero,
                     (binary_op arg_as_bounded_int
                        (fun r  ->
-                          fun uu____11973  ->
-                            fun uu____11974  ->
-                              match (uu____11973, uu____11974) with
-                              | ((int_to_t,x),(uu____11993,y)) ->
-                                  let uu____12003 =
+                          fun uu____11946  ->
+                            fun uu____11947  ->
+                              match (uu____11946, uu____11947) with
+                              | ((int_to_t,x),(uu____11966,y)) ->
+                                  let uu____11976 =
                                     FStar_BigInt.logand_big_int x y  in
-                                  int_as_bounded r int_to_t uu____12003)),
-                    uu____11890)
+                                  int_as_bounded r int_to_t uu____11976)),
+                    uu____11863)
                    in
-                let uu____12004 =
-                  let uu____12036 =
-                    let uu____12066 =
+                let uu____11977 =
+                  let uu____12009 =
+                    let uu____12039 =
                       FStar_Parser_Const.p2l ["FStar"; m; "logxor"]  in
-                    let uu____12073 =
+                    let uu____12046 =
                       FStar_TypeChecker_NBETerm.binary_op
                         FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                        (fun uu____12091  ->
-                           fun uu____12092  ->
-                             match (uu____12091, uu____12092) with
-                             | ((int_to_t,x),(uu____12111,y)) ->
-                                 let uu____12121 =
+                        (fun uu____12064  ->
+                           fun uu____12065  ->
+                             match (uu____12064, uu____12065) with
+                             | ((int_to_t,x),(uu____12084,y)) ->
+                                 let uu____12094 =
                                    FStar_BigInt.logxor_big_int x y  in
                                  FStar_TypeChecker_NBETerm.int_as_bounded
-                                   int_to_t uu____12121)
+                                   int_to_t uu____12094)
                        in
-                    (uu____12066, (Prims.of_int (2)), Prims.int_zero,
+                    (uu____12039, (Prims.of_int (2)), Prims.int_zero,
                       (binary_op arg_as_bounded_int
                          (fun r  ->
-                            fun uu____12156  ->
-                              fun uu____12157  ->
-                                match (uu____12156, uu____12157) with
-                                | ((int_to_t,x),(uu____12176,y)) ->
-                                    let uu____12186 =
+                            fun uu____12129  ->
+                              fun uu____12130  ->
+                                match (uu____12129, uu____12130) with
+                                | ((int_to_t,x),(uu____12149,y)) ->
+                                    let uu____12159 =
                                       FStar_BigInt.logxor_big_int x y  in
-                                    int_as_bounded r int_to_t uu____12186)),
-                      uu____12073)
+                                    int_as_bounded r int_to_t uu____12159)),
+                      uu____12046)
                      in
-                  let uu____12187 =
-                    let uu____12219 =
-                      let uu____12249 =
+                  let uu____12160 =
+                    let uu____12192 =
+                      let uu____12222 =
                         FStar_Parser_Const.p2l ["FStar"; m; "lognot"]  in
-                      let uu____12256 =
+                      let uu____12229 =
                         FStar_TypeChecker_NBETerm.unary_op
                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                          (fun uu____12271  ->
-                             match uu____12271 with
+                          (fun uu____12244  ->
+                             match uu____12244 with
                              | (int_to_t,x) ->
-                                 let uu____12278 =
-                                   let uu____12279 =
+                                 let uu____12251 =
+                                   let uu____12252 =
                                      FStar_BigInt.lognot_big_int x  in
-                                   let uu____12280 = mask m  in
-                                   FStar_BigInt.logand_big_int uu____12279
-                                     uu____12280
+                                   let uu____12253 = mask m  in
+                                   FStar_BigInt.logand_big_int uu____12252
+                                     uu____12253
                                     in
                                  FStar_TypeChecker_NBETerm.int_as_bounded
-                                   int_to_t uu____12278)
+                                   int_to_t uu____12251)
                          in
-                      (uu____12249, Prims.int_one, Prims.int_zero,
+                      (uu____12222, Prims.int_one, Prims.int_zero,
                         (unary_op arg_as_bounded_int
                            (fun r  ->
-                              fun uu____12312  ->
-                                match uu____12312 with
+                              fun uu____12285  ->
+                                match uu____12285 with
                                 | (int_to_t,x) ->
-                                    let uu____12319 =
-                                      let uu____12320 =
+                                    let uu____12292 =
+                                      let uu____12293 =
                                         FStar_BigInt.lognot_big_int x  in
-                                      let uu____12321 = mask m  in
-                                      FStar_BigInt.logand_big_int uu____12320
-                                        uu____12321
+                                      let uu____12294 = mask m  in
+                                      FStar_BigInt.logand_big_int uu____12293
+                                        uu____12294
                                        in
-                                    int_as_bounded r int_to_t uu____12319)),
-                        uu____12256)
+                                    int_as_bounded r int_to_t uu____12292)),
+                        uu____12229)
                        in
-                    let uu____12322 =
-                      let uu____12354 =
-                        let uu____12384 =
+                    let uu____12295 =
+                      let uu____12327 =
+                        let uu____12357 =
                           FStar_Parser_Const.p2l ["FStar"; m; "shift_left"]
                            in
-                        let uu____12391 =
+                        let uu____12364 =
                           FStar_TypeChecker_NBETerm.binary_op
                             FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                            (fun uu____12409  ->
-                               fun uu____12410  ->
-                                 match (uu____12409, uu____12410) with
-                                 | ((int_to_t,x),(uu____12429,y)) ->
-                                     let uu____12439 =
-                                       let uu____12440 =
+                            (fun uu____12382  ->
+                               fun uu____12383  ->
+                                 match (uu____12382, uu____12383) with
+                                 | ((int_to_t,x),(uu____12402,y)) ->
+                                     let uu____12412 =
+                                       let uu____12413 =
                                          FStar_BigInt.shift_left_big_int x y
                                           in
-                                       let uu____12441 = mask m  in
+                                       let uu____12414 = mask m  in
                                        FStar_BigInt.logand_big_int
-                                         uu____12440 uu____12441
+                                         uu____12413 uu____12414
                                         in
                                      FStar_TypeChecker_NBETerm.int_as_bounded
-                                       int_to_t uu____12439)
+                                       int_to_t uu____12412)
                            in
-                        (uu____12384, (Prims.of_int (2)), Prims.int_zero,
+                        (uu____12357, (Prims.of_int (2)), Prims.int_zero,
                           (binary_op arg_as_bounded_int
                              (fun r  ->
-                                fun uu____12476  ->
-                                  fun uu____12477  ->
-                                    match (uu____12476, uu____12477) with
-                                    | ((int_to_t,x),(uu____12496,y)) ->
-                                        let uu____12506 =
-                                          let uu____12507 =
+                                fun uu____12449  ->
+                                  fun uu____12450  ->
+                                    match (uu____12449, uu____12450) with
+                                    | ((int_to_t,x),(uu____12469,y)) ->
+                                        let uu____12479 =
+                                          let uu____12480 =
                                             FStar_BigInt.shift_left_big_int x
                                               y
                                              in
-                                          let uu____12508 = mask m  in
+                                          let uu____12481 = mask m  in
                                           FStar_BigInt.logand_big_int
-                                            uu____12507 uu____12508
+                                            uu____12480 uu____12481
                                            in
-                                        int_as_bounded r int_to_t uu____12506)),
-                          uu____12391)
+                                        int_as_bounded r int_to_t uu____12479)),
+                          uu____12364)
                          in
-                      let uu____12509 =
-                        let uu____12541 =
-                          let uu____12571 =
+                      let uu____12482 =
+                        let uu____12514 =
+                          let uu____12544 =
                             FStar_Parser_Const.p2l
                               ["FStar"; m; "shift_right"]
                              in
-                          let uu____12578 =
+                          let uu____12551 =
                             FStar_TypeChecker_NBETerm.binary_op
                               FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                              (fun uu____12596  ->
-                                 fun uu____12597  ->
-                                   match (uu____12596, uu____12597) with
-                                   | ((int_to_t,x),(uu____12616,y)) ->
-                                       let uu____12626 =
+                              (fun uu____12569  ->
+                                 fun uu____12570  ->
+                                   match (uu____12569, uu____12570) with
+                                   | ((int_to_t,x),(uu____12589,y)) ->
+                                       let uu____12599 =
                                          FStar_BigInt.shift_right_big_int x y
                                           in
                                        FStar_TypeChecker_NBETerm.int_as_bounded
-                                         int_to_t uu____12626)
+                                         int_to_t uu____12599)
                              in
-                          (uu____12571, (Prims.of_int (2)), Prims.int_zero,
+                          (uu____12544, (Prims.of_int (2)), Prims.int_zero,
                             (binary_op arg_as_bounded_int
                                (fun r  ->
-                                  fun uu____12661  ->
-                                    fun uu____12662  ->
-                                      match (uu____12661, uu____12662) with
-                                      | ((int_to_t,x),(uu____12681,y)) ->
-                                          let uu____12691 =
+                                  fun uu____12634  ->
+                                    fun uu____12635  ->
+                                      match (uu____12634, uu____12635) with
+                                      | ((int_to_t,x),(uu____12654,y)) ->
+                                          let uu____12664 =
                                             FStar_BigInt.shift_right_big_int
                                               x y
                                              in
                                           int_as_bounded r int_to_t
-                                            uu____12691)), uu____12578)
+                                            uu____12664)), uu____12551)
                            in
-                        [uu____12541]  in
-                      uu____12354 :: uu____12509  in
-                    uu____12219 :: uu____12322  in
-                  uu____12036 :: uu____12187  in
-                uu____11853 :: uu____12004  in
-              uu____11670 :: uu____11821))
+                        [uu____12514]  in
+                      uu____12327 :: uu____12482  in
+                    uu____12192 :: uu____12295  in
+                  uu____12009 :: uu____12160  in
+                uu____11826 :: uu____11977  in
+              uu____11643 :: uu____11794))
        in
     FStar_List.append add_sub_mul_v
       (FStar_List.append div_mod_unsigned bitwise)
@@ -3016,63 +3011,63 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
   let interp_prop_eq2 psc1 _norm_cb args =
     let r = psc1.psc_range  in
     match args with
-    | (_typ,uu____13079)::(a1,uu____13081)::(a2,uu____13083)::[] ->
-        let uu____13140 = FStar_Syntax_Util.eq_tm a1 a2  in
-        (match uu____13140 with
+    | (_typ,uu____13052)::(a1,uu____13054)::(a2,uu____13056)::[] ->
+        let uu____13113 = FStar_Syntax_Util.eq_tm a1 a2  in
+        (match uu____13113 with
          | FStar_Syntax_Util.Equal  ->
              FStar_Pervasives_Native.Some
-               (let uu___887_13144 = FStar_Syntax_Util.t_true  in
+               (let uu___885_13117 = FStar_Syntax_Util.t_true  in
                 {
                   FStar_Syntax_Syntax.n =
-                    (uu___887_13144.FStar_Syntax_Syntax.n);
+                    (uu___885_13117.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___887_13144.FStar_Syntax_Syntax.vars)
+                    (uu___885_13117.FStar_Syntax_Syntax.vars)
                 })
          | FStar_Syntax_Util.NotEqual  ->
              FStar_Pervasives_Native.Some
-               (let uu___890_13146 = FStar_Syntax_Util.t_false  in
+               (let uu___888_13119 = FStar_Syntax_Util.t_false  in
                 {
                   FStar_Syntax_Syntax.n =
-                    (uu___890_13146.FStar_Syntax_Syntax.n);
+                    (uu___888_13119.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___890_13146.FStar_Syntax_Syntax.vars)
+                    (uu___888_13119.FStar_Syntax_Syntax.vars)
                 })
-         | uu____13147 -> FStar_Pervasives_Native.None)
-    | uu____13148 -> failwith "Unexpected number of arguments"  in
+         | uu____13120 -> FStar_Pervasives_Native.None)
+    | uu____13121 -> failwith "Unexpected number of arguments"  in
   let interp_prop_eq3 psc1 _norm_cb args =
     let r = psc1.psc_range  in
     match args with
-    | (t1,uu____13178)::(t2,uu____13180)::(a1,uu____13182)::(a2,uu____13184)::[]
+    | (t1,uu____13151)::(t2,uu____13153)::(a1,uu____13155)::(a2,uu____13157)::[]
         ->
-        let uu____13257 =
-          let uu____13258 = FStar_Syntax_Util.eq_tm t1 t2  in
-          let uu____13259 = FStar_Syntax_Util.eq_tm a1 a2  in
-          FStar_Syntax_Util.eq_inj uu____13258 uu____13259  in
-        (match uu____13257 with
+        let uu____13230 =
+          let uu____13231 = FStar_Syntax_Util.eq_tm t1 t2  in
+          let uu____13232 = FStar_Syntax_Util.eq_tm a1 a2  in
+          FStar_Syntax_Util.eq_inj uu____13231 uu____13232  in
+        (match uu____13230 with
          | FStar_Syntax_Util.Equal  ->
              FStar_Pervasives_Native.Some
-               (let uu___913_13263 = FStar_Syntax_Util.t_true  in
+               (let uu___911_13236 = FStar_Syntax_Util.t_true  in
                 {
                   FStar_Syntax_Syntax.n =
-                    (uu___913_13263.FStar_Syntax_Syntax.n);
+                    (uu___911_13236.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___913_13263.FStar_Syntax_Syntax.vars)
+                    (uu___911_13236.FStar_Syntax_Syntax.vars)
                 })
          | FStar_Syntax_Util.NotEqual  ->
              FStar_Pervasives_Native.Some
-               (let uu___916_13265 = FStar_Syntax_Util.t_false  in
+               (let uu___914_13238 = FStar_Syntax_Util.t_false  in
                 {
                   FStar_Syntax_Syntax.n =
-                    (uu___916_13265.FStar_Syntax_Syntax.n);
+                    (uu___914_13238.FStar_Syntax_Syntax.n);
                   FStar_Syntax_Syntax.pos = r;
                   FStar_Syntax_Syntax.vars =
-                    (uu___916_13265.FStar_Syntax_Syntax.vars)
+                    (uu___914_13238.FStar_Syntax_Syntax.vars)
                 })
-         | uu____13266 -> FStar_Pervasives_Native.None)
-    | uu____13267 -> failwith "Unexpected number of arguments"  in
+         | uu____13239 -> FStar_Pervasives_Native.None)
+    | uu____13240 -> failwith "Unexpected number of arguments"  in
   let propositional_equality =
     {
       name = FStar_Parser_Const.eq2_lid;
@@ -3101,12 +3096,12 @@ let (equality_ops : primitive_step FStar_Util.psmap) =
 let (primop_time_map : Prims.int FStar_Util.smap) =
   FStar_Util.smap_create (Prims.of_int (50)) 
 let (primop_time_reset : unit -> unit) =
-  fun uu____13298  -> FStar_Util.smap_clear primop_time_map 
+  fun uu____13271  -> FStar_Util.smap_clear primop_time_map 
 let (primop_time_count : Prims.string -> Prims.int -> unit) =
   fun nm  ->
     fun ms  ->
-      let uu____13315 = FStar_Util.smap_try_find primop_time_map nm  in
-      match uu____13315 with
+      let uu____13288 = FStar_Util.smap_try_find primop_time_map nm  in
+      match uu____13288 with
       | FStar_Pervasives_Native.None  ->
           FStar_Util.smap_add primop_time_map nm ms
       | FStar_Pervasives_Native.Some ms0 ->
@@ -3117,35 +3112,35 @@ let (fixto : Prims.int -> Prims.string -> Prims.string) =
     fun s  ->
       if (FStar_String.length s) < n
       then
-        let uu____13344 = FStar_String.make (n - (FStar_String.length s)) 32
+        let uu____13317 = FStar_String.make (n - (FStar_String.length s)) 32
            in
-        FStar_String.op_Hat uu____13344 s
+        FStar_String.op_Hat uu____13317 s
       else s
   
 let (primop_time_report : unit -> Prims.string) =
-  fun uu____13355  ->
+  fun uu____13328  ->
     let pairs =
       FStar_Util.smap_fold primop_time_map
         (fun nm  -> fun ms  -> fun rest  -> (nm, ms) :: rest) []
        in
     let pairs1 =
       FStar_Util.sort_with
-        (fun uu____13426  ->
-           fun uu____13427  ->
-             match (uu____13426, uu____13427) with
-             | ((uu____13453,t1),(uu____13455,t2)) -> t1 - t2) pairs
+        (fun uu____13399  ->
+           fun uu____13400  ->
+             match (uu____13399, uu____13400) with
+             | ((uu____13426,t1),(uu____13428,t2)) -> t1 - t2) pairs
        in
     FStar_List.fold_right
-      (fun uu____13489  ->
+      (fun uu____13462  ->
          fun rest  ->
-           match uu____13489 with
+           match uu____13462 with
            | (nm,ms) ->
-               let uu____13505 =
-                 let uu____13507 =
-                   let uu____13509 = FStar_Util.string_of_int ms  in
-                   fixto (Prims.of_int (10)) uu____13509  in
-                 FStar_Util.format2 "%sms --- %s\n" uu____13507 nm  in
-               FStar_String.op_Hat uu____13505 rest) pairs1 ""
+               let uu____13478 =
+                 let uu____13480 =
+                   let uu____13482 = FStar_Util.string_of_int ms  in
+                   fixto (Prims.of_int (10)) uu____13482  in
+                 FStar_Util.format2 "%sms --- %s\n" uu____13480 nm  in
+               FStar_String.op_Hat uu____13478 rest) pairs1 ""
   
 let (extendable_primops_dirty : Prims.bool FStar_ST.ref) =
   FStar_Util.mk_ref true 
@@ -3153,18 +3148,18 @@ type register_prim_step_t = primitive_step -> unit
 type retrieve_prim_step_t = unit -> prim_step_set
 let (mk_extendable_primop_set :
   unit -> (register_prim_step_t * retrieve_prim_step_t)) =
-  fun uu____13537  ->
+  fun uu____13510  ->
     let steps =
-      let uu____13547 = empty_prim_steps ()  in FStar_Util.mk_ref uu____13547
+      let uu____13520 = empty_prim_steps ()  in FStar_Util.mk_ref uu____13520
        in
     let register p =
       FStar_ST.op_Colon_Equals extendable_primops_dirty true;
-      (let uu____13577 =
-         let uu____13578 = FStar_ST.op_Bang steps  in add_step p uu____13578
+      (let uu____13550 =
+         let uu____13551 = FStar_ST.op_Bang steps  in add_step p uu____13551
           in
-       FStar_ST.op_Colon_Equals steps uu____13577)
+       FStar_ST.op_Colon_Equals steps uu____13550)
        in
-    let retrieve uu____13622 = FStar_ST.op_Bang steps  in
+    let retrieve uu____13595 = FStar_ST.op_Bang steps  in
     (register, retrieve)
   
 let (plugins : (register_prim_step_t * retrieve_prim_step_t)) =
@@ -3174,30 +3169,30 @@ let (extra_steps : (register_prim_step_t * retrieve_prim_step_t)) =
 let (register_plugin : primitive_step -> unit) =
   fun p  -> FStar_Pervasives_Native.fst plugins p 
 let (retrieve_plugins : unit -> prim_step_set) =
-  fun uu____13671  ->
-    let uu____13672 = FStar_Options.no_plugins ()  in
-    if uu____13672
+  fun uu____13644  ->
+    let uu____13645 = FStar_Options.no_plugins ()  in
+    if uu____13645
     then empty_prim_steps ()
     else FStar_Pervasives_Native.snd plugins ()
   
 let (register_extra_step : primitive_step -> unit) =
   fun p  -> FStar_Pervasives_Native.fst extra_steps p 
 let (retrieve_extra_steps : unit -> prim_step_set) =
-  fun uu____13692  -> FStar_Pervasives_Native.snd extra_steps () 
+  fun uu____13665  -> FStar_Pervasives_Native.snd extra_steps () 
 let (cached_steps : unit -> prim_step_set) =
   let memo =
-    let uu____13703 = empty_prim_steps ()  in FStar_Util.mk_ref uu____13703
+    let uu____13676 = empty_prim_steps ()  in FStar_Util.mk_ref uu____13676
      in
-  fun uu____13704  ->
-    let uu____13705 = FStar_ST.op_Bang extendable_primops_dirty  in
-    if uu____13705
+  fun uu____13677  ->
+    let uu____13678 = FStar_ST.op_Bang extendable_primops_dirty  in
+    if uu____13678
     then
       let steps =
-        let uu____13730 =
-          let uu____13731 = retrieve_plugins ()  in
-          let uu____13732 = retrieve_extra_steps ()  in
-          merge_steps uu____13731 uu____13732  in
-        merge_steps built_in_primitive_steps uu____13730  in
+        let uu____13703 =
+          let uu____13704 = retrieve_plugins ()  in
+          let uu____13705 = retrieve_extra_steps ()  in
+          merge_steps uu____13704 uu____13705  in
+        merge_steps built_in_primitive_steps uu____13703  in
       (FStar_ST.op_Colon_Equals memo steps;
        FStar_ST.op_Colon_Equals extendable_primops_dirty false;
        steps)
@@ -3205,39 +3200,39 @@ let (cached_steps : unit -> prim_step_set) =
   
 let (add_nbe : fsteps -> fsteps) =
   fun s  ->
-    let uu____13803 = FStar_Options.use_nbe ()  in
-    if uu____13803
+    let uu____13776 = FStar_Options.use_nbe ()  in
+    if uu____13776
     then
-      let uu___969_13806 = s  in
+      let uu___967_13779 = s  in
       {
-        beta = (uu___969_13806.beta);
-        iota = (uu___969_13806.iota);
-        zeta = (uu___969_13806.zeta);
-        zeta_full = (uu___969_13806.zeta_full);
-        weak = (uu___969_13806.weak);
-        hnf = (uu___969_13806.hnf);
-        primops = (uu___969_13806.primops);
-        do_not_unfold_pure_lets = (uu___969_13806.do_not_unfold_pure_lets);
-        unfold_until = (uu___969_13806.unfold_until);
-        unfold_only = (uu___969_13806.unfold_only);
-        unfold_fully = (uu___969_13806.unfold_fully);
-        unfold_attr = (uu___969_13806.unfold_attr);
-        unfold_tac = (uu___969_13806.unfold_tac);
+        beta = (uu___967_13779.beta);
+        iota = (uu___967_13779.iota);
+        zeta = (uu___967_13779.zeta);
+        zeta_full = (uu___967_13779.zeta_full);
+        weak = (uu___967_13779.weak);
+        hnf = (uu___967_13779.hnf);
+        primops = (uu___967_13779.primops);
+        do_not_unfold_pure_lets = (uu___967_13779.do_not_unfold_pure_lets);
+        unfold_until = (uu___967_13779.unfold_until);
+        unfold_only = (uu___967_13779.unfold_only);
+        unfold_fully = (uu___967_13779.unfold_fully);
+        unfold_attr = (uu___967_13779.unfold_attr);
+        unfold_tac = (uu___967_13779.unfold_tac);
         pure_subterms_within_computations =
-          (uu___969_13806.pure_subterms_within_computations);
-        simplify = (uu___969_13806.simplify);
-        erase_universes = (uu___969_13806.erase_universes);
-        allow_unbound_universes = (uu___969_13806.allow_unbound_universes);
-        reify_ = (uu___969_13806.reify_);
-        compress_uvars = (uu___969_13806.compress_uvars);
-        no_full_norm = (uu___969_13806.no_full_norm);
-        check_no_uvars = (uu___969_13806.check_no_uvars);
-        unmeta = (uu___969_13806.unmeta);
-        unascribe = (uu___969_13806.unascribe);
-        in_full_norm_request = (uu___969_13806.in_full_norm_request);
-        weakly_reduce_scrutinee = (uu___969_13806.weakly_reduce_scrutinee);
+          (uu___967_13779.pure_subterms_within_computations);
+        simplify = (uu___967_13779.simplify);
+        erase_universes = (uu___967_13779.erase_universes);
+        allow_unbound_universes = (uu___967_13779.allow_unbound_universes);
+        reify_ = (uu___967_13779.reify_);
+        compress_uvars = (uu___967_13779.compress_uvars);
+        no_full_norm = (uu___967_13779.no_full_norm);
+        check_no_uvars = (uu___967_13779.check_no_uvars);
+        unmeta = (uu___967_13779.unmeta);
+        unascribe = (uu___967_13779.unascribe);
+        in_full_norm_request = (uu___967_13779.in_full_norm_request);
+        weakly_reduce_scrutinee = (uu___967_13779.weakly_reduce_scrutinee);
         nbe_step = true;
-        for_extraction = (uu___969_13806.for_extraction)
+        for_extraction = (uu___967_13779.for_extraction)
       }
     else s
   
@@ -3251,84 +3246,84 @@ let (config' :
         let d =
           FStar_All.pipe_right s
             (FStar_List.collect
-               (fun uu___0_13843  ->
-                  match uu___0_13843 with
+               (fun uu___0_13816  ->
+                  match uu___0_13816 with
                   | FStar_TypeChecker_Env.UnfoldUntil k ->
                       [FStar_TypeChecker_Env.Unfold k]
                   | FStar_TypeChecker_Env.Eager_unfolding  ->
                       [FStar_TypeChecker_Env.Eager_unfolding_only]
                   | FStar_TypeChecker_Env.Inlining  ->
                       [FStar_TypeChecker_Env.InliningDelta]
-                  | uu____13847 -> []))
+                  | uu____13820 -> []))
            in
         let d1 =
           match d with
           | [] -> [FStar_TypeChecker_Env.NoDelta]
-          | uu____13853 -> d  in
+          | uu____13826 -> d  in
         let steps =
-          let uu____13857 = to_fsteps s  in
-          FStar_All.pipe_right uu____13857 add_nbe  in
+          let uu____13830 = to_fsteps s  in
+          FStar_All.pipe_right uu____13830 add_nbe  in
         let psteps1 =
-          let uu____13859 = cached_steps ()  in add_steps uu____13859 psteps
+          let uu____13832 = cached_steps ()  in add_steps uu____13832 psteps
            in
-        let uu____13860 =
-          let uu____13861 = FStar_Options.debug_any ()  in
-          if uu____13861
+        let uu____13833 =
+          let uu____13834 = FStar_Options.debug_any ()  in
+          if uu____13834
           then
-            let uu____13864 =
+            let uu____13837 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "Norm")  in
-            let uu____13867 =
+            let uu____13840 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "NormTop")
                in
-            let uu____13870 =
+            let uu____13843 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "NormCfg")
                in
-            let uu____13873 =
+            let uu____13846 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "Primops")
                in
-            let uu____13876 =
+            let uu____13849 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "Unfolding")
                in
-            let uu____13879 =
+            let uu____13852 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "380")  in
-            let uu____13882 =
+            let uu____13855 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "WPE")  in
-            let uu____13885 =
+            let uu____13858 =
               FStar_TypeChecker_Env.debug e
                 (FStar_Options.Other "NormDelayed")
                in
-            let uu____13888 =
+            let uu____13861 =
               FStar_TypeChecker_Env.debug e
                 (FStar_Options.Other "print_normalized_terms")
                in
-            let uu____13891 =
+            let uu____13864 =
               FStar_TypeChecker_Env.debug e (FStar_Options.Other "NBE")  in
             {
-              gen = uu____13864;
-              top = uu____13867;
-              cfg = uu____13870;
-              primop = uu____13873;
-              unfolding = uu____13876;
-              b380 = uu____13879;
-              wpe = uu____13882;
-              norm_delayed = uu____13885;
-              print_normalized = uu____13888;
-              debug_nbe = uu____13891
+              gen = uu____13837;
+              top = uu____13840;
+              cfg = uu____13843;
+              primop = uu____13846;
+              unfolding = uu____13849;
+              b380 = uu____13852;
+              wpe = uu____13855;
+              norm_delayed = uu____13858;
+              print_normalized = uu____13861;
+              debug_nbe = uu____13864
             }
           else no_debug_switches  in
-        let uu____13896 =
+        let uu____13869 =
           (Prims.op_Negation steps.pure_subterms_within_computations) ||
             (FStar_Options.normalize_pure_terms_for_extraction ())
            in
         {
           steps;
           tcenv = e;
-          debug = uu____13860;
+          debug = uu____13833;
           delta_level = d1;
           primitive_steps = psteps1;
           strong = false;
           memoize_lazy = true;
-          normalize_pure_lets = uu____13896;
+          normalize_pure_lets = uu____13869;
           reifying = false
         }
   
@@ -3342,26 +3337,26 @@ let (should_reduce_local_let :
       if (cfg1.steps).do_not_unfold_pure_lets
       then false
       else
-        (let uu____13933 =
+        (let uu____13906 =
            (cfg1.steps).pure_subterms_within_computations &&
              (FStar_Syntax_Util.has_attribute lb.FStar_Syntax_Syntax.lbattrs
                 FStar_Parser_Const.inline_let_attr)
             in
-         if uu____13933
+         if uu____13906
          then true
          else
            (let n =
               FStar_TypeChecker_Env.norm_eff_name cfg1.tcenv
                 lb.FStar_Syntax_Syntax.lbeff
                in
-            let uu____13941 =
+            let uu____13914 =
               (FStar_Syntax_Util.is_pure_effect n) &&
                 (cfg1.normalize_pure_lets ||
                    (FStar_Syntax_Util.has_attribute
                       lb.FStar_Syntax_Syntax.lbattrs
                       FStar_Parser_Const.inline_let_attr))
                in
-            if uu____13941
+            if uu____13914
             then true
             else
               (FStar_Syntax_Util.is_ghost_effect n) &&

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -171,13 +171,12 @@ let (mk_by_tactic :
           [FStar_Syntax_Syntax.U_zero]
          in
       let uu____673 =
-        let uu____678 =
-          let uu____679 = FStar_Syntax_Syntax.as_arg tac  in
-          let uu____688 =
-            let uu____699 = FStar_Syntax_Syntax.as_arg f  in [uu____699]  in
-          uu____679 :: uu____688  in
-        FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu____678  in
-      uu____673 FStar_Pervasives_Native.None FStar_Range.dummyRange
+        let uu____674 = FStar_Syntax_Syntax.as_arg tac  in
+        let uu____683 =
+          let uu____694 = FStar_Syntax_Syntax.as_arg f  in [uu____694]  in
+        uu____674 :: uu____683  in
+      FStar_Syntax_Syntax.mk_Tm_app t_by_tactic uu____673
+        FStar_Range.dummyRange
   
 let rec (delta_depth_greater_than :
   FStar_Syntax_Syntax.delta_depth ->
@@ -190,25 +189,25 @@ let rec (delta_depth_greater_than :
          i,FStar_Syntax_Syntax.Delta_equational_at_level j) -> i > j
       | (FStar_Syntax_Syntax.Delta_constant_at_level
          i,FStar_Syntax_Syntax.Delta_constant_at_level j) -> i > j
-      | (FStar_Syntax_Syntax.Delta_abstract d,uu____754) ->
+      | (FStar_Syntax_Syntax.Delta_abstract d,uu____749) ->
           delta_depth_greater_than d m
-      | (uu____755,FStar_Syntax_Syntax.Delta_abstract d) ->
+      | (uu____750,FStar_Syntax_Syntax.Delta_abstract d) ->
           delta_depth_greater_than l d
-      | (FStar_Syntax_Syntax.Delta_equational_at_level uu____757,uu____758)
+      | (FStar_Syntax_Syntax.Delta_equational_at_level uu____752,uu____753)
           -> true
-      | (uu____761,FStar_Syntax_Syntax.Delta_equational_at_level uu____762)
+      | (uu____756,FStar_Syntax_Syntax.Delta_equational_at_level uu____757)
           -> false
   
 let rec (decr_delta_depth :
   FStar_Syntax_Syntax.delta_depth ->
     FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
   =
-  fun uu___1_772  ->
-    match uu___1_772 with
-    | FStar_Syntax_Syntax.Delta_constant_at_level uu____775 when
-        uu____775 = Prims.int_zero -> FStar_Pervasives_Native.None
-    | FStar_Syntax_Syntax.Delta_equational_at_level uu____776 when
-        uu____776 = Prims.int_zero -> FStar_Pervasives_Native.None
+  fun uu___1_767  ->
+    match uu___1_767 with
+    | FStar_Syntax_Syntax.Delta_constant_at_level uu____770 when
+        uu____770 = Prims.int_zero -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Delta_equational_at_level uu____771 when
+        uu____771 = Prims.int_zero -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Delta_constant_at_level i ->
         FStar_Pervasives_Native.Some
           (FStar_Syntax_Syntax.Delta_constant_at_level (i - Prims.int_one))
@@ -260,8 +259,8 @@ let (insert_col_info :
               then (aux, ((col, info) :: rest))
               else __insert ((c, i) :: aux) rest'
            in
-        let uu____1058 = __insert [] col_infos  in
-        match uu____1058 with
+        let uu____1053 = __insert [] col_infos  in
+        match uu____1053 with
         | (l,r) -> FStar_List.append (FStar_List.rev l) r
   
 let (find_nearest_preceding_col_info :
@@ -271,8 +270,8 @@ let (find_nearest_preceding_col_info :
   =
   fun col  ->
     fun col_infos  ->
-      let rec aux out uu___2_1179 =
-        match uu___2_1179 with
+      let rec aux out uu___2_1174 =
+        match uu___2_1174 with
         | [] -> out
         | (c,i)::rest ->
             if c > col
@@ -308,8 +307,8 @@ let (__proj__Mkid_info_table__item__id_info_buffer :
     | { id_info_enabled; id_info_db; id_info_buffer;_} -> id_info_buffer
   
 let (id_info_table_empty : id_info_table) =
-  let uu____1290 = FStar_Util.psmap_empty ()  in
-  { id_info_enabled = false; id_info_db = uu____1290; id_info_buffer = [] } 
+  let uu____1285 = FStar_Util.psmap_empty ()  in
+  { id_info_enabled = false; id_info_db = uu____1285; id_info_buffer = [] } 
 let (id_info__insert :
   (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) ->
     (Prims.int * identifier_info) Prims.list FStar_Util.pimap
@@ -323,33 +322,33 @@ let (id_info__insert :
       fun info  ->
         let range = info.identifier_range  in
         let use_range =
-          let uu____1348 = FStar_Range.use_range range  in
-          FStar_Range.set_def_range range uu____1348  in
+          let uu____1343 = FStar_Range.use_range range  in
+          FStar_Range.set_def_range range uu____1343  in
         let info1 =
-          let uu___143_1350 = info  in
-          let uu____1351 = ty_map info.identifier_ty  in
+          let uu___143_1345 = info  in
+          let uu____1346 = ty_map info.identifier_ty  in
           {
-            identifier = (uu___143_1350.identifier);
-            identifier_ty = uu____1351;
+            identifier = (uu___143_1345.identifier);
+            identifier_ty = uu____1346;
             identifier_range = use_range
           }  in
         let fn = FStar_Range.file_of_range use_range  in
         let start = FStar_Range.start_of_range use_range  in
-        let uu____1355 =
-          let uu____1362 = FStar_Range.line_of_pos start  in
-          let uu____1364 = FStar_Range.col_of_pos start  in
-          (uu____1362, uu____1364)  in
-        match uu____1355 with
+        let uu____1350 =
+          let uu____1357 = FStar_Range.line_of_pos start  in
+          let uu____1359 = FStar_Range.col_of_pos start  in
+          (uu____1357, uu____1359)  in
+        match uu____1350 with
         | (row,col) ->
             let rows =
-              let uu____1395 = FStar_Util.pimap_empty ()  in
-              FStar_Util.psmap_find_default db fn uu____1395  in
+              let uu____1390 = FStar_Util.pimap_empty ()  in
+              FStar_Util.psmap_find_default db fn uu____1390  in
             let cols = FStar_Util.pimap_find_default rows row []  in
-            let uu____1441 =
-              let uu____1451 = insert_col_info col info1 cols  in
-              FStar_All.pipe_right uu____1451 (FStar_Util.pimap_add rows row)
+            let uu____1436 =
+              let uu____1446 = insert_col_info col info1 cols  in
+              FStar_All.pipe_right uu____1446 (FStar_Util.pimap_add rows row)
                in
-            FStar_All.pipe_right uu____1441 (FStar_Util.psmap_add db fn)
+            FStar_All.pipe_right uu____1436 (FStar_Util.psmap_add db fn)
   
 let (id_info_insert :
   id_info_table ->
@@ -363,10 +362,10 @@ let (id_info_insert :
           let info =
             { identifier = id; identifier_ty = ty; identifier_range = range }
              in
-          let uu___158_1541 = table  in
+          let uu___158_1536 = table  in
           {
-            id_info_enabled = (uu___158_1541.id_info_enabled);
-            id_info_db = (uu___158_1541.id_info_db);
+            id_info_enabled = (uu___158_1536.id_info_enabled);
+            id_info_db = (uu___158_1536.id_info_db);
             id_info_buffer = (info :: (table.id_info_buffer))
           }
   
@@ -379,8 +378,8 @@ let (id_info_insert_bv :
       fun ty  ->
         if table.id_info_enabled
         then
-          let uu____1559 = FStar_Syntax_Syntax.range_of_bv bv  in
-          id_info_insert table (FStar_Util.Inl bv) ty uu____1559
+          let uu____1554 = FStar_Syntax_Syntax.range_of_bv bv  in
+          id_info_insert table (FStar_Util.Inl bv) ty uu____1554
         else table
   
 let (id_info_insert_fv :
@@ -392,18 +391,18 @@ let (id_info_insert_fv :
       fun ty  ->
         if table.id_info_enabled
         then
-          let uu____1579 = FStar_Syntax_Syntax.range_of_fv fv  in
-          id_info_insert table (FStar_Util.Inr fv) ty uu____1579
+          let uu____1574 = FStar_Syntax_Syntax.range_of_fv fv  in
+          id_info_insert table (FStar_Util.Inr fv) ty uu____1574
         else table
   
 let (id_info_toggle : id_info_table -> Prims.bool -> id_info_table) =
   fun table  ->
     fun enabled  ->
-      let uu___170_1595 = table  in
+      let uu___170_1590 = table  in
       {
         id_info_enabled = enabled;
-        id_info_db = (uu___170_1595.id_info_db);
-        id_info_buffer = (uu___170_1595.id_info_buffer)
+        id_info_db = (uu___170_1590.id_info_db);
+        id_info_buffer = (uu___170_1590.id_info_buffer)
       }
   
 let (id_info_promote :
@@ -412,14 +411,14 @@ let (id_info_promote :
   =
   fun table  ->
     fun ty_map  ->
-      let uu___174_1612 = table  in
-      let uu____1613 =
+      let uu___174_1607 = table  in
+      let uu____1608 =
         FStar_List.fold_left (id_info__insert ty_map) table.id_info_db
           table.id_info_buffer
          in
       {
-        id_info_enabled = (uu___174_1612.id_info_enabled);
-        id_info_db = uu____1613;
+        id_info_enabled = (uu___174_1607.id_info_enabled);
+        id_info_db = uu____1608;
         id_info_buffer = []
       }
   
@@ -434,17 +433,17 @@ let (id_info_at_pos :
       fun row  ->
         fun col  ->
           let rows =
-            let uu____1657 = FStar_Util.pimap_empty ()  in
-            FStar_Util.psmap_find_default table.id_info_db fn uu____1657  in
+            let uu____1652 = FStar_Util.pimap_empty ()  in
+            FStar_Util.psmap_find_default table.id_info_db fn uu____1652  in
           let cols = FStar_Util.pimap_find_default rows row []  in
-          let uu____1664 = find_nearest_preceding_col_info col cols  in
-          match uu____1664 with
+          let uu____1659 = find_nearest_preceding_col_info col cols  in
+          match uu____1659 with
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some info ->
               let last_col =
-                let uu____1672 =
+                let uu____1667 =
                   FStar_Range.end_of_range info.identifier_range  in
-                FStar_Range.col_of_pos uu____1672  in
+                FStar_Range.col_of_pos uu____1667  in
               if col <= last_col
               then FStar_Pervasives_Native.Some info
               else FStar_Pervasives_Native.None
@@ -461,61 +460,61 @@ let (check_uvar_ctx_invariant :
         fun g  ->
           fun bs  ->
             let print_gamma gamma =
-              let uu____1719 =
+              let uu____1714 =
                 FStar_All.pipe_right gamma
                   (FStar_List.map
-                     (fun uu___3_1732  ->
-                        match uu___3_1732 with
+                     (fun uu___3_1727  ->
+                        match uu___3_1727 with
                         | FStar_Syntax_Syntax.Binding_var x ->
-                            let uu____1735 =
+                            let uu____1730 =
                               FStar_Syntax_Print.bv_to_string x  in
-                            Prims.op_Hat "Binding_var " uu____1735
+                            Prims.op_Hat "Binding_var " uu____1730
                         | FStar_Syntax_Syntax.Binding_univ u ->
-                            let uu____1739 = FStar_Ident.text_of_id u  in
-                            Prims.op_Hat "Binding_univ " uu____1739
-                        | FStar_Syntax_Syntax.Binding_lid (l,uu____1743) ->
-                            let uu____1760 = FStar_Ident.string_of_lid l  in
-                            Prims.op_Hat "Binding_lid " uu____1760))
+                            let uu____1734 = FStar_Ident.text_of_id u  in
+                            Prims.op_Hat "Binding_univ " uu____1734
+                        | FStar_Syntax_Syntax.Binding_lid (l,uu____1738) ->
+                            let uu____1755 = FStar_Ident.string_of_lid l  in
+                            Prims.op_Hat "Binding_lid " uu____1755))
                  in
-              FStar_All.pipe_right uu____1719 (FStar_String.concat "::\n")
+              FStar_All.pipe_right uu____1714 (FStar_String.concat "::\n")
                in
-            let fail uu____1773 =
-              let uu____1774 =
-                let uu____1776 = FStar_Range.string_of_range r  in
-                let uu____1778 = print_gamma g  in
-                let uu____1780 = FStar_Syntax_Print.binders_to_string ", " bs
+            let fail uu____1768 =
+              let uu____1769 =
+                let uu____1771 = FStar_Range.string_of_range r  in
+                let uu____1773 = print_gamma g  in
+                let uu____1775 = FStar_Syntax_Print.binders_to_string ", " bs
                    in
                 FStar_Util.format5
                   "Invariant violation: gamma and binders are out of sync\n\treason=%s, range=%s, should_check=%s\n\t\n                               gamma=%s\n\tbinders=%s\n"
-                  reason uu____1776
-                  (if should_check then "true" else "false") uu____1778
-                  uu____1780
+                  reason uu____1771
+                  (if should_check then "true" else "false") uu____1773
+                  uu____1775
                  in
-              failwith uu____1774  in
+              failwith uu____1769  in
             if Prims.op_Negation should_check
             then ()
             else
-              (let uu____1793 =
-                 let uu____1818 =
+              (let uu____1788 =
+                 let uu____1813 =
                    FStar_Util.prefix_until
-                     (fun uu___4_1833  ->
-                        match uu___4_1833 with
-                        | FStar_Syntax_Syntax.Binding_var uu____1835 -> true
-                        | uu____1837 -> false) g
+                     (fun uu___4_1828  ->
+                        match uu___4_1828 with
+                        | FStar_Syntax_Syntax.Binding_var uu____1830 -> true
+                        | uu____1832 -> false) g
                     in
-                 (uu____1818, bs)  in
-               match uu____1793 with
+                 (uu____1813, bs)  in
+               match uu____1788 with
                | (FStar_Pervasives_Native.None ,[]) -> ()
                | (FStar_Pervasives_Native.Some
-                  (uu____1895,hd,gamma_tail),uu____1898::uu____1899) ->
-                   let uu____1958 = FStar_Util.prefix bs  in
-                   (match uu____1958 with
-                    | (uu____1983,(x,uu____1985)) ->
+                  (uu____1890,hd,gamma_tail),uu____1893::uu____1894) ->
+                   let uu____1953 = FStar_Util.prefix bs  in
+                   (match uu____1953 with
+                    | (uu____1978,(x,uu____1980)) ->
                         (match hd with
                          | FStar_Syntax_Syntax.Binding_var x' when
                              FStar_Syntax_Syntax.bv_eq x x' -> ()
-                         | uu____2013 -> fail ()))
-               | uu____2014 -> fail ())
+                         | uu____2008 -> fail ()))
+               | uu____2009 -> fail ())
   
 type implicit =
   {
@@ -596,19 +595,19 @@ let (conj_guard_f : guard_formula -> guard_formula -> guard_formula) =
       | (Trivial ,g) -> g
       | (g,Trivial ) -> g
       | (NonTrivial f1,NonTrivial f2) ->
-          let uu____2263 = FStar_Syntax_Util.mk_conj f1 f2  in
-          NonTrivial uu____2263
+          let uu____2258 = FStar_Syntax_Util.mk_conj f1 f2  in
+          NonTrivial uu____2258
   
 let (check_trivial : FStar_Syntax_Syntax.term -> guard_formula) =
   fun t  ->
-    let uu____2270 =
-      let uu____2271 = FStar_Syntax_Util.unmeta t  in
-      uu____2271.FStar_Syntax_Syntax.n  in
-    match uu____2270 with
+    let uu____2265 =
+      let uu____2266 = FStar_Syntax_Util.unmeta t  in
+      uu____2266.FStar_Syntax_Syntax.n  in
+    match uu____2265 with
     | FStar_Syntax_Syntax.Tm_fvar tc when
         FStar_Syntax_Syntax.fv_eq_lid tc FStar_Parser_Const.true_lid ->
         Trivial
-    | uu____2275 -> NonTrivial t
+    | uu____2270 -> NonTrivial t
   
 let (imp_guard_f : guard_formula -> guard_formula -> guard_formula) =
   fun g1  ->
@@ -626,9 +625,9 @@ let (binop_guard :
   fun f  ->
     fun g1  ->
       fun g2  ->
-        let uu____2318 = f g1.guard_f g2.guard_f  in
+        let uu____2313 = f g1.guard_f g2.guard_f  in
         {
-          guard_f = uu____2318;
+          guard_f = uu____2313;
           deferred = (FStar_List.append g1.deferred g2.deferred);
           univ_ineqs =
             ((FStar_List.append (FStar_Pervasives_Native.fst g1.univ_ineqs)
@@ -650,15 +649,15 @@ let (weaken_guard_formula : guard_t -> FStar_Syntax_Syntax.typ -> guard_t) =
       match g.guard_f with
       | Trivial  -> g
       | NonTrivial f ->
-          let uu___302_2388 = g  in
-          let uu____2389 =
-            let uu____2390 = FStar_Syntax_Util.mk_imp fml f  in
-            check_trivial uu____2390  in
+          let uu___302_2383 = g  in
+          let uu____2384 =
+            let uu____2385 = FStar_Syntax_Util.mk_imp fml f  in
+            check_trivial uu____2385  in
           {
-            guard_f = uu____2389;
-            deferred = (uu___302_2388.deferred);
-            univ_ineqs = (uu___302_2388.univ_ineqs);
-            implicits = (uu___302_2388.implicits)
+            guard_f = uu____2384;
+            deferred = (uu___302_2383.deferred);
+            univ_ineqs = (uu___302_2383.univ_ineqs);
+            implicits = (uu___302_2383.implicits)
           }
   
 type lcomp =
@@ -705,16 +704,16 @@ let (mk_lcomp :
     fun res_typ  ->
       fun cflags  ->
         fun comp_thunk  ->
-          let uu____2639 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk)  in
-          { eff_name; res_typ; cflags; comp_thunk = uu____2639 }
+          let uu____2634 = FStar_Util.mk_ref (FStar_Util.Inl comp_thunk)  in
+          { eff_name; res_typ; cflags; comp_thunk = uu____2634 }
   
 let (lcomp_comp : lcomp -> (FStar_Syntax_Syntax.comp * guard_t)) =
   fun lc  ->
-    let uu____2681 = FStar_ST.op_Bang lc.comp_thunk  in
-    match uu____2681 with
+    let uu____2676 = FStar_ST.op_Bang lc.comp_thunk  in
+    match uu____2676 with
     | FStar_Util.Inl thunk ->
-        let uu____2753 = thunk ()  in
-        (match uu____2753 with
+        let uu____2748 = thunk ()  in
+        (match uu____2748 with
          | (c,g) ->
              (FStar_ST.op_Colon_Equals lc.comp_thunk (FStar_Util.Inr c);
               (c, g)))
@@ -728,26 +727,26 @@ let (apply_lcomp :
     fun fg  ->
       fun lc  ->
         mk_lcomp lc.eff_name lc.res_typ lc.cflags
-          (fun uu____2853  ->
-             let uu____2854 = lcomp_comp lc  in
-             match uu____2854 with
+          (fun uu____2848  ->
+             let uu____2849 = lcomp_comp lc  in
+             match uu____2849 with
              | (c,g) ->
-                 let uu____2865 = fc c  in
-                 let uu____2866 = fg g  in (uu____2865, uu____2866))
+                 let uu____2860 = fc c  in
+                 let uu____2861 = fg g  in (uu____2860, uu____2861))
   
 let (lcomp_to_string : lcomp -> Prims.string) =
   fun lc  ->
-    let uu____2874 = FStar_Options.print_effect_args ()  in
-    if uu____2874
+    let uu____2869 = FStar_Options.print_effect_args ()  in
+    if uu____2869
     then
-      let uu____2878 =
-        let uu____2879 = FStar_All.pipe_right lc lcomp_comp  in
-        FStar_All.pipe_right uu____2879 FStar_Pervasives_Native.fst  in
-      FStar_Syntax_Print.comp_to_string uu____2878
+      let uu____2873 =
+        let uu____2874 = FStar_All.pipe_right lc lcomp_comp  in
+        FStar_All.pipe_right uu____2874 FStar_Pervasives_Native.fst  in
+      FStar_Syntax_Print.comp_to_string uu____2873
     else
-      (let uu____2894 = FStar_Syntax_Print.lid_to_string lc.eff_name  in
-       let uu____2896 = FStar_Syntax_Print.term_to_string lc.res_typ  in
-       FStar_Util.format2 "%s %s" uu____2894 uu____2896)
+      (let uu____2889 = FStar_Syntax_Print.lid_to_string lc.eff_name  in
+       let uu____2891 = FStar_Syntax_Print.term_to_string lc.res_typ  in
+       FStar_Util.format2 "%s %s" uu____2889 uu____2891)
   
 let (lcomp_set_flags :
   lcomp -> FStar_Syntax_Syntax.cflag Prims.list -> lcomp) =
@@ -755,48 +754,48 @@ let (lcomp_set_flags :
     fun fs  ->
       let comp_typ_set_flags c =
         match c.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Total uu____2924 -> c
-        | FStar_Syntax_Syntax.GTotal uu____2933 -> c
+        | FStar_Syntax_Syntax.Total uu____2919 -> c
+        | FStar_Syntax_Syntax.GTotal uu____2928 -> c
         | FStar_Syntax_Syntax.Comp ct ->
             let ct1 =
-              let uu___352_2944 = ct  in
+              let uu___352_2939 = ct  in
               {
                 FStar_Syntax_Syntax.comp_univs =
-                  (uu___352_2944.FStar_Syntax_Syntax.comp_univs);
+                  (uu___352_2939.FStar_Syntax_Syntax.comp_univs);
                 FStar_Syntax_Syntax.effect_name =
-                  (uu___352_2944.FStar_Syntax_Syntax.effect_name);
+                  (uu___352_2939.FStar_Syntax_Syntax.effect_name);
                 FStar_Syntax_Syntax.result_typ =
-                  (uu___352_2944.FStar_Syntax_Syntax.result_typ);
+                  (uu___352_2939.FStar_Syntax_Syntax.result_typ);
                 FStar_Syntax_Syntax.effect_args =
-                  (uu___352_2944.FStar_Syntax_Syntax.effect_args);
+                  (uu___352_2939.FStar_Syntax_Syntax.effect_args);
                 FStar_Syntax_Syntax.flags = fs
               }  in
-            let uu___355_2945 = c  in
+            let uu___355_2940 = c  in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos =
-                (uu___355_2945.FStar_Syntax_Syntax.pos);
+                (uu___355_2940.FStar_Syntax_Syntax.pos);
               FStar_Syntax_Syntax.vars =
-                (uu___355_2945.FStar_Syntax_Syntax.vars)
+                (uu___355_2940.FStar_Syntax_Syntax.vars)
             }
          in
       mk_lcomp lc.eff_name lc.res_typ fs
-        (fun uu____2948  ->
-           let uu____2949 = FStar_All.pipe_right lc lcomp_comp  in
-           FStar_All.pipe_right uu____2949
-             (fun uu____2971  ->
-                match uu____2971 with | (c,g) -> ((comp_typ_set_flags c), g)))
+        (fun uu____2943  ->
+           let uu____2944 = FStar_All.pipe_right lc lcomp_comp  in
+           FStar_All.pipe_right uu____2944
+             (fun uu____2966  ->
+                match uu____2966 with | (c,g) -> ((comp_typ_set_flags c), g)))
   
 let (is_total_lcomp : lcomp -> Prims.bool) =
   fun c  ->
     (FStar_Ident.lid_equals c.eff_name FStar_Parser_Const.effect_Tot_lid) ||
       (FStar_All.pipe_right c.cflags
          (FStar_Util.for_some
-            (fun uu___5_2997  ->
-               match uu___5_2997 with
+            (fun uu___5_2992  ->
+               match uu___5_2992 with
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
-               | uu____3001 -> false)))
+               | uu____2996 -> false)))
   
 let (is_tot_or_gtot_lcomp : lcomp -> Prims.bool) =
   fun c  ->
@@ -805,21 +804,21 @@ let (is_tot_or_gtot_lcomp : lcomp -> Prims.bool) =
       ||
       (FStar_All.pipe_right c.cflags
          (FStar_Util.for_some
-            (fun uu___6_3014  ->
-               match uu___6_3014 with
+            (fun uu___6_3009  ->
+               match uu___6_3009 with
                | FStar_Syntax_Syntax.TOTAL  -> true
                | FStar_Syntax_Syntax.RETURN  -> true
-               | uu____3018 -> false)))
+               | uu____3013 -> false)))
   
 let (is_lcomp_partial_return : lcomp -> Prims.bool) =
   fun c  ->
     FStar_All.pipe_right c.cflags
       (FStar_Util.for_some
-         (fun uu___7_3031  ->
-            match uu___7_3031 with
+         (fun uu___7_3026  ->
+            match uu___7_3026 with
             | FStar_Syntax_Syntax.RETURN  -> true
             | FStar_Syntax_Syntax.PARTIAL_RETURN  -> true
-            | uu____3035 -> false))
+            | uu____3030 -> false))
   
 let (is_pure_lcomp : lcomp -> Prims.bool) =
   fun lc  ->
@@ -827,10 +826,10 @@ let (is_pure_lcomp : lcomp -> Prims.bool) =
       ||
       (FStar_All.pipe_right lc.cflags
          (FStar_Util.for_some
-            (fun uu___8_3048  ->
-               match uu___8_3048 with
+            (fun uu___8_3043  ->
+               match uu___8_3043 with
                | FStar_Syntax_Syntax.LEMMA  -> true
-               | uu____3051 -> false)))
+               | uu____3046 -> false)))
   
 let (is_pure_or_ghost_lcomp : lcomp -> Prims.bool) =
   fun lc  ->
@@ -840,14 +839,14 @@ let (set_result_typ_lc : lcomp -> FStar_Syntax_Syntax.typ -> lcomp) =
   fun lc  ->
     fun t  ->
       mk_lcomp lc.eff_name t lc.cflags
-        (fun uu____3073  ->
-           let uu____3074 = FStar_All.pipe_right lc lcomp_comp  in
-           FStar_All.pipe_right uu____3074
-             (fun uu____3101  ->
-                match uu____3101 with
+        (fun uu____3068  ->
+           let uu____3069 = FStar_All.pipe_right lc lcomp_comp  in
+           FStar_All.pipe_right uu____3069
+             (fun uu____3096  ->
+                match uu____3096 with
                 | (c,g) ->
-                    let uu____3118 = FStar_Syntax_Util.set_result_typ c t  in
-                    (uu____3118, g)))
+                    let uu____3113 = FStar_Syntax_Util.set_result_typ c t  in
+                    (uu____3113, g)))
   
 let (residual_comp_of_lcomp : lcomp -> FStar_Syntax_Syntax.residual_comp) =
   fun lc  ->
@@ -860,167 +859,167 @@ let (residual_comp_of_lcomp : lcomp -> FStar_Syntax_Syntax.residual_comp) =
   
 let (lcomp_of_comp : FStar_Syntax_Syntax.comp -> lcomp) =
   fun c0  ->
-    let uu____3133 =
+    let uu____3128 =
       match c0.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____3146 ->
+      | FStar_Syntax_Syntax.Total uu____3141 ->
           (FStar_Parser_Const.effect_Tot_lid, [FStar_Syntax_Syntax.TOTAL])
-      | FStar_Syntax_Syntax.GTotal uu____3157 ->
+      | FStar_Syntax_Syntax.GTotal uu____3152 ->
           (FStar_Parser_Const.effect_GTot_lid,
             [FStar_Syntax_Syntax.SOMETRIVIAL])
       | FStar_Syntax_Syntax.Comp c ->
           ((c.FStar_Syntax_Syntax.effect_name),
             (c.FStar_Syntax_Syntax.flags))
        in
-    match uu____3133 with
+    match uu____3128 with
     | (eff_name,flags) ->
         mk_lcomp eff_name (FStar_Syntax_Util.comp_result c0) flags
-          (fun uu____3178  -> (c0, trivial_guard))
+          (fun uu____3173  -> (c0, trivial_guard))
   
 let (simplify :
   Prims.bool -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun debug  ->
     fun tm  ->
       let w t =
-        let uu___404_3204 = t  in
+        let uu___404_3199 = t  in
         {
-          FStar_Syntax_Syntax.n = (uu___404_3204.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___404_3199.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (tm.FStar_Syntax_Syntax.pos);
-          FStar_Syntax_Syntax.vars = (uu___404_3204.FStar_Syntax_Syntax.vars)
+          FStar_Syntax_Syntax.vars = (uu___404_3199.FStar_Syntax_Syntax.vars)
         }  in
       let simp_t t =
-        let uu____3216 =
-          let uu____3217 = FStar_Syntax_Util.unmeta t  in
-          uu____3217.FStar_Syntax_Syntax.n  in
-        match uu____3216 with
+        let uu____3211 =
+          let uu____3212 = FStar_Syntax_Util.unmeta t  in
+          uu____3212.FStar_Syntax_Syntax.n  in
+        match uu____3211 with
         | FStar_Syntax_Syntax.Tm_fvar fv when
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid ->
             FStar_Pervasives_Native.Some true
         | FStar_Syntax_Syntax.Tm_fvar fv when
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.false_lid ->
             FStar_Pervasives_Native.Some false
-        | uu____3229 -> FStar_Pervasives_Native.None  in
+        | uu____3224 -> FStar_Pervasives_Native.None  in
       let rec args_are_binders args bs =
         match (args, bs) with
-        | ((t,uu____3293)::args1,(bv,uu____3296)::bs1) ->
-            let uu____3350 =
-              let uu____3351 = FStar_Syntax_Subst.compress t  in
-              uu____3351.FStar_Syntax_Syntax.n  in
-            (match uu____3350 with
+        | ((t,uu____3288)::args1,(bv,uu____3291)::bs1) ->
+            let uu____3345 =
+              let uu____3346 = FStar_Syntax_Subst.compress t  in
+              uu____3346.FStar_Syntax_Syntax.n  in
+            (match uu____3345 with
              | FStar_Syntax_Syntax.Tm_name bv' ->
                  (FStar_Syntax_Syntax.bv_eq bv bv') &&
                    (args_are_binders args1 bs1)
-             | uu____3356 -> false)
+             | uu____3351 -> false)
         | ([],[]) -> true
-        | (uu____3387,uu____3388) -> false  in
+        | (uu____3382,uu____3383) -> false  in
       let is_applied bs t =
         if debug
         then
-          (let uu____3439 = FStar_Syntax_Print.term_to_string t  in
-           let uu____3441 = FStar_Syntax_Print.tag_of_term t  in
-           FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____3439
-             uu____3441)
+          (let uu____3434 = FStar_Syntax_Print.term_to_string t  in
+           let uu____3436 = FStar_Syntax_Print.tag_of_term t  in
+           FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____3434
+             uu____3436)
         else ();
-        (let uu____3446 = FStar_Syntax_Util.head_and_args' t  in
-         match uu____3446 with
+        (let uu____3441 = FStar_Syntax_Util.head_and_args' t  in
+         match uu____3441 with
          | (hd,args) ->
-             let uu____3485 =
-               let uu____3486 = FStar_Syntax_Subst.compress hd  in
-               uu____3486.FStar_Syntax_Syntax.n  in
-             (match uu____3485 with
+             let uu____3480 =
+               let uu____3481 = FStar_Syntax_Subst.compress hd  in
+               uu____3481.FStar_Syntax_Syntax.n  in
+             (match uu____3480 with
               | FStar_Syntax_Syntax.Tm_name bv when args_are_binders args bs
                   ->
                   (if debug
                    then
-                     (let uu____3494 = FStar_Syntax_Print.term_to_string t
+                     (let uu____3489 = FStar_Syntax_Print.term_to_string t
                          in
-                      let uu____3496 = FStar_Syntax_Print.bv_to_string bv  in
-                      let uu____3498 = FStar_Syntax_Print.term_to_string hd
+                      let uu____3491 = FStar_Syntax_Print.bv_to_string bv  in
+                      let uu____3493 = FStar_Syntax_Print.term_to_string hd
                          in
                       FStar_Util.print3
                         "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                        uu____3494 uu____3496 uu____3498)
+                        uu____3489 uu____3491 uu____3493)
                    else ();
                    FStar_Pervasives_Native.Some bv)
-              | uu____3503 -> FStar_Pervasives_Native.None))
+              | uu____3498 -> FStar_Pervasives_Native.None))
          in
       let is_applied_maybe_squashed bs t =
         if debug
         then
-          (let uu____3521 = FStar_Syntax_Print.term_to_string t  in
-           let uu____3523 = FStar_Syntax_Print.tag_of_term t  in
+          (let uu____3516 = FStar_Syntax_Print.term_to_string t  in
+           let uu____3518 = FStar_Syntax_Print.tag_of_term t  in
            FStar_Util.print2 "WPE> is_applied_maybe_squashed %s -- %s\n"
-             uu____3521 uu____3523)
+             uu____3516 uu____3518)
         else ();
-        (let uu____3528 = FStar_Syntax_Util.is_squash t  in
-         match uu____3528 with
-         | FStar_Pervasives_Native.Some (uu____3539,t') -> is_applied bs t'
-         | uu____3551 ->
-             let uu____3560 = FStar_Syntax_Util.is_auto_squash t  in
-             (match uu____3560 with
-              | FStar_Pervasives_Native.Some (uu____3571,t') ->
+        (let uu____3523 = FStar_Syntax_Util.is_squash t  in
+         match uu____3523 with
+         | FStar_Pervasives_Native.Some (uu____3534,t') -> is_applied bs t'
+         | uu____3546 ->
+             let uu____3555 = FStar_Syntax_Util.is_auto_squash t  in
+             (match uu____3555 with
+              | FStar_Pervasives_Native.Some (uu____3566,t') ->
                   is_applied bs t'
-              | uu____3583 -> is_applied bs t))
+              | uu____3578 -> is_applied bs t))
          in
       let is_const_match phi =
-        let uu____3604 =
-          let uu____3605 = FStar_Syntax_Subst.compress phi  in
-          uu____3605.FStar_Syntax_Syntax.n  in
-        match uu____3604 with
-        | FStar_Syntax_Syntax.Tm_match (uu____3611,br::brs) ->
-            let uu____3678 = br  in
-            (match uu____3678 with
-             | (uu____3696,uu____3697,e) ->
+        let uu____3599 =
+          let uu____3600 = FStar_Syntax_Subst.compress phi  in
+          uu____3600.FStar_Syntax_Syntax.n  in
+        match uu____3599 with
+        | FStar_Syntax_Syntax.Tm_match (uu____3606,br::brs) ->
+            let uu____3673 = br  in
+            (match uu____3673 with
+             | (uu____3691,uu____3692,e) ->
                  let r =
-                   let uu____3719 = simp_t e  in
-                   match uu____3719 with
+                   let uu____3714 = simp_t e  in
+                   match uu____3714 with
                    | FStar_Pervasives_Native.None  ->
                        FStar_Pervasives_Native.None
                    | FStar_Pervasives_Native.Some b ->
-                       let uu____3731 =
+                       let uu____3726 =
                          FStar_List.for_all
-                           (fun uu____3750  ->
-                              match uu____3750 with
-                              | (uu____3764,uu____3765,e') ->
-                                  let uu____3779 = simp_t e'  in
-                                  uu____3779 =
+                           (fun uu____3745  ->
+                              match uu____3745 with
+                              | (uu____3759,uu____3760,e') ->
+                                  let uu____3774 = simp_t e'  in
+                                  uu____3774 =
                                     (FStar_Pervasives_Native.Some b)) brs
                           in
-                       if uu____3731
+                       if uu____3726
                        then FStar_Pervasives_Native.Some b
                        else FStar_Pervasives_Native.None
                     in
                  r)
-        | uu____3795 -> FStar_Pervasives_Native.None  in
+        | uu____3790 -> FStar_Pervasives_Native.None  in
       let maybe_auto_squash t =
-        let uu____3805 = FStar_Syntax_Util.is_sub_singleton t  in
-        if uu____3805
+        let uu____3800 = FStar_Syntax_Util.is_sub_singleton t  in
+        if uu____3800
         then t
         else FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero t
          in
       let squashed_head_un_auto_squash_args t =
-        let maybe_un_auto_squash_arg uu____3843 =
-          match uu____3843 with
+        let maybe_un_auto_squash_arg uu____3836 =
+          match uu____3836 with
           | (t1,q) ->
-              let uu____3864 = FStar_Syntax_Util.is_auto_squash t1  in
-              (match uu____3864 with
+              let uu____3857 = FStar_Syntax_Util.is_auto_squash t1  in
+              (match uu____3857 with
                | FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.U_zero ,t2) -> (t2, q)
-               | uu____3896 -> (t1, q))
+               | uu____3889 -> (t1, q))
            in
-        let uu____3909 = FStar_Syntax_Util.head_and_args t  in
-        match uu____3909 with
+        let uu____3902 = FStar_Syntax_Util.head_and_args t  in
+        match uu____3902 with
         | (head,args) ->
             let args1 = FStar_List.map maybe_un_auto_squash_arg args  in
             FStar_Syntax_Syntax.mk_Tm_app head args1
-              FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+              t.FStar_Syntax_Syntax.pos
          in
       let rec clearly_inhabited ty =
-        let uu____3989 =
-          let uu____3990 = FStar_Syntax_Util.unmeta ty  in
-          uu____3990.FStar_Syntax_Syntax.n  in
-        match uu____3989 with
-        | FStar_Syntax_Syntax.Tm_uinst (t,uu____3995) -> clearly_inhabited t
-        | FStar_Syntax_Syntax.Tm_arrow (uu____4000,c) ->
+        let uu____3980 =
+          let uu____3981 = FStar_Syntax_Util.unmeta ty  in
+          uu____3981.FStar_Syntax_Syntax.n  in
+        match uu____3980 with
+        | FStar_Syntax_Syntax.Tm_uinst (t,uu____3986) -> clearly_inhabited t
+        | FStar_Syntax_Syntax.Tm_arrow (uu____3991,c) ->
             clearly_inhabited (FStar_Syntax_Util.comp_result c)
         | FStar_Syntax_Syntax.Tm_fvar fv ->
             let l = FStar_Syntax_Syntax.lid_of_fv fv  in
@@ -1028,258 +1027,258 @@ let (simplify :
                 (FStar_Ident.lid_equals l FStar_Parser_Const.bool_lid))
                || (FStar_Ident.lid_equals l FStar_Parser_Const.string_lid))
               || (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-        | uu____4024 -> false  in
+        | uu____4015 -> false  in
       let simplify arg =
-        let uu____4057 = simp_t (FStar_Pervasives_Native.fst arg)  in
-        (uu____4057, arg)  in
-      let uu____4072 =
-        let uu____4073 = FStar_Syntax_Subst.compress tm  in
-        uu____4073.FStar_Syntax_Syntax.n  in
-      match uu____4072 with
+        let uu____4048 = simp_t (FStar_Pervasives_Native.fst arg)  in
+        (uu____4048, arg)  in
+      let uu____4063 =
+        let uu____4064 = FStar_Syntax_Subst.compress tm  in
+        uu____4064.FStar_Syntax_Syntax.n  in
+      match uu____4063 with
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.pos = uu____4077;
-                  FStar_Syntax_Syntax.vars = uu____4078;_},uu____4079);
-             FStar_Syntax_Syntax.pos = uu____4080;
-             FStar_Syntax_Syntax.vars = uu____4081;_},args)
+                  FStar_Syntax_Syntax.pos = uu____4068;
+                  FStar_Syntax_Syntax.vars = uu____4069;_},uu____4070);
+             FStar_Syntax_Syntax.pos = uu____4071;
+             FStar_Syntax_Syntax.vars = uu____4072;_},args)
           ->
-          let uu____4111 =
+          let uu____4102 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid  in
-          if uu____4111
+          if uu____4102
           then
-            let uu____4114 =
+            let uu____4105 =
               FStar_All.pipe_right args (FStar_List.map simplify)  in
-            (match uu____4114 with
-             | (FStar_Pervasives_Native.Some (true ),uu____4172)::(uu____4173,
-                                                                   (arg,uu____4175))::[]
+            (match uu____4105 with
+             | (FStar_Pervasives_Native.Some (true ),uu____4163)::(uu____4164,
+                                                                   (arg,uu____4166))::[]
                  -> maybe_auto_squash arg
-             | (uu____4248,(arg,uu____4250))::(FStar_Pervasives_Native.Some
-                                               (true ),uu____4251)::[]
+             | (uu____4239,(arg,uu____4241))::(FStar_Pervasives_Native.Some
+                                               (true ),uu____4242)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false ),uu____4324)::uu____4325::[]
+             | (FStar_Pervasives_Native.Some (false ),uu____4315)::uu____4316::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____4395::(FStar_Pervasives_Native.Some (false ),uu____4396)::[]
+             | uu____4386::(FStar_Pervasives_Native.Some (false ),uu____4387)::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____4466 -> squashed_head_un_auto_squash_args tm)
+             | uu____4457 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu____4484 =
+            (let uu____4475 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid  in
-             if uu____4484
+             if uu____4475
              then
-               let uu____4487 =
+               let uu____4478 =
                  FStar_All.pipe_right args (FStar_List.map simplify)  in
-               match uu____4487 with
-               | (FStar_Pervasives_Native.Some (true ),uu____4545)::uu____4546::[]
+               match uu____4478 with
+               | (FStar_Pervasives_Native.Some (true ),uu____4536)::uu____4537::[]
                    -> w FStar_Syntax_Util.t_true
-               | uu____4616::(FStar_Pervasives_Native.Some (true
-                              ),uu____4617)::[]
+               | uu____4607::(FStar_Pervasives_Native.Some (true
+                              ),uu____4608)::[]
                    -> w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false ),uu____4687)::
-                   (uu____4688,(arg,uu____4690))::[] -> maybe_auto_squash arg
-               | (uu____4763,(arg,uu____4765))::(FStar_Pervasives_Native.Some
-                                                 (false ),uu____4766)::[]
+               | (FStar_Pervasives_Native.Some (false ),uu____4678)::
+                   (uu____4679,(arg,uu____4681))::[] -> maybe_auto_squash arg
+               | (uu____4754,(arg,uu____4756))::(FStar_Pervasives_Native.Some
+                                                 (false ),uu____4757)::[]
                    -> maybe_auto_squash arg
-               | uu____4839 -> squashed_head_un_auto_squash_args tm
+               | uu____4830 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu____4857 =
+               (let uu____4848 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid
                    in
-                if uu____4857
+                if uu____4848
                 then
-                  let uu____4860 =
+                  let uu____4851 =
                     FStar_All.pipe_right args (FStar_List.map simplify)  in
-                  match uu____4860 with
-                  | uu____4918::(FStar_Pervasives_Native.Some (true
-                                 ),uu____4919)::[]
+                  match uu____4851 with
+                  | uu____4909::(FStar_Pervasives_Native.Some (true
+                                 ),uu____4910)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false ),uu____4989)::uu____4990::[]
+                  | (FStar_Pervasives_Native.Some (false ),uu____4980)::uu____4981::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true ),uu____5060)::
-                      (uu____5061,(arg,uu____5063))::[] ->
+                  | (FStar_Pervasives_Native.Some (true ),uu____5051)::
+                      (uu____5052,(arg,uu____5054))::[] ->
                       maybe_auto_squash arg
-                  | (uu____5136,(p,uu____5138))::(uu____5139,(q,uu____5141))::[]
+                  | (uu____5127,(p,uu____5129))::(uu____5130,(q,uu____5132))::[]
                       ->
-                      let uu____5213 = FStar_Syntax_Util.term_eq p q  in
-                      (if uu____5213
+                      let uu____5204 = FStar_Syntax_Util.term_eq p q  in
+                      (if uu____5204
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu____5218 -> squashed_head_un_auto_squash_args tm
+                  | uu____5209 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu____5236 =
+                  (let uu____5227 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid
                       in
-                   if uu____5236
+                   if uu____5227
                    then
-                     let uu____5239 =
+                     let uu____5230 =
                        FStar_All.pipe_right args (FStar_List.map simplify)
                         in
-                     match uu____5239 with
-                     | (FStar_Pervasives_Native.Some (true ),uu____5297)::
-                         (FStar_Pervasives_Native.Some (true ),uu____5298)::[]
+                     match uu____5230 with
+                     | (FStar_Pervasives_Native.Some (true ),uu____5288)::
+                         (FStar_Pervasives_Native.Some (true ),uu____5289)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false ),uu____5372)::
-                         (FStar_Pervasives_Native.Some (false ),uu____5373)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____5363)::
+                         (FStar_Pervasives_Native.Some (false ),uu____5364)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true ),uu____5447)::
-                         (FStar_Pervasives_Native.Some (false ),uu____5448)::[]
+                     | (FStar_Pervasives_Native.Some (true ),uu____5438)::
+                         (FStar_Pervasives_Native.Some (false ),uu____5439)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false ),uu____5522)::
-                         (FStar_Pervasives_Native.Some (true ),uu____5523)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____5513)::
+                         (FStar_Pervasives_Native.Some (true ),uu____5514)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu____5597,(arg,uu____5599))::(FStar_Pervasives_Native.Some
-                                                       (true ),uu____5600)::[]
+                     | (uu____5588,(arg,uu____5590))::(FStar_Pervasives_Native.Some
+                                                       (true ),uu____5591)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true ),uu____5673)::
-                         (uu____5674,(arg,uu____5676))::[] ->
+                     | (FStar_Pervasives_Native.Some (true ),uu____5664)::
+                         (uu____5665,(arg,uu____5667))::[] ->
                          maybe_auto_squash arg
-                     | (uu____5749,(arg,uu____5751))::(FStar_Pervasives_Native.Some
-                                                       (false ),uu____5752)::[]
+                     | (uu____5740,(arg,uu____5742))::(FStar_Pervasives_Native.Some
+                                                       (false ),uu____5743)::[]
                          ->
-                         let uu____5825 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____5825
-                     | (FStar_Pervasives_Native.Some (false ),uu____5826)::
-                         (uu____5827,(arg,uu____5829))::[] ->
-                         let uu____5902 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____5902
-                     | (uu____5903,(p,uu____5905))::(uu____5906,(q,uu____5908))::[]
+                         let uu____5816 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____5816
+                     | (FStar_Pervasives_Native.Some (false ),uu____5817)::
+                         (uu____5818,(arg,uu____5820))::[] ->
+                         let uu____5893 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____5893
+                     | (uu____5894,(p,uu____5896))::(uu____5897,(q,uu____5899))::[]
                          ->
-                         let uu____5980 = FStar_Syntax_Util.term_eq p q  in
-                         (if uu____5980
+                         let uu____5971 = FStar_Syntax_Util.term_eq p q  in
+                         (if uu____5971
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu____5985 -> squashed_head_un_auto_squash_args tm
+                     | uu____5976 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu____6003 =
+                     (let uu____5994 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid
                          in
-                      if uu____6003
+                      if uu____5994
                       then
-                        let uu____6006 =
+                        let uu____5997 =
                           FStar_All.pipe_right args (FStar_List.map simplify)
                            in
-                        match uu____6006 with
-                        | (FStar_Pervasives_Native.Some (true ),uu____6064)::[]
+                        match uu____5997 with
+                        | (FStar_Pervasives_Native.Some (true ),uu____6055)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false ),uu____6108)::[]
+                        | (FStar_Pervasives_Native.Some (false ),uu____6099)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu____6152 -> squashed_head_un_auto_squash_args tm
+                        | uu____6143 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu____6170 =
+                        (let uu____6161 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid
                             in
-                         if uu____6170
+                         if uu____6161
                          then
                            match args with
-                           | (t,uu____6174)::[] ->
-                               let uu____6199 =
-                                 let uu____6200 =
+                           | (t,uu____6165)::[] ->
+                               let uu____6190 =
+                                 let uu____6191 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____6200.FStar_Syntax_Syntax.n  in
-                               (match uu____6199 with
+                                 uu____6191.FStar_Syntax_Syntax.n  in
+                               (match uu____6190 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____6203::[],body,uu____6205) ->
-                                    let uu____6240 = simp_t body  in
-                                    (match uu____6240 with
+                                    (uu____6194::[],body,uu____6196) ->
+                                    let uu____6231 = simp_t body  in
+                                    (match uu____6231 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
-                                     | uu____6246 -> tm)
-                                | uu____6250 -> tm)
+                                     | uu____6237 -> tm)
+                                | uu____6241 -> tm)
                            | (ty,FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____6252))::
-                               (t,uu____6254)::[] ->
-                               let uu____6294 =
-                                 let uu____6295 =
+                              (FStar_Syntax_Syntax.Implicit uu____6243))::
+                               (t,uu____6245)::[] ->
+                               let uu____6285 =
+                                 let uu____6286 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____6295.FStar_Syntax_Syntax.n  in
-                               (match uu____6294 with
+                                 uu____6286.FStar_Syntax_Syntax.n  in
+                               (match uu____6285 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____6298::[],body,uu____6300) ->
-                                    let uu____6335 = simp_t body  in
-                                    (match uu____6335 with
+                                    (uu____6289::[],body,uu____6291) ->
+                                    let uu____6326 = simp_t body  in
+                                    (match uu____6326 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false )
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu____6343 -> tm)
-                                | uu____6347 -> tm)
-                           | uu____6348 -> tm
+                                     | uu____6334 -> tm)
+                                | uu____6338 -> tm)
+                           | uu____6339 -> tm
                          else
-                           (let uu____6361 =
+                           (let uu____6352 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid
                                in
-                            if uu____6361
+                            if uu____6352
                             then
                               match args with
-                              | (t,uu____6365)::[] ->
-                                  let uu____6390 =
-                                    let uu____6391 =
+                              | (t,uu____6356)::[] ->
+                                  let uu____6381 =
+                                    let uu____6382 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____6391.FStar_Syntax_Syntax.n  in
-                                  (match uu____6390 with
+                                    uu____6382.FStar_Syntax_Syntax.n  in
+                                  (match uu____6381 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____6394::[],body,uu____6396) ->
-                                       let uu____6431 = simp_t body  in
-                                       (match uu____6431 with
+                                       (uu____6385::[],body,uu____6387) ->
+                                       let uu____6422 = simp_t body  in
+                                       (match uu____6422 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
-                                        | uu____6437 -> tm)
-                                   | uu____6441 -> tm)
+                                        | uu____6428 -> tm)
+                                   | uu____6432 -> tm)
                               | (ty,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____6443))::
-                                  (t,uu____6445)::[] ->
-                                  let uu____6485 =
-                                    let uu____6486 =
+                                 (FStar_Syntax_Syntax.Implicit uu____6434))::
+                                  (t,uu____6436)::[] ->
+                                  let uu____6476 =
+                                    let uu____6477 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____6486.FStar_Syntax_Syntax.n  in
-                                  (match uu____6485 with
+                                    uu____6477.FStar_Syntax_Syntax.n  in
+                                  (match uu____6476 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____6489::[],body,uu____6491) ->
-                                       let uu____6526 = simp_t body  in
-                                       (match uu____6526 with
+                                       (uu____6480::[],body,uu____6482) ->
+                                       let uu____6517 = simp_t body  in
+                                       (match uu____6517 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true
                                             ) when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu____6534 -> tm)
-                                   | uu____6538 -> tm)
-                              | uu____6539 -> tm
+                                        | uu____6525 -> tm)
+                                   | uu____6529 -> tm)
+                              | uu____6530 -> tm
                             else
-                              (let uu____6552 =
+                              (let uu____6543 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid
                                   in
-                               if uu____6552
+                               if uu____6543
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true ));
-                                      FStar_Syntax_Syntax.pos = uu____6555;
-                                      FStar_Syntax_Syntax.vars = uu____6556;_},uu____6557)::[]
+                                      FStar_Syntax_Syntax.pos = uu____6546;
+                                      FStar_Syntax_Syntax.vars = uu____6547;_},uu____6548)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false ));
-                                      FStar_Syntax_Syntax.pos = uu____6583;
-                                      FStar_Syntax_Syntax.vars = uu____6584;_},uu____6585)::[]
+                                      FStar_Syntax_Syntax.pos = uu____6574;
+                                      FStar_Syntax_Syntax.vars = uu____6575;_},uu____6576)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | uu____6611 -> tm
+                                 | uu____6602 -> tm
                                else
-                                 (let uu____6624 =
+                                 (let uu____6615 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid
                                      in
-                                  if uu____6624
+                                  if uu____6615
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1287,11 +1286,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid]  in
-                                      let uu____6638 =
-                                        let uu____6639 =
+                                      let uu____6629 =
+                                        let uu____6630 =
                                           FStar_Syntax_Subst.compress t  in
-                                        uu____6639.FStar_Syntax_Syntax.n  in
-                                      match uu____6638 with
+                                        uu____6630.FStar_Syntax_Syntax.n  in
+                                      match uu____6629 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_All.pipe_right haseq_lids
                                             (FStar_List.existsb
@@ -1299,129 +1298,129 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu____6650 -> false  in
+                                      | uu____6641 -> false  in
                                     (if
                                        (FStar_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu____6664 =
+                                         let uu____6655 =
                                            FStar_All.pipe_right args
                                              FStar_List.hd
                                             in
-                                         FStar_All.pipe_right uu____6664
+                                         FStar_All.pipe_right uu____6655
                                            FStar_Pervasives_Native.fst
                                           in
-                                       let uu____6703 =
+                                       let uu____6694 =
                                          FStar_All.pipe_right t
                                            t_has_eq_for_sure
                                           in
-                                       (if uu____6703
+                                       (if uu____6694
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu____6709 =
-                                             let uu____6710 =
+                                          (let uu____6700 =
+                                             let uu____6701 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____6710.FStar_Syntax_Syntax.n
+                                             uu____6701.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____6709 with
+                                           match uu____6700 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu____6713 ->
+                                               uu____6704 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t
                                                   in
-                                               let uu____6721 =
+                                               let uu____6712 =
                                                  FStar_All.pipe_right t1
                                                    t_has_eq_for_sure
                                                   in
-                                               if uu____6721
+                                               if uu____6712
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu____6730 =
-                                                      let uu____6731 =
+                                                    let uu____6721 =
+                                                      let uu____6722 =
                                                         FStar_Syntax_Subst.compress
                                                           tm
                                                          in
-                                                      uu____6731.FStar_Syntax_Syntax.n
+                                                      uu____6722.FStar_Syntax_Syntax.n
                                                        in
-                                                    match uu____6730 with
+                                                    match uu____6721 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd,uu____6737) -> hd
-                                                    | uu____6762 ->
+                                                        (hd,uu____6728) -> hd
+                                                    | uu____6753 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app"
                                                      in
-                                                  let uu____6766 =
-                                                    let uu____6777 =
+                                                  let uu____6757 =
+                                                    let uu____6768 =
                                                       FStar_All.pipe_right t1
                                                         FStar_Syntax_Syntax.as_arg
                                                        in
-                                                    [uu____6777]  in
+                                                    [uu____6768]  in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu____6766)
-                                           | uu____6810 -> tm))
+                                                    haseq_tm uu____6757)
+                                           | uu____6801 -> tm))
                                      else tm)
                                   else
-                                    (let uu____6815 =
+                                    (let uu____6806 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid
                                         in
-                                     if uu____6815
+                                     if uu____6806
                                      then
                                        match args with
-                                       | (_typ,uu____6819)::(a1,uu____6821)::
-                                           (a2,uu____6823)::[] ->
-                                           let uu____6880 =
+                                       | (_typ,uu____6810)::(a1,uu____6812)::
+                                           (a2,uu____6814)::[] ->
+                                           let uu____6871 =
                                              FStar_Syntax_Util.eq_tm a1 a2
                                               in
-                                           (match uu____6880 with
+                                           (match uu____6871 with
                                             | FStar_Syntax_Util.Equal  ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual  ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu____6881 -> tm)
-                                       | uu____6882 -> tm
+                                            | uu____6872 -> tm)
+                                       | uu____6873 -> tm
                                      else
-                                       (let uu____6895 =
+                                       (let uu____6886 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.eq3_lid
                                            in
-                                        if uu____6895
+                                        if uu____6886
                                         then
                                           match args with
-                                          | (t1,uu____6899)::(t2,uu____6901)::
-                                              (a1,uu____6903)::(a2,uu____6905)::[]
+                                          | (t1,uu____6890)::(t2,uu____6892)::
+                                              (a1,uu____6894)::(a2,uu____6896)::[]
                                               ->
-                                              let uu____6978 =
-                                                let uu____6979 =
+                                              let uu____6969 =
+                                                let uu____6970 =
                                                   FStar_Syntax_Util.eq_tm t1
                                                     t2
                                                    in
-                                                let uu____6980 =
+                                                let uu____6971 =
                                                   FStar_Syntax_Util.eq_tm a1
                                                     a2
                                                    in
                                                 FStar_Syntax_Util.eq_inj
-                                                  uu____6979 uu____6980
+                                                  uu____6970 uu____6971
                                                  in
-                                              (match uu____6978 with
+                                              (match uu____6969 with
                                                | FStar_Syntax_Util.Equal  ->
                                                    w FStar_Syntax_Util.t_true
                                                | FStar_Syntax_Util.NotEqual 
                                                    ->
                                                    w
                                                      FStar_Syntax_Util.t_false
-                                               | uu____6981 -> tm)
-                                          | uu____6982 -> tm
+                                               | uu____6972 -> tm)
+                                          | uu____6973 -> tm
                                         else
-                                          (let uu____6995 =
+                                          (let uu____6986 =
                                              FStar_Syntax_Util.is_auto_squash
                                                tm
                                               in
-                                           match uu____6995 with
+                                           match uu____6986 with
                                            | FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Syntax.U_zero
                                                 ,t)
@@ -1429,247 +1428,247 @@ let (simplify :
                                                FStar_Syntax_Util.is_sub_singleton
                                                  t
                                                -> t
-                                           | uu____7015 -> tm)))))))))))
+                                           | uu____7006 -> tm)))))))))))
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____7025;
-             FStar_Syntax_Syntax.vars = uu____7026;_},args)
+             FStar_Syntax_Syntax.pos = uu____7016;
+             FStar_Syntax_Syntax.vars = uu____7017;_},args)
           ->
-          let uu____7052 =
+          let uu____7043 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid  in
-          if uu____7052
+          if uu____7043
           then
-            let uu____7055 =
+            let uu____7046 =
               FStar_All.pipe_right args (FStar_List.map simplify)  in
-            (match uu____7055 with
-             | (FStar_Pervasives_Native.Some (true ),uu____7113)::(uu____7114,
-                                                                   (arg,uu____7116))::[]
+            (match uu____7046 with
+             | (FStar_Pervasives_Native.Some (true ),uu____7104)::(uu____7105,
+                                                                   (arg,uu____7107))::[]
                  -> maybe_auto_squash arg
-             | (uu____7189,(arg,uu____7191))::(FStar_Pervasives_Native.Some
-                                               (true ),uu____7192)::[]
+             | (uu____7180,(arg,uu____7182))::(FStar_Pervasives_Native.Some
+                                               (true ),uu____7183)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false ),uu____7265)::uu____7266::[]
+             | (FStar_Pervasives_Native.Some (false ),uu____7256)::uu____7257::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____7336::(FStar_Pervasives_Native.Some (false ),uu____7337)::[]
+             | uu____7327::(FStar_Pervasives_Native.Some (false ),uu____7328)::[]
                  -> w FStar_Syntax_Util.t_false
-             | uu____7407 -> squashed_head_un_auto_squash_args tm)
+             | uu____7398 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu____7425 =
+            (let uu____7416 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid  in
-             if uu____7425
+             if uu____7416
              then
-               let uu____7428 =
+               let uu____7419 =
                  FStar_All.pipe_right args (FStar_List.map simplify)  in
-               match uu____7428 with
-               | (FStar_Pervasives_Native.Some (true ),uu____7486)::uu____7487::[]
+               match uu____7419 with
+               | (FStar_Pervasives_Native.Some (true ),uu____7477)::uu____7478::[]
                    -> w FStar_Syntax_Util.t_true
-               | uu____7557::(FStar_Pervasives_Native.Some (true
-                              ),uu____7558)::[]
+               | uu____7548::(FStar_Pervasives_Native.Some (true
+                              ),uu____7549)::[]
                    -> w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false ),uu____7628)::
-                   (uu____7629,(arg,uu____7631))::[] -> maybe_auto_squash arg
-               | (uu____7704,(arg,uu____7706))::(FStar_Pervasives_Native.Some
-                                                 (false ),uu____7707)::[]
+               | (FStar_Pervasives_Native.Some (false ),uu____7619)::
+                   (uu____7620,(arg,uu____7622))::[] -> maybe_auto_squash arg
+               | (uu____7695,(arg,uu____7697))::(FStar_Pervasives_Native.Some
+                                                 (false ),uu____7698)::[]
                    -> maybe_auto_squash arg
-               | uu____7780 -> squashed_head_un_auto_squash_args tm
+               | uu____7771 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu____7798 =
+               (let uu____7789 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid
                    in
-                if uu____7798
+                if uu____7789
                 then
-                  let uu____7801 =
+                  let uu____7792 =
                     FStar_All.pipe_right args (FStar_List.map simplify)  in
-                  match uu____7801 with
-                  | uu____7859::(FStar_Pervasives_Native.Some (true
-                                 ),uu____7860)::[]
+                  match uu____7792 with
+                  | uu____7850::(FStar_Pervasives_Native.Some (true
+                                 ),uu____7851)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false ),uu____7930)::uu____7931::[]
+                  | (FStar_Pervasives_Native.Some (false ),uu____7921)::uu____7922::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true ),uu____8001)::
-                      (uu____8002,(arg,uu____8004))::[] ->
+                  | (FStar_Pervasives_Native.Some (true ),uu____7992)::
+                      (uu____7993,(arg,uu____7995))::[] ->
                       maybe_auto_squash arg
-                  | (uu____8077,(p,uu____8079))::(uu____8080,(q,uu____8082))::[]
+                  | (uu____8068,(p,uu____8070))::(uu____8071,(q,uu____8073))::[]
                       ->
-                      let uu____8154 = FStar_Syntax_Util.term_eq p q  in
-                      (if uu____8154
+                      let uu____8145 = FStar_Syntax_Util.term_eq p q  in
+                      (if uu____8145
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu____8159 -> squashed_head_un_auto_squash_args tm
+                  | uu____8150 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu____8177 =
+                  (let uu____8168 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid
                       in
-                   if uu____8177
+                   if uu____8168
                    then
-                     let uu____8180 =
+                     let uu____8171 =
                        FStar_All.pipe_right args (FStar_List.map simplify)
                         in
-                     match uu____8180 with
-                     | (FStar_Pervasives_Native.Some (true ),uu____8238)::
-                         (FStar_Pervasives_Native.Some (true ),uu____8239)::[]
+                     match uu____8171 with
+                     | (FStar_Pervasives_Native.Some (true ),uu____8229)::
+                         (FStar_Pervasives_Native.Some (true ),uu____8230)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false ),uu____8313)::
-                         (FStar_Pervasives_Native.Some (false ),uu____8314)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____8304)::
+                         (FStar_Pervasives_Native.Some (false ),uu____8305)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true ),uu____8388)::
-                         (FStar_Pervasives_Native.Some (false ),uu____8389)::[]
+                     | (FStar_Pervasives_Native.Some (true ),uu____8379)::
+                         (FStar_Pervasives_Native.Some (false ),uu____8380)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false ),uu____8463)::
-                         (FStar_Pervasives_Native.Some (true ),uu____8464)::[]
+                     | (FStar_Pervasives_Native.Some (false ),uu____8454)::
+                         (FStar_Pervasives_Native.Some (true ),uu____8455)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu____8538,(arg,uu____8540))::(FStar_Pervasives_Native.Some
-                                                       (true ),uu____8541)::[]
+                     | (uu____8529,(arg,uu____8531))::(FStar_Pervasives_Native.Some
+                                                       (true ),uu____8532)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true ),uu____8614)::
-                         (uu____8615,(arg,uu____8617))::[] ->
+                     | (FStar_Pervasives_Native.Some (true ),uu____8605)::
+                         (uu____8606,(arg,uu____8608))::[] ->
                          maybe_auto_squash arg
-                     | (uu____8690,(arg,uu____8692))::(FStar_Pervasives_Native.Some
-                                                       (false ),uu____8693)::[]
+                     | (uu____8681,(arg,uu____8683))::(FStar_Pervasives_Native.Some
+                                                       (false ),uu____8684)::[]
                          ->
-                         let uu____8766 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____8766
-                     | (FStar_Pervasives_Native.Some (false ),uu____8767)::
-                         (uu____8768,(arg,uu____8770))::[] ->
-                         let uu____8843 = FStar_Syntax_Util.mk_neg arg  in
-                         maybe_auto_squash uu____8843
-                     | (uu____8844,(p,uu____8846))::(uu____8847,(q,uu____8849))::[]
+                         let uu____8757 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____8757
+                     | (FStar_Pervasives_Native.Some (false ),uu____8758)::
+                         (uu____8759,(arg,uu____8761))::[] ->
+                         let uu____8834 = FStar_Syntax_Util.mk_neg arg  in
+                         maybe_auto_squash uu____8834
+                     | (uu____8835,(p,uu____8837))::(uu____8838,(q,uu____8840))::[]
                          ->
-                         let uu____8921 = FStar_Syntax_Util.term_eq p q  in
-                         (if uu____8921
+                         let uu____8912 = FStar_Syntax_Util.term_eq p q  in
+                         (if uu____8912
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu____8926 -> squashed_head_un_auto_squash_args tm
+                     | uu____8917 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu____8944 =
+                     (let uu____8935 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid
                          in
-                      if uu____8944
+                      if uu____8935
                       then
-                        let uu____8947 =
+                        let uu____8938 =
                           FStar_All.pipe_right args (FStar_List.map simplify)
                            in
-                        match uu____8947 with
-                        | (FStar_Pervasives_Native.Some (true ),uu____9005)::[]
+                        match uu____8938 with
+                        | (FStar_Pervasives_Native.Some (true ),uu____8996)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false ),uu____9049)::[]
+                        | (FStar_Pervasives_Native.Some (false ),uu____9040)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu____9093 -> squashed_head_un_auto_squash_args tm
+                        | uu____9084 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu____9111 =
+                        (let uu____9102 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid
                             in
-                         if uu____9111
+                         if uu____9102
                          then
                            match args with
-                           | (t,uu____9115)::[] ->
-                               let uu____9140 =
-                                 let uu____9141 =
+                           | (t,uu____9106)::[] ->
+                               let uu____9131 =
+                                 let uu____9132 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____9141.FStar_Syntax_Syntax.n  in
-                               (match uu____9140 with
+                                 uu____9132.FStar_Syntax_Syntax.n  in
+                               (match uu____9131 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____9144::[],body,uu____9146) ->
-                                    let uu____9181 = simp_t body  in
-                                    (match uu____9181 with
+                                    (uu____9135::[],body,uu____9137) ->
+                                    let uu____9172 = simp_t body  in
+                                    (match uu____9172 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
-                                     | uu____9187 -> tm)
-                                | uu____9191 -> tm)
+                                     | uu____9178 -> tm)
+                                | uu____9182 -> tm)
                            | (ty,FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____9193))::
-                               (t,uu____9195)::[] ->
-                               let uu____9235 =
-                                 let uu____9236 =
+                              (FStar_Syntax_Syntax.Implicit uu____9184))::
+                               (t,uu____9186)::[] ->
+                               let uu____9226 =
+                                 let uu____9227 =
                                    FStar_Syntax_Subst.compress t  in
-                                 uu____9236.FStar_Syntax_Syntax.n  in
-                               (match uu____9235 with
+                                 uu____9227.FStar_Syntax_Syntax.n  in
+                               (match uu____9226 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu____9239::[],body,uu____9241) ->
-                                    let uu____9276 = simp_t body  in
-                                    (match uu____9276 with
+                                    (uu____9230::[],body,uu____9232) ->
+                                    let uu____9267 = simp_t body  in
+                                    (match uu____9267 with
                                      | FStar_Pervasives_Native.Some (true )
                                          -> w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false )
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu____9284 -> tm)
-                                | uu____9288 -> tm)
-                           | uu____9289 -> tm
+                                     | uu____9275 -> tm)
+                                | uu____9279 -> tm)
+                           | uu____9280 -> tm
                          else
-                           (let uu____9302 =
+                           (let uu____9293 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid
                                in
-                            if uu____9302
+                            if uu____9293
                             then
                               match args with
-                              | (t,uu____9306)::[] ->
-                                  let uu____9331 =
-                                    let uu____9332 =
+                              | (t,uu____9297)::[] ->
+                                  let uu____9322 =
+                                    let uu____9323 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____9332.FStar_Syntax_Syntax.n  in
-                                  (match uu____9331 with
+                                    uu____9323.FStar_Syntax_Syntax.n  in
+                                  (match uu____9322 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____9335::[],body,uu____9337) ->
-                                       let uu____9372 = simp_t body  in
-                                       (match uu____9372 with
+                                       (uu____9326::[],body,uu____9328) ->
+                                       let uu____9363 = simp_t body  in
+                                       (match uu____9363 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
-                                        | uu____9378 -> tm)
-                                   | uu____9382 -> tm)
+                                        | uu____9369 -> tm)
+                                   | uu____9373 -> tm)
                               | (ty,FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Implicit uu____9384))::
-                                  (t,uu____9386)::[] ->
-                                  let uu____9426 =
-                                    let uu____9427 =
+                                 (FStar_Syntax_Syntax.Implicit uu____9375))::
+                                  (t,uu____9377)::[] ->
+                                  let uu____9417 =
+                                    let uu____9418 =
                                       FStar_Syntax_Subst.compress t  in
-                                    uu____9427.FStar_Syntax_Syntax.n  in
-                                  (match uu____9426 with
+                                    uu____9418.FStar_Syntax_Syntax.n  in
+                                  (match uu____9417 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu____9430::[],body,uu____9432) ->
-                                       let uu____9467 = simp_t body  in
-                                       (match uu____9467 with
+                                       (uu____9421::[],body,uu____9423) ->
+                                       let uu____9458 = simp_t body  in
+                                       (match uu____9458 with
                                         | FStar_Pervasives_Native.Some (false
                                             ) -> w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true
                                             ) when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu____9475 -> tm)
-                                   | uu____9479 -> tm)
-                              | uu____9480 -> tm
+                                        | uu____9466 -> tm)
+                                   | uu____9470 -> tm)
+                              | uu____9471 -> tm
                             else
-                              (let uu____9493 =
+                              (let uu____9484 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid
                                   in
-                               if uu____9493
+                               if uu____9484
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true ));
-                                      FStar_Syntax_Syntax.pos = uu____9496;
-                                      FStar_Syntax_Syntax.vars = uu____9497;_},uu____9498)::[]
+                                      FStar_Syntax_Syntax.pos = uu____9487;
+                                      FStar_Syntax_Syntax.vars = uu____9488;_},uu____9489)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false ));
-                                      FStar_Syntax_Syntax.pos = uu____9524;
-                                      FStar_Syntax_Syntax.vars = uu____9525;_},uu____9526)::[]
+                                      FStar_Syntax_Syntax.pos = uu____9515;
+                                      FStar_Syntax_Syntax.vars = uu____9516;_},uu____9517)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | uu____9552 -> tm
+                                 | uu____9543 -> tm
                                else
-                                 (let uu____9565 =
+                                 (let uu____9556 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid
                                      in
-                                  if uu____9565
+                                  if uu____9556
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1677,11 +1676,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid]  in
-                                      let uu____9579 =
-                                        let uu____9580 =
+                                      let uu____9570 =
+                                        let uu____9571 =
                                           FStar_Syntax_Subst.compress t  in
-                                        uu____9580.FStar_Syntax_Syntax.n  in
-                                      match uu____9579 with
+                                        uu____9571.FStar_Syntax_Syntax.n  in
+                                      match uu____9570 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_All.pipe_right haseq_lids
                                             (FStar_List.existsb
@@ -1689,129 +1688,129 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu____9591 -> false  in
+                                      | uu____9582 -> false  in
                                     (if
                                        (FStar_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu____9605 =
+                                         let uu____9596 =
                                            FStar_All.pipe_right args
                                              FStar_List.hd
                                             in
-                                         FStar_All.pipe_right uu____9605
+                                         FStar_All.pipe_right uu____9596
                                            FStar_Pervasives_Native.fst
                                           in
-                                       let uu____9640 =
+                                       let uu____9631 =
                                          FStar_All.pipe_right t
                                            t_has_eq_for_sure
                                           in
-                                       (if uu____9640
+                                       (if uu____9631
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu____9646 =
-                                             let uu____9647 =
+                                          (let uu____9637 =
+                                             let uu____9638 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____9647.FStar_Syntax_Syntax.n
+                                             uu____9638.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____9646 with
+                                           match uu____9637 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu____9650 ->
+                                               uu____9641 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t
                                                   in
-                                               let uu____9658 =
+                                               let uu____9649 =
                                                  FStar_All.pipe_right t1
                                                    t_has_eq_for_sure
                                                   in
-                                               if uu____9658
+                                               if uu____9649
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu____9667 =
-                                                      let uu____9668 =
+                                                    let uu____9658 =
+                                                      let uu____9659 =
                                                         FStar_Syntax_Subst.compress
                                                           tm
                                                          in
-                                                      uu____9668.FStar_Syntax_Syntax.n
+                                                      uu____9659.FStar_Syntax_Syntax.n
                                                        in
-                                                    match uu____9667 with
+                                                    match uu____9658 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd,uu____9674) -> hd
-                                                    | uu____9699 ->
+                                                        (hd,uu____9665) -> hd
+                                                    | uu____9690 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app"
                                                      in
-                                                  let uu____9703 =
-                                                    let uu____9714 =
+                                                  let uu____9694 =
+                                                    let uu____9705 =
                                                       FStar_All.pipe_right t1
                                                         FStar_Syntax_Syntax.as_arg
                                                        in
-                                                    [uu____9714]  in
+                                                    [uu____9705]  in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu____9703)
-                                           | uu____9747 -> tm))
+                                                    haseq_tm uu____9694)
+                                           | uu____9738 -> tm))
                                      else tm)
                                   else
-                                    (let uu____9752 =
+                                    (let uu____9743 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid
                                         in
-                                     if uu____9752
+                                     if uu____9743
                                      then
                                        match args with
-                                       | (_typ,uu____9756)::(a1,uu____9758)::
-                                           (a2,uu____9760)::[] ->
-                                           let uu____9817 =
+                                       | (_typ,uu____9747)::(a1,uu____9749)::
+                                           (a2,uu____9751)::[] ->
+                                           let uu____9808 =
                                              FStar_Syntax_Util.eq_tm a1 a2
                                               in
-                                           (match uu____9817 with
+                                           (match uu____9808 with
                                             | FStar_Syntax_Util.Equal  ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual  ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu____9818 -> tm)
-                                       | uu____9819 -> tm
+                                            | uu____9809 -> tm)
+                                       | uu____9810 -> tm
                                      else
-                                       (let uu____9832 =
+                                       (let uu____9823 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.eq3_lid
                                            in
-                                        if uu____9832
+                                        if uu____9823
                                         then
                                           match args with
-                                          | (t1,uu____9836)::(t2,uu____9838)::
-                                              (a1,uu____9840)::(a2,uu____9842)::[]
+                                          | (t1,uu____9827)::(t2,uu____9829)::
+                                              (a1,uu____9831)::(a2,uu____9833)::[]
                                               ->
-                                              let uu____9915 =
-                                                let uu____9916 =
+                                              let uu____9906 =
+                                                let uu____9907 =
                                                   FStar_Syntax_Util.eq_tm t1
                                                     t2
                                                    in
-                                                let uu____9917 =
+                                                let uu____9908 =
                                                   FStar_Syntax_Util.eq_tm a1
                                                     a2
                                                    in
                                                 FStar_Syntax_Util.eq_inj
-                                                  uu____9916 uu____9917
+                                                  uu____9907 uu____9908
                                                  in
-                                              (match uu____9915 with
+                                              (match uu____9906 with
                                                | FStar_Syntax_Util.Equal  ->
                                                    w FStar_Syntax_Util.t_true
                                                | FStar_Syntax_Util.NotEqual 
                                                    ->
                                                    w
                                                      FStar_Syntax_Util.t_false
-                                               | uu____9918 -> tm)
-                                          | uu____9919 -> tm
+                                               | uu____9909 -> tm)
+                                          | uu____9910 -> tm
                                         else
-                                          (let uu____9932 =
+                                          (let uu____9923 =
                                              FStar_Syntax_Util.is_auto_squash
                                                tm
                                               in
-                                           match uu____9932 with
+                                           match uu____9923 with
                                            | FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Syntax.U_zero
                                                 ,t)
@@ -1819,21 +1818,21 @@ let (simplify :
                                                FStar_Syntax_Util.is_sub_singleton
                                                  t
                                                -> t
-                                           | uu____9952 -> tm)))))))))))
+                                           | uu____9943 -> tm)))))))))))
       | FStar_Syntax_Syntax.Tm_refine (bv,t) ->
-          let uu____9967 = simp_t t  in
-          (match uu____9967 with
+          let uu____9958 = simp_t t  in
+          (match uu____9958 with
            | FStar_Pervasives_Native.Some (true ) ->
                bv.FStar_Syntax_Syntax.sort
            | FStar_Pervasives_Native.Some (false ) -> tm
            | FStar_Pervasives_Native.None  -> tm)
-      | FStar_Syntax_Syntax.Tm_match uu____9976 ->
-          let uu____9999 = is_const_match tm  in
-          (match uu____9999 with
+      | FStar_Syntax_Syntax.Tm_match uu____9967 ->
+          let uu____9990 = is_const_match tm  in
+          (match uu____9990 with
            | FStar_Pervasives_Native.Some (true ) ->
                w FStar_Syntax_Util.t_true
            | FStar_Pervasives_Native.Some (false ) ->
                w FStar_Syntax_Util.t_false
            | FStar_Pervasives_Native.None  -> tm)
-      | uu____10008 -> tm
+      | uu____9999 -> tm
   

--- a/src/ocaml-output/FStar_TypeChecker_DMFF.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DMFF.ml
@@ -120,10 +120,7 @@ let (gen_wps_for_free :
                 d uu____317
               else ());
              (let unknown = FStar_Syntax_Syntax.tun  in
-              let mk x =
-                FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-                  FStar_Range.dummyRange
-                 in
+              let mk x = FStar_Syntax_Syntax.mk x FStar_Range.dummyRange  in
               let sigelts = FStar_Util.mk_ref []  in
               let register env2 lident def =
                 let uu____357 =
@@ -755,54 +752,51 @@ let (gen_wps_for_free :
                     FStar_Pervasives_Native.Some uu____2066  in
                   let mk_forall x body =
                     let uu____2080 =
-                      let uu____2087 =
-                        let uu____2088 =
-                          let uu____2105 =
-                            let uu____2116 =
-                              let uu____2125 =
-                                let uu____2126 =
-                                  let uu____2127 =
-                                    FStar_Syntax_Syntax.mk_binder x  in
-                                  [uu____2127]  in
-                                FStar_Syntax_Util.abs uu____2126 body
-                                  ret_tot_type
-                                 in
-                              FStar_Syntax_Syntax.as_arg uu____2125  in
-                            [uu____2116]  in
-                          (FStar_Syntax_Util.tforall, uu____2105)  in
-                        FStar_Syntax_Syntax.Tm_app uu____2088  in
-                      FStar_Syntax_Syntax.mk uu____2087  in
-                    uu____2080 FStar_Pervasives_Native.None
-                      FStar_Range.dummyRange
+                      let uu____2081 =
+                        let uu____2098 =
+                          let uu____2109 =
+                            let uu____2118 =
+                              let uu____2119 =
+                                let uu____2120 =
+                                  FStar_Syntax_Syntax.mk_binder x  in
+                                [uu____2120]  in
+                              FStar_Syntax_Util.abs uu____2119 body
+                                ret_tot_type
+                               in
+                            FStar_Syntax_Syntax.as_arg uu____2118  in
+                          [uu____2109]  in
+                        (FStar_Syntax_Util.tforall, uu____2098)  in
+                      FStar_Syntax_Syntax.Tm_app uu____2081  in
+                    FStar_Syntax_Syntax.mk uu____2080 FStar_Range.dummyRange
                      in
                   let rec is_discrete t =
-                    let uu____2185 =
-                      let uu____2186 = FStar_Syntax_Subst.compress t  in
-                      uu____2186.FStar_Syntax_Syntax.n  in
-                    match uu____2185 with
-                    | FStar_Syntax_Syntax.Tm_type uu____2190 -> false
+                    let uu____2178 =
+                      let uu____2179 = FStar_Syntax_Subst.compress t  in
+                      uu____2179.FStar_Syntax_Syntax.n  in
+                    match uu____2178 with
+                    | FStar_Syntax_Syntax.Tm_type uu____2183 -> false
                     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                         (FStar_List.for_all
-                           (fun uu____2223  ->
-                              match uu____2223 with
-                              | (b,uu____2232) ->
+                           (fun uu____2216  ->
+                              match uu____2216 with
+                              | (b,uu____2225) ->
                                   is_discrete b.FStar_Syntax_Syntax.sort) bs)
                           && (is_discrete (FStar_Syntax_Util.comp_result c))
-                    | uu____2237 -> true  in
+                    | uu____2230 -> true  in
                   let rec is_monotonic t =
-                    let uu____2250 =
-                      let uu____2251 = FStar_Syntax_Subst.compress t  in
-                      uu____2251.FStar_Syntax_Syntax.n  in
-                    match uu____2250 with
-                    | FStar_Syntax_Syntax.Tm_type uu____2255 -> true
+                    let uu____2243 =
+                      let uu____2244 = FStar_Syntax_Subst.compress t  in
+                      uu____2244.FStar_Syntax_Syntax.n  in
+                    match uu____2243 with
+                    | FStar_Syntax_Syntax.Tm_type uu____2248 -> true
                     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                         (FStar_List.for_all
-                           (fun uu____2288  ->
-                              match uu____2288 with
-                              | (b,uu____2297) ->
+                           (fun uu____2281  ->
+                              match uu____2281 with
+                              | (b,uu____2290) ->
                                   is_discrete b.FStar_Syntax_Syntax.sort) bs)
                           && (is_monotonic (FStar_Syntax_Util.comp_result c))
-                    | uu____2302 -> is_discrete t  in
+                    | uu____2295 -> is_discrete t  in
                   let rec mk_rel rel t x y =
                     let mk_rel1 = mk_rel rel  in
                     let t1 =
@@ -812,48 +806,48 @@ let (gen_wps_for_free :
                         FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant] env2 t
                        in
-                    let uu____2376 =
-                      let uu____2377 = FStar_Syntax_Subst.compress t1  in
-                      uu____2377.FStar_Syntax_Syntax.n  in
-                    match uu____2376 with
-                    | FStar_Syntax_Syntax.Tm_type uu____2382 -> rel x y
+                    let uu____2369 =
+                      let uu____2370 = FStar_Syntax_Subst.compress t1  in
+                      uu____2370.FStar_Syntax_Syntax.n  in
+                    match uu____2369 with
+                    | FStar_Syntax_Syntax.Tm_type uu____2375 -> rel x y
                     | FStar_Syntax_Syntax.Tm_arrow
                         (binder::[],{
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.GTotal
-                                        (b,uu____2385);
-                                      FStar_Syntax_Syntax.pos = uu____2386;
-                                      FStar_Syntax_Syntax.vars = uu____2387;_})
+                                        (b,uu____2378);
+                                      FStar_Syntax_Syntax.pos = uu____2379;
+                                      FStar_Syntax_Syntax.vars = uu____2380;_})
                         ->
                         let a2 =
                           (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort
                            in
-                        let uu____2431 =
+                        let uu____2424 =
                           (is_monotonic a2) || (is_monotonic b)  in
-                        if uu____2431
+                        if uu____2424
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
                               FStar_Pervasives_Native.None a2
                              in
                           let body =
-                            let uu____2441 =
-                              let uu____2444 =
-                                let uu____2455 =
-                                  let uu____2464 =
+                            let uu____2434 =
+                              let uu____2437 =
+                                let uu____2448 =
+                                  let uu____2457 =
                                     FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____2464  in
-                                [uu____2455]  in
-                              FStar_Syntax_Util.mk_app x uu____2444  in
-                            let uu____2481 =
-                              let uu____2484 =
-                                let uu____2495 =
-                                  let uu____2504 =
+                                  FStar_Syntax_Syntax.as_arg uu____2457  in
+                                [uu____2448]  in
+                              FStar_Syntax_Util.mk_app x uu____2437  in
+                            let uu____2474 =
+                              let uu____2477 =
+                                let uu____2488 =
+                                  let uu____2497 =
                                     FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____2504  in
-                                [uu____2495]  in
-                              FStar_Syntax_Util.mk_app y uu____2484  in
-                            mk_rel1 b uu____2441 uu____2481  in
+                                  FStar_Syntax_Syntax.as_arg uu____2497  in
+                                [uu____2488]  in
+                              FStar_Syntax_Util.mk_app y uu____2477  in
+                            mk_rel1 b uu____2434 uu____2474  in
                           mk_forall a11 body
                         else
                           (let a11 =
@@ -865,73 +859,73 @@ let (gen_wps_for_free :
                                FStar_Pervasives_Native.None a2
                               in
                            let body =
-                             let uu____2528 =
-                               let uu____2531 =
+                             let uu____2521 =
+                               let uu____2524 =
                                  FStar_Syntax_Syntax.bv_to_name a11  in
-                               let uu____2534 =
+                               let uu____2527 =
                                  FStar_Syntax_Syntax.bv_to_name a21  in
-                               mk_rel1 a2 uu____2531 uu____2534  in
-                             let uu____2537 =
-                               let uu____2540 =
-                                 let uu____2543 =
-                                   let uu____2554 =
-                                     let uu____2563 =
+                               mk_rel1 a2 uu____2524 uu____2527  in
+                             let uu____2530 =
+                               let uu____2533 =
+                                 let uu____2536 =
+                                   let uu____2547 =
+                                     let uu____2556 =
                                        FStar_Syntax_Syntax.bv_to_name a11  in
-                                     FStar_Syntax_Syntax.as_arg uu____2563
+                                     FStar_Syntax_Syntax.as_arg uu____2556
                                       in
-                                   [uu____2554]  in
-                                 FStar_Syntax_Util.mk_app x uu____2543  in
-                               let uu____2580 =
-                                 let uu____2583 =
-                                   let uu____2594 =
-                                     let uu____2603 =
+                                   [uu____2547]  in
+                                 FStar_Syntax_Util.mk_app x uu____2536  in
+                               let uu____2573 =
+                                 let uu____2576 =
+                                   let uu____2587 =
+                                     let uu____2596 =
                                        FStar_Syntax_Syntax.bv_to_name a21  in
-                                     FStar_Syntax_Syntax.as_arg uu____2603
+                                     FStar_Syntax_Syntax.as_arg uu____2596
                                       in
-                                   [uu____2594]  in
-                                 FStar_Syntax_Util.mk_app y uu____2583  in
-                               mk_rel1 b uu____2540 uu____2580  in
-                             FStar_Syntax_Util.mk_imp uu____2528 uu____2537
+                                   [uu____2587]  in
+                                 FStar_Syntax_Util.mk_app y uu____2576  in
+                               mk_rel1 b uu____2533 uu____2573  in
+                             FStar_Syntax_Util.mk_imp uu____2521 uu____2530
                               in
-                           let uu____2620 = mk_forall a21 body  in
-                           mk_forall a11 uu____2620)
+                           let uu____2613 = mk_forall a21 body  in
+                           mk_forall a11 uu____2613)
                     | FStar_Syntax_Syntax.Tm_arrow
                         (binder::[],{
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Total
-                                        (b,uu____2623);
-                                      FStar_Syntax_Syntax.pos = uu____2624;
-                                      FStar_Syntax_Syntax.vars = uu____2625;_})
+                                        (b,uu____2616);
+                                      FStar_Syntax_Syntax.pos = uu____2617;
+                                      FStar_Syntax_Syntax.vars = uu____2618;_})
                         ->
                         let a2 =
                           (FStar_Pervasives_Native.fst binder).FStar_Syntax_Syntax.sort
                            in
-                        let uu____2669 =
+                        let uu____2662 =
                           (is_monotonic a2) || (is_monotonic b)  in
-                        if uu____2669
+                        if uu____2662
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
                               FStar_Pervasives_Native.None a2
                              in
                           let body =
-                            let uu____2679 =
-                              let uu____2682 =
-                                let uu____2693 =
-                                  let uu____2702 =
+                            let uu____2672 =
+                              let uu____2675 =
+                                let uu____2686 =
+                                  let uu____2695 =
                                     FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____2702  in
-                                [uu____2693]  in
-                              FStar_Syntax_Util.mk_app x uu____2682  in
-                            let uu____2719 =
-                              let uu____2722 =
-                                let uu____2733 =
-                                  let uu____2742 =
+                                  FStar_Syntax_Syntax.as_arg uu____2695  in
+                                [uu____2686]  in
+                              FStar_Syntax_Util.mk_app x uu____2675  in
+                            let uu____2712 =
+                              let uu____2715 =
+                                let uu____2726 =
+                                  let uu____2735 =
                                     FStar_Syntax_Syntax.bv_to_name a11  in
-                                  FStar_Syntax_Syntax.as_arg uu____2742  in
-                                [uu____2733]  in
-                              FStar_Syntax_Util.mk_app y uu____2722  in
-                            mk_rel1 b uu____2679 uu____2719  in
+                                  FStar_Syntax_Syntax.as_arg uu____2735  in
+                                [uu____2726]  in
+                              FStar_Syntax_Util.mk_app y uu____2715  in
+                            mk_rel1 b uu____2672 uu____2712  in
                           mk_forall a11 body
                         else
                           (let a11 =
@@ -943,58 +937,58 @@ let (gen_wps_for_free :
                                FStar_Pervasives_Native.None a2
                               in
                            let body =
-                             let uu____2766 =
-                               let uu____2769 =
+                             let uu____2759 =
+                               let uu____2762 =
                                  FStar_Syntax_Syntax.bv_to_name a11  in
-                               let uu____2772 =
+                               let uu____2765 =
                                  FStar_Syntax_Syntax.bv_to_name a21  in
-                               mk_rel1 a2 uu____2769 uu____2772  in
-                             let uu____2775 =
-                               let uu____2778 =
-                                 let uu____2781 =
-                                   let uu____2792 =
-                                     let uu____2801 =
+                               mk_rel1 a2 uu____2762 uu____2765  in
+                             let uu____2768 =
+                               let uu____2771 =
+                                 let uu____2774 =
+                                   let uu____2785 =
+                                     let uu____2794 =
                                        FStar_Syntax_Syntax.bv_to_name a11  in
-                                     FStar_Syntax_Syntax.as_arg uu____2801
+                                     FStar_Syntax_Syntax.as_arg uu____2794
                                       in
-                                   [uu____2792]  in
-                                 FStar_Syntax_Util.mk_app x uu____2781  in
-                               let uu____2818 =
-                                 let uu____2821 =
-                                   let uu____2832 =
-                                     let uu____2841 =
+                                   [uu____2785]  in
+                                 FStar_Syntax_Util.mk_app x uu____2774  in
+                               let uu____2811 =
+                                 let uu____2814 =
+                                   let uu____2825 =
+                                     let uu____2834 =
                                        FStar_Syntax_Syntax.bv_to_name a21  in
-                                     FStar_Syntax_Syntax.as_arg uu____2841
+                                     FStar_Syntax_Syntax.as_arg uu____2834
                                       in
-                                   [uu____2832]  in
-                                 FStar_Syntax_Util.mk_app y uu____2821  in
-                               mk_rel1 b uu____2778 uu____2818  in
-                             FStar_Syntax_Util.mk_imp uu____2766 uu____2775
+                                   [uu____2825]  in
+                                 FStar_Syntax_Util.mk_app y uu____2814  in
+                               mk_rel1 b uu____2771 uu____2811  in
+                             FStar_Syntax_Util.mk_imp uu____2759 uu____2768
                               in
-                           let uu____2858 = mk_forall a21 body  in
-                           mk_forall a11 uu____2858)
+                           let uu____2851 = mk_forall a21 body  in
+                           mk_forall a11 uu____2851)
                     | FStar_Syntax_Syntax.Tm_arrow (binder::binders1,comp) ->
                         let t2 =
-                          let uu___229_2897 = t1  in
-                          let uu____2898 =
-                            let uu____2899 =
-                              let uu____2914 =
-                                let uu____2917 =
+                          let uu___229_2890 = t1  in
+                          let uu____2891 =
+                            let uu____2892 =
+                              let uu____2907 =
+                                let uu____2910 =
                                   FStar_Syntax_Util.arrow binders1 comp  in
-                                FStar_Syntax_Syntax.mk_Total uu____2917  in
-                              ([binder], uu____2914)  in
-                            FStar_Syntax_Syntax.Tm_arrow uu____2899  in
+                                FStar_Syntax_Syntax.mk_Total uu____2910  in
+                              ([binder], uu____2907)  in
+                            FStar_Syntax_Syntax.Tm_arrow uu____2892  in
                           {
-                            FStar_Syntax_Syntax.n = uu____2898;
+                            FStar_Syntax_Syntax.n = uu____2891;
                             FStar_Syntax_Syntax.pos =
-                              (uu___229_2897.FStar_Syntax_Syntax.pos);
+                              (uu___229_2890.FStar_Syntax_Syntax.pos);
                             FStar_Syntax_Syntax.vars =
-                              (uu___229_2897.FStar_Syntax_Syntax.vars)
+                              (uu___229_2890.FStar_Syntax_Syntax.vars)
                           }  in
                         mk_rel1 t2 x y
-                    | FStar_Syntax_Syntax.Tm_arrow ([],uu____2940) ->
+                    | FStar_Syntax_Syntax.Tm_arrow ([],uu____2933) ->
                         failwith "impossible: arrow with empty binders"
-                    | uu____2962 -> FStar_Syntax_Util.mk_untyped_eq2 x y  in
+                    | uu____2955 -> FStar_Syntax_Util.mk_untyped_eq2 x y  in
                   let stronger =
                     let wp1 =
                       FStar_Syntax_Syntax.gen_bv "wp1"
@@ -1012,29 +1006,29 @@ let (gen_wps_for_free :
                           FStar_TypeChecker_Env.UnfoldUntil
                             FStar_Syntax_Syntax.delta_constant] env2 t
                          in
-                      let uu____2999 =
-                        let uu____3000 = FStar_Syntax_Subst.compress t1  in
-                        uu____3000.FStar_Syntax_Syntax.n  in
-                      match uu____2999 with
-                      | FStar_Syntax_Syntax.Tm_type uu____3003 ->
+                      let uu____2992 =
+                        let uu____2993 = FStar_Syntax_Subst.compress t1  in
+                        uu____2993.FStar_Syntax_Syntax.n  in
+                      match uu____2992 with
+                      | FStar_Syntax_Syntax.Tm_type uu____2996 ->
                           FStar_Syntax_Util.mk_imp x y
                       | FStar_Syntax_Syntax.Tm_app (head,args) when
-                          let uu____3030 = FStar_Syntax_Subst.compress head
+                          let uu____3023 = FStar_Syntax_Subst.compress head
                              in
-                          FStar_Syntax_Util.is_tuple_constructor uu____3030
+                          FStar_Syntax_Util.is_tuple_constructor uu____3023
                           ->
                           let project i tuple =
                             let projector =
-                              let uu____3051 =
-                                let uu____3052 =
+                              let uu____3044 =
+                                let uu____3045 =
                                   FStar_Parser_Const.mk_tuple_data_lid
                                     (FStar_List.length args)
                                     FStar_Range.dummyRange
                                    in
                                 FStar_TypeChecker_Env.lookup_projector env2
-                                  uu____3052 i
+                                  uu____3045 i
                                  in
-                              FStar_Syntax_Syntax.fvar uu____3051
+                              FStar_Syntax_Syntax.fvar uu____3044
                                 (FStar_Syntax_Syntax.Delta_constant_at_level
                                    Prims.int_one)
                                 FStar_Pervasives_Native.None
@@ -1042,24 +1036,24 @@ let (gen_wps_for_free :
                             FStar_Syntax_Util.mk_app projector
                               [(tuple, FStar_Pervasives_Native.None)]
                              in
-                          let uu____3082 =
-                            let uu____3093 =
+                          let uu____3075 =
+                            let uu____3086 =
                               FStar_List.mapi
                                 (fun i  ->
-                                   fun uu____3111  ->
-                                     match uu____3111 with
+                                   fun uu____3104  ->
+                                     match uu____3104 with
                                      | (t2,q) ->
-                                         let uu____3131 = project i x  in
-                                         let uu____3134 = project i y  in
-                                         mk_stronger t2 uu____3131 uu____3134)
+                                         let uu____3124 = project i x  in
+                                         let uu____3127 = project i y  in
+                                         mk_stronger t2 uu____3124 uu____3127)
                                 args
                                in
-                            match uu____3093 with
+                            match uu____3086 with
                             | [] ->
                                 failwith
                                   "Impossible: empty application when creating stronger relation in DM4F"
                             | rel0::rels -> (rel0, rels)  in
-                          (match uu____3082 with
+                          (match uu____3075 with
                            | (rel0,rels) ->
                                FStar_List.fold_left FStar_Syntax_Util.mk_conj
                                  rel0 rels)
@@ -1067,21 +1061,21 @@ let (gen_wps_for_free :
                           (binders1,{
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.GTotal
-                                        (b,uu____3188);
-                                      FStar_Syntax_Syntax.pos = uu____3189;
-                                      FStar_Syntax_Syntax.vars = uu____3190;_})
+                                        (b,uu____3181);
+                                      FStar_Syntax_Syntax.pos = uu____3182;
+                                      FStar_Syntax_Syntax.vars = uu____3183;_})
                           ->
                           let bvs =
                             FStar_List.mapi
                               (fun i  ->
-                                 fun uu____3234  ->
-                                   match uu____3234 with
+                                 fun uu____3227  ->
+                                   match uu____3227 with
                                    | (bv,q) ->
-                                       let uu____3248 =
-                                         let uu____3250 =
+                                       let uu____3241 =
+                                         let uu____3243 =
                                            FStar_Util.string_of_int i  in
-                                         Prims.op_Hat "a" uu____3250  in
-                                       FStar_Syntax_Syntax.gen_bv uu____3248
+                                         Prims.op_Hat "a" uu____3243  in
+                                       FStar_Syntax_Syntax.gen_bv uu____3241
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
                               binders1
@@ -1089,16 +1083,16 @@ let (gen_wps_for_free :
                           let args =
                             FStar_List.map
                               (fun ai  ->
-                                 let uu____3259 =
+                                 let uu____3252 =
                                    FStar_Syntax_Syntax.bv_to_name ai  in
-                                 FStar_Syntax_Syntax.as_arg uu____3259) bvs
+                                 FStar_Syntax_Syntax.as_arg uu____3252) bvs
                              in
                           let body =
-                            let uu____3261 = FStar_Syntax_Util.mk_app x args
+                            let uu____3254 = FStar_Syntax_Util.mk_app x args
                                in
-                            let uu____3264 = FStar_Syntax_Util.mk_app y args
+                            let uu____3257 = FStar_Syntax_Util.mk_app y args
                                in
-                            mk_stronger b uu____3261 uu____3264  in
+                            mk_stronger b uu____3254 uu____3257  in
                           FStar_List.fold_right
                             (fun bv  -> fun body1  -> mk_forall bv body1) bvs
                             body
@@ -1106,21 +1100,21 @@ let (gen_wps_for_free :
                           (binders1,{
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Total
-                                        (b,uu____3273);
-                                      FStar_Syntax_Syntax.pos = uu____3274;
-                                      FStar_Syntax_Syntax.vars = uu____3275;_})
+                                        (b,uu____3266);
+                                      FStar_Syntax_Syntax.pos = uu____3267;
+                                      FStar_Syntax_Syntax.vars = uu____3268;_})
                           ->
                           let bvs =
                             FStar_List.mapi
                               (fun i  ->
-                                 fun uu____3319  ->
-                                   match uu____3319 with
+                                 fun uu____3312  ->
+                                   match uu____3312 with
                                    | (bv,q) ->
-                                       let uu____3333 =
-                                         let uu____3335 =
+                                       let uu____3326 =
+                                         let uu____3328 =
                                            FStar_Util.string_of_int i  in
-                                         Prims.op_Hat "a" uu____3335  in
-                                       FStar_Syntax_Syntax.gen_bv uu____3333
+                                         Prims.op_Hat "a" uu____3328  in
+                                       FStar_Syntax_Syntax.gen_bv uu____3326
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
                               binders1
@@ -1128,43 +1122,43 @@ let (gen_wps_for_free :
                           let args =
                             FStar_List.map
                               (fun ai  ->
-                                 let uu____3344 =
+                                 let uu____3337 =
                                    FStar_Syntax_Syntax.bv_to_name ai  in
-                                 FStar_Syntax_Syntax.as_arg uu____3344) bvs
+                                 FStar_Syntax_Syntax.as_arg uu____3337) bvs
                              in
                           let body =
-                            let uu____3346 = FStar_Syntax_Util.mk_app x args
+                            let uu____3339 = FStar_Syntax_Util.mk_app x args
                                in
-                            let uu____3349 = FStar_Syntax_Util.mk_app y args
+                            let uu____3342 = FStar_Syntax_Util.mk_app y args
                                in
-                            mk_stronger b uu____3346 uu____3349  in
+                            mk_stronger b uu____3339 uu____3342  in
                           FStar_List.fold_right
                             (fun bv  -> fun body1  -> mk_forall bv body1) bvs
                             body
-                      | uu____3356 -> failwith "Not a DM elaborated type"  in
+                      | uu____3349 -> failwith "Not a DM elaborated type"  in
                     let body =
-                      let uu____3359 = FStar_Syntax_Util.unascribe wp_a1  in
-                      let uu____3362 = FStar_Syntax_Syntax.bv_to_name wp1  in
-                      let uu____3365 = FStar_Syntax_Syntax.bv_to_name wp2  in
-                      mk_stronger uu____3359 uu____3362 uu____3365  in
-                    let uu____3368 =
-                      let uu____3369 =
+                      let uu____3352 = FStar_Syntax_Util.unascribe wp_a1  in
+                      let uu____3355 = FStar_Syntax_Syntax.bv_to_name wp1  in
+                      let uu____3358 = FStar_Syntax_Syntax.bv_to_name wp2  in
+                      mk_stronger uu____3352 uu____3355 uu____3358  in
+                    let uu____3361 =
+                      let uu____3362 =
                         binders_of_list
                           [(a1, false); (wp1, false); (wp2, false)]
                          in
-                      FStar_List.append binders uu____3369  in
-                    FStar_Syntax_Util.abs uu____3368 body ret_tot_type  in
+                      FStar_List.append binders uu____3362  in
+                    FStar_Syntax_Util.abs uu____3361 body ret_tot_type  in
                   let stronger1 =
-                    let uu____3411 = mk_lid "stronger"  in
-                    register env2 uu____3411 stronger  in
+                    let uu____3404 = mk_lid "stronger"  in
+                    register env2 uu____3404 stronger  in
                   let stronger2 = mk_generic_app stronger1  in
                   let ite_wp =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
                         FStar_Pervasives_Native.None wp_a1
                        in
-                    let uu____3419 = FStar_Util.prefix gamma  in
-                    match uu____3419 with
+                    let uu____3412 = FStar_Util.prefix gamma  in
+                    match uu____3412 with
                     | (wp_args,post) ->
                         let k =
                           FStar_Syntax_Syntax.gen_bv "k"
@@ -1174,109 +1168,109 @@ let (gen_wps_for_free :
                         let equiv =
                           let k_tm = FStar_Syntax_Syntax.bv_to_name k  in
                           let eq =
-                            let uu____3485 =
+                            let uu____3478 =
                               FStar_Syntax_Syntax.bv_to_name
                                 (FStar_Pervasives_Native.fst post)
                                in
                             mk_rel FStar_Syntax_Util.mk_iff
-                              k.FStar_Syntax_Syntax.sort k_tm uu____3485
+                              k.FStar_Syntax_Syntax.sort k_tm uu____3478
                              in
-                          let uu____3490 =
+                          let uu____3483 =
                             FStar_Syntax_Util.destruct_typ_as_formula eq  in
-                          match uu____3490 with
+                          match uu____3483 with
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.QAll (binders1,[],body)) ->
                               let k_app =
-                                let uu____3500 = args_of_binders binders1  in
-                                FStar_Syntax_Util.mk_app k_tm uu____3500  in
+                                let uu____3493 = args_of_binders binders1  in
+                                FStar_Syntax_Util.mk_app k_tm uu____3493  in
                               let guard_free =
-                                let uu____3512 =
+                                let uu____3505 =
                                   FStar_Syntax_Syntax.lid_as_fv
                                     FStar_Parser_Const.guard_free
                                     FStar_Syntax_Syntax.delta_constant
                                     FStar_Pervasives_Native.None
                                    in
-                                FStar_Syntax_Syntax.fv_to_tm uu____3512  in
+                                FStar_Syntax_Syntax.fv_to_tm uu____3505  in
                               let pat =
-                                let uu____3516 =
-                                  let uu____3527 =
+                                let uu____3509 =
+                                  let uu____3520 =
                                     FStar_Syntax_Syntax.as_arg k_app  in
-                                  [uu____3527]  in
+                                  [uu____3520]  in
                                 FStar_Syntax_Util.mk_app guard_free
-                                  uu____3516
+                                  uu____3509
                                  in
                               let pattern_guarded_body =
-                                let uu____3555 =
-                                  let uu____3556 =
-                                    let uu____3563 =
-                                      let uu____3564 =
-                                        let uu____3585 =
+                                let uu____3548 =
+                                  let uu____3549 =
+                                    let uu____3556 =
+                                      let uu____3557 =
+                                        let uu____3578 =
                                           FStar_Syntax_Syntax.binders_to_names
                                             binders1
                                            in
-                                        let uu____3590 =
-                                          let uu____3603 =
-                                            let uu____3614 =
+                                        let uu____3583 =
+                                          let uu____3596 =
+                                            let uu____3607 =
                                               FStar_Syntax_Syntax.as_arg pat
                                                in
-                                            [uu____3614]  in
-                                          [uu____3603]  in
-                                        (uu____3585, uu____3590)  in
+                                            [uu____3607]  in
+                                          [uu____3596]  in
+                                        (uu____3578, uu____3583)  in
                                       FStar_Syntax_Syntax.Meta_pattern
-                                        uu____3564
+                                        uu____3557
                                        in
-                                    (body, uu____3563)  in
-                                  FStar_Syntax_Syntax.Tm_meta uu____3556  in
-                                mk uu____3555  in
+                                    (body, uu____3556)  in
+                                  FStar_Syntax_Syntax.Tm_meta uu____3549  in
+                                mk uu____3548  in
                               FStar_Syntax_Util.close_forall_no_univs
                                 binders1 pattern_guarded_body
-                          | uu____3677 ->
+                          | uu____3670 ->
                               failwith
                                 "Impossible: Expected the equivalence to be a quantified formula"
                            in
                         let body =
-                          let uu____3686 =
-                            let uu____3689 =
-                              let uu____3690 =
-                                let uu____3693 =
+                          let uu____3679 =
+                            let uu____3682 =
+                              let uu____3683 =
+                                let uu____3686 =
                                   FStar_Syntax_Syntax.bv_to_name wp  in
-                                let uu____3696 =
-                                  let uu____3707 = args_of_binders wp_args
+                                let uu____3689 =
+                                  let uu____3700 = args_of_binders wp_args
                                      in
-                                  let uu____3710 =
-                                    let uu____3713 =
-                                      let uu____3714 =
+                                  let uu____3703 =
+                                    let uu____3706 =
+                                      let uu____3707 =
                                         FStar_Syntax_Syntax.bv_to_name k  in
-                                      FStar_Syntax_Syntax.as_arg uu____3714
+                                      FStar_Syntax_Syntax.as_arg uu____3707
                                        in
-                                    [uu____3713]  in
-                                  FStar_List.append uu____3707 uu____3710  in
-                                FStar_Syntax_Util.mk_app uu____3693
-                                  uu____3696
+                                    [uu____3706]  in
+                                  FStar_List.append uu____3700 uu____3703  in
+                                FStar_Syntax_Util.mk_app uu____3686
+                                  uu____3689
                                  in
-                              FStar_Syntax_Util.mk_imp equiv uu____3690  in
-                            FStar_Syntax_Util.mk_forall_no_univ k uu____3689
+                              FStar_Syntax_Util.mk_imp equiv uu____3683  in
+                            FStar_Syntax_Util.mk_forall_no_univ k uu____3682
                              in
-                          FStar_Syntax_Util.abs gamma uu____3686
+                          FStar_Syntax_Util.abs gamma uu____3679
                             ret_gtot_type
                            in
-                        let uu____3715 =
-                          let uu____3716 =
+                        let uu____3708 =
+                          let uu____3709 =
                             FStar_Syntax_Syntax.binders_of_list [a1; wp]  in
-                          FStar_List.append binders uu____3716  in
-                        FStar_Syntax_Util.abs uu____3715 body ret_gtot_type
+                          FStar_List.append binders uu____3709  in
+                        FStar_Syntax_Util.abs uu____3708 body ret_gtot_type
                      in
                   let ite_wp1 =
-                    let uu____3732 = mk_lid "ite_wp"  in
-                    register env2 uu____3732 ite_wp  in
+                    let uu____3725 = mk_lid "ite_wp"  in
+                    register env2 uu____3725 ite_wp  in
                   let ite_wp2 = mk_generic_app ite_wp1  in
                   let null_wp =
                     let wp =
                       FStar_Syntax_Syntax.gen_bv "wp"
                         FStar_Pervasives_Native.None wp_a1
                        in
-                    let uu____3740 = FStar_Util.prefix gamma  in
-                    match uu____3740 with
+                    let uu____3733 = FStar_Util.prefix gamma  in
+                    match uu____3733 with
                     | (wp_args,post) ->
                         let x =
                           FStar_Syntax_Syntax.gen_bv "x"
@@ -1284,33 +1278,33 @@ let (gen_wps_for_free :
                             FStar_Syntax_Syntax.tun
                            in
                         let body =
-                          let uu____3798 =
-                            let uu____3799 =
+                          let uu____3791 =
+                            let uu____3792 =
                               FStar_All.pipe_left
                                 FStar_Syntax_Syntax.bv_to_name
                                 (FStar_Pervasives_Native.fst post)
                                in
-                            let uu____3806 =
-                              let uu____3817 =
-                                let uu____3826 =
+                            let uu____3799 =
+                              let uu____3810 =
+                                let uu____3819 =
                                   FStar_Syntax_Syntax.bv_to_name x  in
-                                FStar_Syntax_Syntax.as_arg uu____3826  in
-                              [uu____3817]  in
-                            FStar_Syntax_Util.mk_app uu____3799 uu____3806
+                                FStar_Syntax_Syntax.as_arg uu____3819  in
+                              [uu____3810]  in
+                            FStar_Syntax_Util.mk_app uu____3792 uu____3799
                              in
-                          FStar_Syntax_Util.mk_forall_no_univ x uu____3798
+                          FStar_Syntax_Util.mk_forall_no_univ x uu____3791
                            in
-                        let uu____3843 =
-                          let uu____3844 =
-                            let uu____3853 =
+                        let uu____3836 =
+                          let uu____3837 =
+                            let uu____3846 =
                               FStar_Syntax_Syntax.binders_of_list [a1]  in
-                            FStar_List.append uu____3853 gamma  in
-                          FStar_List.append binders uu____3844  in
-                        FStar_Syntax_Util.abs uu____3843 body ret_gtot_type
+                            FStar_List.append uu____3846 gamma  in
+                          FStar_List.append binders uu____3837  in
+                        FStar_Syntax_Util.abs uu____3836 body ret_gtot_type
                      in
                   let null_wp1 =
-                    let uu____3875 = mk_lid "null_wp"  in
-                    register env2 uu____3875 null_wp  in
+                    let uu____3868 = mk_lid "null_wp"  in
+                    register env2 uu____3868 null_wp  in
                   let null_wp2 = mk_generic_app null_wp1  in
                   let wp_trivial =
                     let wp =
@@ -1318,109 +1312,109 @@ let (gen_wps_for_free :
                         FStar_Pervasives_Native.None wp_a1
                        in
                     let body =
-                      let uu____3888 =
-                        let uu____3899 =
-                          let uu____3902 = FStar_Syntax_Syntax.bv_to_name a1
+                      let uu____3881 =
+                        let uu____3892 =
+                          let uu____3895 = FStar_Syntax_Syntax.bv_to_name a1
                              in
-                          let uu____3903 =
-                            let uu____3906 =
-                              let uu____3907 =
-                                let uu____3918 =
-                                  let uu____3927 =
+                          let uu____3896 =
+                            let uu____3899 =
+                              let uu____3900 =
+                                let uu____3911 =
+                                  let uu____3920 =
                                     FStar_Syntax_Syntax.bv_to_name a1  in
-                                  FStar_Syntax_Syntax.as_arg uu____3927  in
-                                [uu____3918]  in
-                              FStar_Syntax_Util.mk_app null_wp2 uu____3907
+                                  FStar_Syntax_Syntax.as_arg uu____3920  in
+                                [uu____3911]  in
+                              FStar_Syntax_Util.mk_app null_wp2 uu____3900
                                in
-                            let uu____3944 =
-                              let uu____3947 =
+                            let uu____3937 =
+                              let uu____3940 =
                                 FStar_Syntax_Syntax.bv_to_name wp  in
-                              [uu____3947]  in
-                            uu____3906 :: uu____3944  in
-                          uu____3902 :: uu____3903  in
-                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____3899
+                              [uu____3940]  in
+                            uu____3899 :: uu____3937  in
+                          uu____3895 :: uu____3896  in
+                        FStar_List.map FStar_Syntax_Syntax.as_arg uu____3892
                          in
-                      FStar_Syntax_Util.mk_app stronger2 uu____3888  in
-                    let uu____3956 =
-                      let uu____3957 =
+                      FStar_Syntax_Util.mk_app stronger2 uu____3881  in
+                    let uu____3949 =
+                      let uu____3950 =
                         FStar_Syntax_Syntax.binders_of_list [a1; wp]  in
-                      FStar_List.append binders uu____3957  in
-                    FStar_Syntax_Util.abs uu____3956 body ret_tot_type  in
+                      FStar_List.append binders uu____3950  in
+                    FStar_Syntax_Util.abs uu____3949 body ret_tot_type  in
                   let wp_trivial1 =
-                    let uu____3973 = mk_lid "wp_trivial"  in
-                    register env2 uu____3973 wp_trivial  in
+                    let uu____3966 = mk_lid "wp_trivial"  in
+                    register env2 uu____3966 wp_trivial  in
                   let wp_trivial2 = mk_generic_app wp_trivial1  in
-                  ((let uu____3979 =
+                  ((let uu____3972 =
                       FStar_TypeChecker_Env.debug env2
                         (FStar_Options.Other "ED")
                        in
-                    if uu____3979
+                    if uu____3972
                     then d "End Dijkstra monads for free"
                     else ());
                    (let c = FStar_Syntax_Subst.close binders  in
                     let ed_combs =
                       match ed.FStar_Syntax_Syntax.combinators with
                       | FStar_Syntax_Syntax.DM4F_eff combs ->
-                          let uu____3993 =
-                            let uu___340_3994 = combs  in
-                            let uu____3995 =
-                              let uu____3996 = c stronger2  in
-                              ([], uu____3996)  in
-                            let uu____4003 =
-                              let uu____4004 = c wp_if_then_else2  in
-                              ([], uu____4004)  in
-                            let uu____4011 =
-                              let uu____4012 = c ite_wp2  in ([], uu____4012)
+                          let uu____3986 =
+                            let uu___340_3987 = combs  in
+                            let uu____3988 =
+                              let uu____3989 = c stronger2  in
+                              ([], uu____3989)  in
+                            let uu____3996 =
+                              let uu____3997 = c wp_if_then_else2  in
+                              ([], uu____3997)  in
+                            let uu____4004 =
+                              let uu____4005 = c ite_wp2  in ([], uu____4005)
                                in
-                            let uu____4019 =
-                              let uu____4020 = c wp_close2  in
-                              ([], uu____4020)  in
-                            let uu____4027 =
-                              let uu____4028 = c wp_trivial2  in
-                              ([], uu____4028)  in
+                            let uu____4012 =
+                              let uu____4013 = c wp_close2  in
+                              ([], uu____4013)  in
+                            let uu____4020 =
+                              let uu____4021 = c wp_trivial2  in
+                              ([], uu____4021)  in
                             {
                               FStar_Syntax_Syntax.ret_wp =
-                                (uu___340_3994.FStar_Syntax_Syntax.ret_wp);
+                                (uu___340_3987.FStar_Syntax_Syntax.ret_wp);
                               FStar_Syntax_Syntax.bind_wp =
-                                (uu___340_3994.FStar_Syntax_Syntax.bind_wp);
-                              FStar_Syntax_Syntax.stronger = uu____3995;
-                              FStar_Syntax_Syntax.if_then_else = uu____4003;
-                              FStar_Syntax_Syntax.ite_wp = uu____4011;
-                              FStar_Syntax_Syntax.close_wp = uu____4019;
-                              FStar_Syntax_Syntax.trivial = uu____4027;
+                                (uu___340_3987.FStar_Syntax_Syntax.bind_wp);
+                              FStar_Syntax_Syntax.stronger = uu____3988;
+                              FStar_Syntax_Syntax.if_then_else = uu____3996;
+                              FStar_Syntax_Syntax.ite_wp = uu____4004;
+                              FStar_Syntax_Syntax.close_wp = uu____4012;
+                              FStar_Syntax_Syntax.trivial = uu____4020;
                               FStar_Syntax_Syntax.repr =
-                                (uu___340_3994.FStar_Syntax_Syntax.repr);
+                                (uu___340_3987.FStar_Syntax_Syntax.repr);
                               FStar_Syntax_Syntax.return_repr =
-                                (uu___340_3994.FStar_Syntax_Syntax.return_repr);
+                                (uu___340_3987.FStar_Syntax_Syntax.return_repr);
                               FStar_Syntax_Syntax.bind_repr =
-                                (uu___340_3994.FStar_Syntax_Syntax.bind_repr)
+                                (uu___340_3987.FStar_Syntax_Syntax.bind_repr)
                             }  in
-                          FStar_Syntax_Syntax.DM4F_eff uu____3993
-                      | uu____4035 ->
+                          FStar_Syntax_Syntax.DM4F_eff uu____3986
+                      | uu____4028 ->
                           failwith
                             "Impossible! For a DM4F effect combinators must be in DM4f_eff"
                        in
-                    let uu____4037 =
-                      let uu____4038 = FStar_ST.op_Bang sigelts  in
-                      FStar_List.rev uu____4038  in
-                    (uu____4037,
-                      (let uu___344_4065 = ed  in
+                    let uu____4030 =
+                      let uu____4031 = FStar_ST.op_Bang sigelts  in
+                      FStar_List.rev uu____4031  in
+                    (uu____4030,
+                      (let uu___344_4058 = ed  in
                        {
                          FStar_Syntax_Syntax.mname =
-                           (uu___344_4065.FStar_Syntax_Syntax.mname);
+                           (uu___344_4058.FStar_Syntax_Syntax.mname);
                          FStar_Syntax_Syntax.cattributes =
-                           (uu___344_4065.FStar_Syntax_Syntax.cattributes);
+                           (uu___344_4058.FStar_Syntax_Syntax.cattributes);
                          FStar_Syntax_Syntax.univs =
-                           (uu___344_4065.FStar_Syntax_Syntax.univs);
+                           (uu___344_4058.FStar_Syntax_Syntax.univs);
                          FStar_Syntax_Syntax.binders =
-                           (uu___344_4065.FStar_Syntax_Syntax.binders);
+                           (uu___344_4058.FStar_Syntax_Syntax.binders);
                          FStar_Syntax_Syntax.signature =
-                           (uu___344_4065.FStar_Syntax_Syntax.signature);
+                           (uu___344_4058.FStar_Syntax_Syntax.signature);
                          FStar_Syntax_Syntax.combinators = ed_combs;
                          FStar_Syntax_Syntax.actions =
-                           (uu___344_4065.FStar_Syntax_Syntax.actions);
+                           (uu___344_4058.FStar_Syntax_Syntax.actions);
                          FStar_Syntax_Syntax.eff_attrs =
-                           (uu___344_4065.FStar_Syntax_Syntax.eff_attrs)
+                           (uu___344_4058.FStar_Syntax_Syntax.eff_attrs)
                        }))))))
   
 type env_ = env
@@ -1428,22 +1422,22 @@ let (get_env : env -> FStar_TypeChecker_Env.env) = fun env1  -> env1.tcenv
 let (set_env : env -> FStar_TypeChecker_Env.env -> env) =
   fun dmff_env  ->
     fun env'  ->
-      let uu___349_4083 = dmff_env  in
+      let uu___349_4076 = dmff_env  in
       {
         tcenv = env';
-        subst = (uu___349_4083.subst);
-        tc_const = (uu___349_4083.tc_const)
+        subst = (uu___349_4076.subst);
+        tc_const = (uu___349_4076.tc_const)
       }
   
 type nm =
   | N of FStar_Syntax_Syntax.typ 
   | M of FStar_Syntax_Syntax.typ 
 let (uu___is_N : nm -> Prims.bool) =
-  fun projectee  -> match projectee with | N _0 -> true | uu____4104 -> false 
+  fun projectee  -> match projectee with | N _0 -> true | uu____4097 -> false 
 let (__proj__N__item___0 : nm -> FStar_Syntax_Syntax.typ) =
   fun projectee  -> match projectee with | N _0 -> _0 
 let (uu___is_M : nm -> Prims.bool) =
-  fun projectee  -> match projectee with | M _0 -> true | uu____4123 -> false 
+  fun projectee  -> match projectee with | M _0 -> true | uu____4116 -> false 
 let (__proj__M__item___0 : nm -> FStar_Syntax_Syntax.typ) =
   fun projectee  -> match projectee with | M _0 -> _0 
 type nm_ = nm
@@ -1451,66 +1445,66 @@ let (nm_of_comp : FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> nm)
   =
   fun c  ->
     match c.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Total (t,uu____4143) -> N t
+    | FStar_Syntax_Syntax.Total (t,uu____4136) -> N t
     | FStar_Syntax_Syntax.Comp c1 when
         FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
           (FStar_Util.for_some
-             (fun uu___0_4157  ->
-                match uu___0_4157 with
+             (fun uu___0_4150  ->
+                match uu___0_4150 with
                 | FStar_Syntax_Syntax.CPS  -> true
-                | uu____4160 -> false))
+                | uu____4153 -> false))
         -> M (c1.FStar_Syntax_Syntax.result_typ)
-    | uu____4162 ->
-        let uu____4163 =
-          let uu____4169 =
-            let uu____4171 = FStar_Syntax_Print.comp_to_string c  in
+    | uu____4155 ->
+        let uu____4156 =
+          let uu____4162 =
+            let uu____4164 = FStar_Syntax_Print.comp_to_string c  in
             FStar_Util.format1 "[nm_of_comp]: unexpected computation type %s"
-              uu____4171
+              uu____4164
              in
-          (FStar_Errors.Error_UnexpectedDM4FType, uu____4169)  in
-        FStar_Errors.raise_error uu____4163 c.FStar_Syntax_Syntax.pos
+          (FStar_Errors.Error_UnexpectedDM4FType, uu____4162)  in
+        FStar_Errors.raise_error uu____4156 c.FStar_Syntax_Syntax.pos
   
 let (string_of_nm : nm -> Prims.string) =
-  fun uu___1_4181  ->
-    match uu___1_4181 with
+  fun uu___1_4174  ->
+    match uu___1_4174 with
     | N t ->
-        let uu____4184 = FStar_Syntax_Print.term_to_string t  in
-        FStar_Util.format1 "N[%s]" uu____4184
+        let uu____4177 = FStar_Syntax_Print.term_to_string t  in
+        FStar_Util.format1 "N[%s]" uu____4177
     | M t ->
-        let uu____4188 = FStar_Syntax_Print.term_to_string t  in
-        FStar_Util.format1 "M[%s]" uu____4188
+        let uu____4181 = FStar_Syntax_Print.term_to_string t  in
+        FStar_Util.format1 "M[%s]" uu____4181
   
 let (is_monadic_arrow : FStar_Syntax_Syntax.term' -> nm) =
   fun n  ->
     match n with
-    | FStar_Syntax_Syntax.Tm_arrow (uu____4197,c) -> nm_of_comp c
-    | uu____4219 -> failwith "unexpected_argument: [is_monadic_arrow]"
+    | FStar_Syntax_Syntax.Tm_arrow (uu____4190,c) -> nm_of_comp c
+    | uu____4212 -> failwith "unexpected_argument: [is_monadic_arrow]"
   
 let (is_monadic_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c  ->
-    let uu____4232 = nm_of_comp c  in
-    match uu____4232 with | M uu____4234 -> true | N uu____4236 -> false
+    let uu____4225 = nm_of_comp c  in
+    match uu____4225 with | M uu____4227 -> true | N uu____4229 -> false
   
 exception Not_found 
 let (uu___is_Not_found : Prims.exn -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Not_found  -> true | uu____4247 -> false
+    match projectee with | Not_found  -> true | uu____4240 -> false
   
 let (double_star : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
   fun typ  ->
     let star_once typ1 =
-      let uu____4263 =
-        let uu____4272 =
-          let uu____4279 =
+      let uu____4256 =
+        let uu____4265 =
+          let uu____4272 =
             FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None typ1  in
-          FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____4279  in
-        [uu____4272]  in
-      let uu____4298 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0
+          FStar_All.pipe_left FStar_Syntax_Syntax.mk_binder uu____4272  in
+        [uu____4265]  in
+      let uu____4291 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0
          in
-      FStar_Syntax_Util.arrow uu____4263 uu____4298  in
-    let uu____4301 = FStar_All.pipe_right typ star_once  in
-    FStar_All.pipe_left star_once uu____4301
+      FStar_Syntax_Util.arrow uu____4256 uu____4291  in
+    let uu____4294 = FStar_All.pipe_right typ star_once  in
+    FStar_All.pipe_left star_once uu____4294
   
 let rec (mk_star_to_type :
   (FStar_Syntax_Syntax.term' ->
@@ -1523,21 +1517,21 @@ let rec (mk_star_to_type :
   fun mk  ->
     fun env1  ->
       fun a  ->
-        let uu____4343 =
-          let uu____4344 =
-            let uu____4359 =
-              let uu____4368 =
-                let uu____4375 =
-                  let uu____4376 = star_type' env1 a  in
-                  FStar_Syntax_Syntax.null_bv uu____4376  in
-                let uu____4377 = FStar_Syntax_Syntax.as_implicit false  in
-                (uu____4375, uu____4377)  in
-              [uu____4368]  in
-            let uu____4395 =
+        let uu____4336 =
+          let uu____4337 =
+            let uu____4352 =
+              let uu____4361 =
+                let uu____4368 =
+                  let uu____4369 = star_type' env1 a  in
+                  FStar_Syntax_Syntax.null_bv uu____4369  in
+                let uu____4370 = FStar_Syntax_Syntax.as_implicit false  in
+                (uu____4368, uu____4370)  in
+              [uu____4361]  in
+            let uu____4388 =
               FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0  in
-            (uu____4359, uu____4395)  in
-          FStar_Syntax_Syntax.Tm_arrow uu____4344  in
-        mk uu____4343
+            (uu____4352, uu____4388)  in
+          FStar_Syntax_Syntax.Tm_arrow uu____4337  in
+        mk uu____4336
 
 and (star_type' :
   env ->
@@ -1546,81 +1540,78 @@ and (star_type' :
   =
   fun env1  ->
     fun t  ->
-      let mk x =
-        FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-          t.FStar_Syntax_Syntax.pos
-         in
+      let mk x = FStar_Syntax_Syntax.mk x t.FStar_Syntax_Syntax.pos  in
       let mk_star_to_type1 = mk_star_to_type mk  in
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_arrow (binders,uu____4435) ->
+      | FStar_Syntax_Syntax.Tm_arrow (binders,uu____4428) ->
           let binders1 =
             FStar_List.map
-              (fun uu____4481  ->
-                 match uu____4481 with
+              (fun uu____4474  ->
+                 match uu____4474 with
                  | (bv,aqual) ->
-                     let uu____4500 =
-                       let uu___399_4501 = bv  in
-                       let uu____4502 =
+                     let uu____4493 =
+                       let uu___399_4494 = bv  in
+                       let uu____4495 =
                          star_type' env1 bv.FStar_Syntax_Syntax.sort  in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___399_4501.FStar_Syntax_Syntax.ppname);
+                           (uu___399_4494.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___399_4501.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____4502
+                           (uu___399_4494.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu____4495
                        }  in
-                     (uu____4500, aqual)) binders
+                     (uu____4493, aqual)) binders
              in
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_arrow
-               (uu____4507,{
+               (uu____4500,{
                              FStar_Syntax_Syntax.n =
-                               FStar_Syntax_Syntax.GTotal (hn,uu____4509);
-                             FStar_Syntax_Syntax.pos = uu____4510;
-                             FStar_Syntax_Syntax.vars = uu____4511;_})
+                               FStar_Syntax_Syntax.GTotal (hn,uu____4502);
+                             FStar_Syntax_Syntax.pos = uu____4503;
+                             FStar_Syntax_Syntax.vars = uu____4504;_})
                ->
-               let uu____4540 =
-                 let uu____4541 =
-                   let uu____4556 =
-                     let uu____4559 = star_type' env1 hn  in
-                     FStar_Syntax_Syntax.mk_GTotal uu____4559  in
-                   (binders1, uu____4556)  in
-                 FStar_Syntax_Syntax.Tm_arrow uu____4541  in
-               mk uu____4540
-           | uu____4570 ->
-               let uu____4571 = is_monadic_arrow t1.FStar_Syntax_Syntax.n  in
-               (match uu____4571 with
+               let uu____4533 =
+                 let uu____4534 =
+                   let uu____4549 =
+                     let uu____4552 = star_type' env1 hn  in
+                     FStar_Syntax_Syntax.mk_GTotal uu____4552  in
+                   (binders1, uu____4549)  in
+                 FStar_Syntax_Syntax.Tm_arrow uu____4534  in
+               mk uu____4533
+           | uu____4563 ->
+               let uu____4564 = is_monadic_arrow t1.FStar_Syntax_Syntax.n  in
+               (match uu____4564 with
                 | N hn ->
-                    let uu____4573 =
-                      let uu____4574 =
-                        let uu____4589 =
-                          let uu____4592 = star_type' env1 hn  in
-                          FStar_Syntax_Syntax.mk_Total uu____4592  in
-                        (binders1, uu____4589)  in
-                      FStar_Syntax_Syntax.Tm_arrow uu____4574  in
-                    mk uu____4573
+                    let uu____4566 =
+                      let uu____4567 =
+                        let uu____4582 =
+                          let uu____4585 = star_type' env1 hn  in
+                          FStar_Syntax_Syntax.mk_Total uu____4585  in
+                        (binders1, uu____4582)  in
+                      FStar_Syntax_Syntax.Tm_arrow uu____4567  in
+                    mk uu____4566
                 | M a ->
-                    let uu____4604 =
-                      let uu____4605 =
-                        let uu____4620 =
-                          let uu____4629 =
-                            let uu____4638 =
-                              let uu____4645 =
-                                let uu____4646 = mk_star_to_type1 env1 a  in
-                                FStar_Syntax_Syntax.null_bv uu____4646  in
-                              let uu____4647 =
+                    let uu____4597 =
+                      let uu____4598 =
+                        let uu____4613 =
+                          let uu____4622 =
+                            let uu____4631 =
+                              let uu____4638 =
+                                let uu____4639 = mk_star_to_type1 env1 a  in
+                                FStar_Syntax_Syntax.null_bv uu____4639  in
+                              let uu____4640 =
                                 FStar_Syntax_Syntax.as_implicit false  in
-                              (uu____4645, uu____4647)  in
-                            [uu____4638]  in
-                          FStar_List.append binders1 uu____4629  in
-                        let uu____4671 =
+                              (uu____4638, uu____4640)  in
+                            [uu____4631]  in
+                          FStar_List.append binders1 uu____4622  in
+                        let uu____4664 =
                           FStar_Syntax_Syntax.mk_Total
                             FStar_Syntax_Util.ktype0
                            in
-                        (uu____4620, uu____4671)  in
-                      FStar_Syntax_Syntax.Tm_arrow uu____4605  in
-                    mk uu____4604))
+                        (uu____4613, uu____4664)  in
+                      FStar_Syntax_Syntax.Tm_arrow uu____4598  in
+                    mk uu____4597))
       | FStar_Syntax_Syntax.Tm_app (head,args) ->
           let debug t2 s =
             let string_of_set f s1 =
@@ -1630,67 +1621,67 @@ and (star_type' :
               | x::xs ->
                   let strb = FStar_Util.new_string_builder ()  in
                   (FStar_Util.string_builder_append strb "{";
-                   (let uu____4765 = f x  in
-                    FStar_Util.string_builder_append strb uu____4765);
+                   (let uu____4758 = f x  in
+                    FStar_Util.string_builder_append strb uu____4758);
                    FStar_List.iter
                      (fun x1  ->
                         FStar_Util.string_builder_append strb ", ";
-                        (let uu____4774 = f x1  in
-                         FStar_Util.string_builder_append strb uu____4774))
+                        (let uu____4767 = f x1  in
+                         FStar_Util.string_builder_append strb uu____4767))
                      xs;
                    FStar_Util.string_builder_append strb "}";
                    FStar_Util.string_of_string_builder strb)
                in
-            let uu____4778 =
-              let uu____4784 =
-                let uu____4786 = FStar_Syntax_Print.term_to_string t2  in
-                let uu____4788 =
+            let uu____4771 =
+              let uu____4777 =
+                let uu____4779 = FStar_Syntax_Print.term_to_string t2  in
+                let uu____4781 =
                   string_of_set FStar_Syntax_Print.bv_to_string s  in
                 FStar_Util.format2 "Dependency found in term %s : %s"
-                  uu____4786 uu____4788
+                  uu____4779 uu____4781
                  in
-              (FStar_Errors.Warning_DependencyFound, uu____4784)  in
-            FStar_Errors.log_issue t2.FStar_Syntax_Syntax.pos uu____4778  in
+              (FStar_Errors.Warning_DependencyFound, uu____4777)  in
+            FStar_Errors.log_issue t2.FStar_Syntax_Syntax.pos uu____4771  in
           let rec is_non_dependent_arrow ty n =
-            let uu____4810 =
-              let uu____4811 = FStar_Syntax_Subst.compress ty  in
-              uu____4811.FStar_Syntax_Syntax.n  in
-            match uu____4810 with
+            let uu____4803 =
+              let uu____4804 = FStar_Syntax_Subst.compress ty  in
+              uu____4804.FStar_Syntax_Syntax.n  in
+            match uu____4803 with
             | FStar_Syntax_Syntax.Tm_arrow (binders,c) ->
-                let uu____4837 =
-                  let uu____4839 = FStar_Syntax_Util.is_tot_or_gtot_comp c
+                let uu____4830 =
+                  let uu____4832 = FStar_Syntax_Util.is_tot_or_gtot_comp c
                      in
-                  Prims.op_Negation uu____4839  in
-                if uu____4837
+                  Prims.op_Negation uu____4832  in
+                if uu____4830
                 then false
                 else
                   (try
-                     (fun uu___448_4856  ->
+                     (fun uu___448_4849  ->
                         match () with
                         | () ->
                             let non_dependent_or_raise s ty1 =
                               let sinter =
-                                let uu____4880 = FStar_Syntax_Free.names ty1
+                                let uu____4873 = FStar_Syntax_Free.names ty1
                                    in
-                                FStar_Util.set_intersect uu____4880 s  in
-                              let uu____4883 =
-                                let uu____4885 =
+                                FStar_Util.set_intersect uu____4873 s  in
+                              let uu____4876 =
+                                let uu____4878 =
                                   FStar_Util.set_is_empty sinter  in
-                                Prims.op_Negation uu____4885  in
-                              if uu____4883
+                                Prims.op_Negation uu____4878  in
+                              if uu____4876
                               then
                                 (debug ty1 sinter; FStar_Exn.raise Not_found)
                               else ()  in
-                            let uu____4891 =
+                            let uu____4884 =
                               FStar_Syntax_Subst.open_comp binders c  in
-                            (match uu____4891 with
+                            (match uu____4884 with
                              | (binders1,c1) ->
                                  let s =
                                    FStar_List.fold_left
                                      (fun s  ->
-                                        fun uu____4916  ->
-                                          match uu____4916 with
-                                          | (bv,uu____4928) ->
+                                        fun uu____4909  ->
+                                          match uu____4909 with
+                                          | (bv,uu____4921) ->
                                               (non_dependent_or_raise s
                                                  bv.FStar_Syntax_Syntax.sort;
                                                FStar_Util.set_add bv s))
@@ -1705,24 +1696,24 @@ and (star_type' :
                                    then is_non_dependent_arrow ct k
                                    else true)))) ()
                    with | Not_found  -> false)
-            | uu____4956 ->
-                ((let uu____4958 =
-                    let uu____4964 =
-                      let uu____4966 = FStar_Syntax_Print.term_to_string ty
+            | uu____4949 ->
+                ((let uu____4951 =
+                    let uu____4957 =
+                      let uu____4959 = FStar_Syntax_Print.term_to_string ty
                          in
                       FStar_Util.format1 "Not a dependent arrow : %s"
-                        uu____4966
+                        uu____4959
                        in
-                    (FStar_Errors.Warning_NotDependentArrow, uu____4964)  in
+                    (FStar_Errors.Warning_NotDependentArrow, uu____4957)  in
                   FStar_Errors.log_issue ty.FStar_Syntax_Syntax.pos
-                    uu____4958);
+                    uu____4951);
                  false)
              in
           let rec is_valid_application head1 =
-            let uu____4982 =
-              let uu____4983 = FStar_Syntax_Subst.compress head1  in
-              uu____4983.FStar_Syntax_Syntax.n  in
-            match uu____4982 with
+            let uu____4975 =
+              let uu____4976 = FStar_Syntax_Subst.compress head1  in
+              uu____4976.FStar_Syntax_Syntax.n  in
+            match uu____4975 with
             | FStar_Syntax_Syntax.Tm_fvar fv when
                 (((FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.option_lid)
@@ -1733,19 +1724,19 @@ and (star_type' :
                    (FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.eq2_lid))
                   ||
-                  (let uu____4989 = FStar_Syntax_Subst.compress head1  in
-                   FStar_Syntax_Util.is_tuple_constructor uu____4989)
+                  (let uu____4982 = FStar_Syntax_Subst.compress head1  in
+                   FStar_Syntax_Util.is_tuple_constructor uu____4982)
                 -> true
             | FStar_Syntax_Syntax.Tm_fvar fv ->
-                let uu____4992 =
+                let uu____4985 =
                   FStar_TypeChecker_Env.lookup_lid env1.tcenv
                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                    in
-                (match uu____4992 with
-                 | ((uu____5002,ty),uu____5004) ->
-                     let uu____5009 =
+                (match uu____4985 with
+                 | ((uu____4995,ty),uu____4997) ->
+                     let uu____5002 =
                        is_non_dependent_arrow ty (FStar_List.length args)  in
-                     if uu____5009
+                     if uu____5002
                      then
                        let res =
                          FStar_TypeChecker_Normalize.normalize
@@ -1755,75 +1746,75 @@ and (star_type' :
                              FStar_Syntax_Syntax.delta_constant] env1.tcenv
                            t1
                           in
-                       let uu____5022 =
-                         let uu____5023 = FStar_Syntax_Subst.compress res  in
-                         uu____5023.FStar_Syntax_Syntax.n  in
-                       (match uu____5022 with
-                        | FStar_Syntax_Syntax.Tm_app uu____5027 -> true
-                        | uu____5045 ->
-                            ((let uu____5047 =
-                                let uu____5053 =
-                                  let uu____5055 =
+                       let uu____5015 =
+                         let uu____5016 = FStar_Syntax_Subst.compress res  in
+                         uu____5016.FStar_Syntax_Syntax.n  in
+                       (match uu____5015 with
+                        | FStar_Syntax_Syntax.Tm_app uu____5020 -> true
+                        | uu____5038 ->
+                            ((let uu____5040 =
+                                let uu____5046 =
+                                  let uu____5048 =
                                     FStar_Syntax_Print.term_to_string head1
                                      in
                                   FStar_Util.format1
                                     "Got a term which might be a non-dependent user-defined data-type %s\n"
-                                    uu____5055
+                                    uu____5048
                                    in
                                 (FStar_Errors.Warning_NondependentUserDefinedDataType,
-                                  uu____5053)
+                                  uu____5046)
                                  in
                               FStar_Errors.log_issue
-                                head1.FStar_Syntax_Syntax.pos uu____5047);
+                                head1.FStar_Syntax_Syntax.pos uu____5040);
                              false))
                      else false)
-            | FStar_Syntax_Syntax.Tm_bvar uu____5063 -> true
-            | FStar_Syntax_Syntax.Tm_name uu____5065 -> true
-            | FStar_Syntax_Syntax.Tm_uinst (t2,uu____5068) ->
+            | FStar_Syntax_Syntax.Tm_bvar uu____5056 -> true
+            | FStar_Syntax_Syntax.Tm_name uu____5058 -> true
+            | FStar_Syntax_Syntax.Tm_uinst (t2,uu____5061) ->
                 is_valid_application t2
-            | uu____5073 -> false  in
-          let uu____5075 = is_valid_application head  in
-          if uu____5075
+            | uu____5066 -> false  in
+          let uu____5068 = is_valid_application head  in
+          if uu____5068
           then
-            let uu____5078 =
-              let uu____5079 =
-                let uu____5096 =
+            let uu____5071 =
+              let uu____5072 =
+                let uu____5089 =
                   FStar_List.map
-                    (fun uu____5125  ->
-                       match uu____5125 with
+                    (fun uu____5118  ->
+                       match uu____5118 with
                        | (t2,qual) ->
-                           let uu____5150 = star_type' env1 t2  in
-                           (uu____5150, qual)) args
+                           let uu____5143 = star_type' env1 t2  in
+                           (uu____5143, qual)) args
                    in
-                (head, uu____5096)  in
-              FStar_Syntax_Syntax.Tm_app uu____5079  in
-            mk uu____5078
+                (head, uu____5089)  in
+              FStar_Syntax_Syntax.Tm_app uu____5072  in
+            mk uu____5071
           else
-            (let uu____5167 =
-               let uu____5173 =
-                 let uu____5175 = FStar_Syntax_Print.term_to_string t1  in
+            (let uu____5160 =
+               let uu____5166 =
+                 let uu____5168 = FStar_Syntax_Print.term_to_string t1  in
                  FStar_Util.format1
                    "For now, only [either], [option] and [eq2] are supported in the definition language (got: %s)"
-                   uu____5175
+                   uu____5168
                   in
-               (FStar_Errors.Fatal_WrongTerm, uu____5173)  in
-             FStar_Errors.raise_err uu____5167)
-      | FStar_Syntax_Syntax.Tm_bvar uu____5179 -> t1
-      | FStar_Syntax_Syntax.Tm_name uu____5180 -> t1
-      | FStar_Syntax_Syntax.Tm_type uu____5181 -> t1
-      | FStar_Syntax_Syntax.Tm_fvar uu____5182 -> t1
+               (FStar_Errors.Fatal_WrongTerm, uu____5166)  in
+             FStar_Errors.raise_err uu____5160)
+      | FStar_Syntax_Syntax.Tm_bvar uu____5172 -> t1
+      | FStar_Syntax_Syntax.Tm_name uu____5173 -> t1
+      | FStar_Syntax_Syntax.Tm_type uu____5174 -> t1
+      | FStar_Syntax_Syntax.Tm_fvar uu____5175 -> t1
       | FStar_Syntax_Syntax.Tm_abs (binders,repr,something) ->
-          let uu____5210 = FStar_Syntax_Subst.open_term binders repr  in
-          (match uu____5210 with
+          let uu____5203 = FStar_Syntax_Subst.open_term binders repr  in
+          (match uu____5203 with
            | (binders1,repr1) ->
                let env2 =
-                 let uu___520_5218 = env1  in
-                 let uu____5219 =
+                 let uu___520_5211 = env1  in
+                 let uu____5212 =
                    FStar_TypeChecker_Env.push_binders env1.tcenv binders1  in
                  {
-                   tcenv = uu____5219;
-                   subst = (uu___520_5218.subst);
-                   tc_const = (uu___520_5218.tc_const)
+                   tcenv = uu____5212;
+                   subst = (uu___520_5211.subst);
+                   tc_const = (uu___520_5211.tc_const)
                  }  in
                let repr2 = star_type' env2 repr1  in
                FStar_Syntax_Util.abs binders1 repr2 something)
@@ -1837,237 +1828,237 @@ and (star_type' :
           let t5 = FStar_Syntax_Subst.subst subst1 t4  in
           mk
             (FStar_Syntax_Syntax.Tm_refine
-               ((let uu___535_5246 = x1  in
+               ((let uu___535_5239 = x1  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___535_5246.FStar_Syntax_Syntax.ppname);
+                     (uu___535_5239.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___535_5246.FStar_Syntax_Syntax.index);
+                     (uu___535_5239.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = sort
                  }), t5))
       | FStar_Syntax_Syntax.Tm_meta (t2,m) ->
-          let uu____5253 =
-            let uu____5254 =
-              let uu____5261 = star_type' env1 t2  in (uu____5261, m)  in
-            FStar_Syntax_Syntax.Tm_meta uu____5254  in
-          mk uu____5253
+          let uu____5246 =
+            let uu____5247 =
+              let uu____5254 = star_type' env1 t2  in (uu____5254, m)  in
+            FStar_Syntax_Syntax.Tm_meta uu____5247  in
+          mk uu____5246
       | FStar_Syntax_Syntax.Tm_ascribed
           (e,(FStar_Util.Inl t2,FStar_Pervasives_Native.None ),something) ->
-          let uu____5313 =
-            let uu____5314 =
-              let uu____5341 = star_type' env1 e  in
-              let uu____5344 =
-                let uu____5361 =
-                  let uu____5370 = star_type' env1 t2  in
-                  FStar_Util.Inl uu____5370  in
-                (uu____5361, FStar_Pervasives_Native.None)  in
-              (uu____5341, uu____5344, something)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____5314  in
-          mk uu____5313
+          let uu____5306 =
+            let uu____5307 =
+              let uu____5334 = star_type' env1 e  in
+              let uu____5337 =
+                let uu____5354 =
+                  let uu____5363 = star_type' env1 t2  in
+                  FStar_Util.Inl uu____5363  in
+                (uu____5354, FStar_Pervasives_Native.None)  in
+              (uu____5334, uu____5337, something)  in
+            FStar_Syntax_Syntax.Tm_ascribed uu____5307  in
+          mk uu____5306
       | FStar_Syntax_Syntax.Tm_ascribed
           (e,(FStar_Util.Inr c,FStar_Pervasives_Native.None ),something) ->
-          let uu____5458 =
-            let uu____5459 =
-              let uu____5486 = star_type' env1 e  in
-              let uu____5489 =
-                let uu____5506 =
-                  let uu____5515 =
+          let uu____5451 =
+            let uu____5452 =
+              let uu____5479 = star_type' env1 e  in
+              let uu____5482 =
+                let uu____5499 =
+                  let uu____5508 =
                     star_type' env1 (FStar_Syntax_Util.comp_result c)  in
-                  FStar_Util.Inl uu____5515  in
-                (uu____5506, FStar_Pervasives_Native.None)  in
-              (uu____5486, uu____5489, something)  in
-            FStar_Syntax_Syntax.Tm_ascribed uu____5459  in
-          mk uu____5458
+                  FStar_Util.Inl uu____5508  in
+                (uu____5499, FStar_Pervasives_Native.None)  in
+              (uu____5479, uu____5482, something)  in
+            FStar_Syntax_Syntax.Tm_ascribed uu____5452  in
+          mk uu____5451
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____5556,(uu____5557,FStar_Pervasives_Native.Some uu____5558),uu____5559)
+          (uu____5549,(uu____5550,FStar_Pervasives_Native.Some uu____5551),uu____5552)
           ->
-          let uu____5608 =
-            let uu____5614 =
-              let uu____5616 = FStar_Syntax_Print.term_to_string t1  in
+          let uu____5601 =
+            let uu____5607 =
+              let uu____5609 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Ascriptions with tactics are outside of the definition language: %s"
-                uu____5616
+                uu____5609
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5614)  in
-          FStar_Errors.raise_err uu____5608
-      | FStar_Syntax_Syntax.Tm_refine uu____5620 ->
-          let uu____5627 =
-            let uu____5633 =
-              let uu____5635 = FStar_Syntax_Print.term_to_string t1  in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5607)  in
+          FStar_Errors.raise_err uu____5601
+      | FStar_Syntax_Syntax.Tm_refine uu____5613 ->
+          let uu____5620 =
+            let uu____5626 =
+              let uu____5628 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Tm_refine is outside of the definition language: %s"
-                uu____5635
+                uu____5628
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5633)  in
-          FStar_Errors.raise_err uu____5627
-      | FStar_Syntax_Syntax.Tm_uinst uu____5639 ->
-          let uu____5646 =
-            let uu____5652 =
-              let uu____5654 = FStar_Syntax_Print.term_to_string t1  in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5626)  in
+          FStar_Errors.raise_err uu____5620
+      | FStar_Syntax_Syntax.Tm_uinst uu____5632 ->
+          let uu____5639 =
+            let uu____5645 =
+              let uu____5647 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Tm_uinst is outside of the definition language: %s"
-                uu____5654
+                uu____5647
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5652)  in
-          FStar_Errors.raise_err uu____5646
-      | FStar_Syntax_Syntax.Tm_quoted uu____5658 ->
-          let uu____5665 =
-            let uu____5671 =
-              let uu____5673 = FStar_Syntax_Print.term_to_string t1  in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5645)  in
+          FStar_Errors.raise_err uu____5639
+      | FStar_Syntax_Syntax.Tm_quoted uu____5651 ->
+          let uu____5658 =
+            let uu____5664 =
+              let uu____5666 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Tm_quoted is outside of the definition language: %s"
-                uu____5673
+                uu____5666
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5671)  in
-          FStar_Errors.raise_err uu____5665
-      | FStar_Syntax_Syntax.Tm_constant uu____5677 ->
-          let uu____5678 =
-            let uu____5684 =
-              let uu____5686 = FStar_Syntax_Print.term_to_string t1  in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5664)  in
+          FStar_Errors.raise_err uu____5658
+      | FStar_Syntax_Syntax.Tm_constant uu____5670 ->
+          let uu____5671 =
+            let uu____5677 =
+              let uu____5679 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Tm_constant is outside of the definition language: %s"
-                uu____5686
+                uu____5679
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5684)  in
-          FStar_Errors.raise_err uu____5678
-      | FStar_Syntax_Syntax.Tm_match uu____5690 ->
-          let uu____5713 =
-            let uu____5719 =
-              let uu____5721 = FStar_Syntax_Print.term_to_string t1  in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5677)  in
+          FStar_Errors.raise_err uu____5671
+      | FStar_Syntax_Syntax.Tm_match uu____5683 ->
+          let uu____5706 =
+            let uu____5712 =
+              let uu____5714 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Tm_match is outside of the definition language: %s"
-                uu____5721
+                uu____5714
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5719)  in
-          FStar_Errors.raise_err uu____5713
-      | FStar_Syntax_Syntax.Tm_let uu____5725 ->
-          let uu____5739 =
-            let uu____5745 =
-              let uu____5747 = FStar_Syntax_Print.term_to_string t1  in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5712)  in
+          FStar_Errors.raise_err uu____5706
+      | FStar_Syntax_Syntax.Tm_let uu____5718 ->
+          let uu____5732 =
+            let uu____5738 =
+              let uu____5740 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
-                "Tm_let is outside of the definition language: %s" uu____5747
+                "Tm_let is outside of the definition language: %s" uu____5740
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5745)  in
-          FStar_Errors.raise_err uu____5739
-      | FStar_Syntax_Syntax.Tm_uvar uu____5751 ->
-          let uu____5764 =
-            let uu____5770 =
-              let uu____5772 = FStar_Syntax_Print.term_to_string t1  in
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5738)  in
+          FStar_Errors.raise_err uu____5732
+      | FStar_Syntax_Syntax.Tm_uvar uu____5744 ->
+          let uu____5757 =
+            let uu____5763 =
+              let uu____5765 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Tm_uvar is outside of the definition language: %s"
-                uu____5772
+                uu____5765
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5770)  in
-          FStar_Errors.raise_err uu____5764
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5763)  in
+          FStar_Errors.raise_err uu____5757
       | FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____5776 =
-            let uu____5782 =
-              let uu____5784 = FStar_Syntax_Print.term_to_string t1  in
+          let uu____5769 =
+            let uu____5775 =
+              let uu____5777 = FStar_Syntax_Print.term_to_string t1  in
               FStar_Util.format1
                 "Tm_unknown is outside of the definition language: %s"
-                uu____5784
+                uu____5777
                in
-            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5782)  in
-          FStar_Errors.raise_err uu____5776
+            (FStar_Errors.Fatal_TermOutsideOfDefLanguage, uu____5775)  in
+          FStar_Errors.raise_err uu____5769
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____5789 = FStar_Syntax_Util.unfold_lazy i  in
-          star_type' env1 uu____5789
-      | FStar_Syntax_Syntax.Tm_delayed uu____5792 -> failwith "impossible"
+          let uu____5782 = FStar_Syntax_Util.unfold_lazy i  in
+          star_type' env1 uu____5782
+      | FStar_Syntax_Syntax.Tm_delayed uu____5785 -> failwith "impossible"
 
 let (is_monadic :
   FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
     Prims.bool)
   =
-  fun uu___3_5816  ->
-    match uu___3_5816 with
+  fun uu___3_5809  ->
+    match uu___3_5809 with
     | FStar_Pervasives_Native.None  -> failwith "un-annotated lambda?!"
     | FStar_Pervasives_Native.Some rc ->
         FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
           (FStar_Util.for_some
-             (fun uu___2_5827  ->
-                match uu___2_5827 with
+             (fun uu___2_5820  ->
+                match uu___2_5820 with
                 | FStar_Syntax_Syntax.CPS  -> true
-                | uu____5830 -> false))
+                | uu____5823 -> false))
   
 let rec (is_C : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t  ->
-    let uu____5840 =
-      let uu____5841 = FStar_Syntax_Subst.compress t  in
-      uu____5841.FStar_Syntax_Syntax.n  in
-    match uu____5840 with
+    let uu____5833 =
+      let uu____5834 = FStar_Syntax_Subst.compress t  in
+      uu____5834.FStar_Syntax_Syntax.n  in
+    match uu____5833 with
     | FStar_Syntax_Syntax.Tm_app (head,args) when
         FStar_Syntax_Util.is_tuple_constructor head ->
         let r =
-          let uu____5873 =
-            let uu____5874 = FStar_List.hd args  in
-            FStar_Pervasives_Native.fst uu____5874  in
-          is_C uu____5873  in
+          let uu____5866 =
+            let uu____5867 = FStar_List.hd args  in
+            FStar_Pervasives_Native.fst uu____5867  in
+          is_C uu____5866  in
         if r
         then
-          ((let uu____5898 =
-              let uu____5900 =
+          ((let uu____5891 =
+              let uu____5893 =
                 FStar_List.for_all
-                  (fun uu____5911  ->
-                     match uu____5911 with | (h,uu____5920) -> is_C h) args
+                  (fun uu____5904  ->
+                     match uu____5904 with | (h,uu____5913) -> is_C h) args
                  in
-              Prims.op_Negation uu____5900  in
-            if uu____5898
+              Prims.op_Negation uu____5893  in
+            if uu____5891
             then
-              let uu____5926 =
-                let uu____5932 =
-                  let uu____5934 = FStar_Syntax_Print.term_to_string t  in
-                  FStar_Util.format1 "Not a C-type (A * C): %s" uu____5934
+              let uu____5919 =
+                let uu____5925 =
+                  let uu____5927 = FStar_Syntax_Print.term_to_string t  in
+                  FStar_Util.format1 "Not a C-type (A * C): %s" uu____5927
                    in
-                (FStar_Errors.Error_UnexpectedDM4FType, uu____5932)  in
-              FStar_Errors.raise_error uu____5926 t.FStar_Syntax_Syntax.pos
+                (FStar_Errors.Error_UnexpectedDM4FType, uu____5925)  in
+              FStar_Errors.raise_error uu____5919 t.FStar_Syntax_Syntax.pos
             else ());
            true)
         else
-          ((let uu____5944 =
-              let uu____5946 =
+          ((let uu____5937 =
+              let uu____5939 =
                 FStar_List.for_all
-                  (fun uu____5958  ->
-                     match uu____5958 with
-                     | (h,uu____5967) ->
-                         let uu____5972 = is_C h  in
-                         Prims.op_Negation uu____5972) args
+                  (fun uu____5951  ->
+                     match uu____5951 with
+                     | (h,uu____5960) ->
+                         let uu____5965 = is_C h  in
+                         Prims.op_Negation uu____5965) args
                  in
-              Prims.op_Negation uu____5946  in
-            if uu____5944
+              Prims.op_Negation uu____5939  in
+            if uu____5937
             then
-              let uu____5975 =
-                let uu____5981 =
-                  let uu____5983 = FStar_Syntax_Print.term_to_string t  in
-                  FStar_Util.format1 "Not a C-type (C * A): %s" uu____5983
+              let uu____5968 =
+                let uu____5974 =
+                  let uu____5976 = FStar_Syntax_Print.term_to_string t  in
+                  FStar_Util.format1 "Not a C-type (C * A): %s" uu____5976
                    in
-                (FStar_Errors.Error_UnexpectedDM4FType, uu____5981)  in
-              FStar_Errors.raise_error uu____5975 t.FStar_Syntax_Syntax.pos
+                (FStar_Errors.Error_UnexpectedDM4FType, uu____5974)  in
+              FStar_Errors.raise_error uu____5968 t.FStar_Syntax_Syntax.pos
             else ());
            false)
     | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
-        let uu____6012 = nm_of_comp comp  in
-        (match uu____6012 with
+        let uu____6005 = nm_of_comp comp  in
+        (match uu____6005 with
          | M t1 ->
-             ((let uu____6016 = is_C t1  in
-               if uu____6016
+             ((let uu____6009 = is_C t1  in
+               if uu____6009
                then
-                 let uu____6019 =
-                   let uu____6025 =
-                     let uu____6027 = FStar_Syntax_Print.term_to_string t1
+                 let uu____6012 =
+                   let uu____6018 =
+                     let uu____6020 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.format1 "Not a C-type (C -> C): %s"
-                       uu____6027
+                       uu____6020
                       in
-                   (FStar_Errors.Error_UnexpectedDM4FType, uu____6025)  in
-                 FStar_Errors.raise_error uu____6019
+                   (FStar_Errors.Error_UnexpectedDM4FType, uu____6018)  in
+                 FStar_Errors.raise_error uu____6012
                    t1.FStar_Syntax_Syntax.pos
                else ());
               true)
          | N t1 -> is_C t1)
-    | FStar_Syntax_Syntax.Tm_meta (t1,uu____6036) -> is_C t1
-    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____6042) -> is_C t1
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____6048,uu____6049) -> is_C t1
-    | uu____6090 -> false
+    | FStar_Syntax_Syntax.Tm_meta (t1,uu____6029) -> is_C t1
+    | FStar_Syntax_Syntax.Tm_uinst (t1,uu____6035) -> is_C t1
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,uu____6041,uu____6042) -> is_C t1
+    | uu____6083 -> false
   
 let (mk_return :
   env ->
@@ -2078,38 +2069,35 @@ let (mk_return :
   fun env1  ->
     fun t  ->
       fun e  ->
-        let mk x =
-          FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-            e.FStar_Syntax_Syntax.pos
-           in
+        let mk x = FStar_Syntax_Syntax.mk x e.FStar_Syntax_Syntax.pos  in
         let p_type = mk_star_to_type mk env1 t  in
         let p =
           FStar_Syntax_Syntax.gen_bv "p'" FStar_Pervasives_Native.None p_type
            in
         let body =
-          let uu____6126 =
-            let uu____6127 =
-              let uu____6144 = FStar_Syntax_Syntax.bv_to_name p  in
-              let uu____6147 =
-                let uu____6158 =
-                  let uu____6167 = FStar_Syntax_Syntax.as_implicit false  in
-                  (e, uu____6167)  in
-                [uu____6158]  in
-              (uu____6144, uu____6147)  in
-            FStar_Syntax_Syntax.Tm_app uu____6127  in
-          mk uu____6126  in
-        let uu____6203 =
-          let uu____6204 = FStar_Syntax_Syntax.mk_binder p  in [uu____6204]
+          let uu____6119 =
+            let uu____6120 =
+              let uu____6137 = FStar_Syntax_Syntax.bv_to_name p  in
+              let uu____6140 =
+                let uu____6151 =
+                  let uu____6160 = FStar_Syntax_Syntax.as_implicit false  in
+                  (e, uu____6160)  in
+                [uu____6151]  in
+              (uu____6137, uu____6140)  in
+            FStar_Syntax_Syntax.Tm_app uu____6120  in
+          mk uu____6119  in
+        let uu____6196 =
+          let uu____6197 = FStar_Syntax_Syntax.mk_binder p  in [uu____6197]
            in
-        FStar_Syntax_Util.abs uu____6203 body
+        FStar_Syntax_Util.abs uu____6196 body
           (FStar_Pervasives_Native.Some
              (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
   
 let (is_unknown : FStar_Syntax_Syntax.term' -> Prims.bool) =
-  fun uu___4_6229  ->
-    match uu___4_6229 with
+  fun uu___4_6222  ->
+    match uu___4_6222 with
     | FStar_Syntax_Syntax.Tm_unknown  -> true
-    | uu____6232 -> false
+    | uu____6225 -> false
   
 let rec (check :
   env ->
@@ -2119,140 +2107,140 @@ let rec (check :
   fun env1  ->
     fun e  ->
       fun context_nm  ->
-        let return_if uu____6470 =
-          match uu____6470 with
+        let return_if uu____6463 =
+          match uu____6463 with
           | (rec_nm,s_e,u_e) ->
               let check1 t1 t2 =
-                let uu____6507 =
+                let uu____6500 =
                   (Prims.op_Negation (is_unknown t2.FStar_Syntax_Syntax.n))
                     &&
-                    (let uu____6510 =
-                       let uu____6512 =
+                    (let uu____6503 =
+                       let uu____6505 =
                          FStar_TypeChecker_Rel.teq env1.tcenv t1 t2  in
-                       FStar_TypeChecker_Env.is_trivial uu____6512  in
-                     Prims.op_Negation uu____6510)
+                       FStar_TypeChecker_Env.is_trivial uu____6505  in
+                     Prims.op_Negation uu____6503)
                    in
-                if uu____6507
+                if uu____6500
                 then
-                  let uu____6514 =
-                    let uu____6520 =
-                      let uu____6522 = FStar_Syntax_Print.term_to_string e
+                  let uu____6507 =
+                    let uu____6513 =
+                      let uu____6515 = FStar_Syntax_Print.term_to_string e
                          in
-                      let uu____6524 = FStar_Syntax_Print.term_to_string t1
+                      let uu____6517 = FStar_Syntax_Print.term_to_string t1
                          in
-                      let uu____6526 = FStar_Syntax_Print.term_to_string t2
+                      let uu____6519 = FStar_Syntax_Print.term_to_string t2
                          in
                       FStar_Util.format3
                         "[check]: the expression [%s] has type [%s] but should have type [%s]"
-                        uu____6522 uu____6524 uu____6526
+                        uu____6515 uu____6517 uu____6519
                        in
-                    (FStar_Errors.Fatal_TypeMismatch, uu____6520)  in
-                  FStar_Errors.raise_err uu____6514
+                    (FStar_Errors.Fatal_TypeMismatch, uu____6513)  in
+                  FStar_Errors.raise_err uu____6507
                 else ()  in
               (match (rec_nm, context_nm) with
                | (N t1,N t2) -> (check1 t1 t2; (rec_nm, s_e, u_e))
                | (M t1,M t2) -> (check1 t1 t2; (rec_nm, s_e, u_e))
                | (N t1,M t2) ->
                    (check1 t1 t2;
-                    (let uu____6551 = mk_return env1 t1 s_e  in
-                     ((M t1), uu____6551, u_e)))
+                    (let uu____6544 = mk_return env1 t1 s_e  in
+                     ((M t1), uu____6544, u_e)))
                | (M t1,N t2) ->
-                   let uu____6558 =
-                     let uu____6564 =
-                       let uu____6566 = FStar_Syntax_Print.term_to_string e
+                   let uu____6551 =
+                     let uu____6557 =
+                       let uu____6559 = FStar_Syntax_Print.term_to_string e
                           in
-                       let uu____6568 = FStar_Syntax_Print.term_to_string t1
+                       let uu____6561 = FStar_Syntax_Print.term_to_string t1
                           in
-                       let uu____6570 = FStar_Syntax_Print.term_to_string t2
+                       let uu____6563 = FStar_Syntax_Print.term_to_string t2
                           in
                        FStar_Util.format3
                          "[check %s]: got an effectful computation [%s] in lieu of a pure computation [%s]"
-                         uu____6566 uu____6568 uu____6570
+                         uu____6559 uu____6561 uu____6563
                         in
                      (FStar_Errors.Fatal_EffectfulAndPureComputationMismatch,
-                       uu____6564)
+                       uu____6557)
                       in
-                   FStar_Errors.raise_err uu____6558)
+                   FStar_Errors.raise_err uu____6551)
            in
         let ensure_m env2 e2 =
-          let strip_m uu___5_6622 =
-            match uu___5_6622 with
+          let strip_m uu___5_6615 =
+            match uu___5_6615 with
             | (M t,s_e,u_e) -> (t, s_e, u_e)
-            | uu____6638 -> failwith "impossible"  in
+            | uu____6631 -> failwith "impossible"  in
           match context_nm with
           | N t ->
-              let uu____6659 =
-                let uu____6665 =
-                  let uu____6667 = FStar_Syntax_Print.term_to_string t  in
+              let uu____6652 =
+                let uu____6658 =
+                  let uu____6660 = FStar_Syntax_Print.term_to_string t  in
                   Prims.op_Hat
                     "let-bound monadic body has a non-monadic continuation or a branch of a match is monadic and the others aren't : "
-                    uu____6667
+                    uu____6660
                    in
-                (FStar_Errors.Fatal_LetBoundMonadicMismatch, uu____6665)  in
-              FStar_Errors.raise_error uu____6659 e2.FStar_Syntax_Syntax.pos
-          | M uu____6677 ->
-              let uu____6678 = check env2 e2 context_nm  in
-              strip_m uu____6678
+                (FStar_Errors.Fatal_LetBoundMonadicMismatch, uu____6658)  in
+              FStar_Errors.raise_error uu____6652 e2.FStar_Syntax_Syntax.pos
+          | M uu____6670 ->
+              let uu____6671 = check env2 e2 context_nm  in
+              strip_m uu____6671
            in
-        let uu____6685 =
-          let uu____6686 = FStar_Syntax_Subst.compress e  in
-          uu____6686.FStar_Syntax_Syntax.n  in
-        match uu____6685 with
-        | FStar_Syntax_Syntax.Tm_bvar uu____6695 ->
-            let uu____6696 = infer env1 e  in return_if uu____6696
-        | FStar_Syntax_Syntax.Tm_name uu____6703 ->
-            let uu____6704 = infer env1 e  in return_if uu____6704
-        | FStar_Syntax_Syntax.Tm_fvar uu____6711 ->
-            let uu____6712 = infer env1 e  in return_if uu____6712
-        | FStar_Syntax_Syntax.Tm_abs uu____6719 ->
-            let uu____6738 = infer env1 e  in return_if uu____6738
-        | FStar_Syntax_Syntax.Tm_constant uu____6745 ->
-            let uu____6746 = infer env1 e  in return_if uu____6746
-        | FStar_Syntax_Syntax.Tm_quoted uu____6753 ->
-            let uu____6760 = infer env1 e  in return_if uu____6760
-        | FStar_Syntax_Syntax.Tm_app uu____6767 ->
-            let uu____6784 = infer env1 e  in return_if uu____6784
+        let uu____6678 =
+          let uu____6679 = FStar_Syntax_Subst.compress e  in
+          uu____6679.FStar_Syntax_Syntax.n  in
+        match uu____6678 with
+        | FStar_Syntax_Syntax.Tm_bvar uu____6688 ->
+            let uu____6689 = infer env1 e  in return_if uu____6689
+        | FStar_Syntax_Syntax.Tm_name uu____6696 ->
+            let uu____6697 = infer env1 e  in return_if uu____6697
+        | FStar_Syntax_Syntax.Tm_fvar uu____6704 ->
+            let uu____6705 = infer env1 e  in return_if uu____6705
+        | FStar_Syntax_Syntax.Tm_abs uu____6712 ->
+            let uu____6731 = infer env1 e  in return_if uu____6731
+        | FStar_Syntax_Syntax.Tm_constant uu____6738 ->
+            let uu____6739 = infer env1 e  in return_if uu____6739
+        | FStar_Syntax_Syntax.Tm_quoted uu____6746 ->
+            let uu____6753 = infer env1 e  in return_if uu____6753
+        | FStar_Syntax_Syntax.Tm_app uu____6760 ->
+            let uu____6777 = infer env1 e  in return_if uu____6777
         | FStar_Syntax_Syntax.Tm_lazy i ->
-            let uu____6792 = FStar_Syntax_Util.unfold_lazy i  in
-            check env1 uu____6792 context_nm
+            let uu____6785 = FStar_Syntax_Util.unfold_lazy i  in
+            check env1 uu____6785 context_nm
         | FStar_Syntax_Syntax.Tm_let ((false ,binding::[]),e2) ->
             mk_let env1 binding e2
               (fun env2  -> fun e21  -> check env2 e21 context_nm) ensure_m
         | FStar_Syntax_Syntax.Tm_match (e0,branches) ->
             mk_match env1 e0 branches
               (fun env2  -> fun body  -> check env2 body context_nm)
-        | FStar_Syntax_Syntax.Tm_meta (e1,uu____6857) ->
+        | FStar_Syntax_Syntax.Tm_meta (e1,uu____6850) ->
             check env1 e1 context_nm
-        | FStar_Syntax_Syntax.Tm_uinst (e1,uu____6863) ->
+        | FStar_Syntax_Syntax.Tm_uinst (e1,uu____6856) ->
             check env1 e1 context_nm
-        | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____6869,uu____6870) ->
+        | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____6862,uu____6863) ->
             check env1 e1 context_nm
-        | FStar_Syntax_Syntax.Tm_let uu____6911 ->
-            let uu____6925 =
-              let uu____6927 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_let %s" uu____6927  in
-            failwith uu____6925
-        | FStar_Syntax_Syntax.Tm_type uu____6936 ->
+        | FStar_Syntax_Syntax.Tm_let uu____6904 ->
+            let uu____6918 =
+              let uu____6920 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "[check]: Tm_let %s" uu____6920  in
+            failwith uu____6918
+        | FStar_Syntax_Syntax.Tm_type uu____6929 ->
             failwith "impossible (DM stratification)"
-        | FStar_Syntax_Syntax.Tm_arrow uu____6944 ->
+        | FStar_Syntax_Syntax.Tm_arrow uu____6937 ->
             failwith "impossible (DM stratification)"
-        | FStar_Syntax_Syntax.Tm_refine uu____6966 ->
-            let uu____6973 =
-              let uu____6975 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_refine %s" uu____6975  in
-            failwith uu____6973
-        | FStar_Syntax_Syntax.Tm_uvar uu____6984 ->
-            let uu____6997 =
-              let uu____6999 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_uvar %s" uu____6999  in
-            failwith uu____6997
-        | FStar_Syntax_Syntax.Tm_delayed uu____7008 ->
+        | FStar_Syntax_Syntax.Tm_refine uu____6959 ->
+            let uu____6966 =
+              let uu____6968 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "[check]: Tm_refine %s" uu____6968  in
+            failwith uu____6966
+        | FStar_Syntax_Syntax.Tm_uvar uu____6977 ->
+            let uu____6990 =
+              let uu____6992 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "[check]: Tm_uvar %s" uu____6992  in
+            failwith uu____6990
+        | FStar_Syntax_Syntax.Tm_delayed uu____7001 ->
             failwith "impossible (compressed)"
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____7030 =
-              let uu____7032 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "[check]: Tm_unknown %s" uu____7032  in
-            failwith uu____7030
+            let uu____7023 =
+              let uu____7025 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "[check]: Tm_unknown %s" uu____7025  in
+            failwith uu____7023
 
 and (infer :
   env ->
@@ -2261,10 +2249,7 @@ and (infer :
   =
   fun env1  ->
     fun e  ->
-      let mk x =
-        FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-          e.FStar_Syntax_Syntax.pos
-         in
+      let mk x = FStar_Syntax_Syntax.mk x e.FStar_Syntax_Syntax.pos  in
       let normalize =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Env.Beta;
@@ -2273,169 +2258,169 @@ and (infer :
             FStar_Syntax_Syntax.delta_constant;
           FStar_TypeChecker_Env.EraseUniverses] env1.tcenv
          in
-      let uu____7062 =
-        let uu____7063 = FStar_Syntax_Subst.compress e  in
-        uu____7063.FStar_Syntax_Syntax.n  in
-      match uu____7062 with
+      let uu____7055 =
+        let uu____7056 = FStar_Syntax_Subst.compress e  in
+        uu____7056.FStar_Syntax_Syntax.n  in
+      match uu____7055 with
       | FStar_Syntax_Syntax.Tm_bvar bv ->
           failwith "I failed to open a binder... boo"
       | FStar_Syntax_Syntax.Tm_name bv ->
           ((N (bv.FStar_Syntax_Syntax.sort)), e, e)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____7082 = FStar_Syntax_Util.unfold_lazy i  in
-          infer env1 uu____7082
+          let uu____7075 = FStar_Syntax_Util.unfold_lazy i  in
+          infer env1 uu____7075
       | FStar_Syntax_Syntax.Tm_abs (binders,body,rc_opt) ->
           let subst_rc_opt subst rc_opt1 =
             match rc_opt1 with
             | FStar_Pervasives_Native.Some
-                { FStar_Syntax_Syntax.residual_effect = uu____7133;
+                { FStar_Syntax_Syntax.residual_effect = uu____7126;
                   FStar_Syntax_Syntax.residual_typ =
                     FStar_Pervasives_Native.None ;
-                  FStar_Syntax_Syntax.residual_flags = uu____7134;_}
+                  FStar_Syntax_Syntax.residual_flags = uu____7127;_}
                 -> rc_opt1
             | FStar_Pervasives_Native.None  -> rc_opt1
             | FStar_Pervasives_Native.Some rc ->
-                let uu____7140 =
-                  let uu___770_7141 = rc  in
-                  let uu____7142 =
-                    let uu____7147 =
-                      let uu____7150 =
+                let uu____7133 =
+                  let uu___770_7134 = rc  in
+                  let uu____7135 =
+                    let uu____7140 =
+                      let uu____7143 =
                         FStar_Util.must rc.FStar_Syntax_Syntax.residual_typ
                          in
-                      FStar_Syntax_Subst.subst subst uu____7150  in
-                    FStar_Pervasives_Native.Some uu____7147  in
+                      FStar_Syntax_Subst.subst subst uu____7143  in
+                    FStar_Pervasives_Native.Some uu____7140  in
                   {
                     FStar_Syntax_Syntax.residual_effect =
-                      (uu___770_7141.FStar_Syntax_Syntax.residual_effect);
-                    FStar_Syntax_Syntax.residual_typ = uu____7142;
+                      (uu___770_7134.FStar_Syntax_Syntax.residual_effect);
+                    FStar_Syntax_Syntax.residual_typ = uu____7135;
                     FStar_Syntax_Syntax.residual_flags =
-                      (uu___770_7141.FStar_Syntax_Syntax.residual_flags)
+                      (uu___770_7134.FStar_Syntax_Syntax.residual_flags)
                   }  in
-                FStar_Pervasives_Native.Some uu____7140
+                FStar_Pervasives_Native.Some uu____7133
              in
           let binders1 = FStar_Syntax_Subst.open_binders binders  in
           let subst = FStar_Syntax_Subst.opening_of_binders binders1  in
           let body1 = FStar_Syntax_Subst.subst subst body  in
           let rc_opt1 = subst_rc_opt subst rc_opt  in
           let env2 =
-            let uu___776_7162 = env1  in
-            let uu____7163 =
+            let uu___776_7155 = env1  in
+            let uu____7156 =
               FStar_TypeChecker_Env.push_binders env1.tcenv binders1  in
             {
-              tcenv = uu____7163;
-              subst = (uu___776_7162.subst);
-              tc_const = (uu___776_7162.tc_const)
+              tcenv = uu____7156;
+              subst = (uu___776_7155.subst);
+              tc_const = (uu___776_7155.tc_const)
             }  in
           let s_binders =
             FStar_List.map
-              (fun uu____7189  ->
-                 match uu____7189 with
+              (fun uu____7182  ->
+                 match uu____7182 with
                  | (bv,qual) ->
                      let sort = star_type' env2 bv.FStar_Syntax_Syntax.sort
                         in
-                     ((let uu___783_7212 = bv  in
+                     ((let uu___783_7205 = bv  in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___783_7212.FStar_Syntax_Syntax.ppname);
+                           (uu___783_7205.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___783_7212.FStar_Syntax_Syntax.index);
+                           (uu___783_7205.FStar_Syntax_Syntax.index);
                          FStar_Syntax_Syntax.sort = sort
                        }), qual)) binders1
              in
-          let uu____7213 =
+          let uu____7206 =
             FStar_List.fold_left
-              (fun uu____7244  ->
-                 fun uu____7245  ->
-                   match (uu____7244, uu____7245) with
+              (fun uu____7237  ->
+                 fun uu____7238  ->
+                   match (uu____7237, uu____7238) with
                    | ((env3,acc),(bv,qual)) ->
                        let c = bv.FStar_Syntax_Syntax.sort  in
-                       let uu____7303 = is_C c  in
-                       if uu____7303
+                       let uu____7296 = is_C c  in
+                       if uu____7296
                        then
                          let xw =
-                           let uu____7313 =
-                             let uu____7315 =
+                           let uu____7306 =
+                             let uu____7308 =
                                FStar_Ident.text_of_id
                                  bv.FStar_Syntax_Syntax.ppname
                                 in
-                             Prims.op_Hat uu____7315 "__w"  in
-                           let uu____7318 = star_type' env3 c  in
-                           FStar_Syntax_Syntax.gen_bv uu____7313
-                             FStar_Pervasives_Native.None uu____7318
+                             Prims.op_Hat uu____7308 "__w"  in
+                           let uu____7311 = star_type' env3 c  in
+                           FStar_Syntax_Syntax.gen_bv uu____7306
+                             FStar_Pervasives_Native.None uu____7311
                             in
                          let x =
-                           let uu___795_7320 = bv  in
-                           let uu____7321 =
-                             let uu____7324 =
+                           let uu___795_7313 = bv  in
+                           let uu____7314 =
+                             let uu____7317 =
                                FStar_Syntax_Syntax.bv_to_name xw  in
-                             trans_F_ env3 c uu____7324  in
+                             trans_F_ env3 c uu____7317  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___795_7320.FStar_Syntax_Syntax.ppname);
+                               (uu___795_7313.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___795_7320.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort = uu____7321
+                               (uu___795_7313.FStar_Syntax_Syntax.index);
+                             FStar_Syntax_Syntax.sort = uu____7314
                            }  in
                          let env4 =
-                           let uu___798_7326 = env3  in
-                           let uu____7327 =
-                             let uu____7330 =
-                               let uu____7331 =
-                                 let uu____7338 =
+                           let uu___798_7319 = env3  in
+                           let uu____7320 =
+                             let uu____7323 =
+                               let uu____7324 =
+                                 let uu____7331 =
                                    FStar_Syntax_Syntax.bv_to_name xw  in
-                                 (bv, uu____7338)  in
-                               FStar_Syntax_Syntax.NT uu____7331  in
-                             uu____7330 :: (env3.subst)  in
+                                 (bv, uu____7331)  in
+                               FStar_Syntax_Syntax.NT uu____7324  in
+                             uu____7323 :: (env3.subst)  in
                            {
-                             tcenv = (uu___798_7326.tcenv);
-                             subst = uu____7327;
-                             tc_const = (uu___798_7326.tc_const)
+                             tcenv = (uu___798_7319.tcenv);
+                             subst = uu____7320;
+                             tc_const = (uu___798_7319.tc_const)
                            }  in
-                         let uu____7343 =
-                           let uu____7346 = FStar_Syntax_Syntax.mk_binder x
+                         let uu____7336 =
+                           let uu____7339 = FStar_Syntax_Syntax.mk_binder x
                               in
-                           let uu____7347 =
-                             let uu____7350 =
+                           let uu____7340 =
+                             let uu____7343 =
                                FStar_Syntax_Syntax.mk_binder xw  in
-                             uu____7350 :: acc  in
-                           uu____7346 :: uu____7347  in
-                         (env4, uu____7343)
+                             uu____7343 :: acc  in
+                           uu____7339 :: uu____7340  in
+                         (env4, uu____7336)
                        else
                          (let x =
-                            let uu___801_7356 = bv  in
-                            let uu____7357 =
+                            let uu___801_7349 = bv  in
+                            let uu____7350 =
                               star_type' env3 bv.FStar_Syntax_Syntax.sort  in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___801_7356.FStar_Syntax_Syntax.ppname);
+                                (uu___801_7349.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___801_7356.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = uu____7357
+                                (uu___801_7349.FStar_Syntax_Syntax.index);
+                              FStar_Syntax_Syntax.sort = uu____7350
                             }  in
-                          let uu____7360 =
-                            let uu____7363 = FStar_Syntax_Syntax.mk_binder x
+                          let uu____7353 =
+                            let uu____7356 = FStar_Syntax_Syntax.mk_binder x
                                in
-                            uu____7363 :: acc  in
-                          (env3, uu____7360))) (env2, []) binders1
+                            uu____7356 :: acc  in
+                          (env3, uu____7353))) (env2, []) binders1
              in
-          (match uu____7213 with
+          (match uu____7206 with
            | (env3,u_binders) ->
                let u_binders1 = FStar_List.rev u_binders  in
-               let uu____7383 =
+               let uu____7376 =
                  let check_what =
-                   let uu____7409 = is_monadic rc_opt1  in
-                   if uu____7409 then check_m else check_n  in
-                 let uu____7426 = check_what env3 body1  in
-                 match uu____7426 with
+                   let uu____7402 = is_monadic rc_opt1  in
+                   if uu____7402 then check_m else check_n  in
+                 let uu____7419 = check_what env3 body1  in
+                 match uu____7419 with
                  | (t,s_body,u_body) ->
-                     let uu____7446 =
-                       let uu____7449 =
-                         let uu____7450 = is_monadic rc_opt1  in
-                         if uu____7450 then M t else N t  in
-                       comp_of_nm uu____7449  in
-                     (uu____7446, s_body, u_body)
+                     let uu____7439 =
+                       let uu____7442 =
+                         let uu____7443 = is_monadic rc_opt1  in
+                         if uu____7443 then M t else N t  in
+                       comp_of_nm uu____7442  in
+                     (uu____7439, s_body, u_body)
                   in
-               (match uu____7383 with
+               (match uu____7376 with
                 | (comp,s_body,u_body) ->
                     let t = FStar_Syntax_Util.arrow binders1 comp  in
                     let s_rc_opt =
@@ -2446,157 +2431,157 @@ and (infer :
                           (match rc.FStar_Syntax_Syntax.residual_typ with
                            | FStar_Pervasives_Native.None  ->
                                let rc1 =
-                                 let uu____7490 =
+                                 let uu____7483 =
                                    FStar_All.pipe_right
                                      rc.FStar_Syntax_Syntax.residual_flags
                                      (FStar_Util.for_some
-                                        (fun uu___6_7496  ->
-                                           match uu___6_7496 with
+                                        (fun uu___6_7489  ->
+                                           match uu___6_7489 with
                                            | FStar_Syntax_Syntax.CPS  -> true
-                                           | uu____7499 -> false))
+                                           | uu____7492 -> false))
                                     in
-                                 if uu____7490
+                                 if uu____7483
                                  then
-                                   let uu____7502 =
+                                   let uu____7495 =
                                      FStar_List.filter
-                                       (fun uu___7_7506  ->
-                                          match uu___7_7506 with
+                                       (fun uu___7_7499  ->
+                                          match uu___7_7499 with
                                           | FStar_Syntax_Syntax.CPS  -> false
-                                          | uu____7509 -> true)
+                                          | uu____7502 -> true)
                                        rc.FStar_Syntax_Syntax.residual_flags
                                       in
                                    FStar_Syntax_Util.mk_residual_comp
                                      FStar_Parser_Const.effect_Tot_lid
-                                     FStar_Pervasives_Native.None uu____7502
+                                     FStar_Pervasives_Native.None uu____7495
                                  else rc  in
                                FStar_Pervasives_Native.Some rc1
                            | FStar_Pervasives_Native.Some rt ->
-                               let uu____7520 =
+                               let uu____7513 =
                                  FStar_All.pipe_right
                                    rc.FStar_Syntax_Syntax.residual_flags
                                    (FStar_Util.for_some
-                                      (fun uu___8_7526  ->
-                                         match uu___8_7526 with
+                                      (fun uu___8_7519  ->
+                                         match uu___8_7519 with
                                          | FStar_Syntax_Syntax.CPS  -> true
-                                         | uu____7529 -> false))
+                                         | uu____7522 -> false))
                                   in
-                               if uu____7520
+                               if uu____7513
                                then
                                  let flags =
                                    FStar_List.filter
-                                     (fun uu___9_7538  ->
-                                        match uu___9_7538 with
+                                     (fun uu___9_7531  ->
+                                        match uu___9_7531 with
                                         | FStar_Syntax_Syntax.CPS  -> false
-                                        | uu____7541 -> true)
+                                        | uu____7534 -> true)
                                      rc.FStar_Syntax_Syntax.residual_flags
                                     in
-                                 let uu____7543 =
-                                   let uu____7544 =
-                                     let uu____7549 = double_star rt  in
-                                     FStar_Pervasives_Native.Some uu____7549
+                                 let uu____7536 =
+                                   let uu____7537 =
+                                     let uu____7542 = double_star rt  in
+                                     FStar_Pervasives_Native.Some uu____7542
                                       in
                                    FStar_Syntax_Util.mk_residual_comp
                                      FStar_Parser_Const.effect_Tot_lid
-                                     uu____7544 flags
+                                     uu____7537 flags
                                     in
-                                 FStar_Pervasives_Native.Some uu____7543
+                                 FStar_Pervasives_Native.Some uu____7536
                                else
-                                 (let uu____7556 =
-                                    let uu___842_7557 = rc  in
-                                    let uu____7558 =
-                                      let uu____7563 = star_type' env3 rt  in
-                                      FStar_Pervasives_Native.Some uu____7563
+                                 (let uu____7549 =
+                                    let uu___842_7550 = rc  in
+                                    let uu____7551 =
+                                      let uu____7556 = star_type' env3 rt  in
+                                      FStar_Pervasives_Native.Some uu____7556
                                        in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___842_7557.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___842_7550.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ =
-                                        uu____7558;
+                                        uu____7551;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___842_7557.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___842_7550.FStar_Syntax_Syntax.residual_flags)
                                     }  in
-                                  FStar_Pervasives_Native.Some uu____7556))
+                                  FStar_Pervasives_Native.Some uu____7549))
                        in
-                    let uu____7568 =
+                    let uu____7561 =
                       let comp1 =
-                        let uu____7576 = is_monadic rc_opt1  in
-                        let uu____7578 =
+                        let uu____7569 = is_monadic rc_opt1  in
+                        let uu____7571 =
                           FStar_Syntax_Subst.subst env3.subst s_body  in
                         trans_G env3 (FStar_Syntax_Util.comp_result comp)
-                          uu____7576 uu____7578
+                          uu____7569 uu____7571
                          in
-                      let uu____7579 =
+                      let uu____7572 =
                         FStar_Syntax_Util.ascribe u_body
                           ((FStar_Util.Inr comp1),
                             FStar_Pervasives_Native.None)
                          in
-                      (uu____7579,
+                      (uu____7572,
                         (FStar_Pervasives_Native.Some
                            (FStar_Syntax_Util.residual_comp_of_comp comp1)))
                        in
-                    (match uu____7568 with
+                    (match uu____7561 with
                      | (u_body1,u_rc_opt) ->
                          let s_body1 =
                            FStar_Syntax_Subst.close s_binders s_body  in
                          let s_binders1 =
                            FStar_Syntax_Subst.close_binders s_binders  in
                          let s_term =
-                           let uu____7617 =
-                             let uu____7618 =
-                               let uu____7637 =
-                                 let uu____7640 =
+                           let uu____7610 =
+                             let uu____7611 =
+                               let uu____7630 =
+                                 let uu____7633 =
                                    FStar_Syntax_Subst.closing_of_binders
                                      s_binders1
                                     in
-                                 subst_rc_opt uu____7640 s_rc_opt  in
-                               (s_binders1, s_body1, uu____7637)  in
-                             FStar_Syntax_Syntax.Tm_abs uu____7618  in
-                           mk uu____7617  in
+                                 subst_rc_opt uu____7633 s_rc_opt  in
+                               (s_binders1, s_body1, uu____7630)  in
+                             FStar_Syntax_Syntax.Tm_abs uu____7611  in
+                           mk uu____7610  in
                          let u_body2 =
                            FStar_Syntax_Subst.close u_binders1 u_body1  in
                          let u_binders2 =
                            FStar_Syntax_Subst.close_binders u_binders1  in
                          let u_term =
-                           let uu____7660 =
-                             let uu____7661 =
-                               let uu____7680 =
-                                 let uu____7683 =
+                           let uu____7653 =
+                             let uu____7654 =
+                               let uu____7673 =
+                                 let uu____7676 =
                                    FStar_Syntax_Subst.closing_of_binders
                                      u_binders2
                                     in
-                                 subst_rc_opt uu____7683 u_rc_opt  in
-                               (u_binders2, u_body2, uu____7680)  in
-                             FStar_Syntax_Syntax.Tm_abs uu____7661  in
-                           mk uu____7660  in
+                                 subst_rc_opt uu____7676 u_rc_opt  in
+                               (u_binders2, u_body2, uu____7673)  in
+                             FStar_Syntax_Syntax.Tm_abs uu____7654  in
+                           mk uu____7653  in
                          ((N t), s_term, u_term))))
       | FStar_Syntax_Syntax.Tm_fvar
           {
             FStar_Syntax_Syntax.fv_name =
               { FStar_Syntax_Syntax.v = lid;
-                FStar_Syntax_Syntax.p = uu____7699;_};
-            FStar_Syntax_Syntax.fv_delta = uu____7700;
-            FStar_Syntax_Syntax.fv_qual = uu____7701;_}
+                FStar_Syntax_Syntax.p = uu____7692;_};
+            FStar_Syntax_Syntax.fv_delta = uu____7693;
+            FStar_Syntax_Syntax.fv_qual = uu____7694;_}
           ->
-          let uu____7704 =
-            let uu____7709 = FStar_TypeChecker_Env.lookup_lid env1.tcenv lid
+          let uu____7697 =
+            let uu____7702 = FStar_TypeChecker_Env.lookup_lid env1.tcenv lid
                in
-            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7709  in
-          (match uu____7704 with
-           | (uu____7740,t) ->
-               let uu____7742 = let uu____7743 = normalize t  in N uu____7743
+            FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7702  in
+          (match uu____7697 with
+           | (uu____7733,t) ->
+               let uu____7735 = let uu____7736 = normalize t  in N uu____7736
                   in
-               (uu____7742, e, e))
+               (uu____7735, e, e))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____7744;
-             FStar_Syntax_Syntax.vars = uu____7745;_},a::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____7737;
+             FStar_Syntax_Syntax.vars = uu____7738;_},a::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____7824 = FStar_Syntax_Util.head_and_args e  in
-          (match uu____7824 with
-           | (unary_op,uu____7848) ->
+          let uu____7817 = FStar_Syntax_Util.head_and_args e  in
+          (match uu____7817 with
+           | (unary_op,uu____7841) ->
                let head = mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))  in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1))  in
                infer env1 t)
@@ -2604,13 +2589,13 @@ and (infer :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____7919;
-             FStar_Syntax_Syntax.vars = uu____7920;_},a1::a2::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____7912;
+             FStar_Syntax_Syntax.vars = uu____7913;_},a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____8016 = FStar_Syntax_Util.head_and_args e  in
-          (match uu____8016 with
-           | (unary_op,uu____8040) ->
+          let uu____8009 = FStar_Syntax_Util.head_and_args e  in
+          (match uu____8009 with
+           | (unary_op,uu____8033) ->
                let head =
                  mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))  in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1))  in
@@ -2619,216 +2604,216 @@ and (infer :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____8119;
-             FStar_Syntax_Syntax.vars = uu____8120;_},(a,FStar_Pervasives_Native.None
+             FStar_Syntax_Syntax.pos = uu____8112;
+             FStar_Syntax_Syntax.vars = uu____8113;_},(a,FStar_Pervasives_Native.None
                                                        )::[])
           ->
-          let uu____8158 = infer env1 a  in
-          (match uu____8158 with
+          let uu____8151 = infer env1 a  in
+          (match uu____8151 with
            | (t,s,u) ->
-               let uu____8174 = FStar_Syntax_Util.head_and_args e  in
-               (match uu____8174 with
-                | (head,uu____8198) ->
-                    let uu____8223 =
-                      let uu____8224 =
+               let uu____8167 = FStar_Syntax_Util.head_and_args e  in
+               (match uu____8167 with
+                | (head,uu____8191) ->
+                    let uu____8216 =
+                      let uu____8217 =
                         FStar_Syntax_Syntax.tabbrev
                           FStar_Parser_Const.range_lid
                          in
-                      N uu____8224  in
-                    let uu____8225 =
-                      let uu____8226 =
-                        let uu____8227 =
-                          let uu____8244 =
-                            let uu____8255 = FStar_Syntax_Syntax.as_arg s  in
-                            [uu____8255]  in
-                          (head, uu____8244)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8227  in
-                      mk uu____8226  in
-                    let uu____8292 =
-                      let uu____8293 =
-                        let uu____8294 =
-                          let uu____8311 =
-                            let uu____8322 = FStar_Syntax_Syntax.as_arg u  in
-                            [uu____8322]  in
-                          (head, uu____8311)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8294  in
-                      mk uu____8293  in
-                    (uu____8223, uu____8225, uu____8292)))
+                      N uu____8217  in
+                    let uu____8218 =
+                      let uu____8219 =
+                        let uu____8220 =
+                          let uu____8237 =
+                            let uu____8248 = FStar_Syntax_Syntax.as_arg s  in
+                            [uu____8248]  in
+                          (head, uu____8237)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8220  in
+                      mk uu____8219  in
+                    let uu____8285 =
+                      let uu____8286 =
+                        let uu____8287 =
+                          let uu____8304 =
+                            let uu____8315 = FStar_Syntax_Syntax.as_arg u  in
+                            [uu____8315]  in
+                          (head, uu____8304)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8287  in
+                      mk uu____8286  in
+                    (uu____8216, uu____8218, uu____8285)))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____8359;
-             FStar_Syntax_Syntax.vars = uu____8360;_},(a1,uu____8362)::a2::[])
+             FStar_Syntax_Syntax.pos = uu____8352;
+             FStar_Syntax_Syntax.vars = uu____8353;_},(a1,uu____8355)::a2::[])
           ->
-          let uu____8418 = infer env1 a1  in
-          (match uu____8418 with
+          let uu____8411 = infer env1 a1  in
+          (match uu____8411 with
            | (t,s,u) ->
-               let uu____8434 = FStar_Syntax_Util.head_and_args e  in
-               (match uu____8434 with
-                | (head,uu____8458) ->
-                    let uu____8483 =
-                      let uu____8484 =
-                        let uu____8485 =
-                          let uu____8502 =
-                            let uu____8513 = FStar_Syntax_Syntax.as_arg s  in
-                            [uu____8513; a2]  in
-                          (head, uu____8502)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8485  in
-                      mk uu____8484  in
-                    let uu____8558 =
-                      let uu____8559 =
-                        let uu____8560 =
-                          let uu____8577 =
-                            let uu____8588 = FStar_Syntax_Syntax.as_arg u  in
-                            [uu____8588; a2]  in
-                          (head, uu____8577)  in
-                        FStar_Syntax_Syntax.Tm_app uu____8560  in
-                      mk uu____8559  in
-                    (t, uu____8483, uu____8558)))
+               let uu____8427 = FStar_Syntax_Util.head_and_args e  in
+               (match uu____8427 with
+                | (head,uu____8451) ->
+                    let uu____8476 =
+                      let uu____8477 =
+                        let uu____8478 =
+                          let uu____8495 =
+                            let uu____8506 = FStar_Syntax_Syntax.as_arg s  in
+                            [uu____8506; a2]  in
+                          (head, uu____8495)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8478  in
+                      mk uu____8477  in
+                    let uu____8551 =
+                      let uu____8552 =
+                        let uu____8553 =
+                          let uu____8570 =
+                            let uu____8581 = FStar_Syntax_Syntax.as_arg u  in
+                            [uu____8581; a2]  in
+                          (head, uu____8570)  in
+                        FStar_Syntax_Syntax.Tm_app uu____8553  in
+                      mk uu____8552  in
+                    (t, uu____8476, uu____8551)))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____8633;
-             FStar_Syntax_Syntax.vars = uu____8634;_},uu____8635)
+             FStar_Syntax_Syntax.pos = uu____8626;
+             FStar_Syntax_Syntax.vars = uu____8627;_},uu____8628)
           ->
-          let uu____8660 =
-            let uu____8666 =
-              let uu____8668 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8668
+          let uu____8653 =
+            let uu____8659 =
+              let uu____8661 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8661
                in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____8666)  in
-          FStar_Errors.raise_error uu____8660 e.FStar_Syntax_Syntax.pos
+            (FStar_Errors.Fatal_IllAppliedConstant, uu____8659)  in
+          FStar_Errors.raise_error uu____8653 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____8678;
-             FStar_Syntax_Syntax.vars = uu____8679;_},uu____8680)
+             FStar_Syntax_Syntax.pos = uu____8671;
+             FStar_Syntax_Syntax.vars = uu____8672;_},uu____8673)
           ->
-          let uu____8705 =
-            let uu____8711 =
-              let uu____8713 = FStar_Syntax_Print.term_to_string e  in
-              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8713
+          let uu____8698 =
+            let uu____8704 =
+              let uu____8706 = FStar_Syntax_Print.term_to_string e  in
+              FStar_Util.format1 "DMFF: Ill-applied constant %s" uu____8706
                in
-            (FStar_Errors.Fatal_IllAppliedConstant, uu____8711)  in
-          FStar_Errors.raise_error uu____8705 e.FStar_Syntax_Syntax.pos
+            (FStar_Errors.Fatal_IllAppliedConstant, uu____8704)  in
+          FStar_Errors.raise_error uu____8698 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app (head,args) ->
-          let uu____8749 = check_n env1 head  in
-          (match uu____8749 with
+          let uu____8742 = check_n env1 head  in
+          (match uu____8742 with
            | (t_head,s_head,u_head) ->
                let is_arrow t =
-                 let uu____8772 =
-                   let uu____8773 = FStar_Syntax_Subst.compress t  in
-                   uu____8773.FStar_Syntax_Syntax.n  in
-                 match uu____8772 with
-                 | FStar_Syntax_Syntax.Tm_arrow uu____8777 -> true
-                 | uu____8793 -> false  in
+                 let uu____8765 =
+                   let uu____8766 = FStar_Syntax_Subst.compress t  in
+                   uu____8766.FStar_Syntax_Syntax.n  in
+                 match uu____8765 with
+                 | FStar_Syntax_Syntax.Tm_arrow uu____8770 -> true
+                 | uu____8786 -> false  in
                let rec flatten t =
-                 let uu____8815 =
-                   let uu____8816 = FStar_Syntax_Subst.compress t  in
-                   uu____8816.FStar_Syntax_Syntax.n  in
-                 match uu____8815 with
+                 let uu____8808 =
+                   let uu____8809 = FStar_Syntax_Subst.compress t  in
+                   uu____8809.FStar_Syntax_Syntax.n  in
+                 match uu____8808 with
                  | FStar_Syntax_Syntax.Tm_arrow
                      (binders,{
                                 FStar_Syntax_Syntax.n =
-                                  FStar_Syntax_Syntax.Total (t1,uu____8835);
-                                FStar_Syntax_Syntax.pos = uu____8836;
-                                FStar_Syntax_Syntax.vars = uu____8837;_})
+                                  FStar_Syntax_Syntax.Total (t1,uu____8828);
+                                FStar_Syntax_Syntax.pos = uu____8829;
+                                FStar_Syntax_Syntax.vars = uu____8830;_})
                      when is_arrow t1 ->
-                     let uu____8866 = flatten t1  in
-                     (match uu____8866 with
+                     let uu____8859 = flatten t1  in
+                     (match uu____8859 with
                       | (binders',comp) ->
                           ((FStar_List.append binders binders'), comp))
                  | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
                      (binders, comp)
-                 | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____8966,uu____8967)
+                 | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____8959,uu____8960)
                      -> flatten e1
-                 | uu____9008 ->
-                     let uu____9009 =
-                       let uu____9015 =
-                         let uu____9017 =
+                 | uu____9001 ->
+                     let uu____9002 =
+                       let uu____9008 =
+                         let uu____9010 =
                            FStar_Syntax_Print.term_to_string t_head  in
                          FStar_Util.format1 "%s: not a function type"
-                           uu____9017
+                           uu____9010
                           in
-                       (FStar_Errors.Fatal_NotFunctionType, uu____9015)  in
-                     FStar_Errors.raise_err uu____9009
+                       (FStar_Errors.Fatal_NotFunctionType, uu____9008)  in
+                     FStar_Errors.raise_err uu____9002
                   in
-               let uu____9035 = flatten t_head  in
-               (match uu____9035 with
+               let uu____9028 = flatten t_head  in
+               (match uu____9028 with
                 | (binders,comp) ->
                     let n = FStar_List.length binders  in
                     let n' = FStar_List.length args  in
                     (if
                        (FStar_List.length binders) < (FStar_List.length args)
                      then
-                       (let uu____9110 =
-                          let uu____9116 =
-                            let uu____9118 = FStar_Util.string_of_int n  in
-                            let uu____9120 =
+                       (let uu____9103 =
+                          let uu____9109 =
+                            let uu____9111 = FStar_Util.string_of_int n  in
+                            let uu____9113 =
                               FStar_Util.string_of_int (n' - n)  in
-                            let uu____9122 = FStar_Util.string_of_int n  in
+                            let uu____9115 = FStar_Util.string_of_int n  in
                             FStar_Util.format3
                               "The head of this application, after being applied to %s arguments, is an effectful computation (leaving %s arguments to be applied). Please let-bind the head applied to the %s first arguments."
-                              uu____9118 uu____9120 uu____9122
+                              uu____9111 uu____9113 uu____9115
                              in
                           (FStar_Errors.Fatal_BinderAndArgsLengthMismatch,
-                            uu____9116)
+                            uu____9109)
                            in
-                        FStar_Errors.raise_err uu____9110)
+                        FStar_Errors.raise_err uu____9103)
                      else ();
-                     (let uu____9128 =
+                     (let uu____9121 =
                         FStar_Syntax_Subst.open_comp binders comp  in
-                      match uu____9128 with
+                      match uu____9121 with
                       | (binders1,comp1) ->
-                          let rec final_type subst uu____9181 args1 =
-                            match uu____9181 with
+                          let rec final_type subst uu____9174 args1 =
+                            match uu____9174 with
                             | (binders2,comp2) ->
                                 (match (binders2, args1) with
                                  | ([],[]) ->
-                                     let uu____9281 =
+                                     let uu____9274 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          comp2
                                         in
-                                     nm_of_comp uu____9281
+                                     nm_of_comp uu____9274
                                  | (binders3,[]) ->
-                                     let uu____9319 =
-                                       let uu____9320 =
-                                         let uu____9323 =
-                                           let uu____9324 =
+                                     let uu____9312 =
+                                       let uu____9313 =
+                                         let uu____9316 =
+                                           let uu____9317 =
                                              mk
                                                (FStar_Syntax_Syntax.Tm_arrow
                                                   (binders3, comp2))
                                               in
                                            FStar_Syntax_Subst.subst subst
-                                             uu____9324
+                                             uu____9317
                                             in
                                          FStar_Syntax_Subst.compress
-                                           uu____9323
+                                           uu____9316
                                           in
-                                       uu____9320.FStar_Syntax_Syntax.n  in
-                                     (match uu____9319 with
+                                       uu____9313.FStar_Syntax_Syntax.n  in
+                                     (match uu____9312 with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (binders4,comp3) ->
-                                          let uu____9357 =
-                                            let uu____9358 =
-                                              let uu____9359 =
-                                                let uu____9374 =
+                                          let uu____9350 =
+                                            let uu____9351 =
+                                              let uu____9352 =
+                                                let uu____9367 =
                                                   FStar_Syntax_Subst.close_comp
                                                     binders4 comp3
                                                    in
-                                                (binders4, uu____9374)  in
+                                                (binders4, uu____9367)  in
                                               FStar_Syntax_Syntax.Tm_arrow
-                                                uu____9359
+                                                uu____9352
                                                in
-                                            mk uu____9358  in
-                                          N uu____9357
-                                      | uu____9387 -> failwith "wat?")
-                                 | ([],uu____9389::uu____9390) ->
+                                            mk uu____9351  in
+                                          N uu____9350
+                                      | uu____9380 -> failwith "wat?")
+                                 | ([],uu____9382::uu____9383) ->
                                      failwith "just checked that?!"
-                                 | ((bv,uu____9443)::binders3,(arg,uu____9446)::args2)
+                                 | ((bv,uu____9436)::binders3,(arg,uu____9439)::args2)
                                      ->
                                      final_type
                                        ((FStar_Syntax_Syntax.NT (bv, arg)) ::
@@ -2836,118 +2821,118 @@ and (infer :
                              in
                           let final_type1 =
                             final_type [] (binders1, comp1) args  in
-                          let uu____9533 = FStar_List.splitAt n' binders1  in
-                          (match uu____9533 with
-                           | (binders2,uu____9567) ->
-                               let uu____9600 =
-                                 let uu____9623 =
+                          let uu____9526 = FStar_List.splitAt n' binders1  in
+                          (match uu____9526 with
+                           | (binders2,uu____9560) ->
+                               let uu____9593 =
+                                 let uu____9616 =
                                    FStar_List.map2
-                                     (fun uu____9685  ->
-                                        fun uu____9686  ->
-                                          match (uu____9685, uu____9686) with
-                                          | ((bv,uu____9734),(arg,q)) ->
-                                              let uu____9763 =
-                                                let uu____9764 =
+                                     (fun uu____9678  ->
+                                        fun uu____9679  ->
+                                          match (uu____9678, uu____9679) with
+                                          | ((bv,uu____9727),(arg,q)) ->
+                                              let uu____9756 =
+                                                let uu____9757 =
                                                   FStar_Syntax_Subst.compress
                                                     bv.FStar_Syntax_Syntax.sort
                                                    in
-                                                uu____9764.FStar_Syntax_Syntax.n
+                                                uu____9757.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____9763 with
+                                              (match uu____9756 with
                                                | FStar_Syntax_Syntax.Tm_type
-                                                   uu____9785 ->
-                                                   let uu____9786 =
-                                                     let uu____9793 =
+                                                   uu____9778 ->
+                                                   let uu____9779 =
+                                                     let uu____9786 =
                                                        star_type' env1 arg
                                                         in
-                                                     (uu____9793, q)  in
-                                                   (uu____9786, [(arg, q)])
-                                               | uu____9830 ->
-                                                   let uu____9831 =
+                                                     (uu____9786, q)  in
+                                                   (uu____9779, [(arg, q)])
+                                               | uu____9823 ->
+                                                   let uu____9824 =
                                                      check_n env1 arg  in
-                                                   (match uu____9831 with
-                                                    | (uu____9856,s_arg,u_arg)
+                                                   (match uu____9824 with
+                                                    | (uu____9849,s_arg,u_arg)
                                                         ->
-                                                        let uu____9859 =
-                                                          let uu____9868 =
+                                                        let uu____9852 =
+                                                          let uu____9861 =
                                                             is_C
                                                               bv.FStar_Syntax_Syntax.sort
                                                              in
-                                                          if uu____9868
+                                                          if uu____9861
                                                           then
-                                                            let uu____9879 =
-                                                              let uu____9886
+                                                            let uu____9872 =
+                                                              let uu____9879
                                                                 =
                                                                 FStar_Syntax_Subst.subst
                                                                   env1.subst
                                                                   s_arg
                                                                  in
-                                                              (uu____9886, q)
+                                                              (uu____9879, q)
                                                                in
-                                                            [uu____9879;
+                                                            [uu____9872;
                                                             (u_arg, q)]
                                                           else [(u_arg, q)]
                                                            in
                                                         ((s_arg, q),
-                                                          uu____9859))))
+                                                          uu____9852))))
                                      binders2 args
                                     in
-                                 FStar_List.split uu____9623  in
-                               (match uu____9600 with
+                                 FStar_List.split uu____9616  in
+                               (match uu____9593 with
                                 | (s_args,u_args) ->
                                     let u_args1 = FStar_List.flatten u_args
                                        in
-                                    let uu____10014 =
+                                    let uu____10007 =
                                       mk
                                         (FStar_Syntax_Syntax.Tm_app
                                            (s_head, s_args))
                                        in
-                                    let uu____10027 =
+                                    let uu____10020 =
                                       mk
                                         (FStar_Syntax_Syntax.Tm_app
                                            (u_head, u_args1))
                                        in
-                                    (final_type1, uu____10014, uu____10027)))))))
+                                    (final_type1, uu____10007, uu____10020)))))))
       | FStar_Syntax_Syntax.Tm_let ((false ,binding::[]),e2) ->
           mk_let env1 binding e2 infer check_m
       | FStar_Syntax_Syntax.Tm_match (e0,branches) ->
           mk_match env1 e0 branches infer
-      | FStar_Syntax_Syntax.Tm_uinst (e1,uu____10096) -> infer env1 e1
-      | FStar_Syntax_Syntax.Tm_meta (e1,uu____10102) -> infer env1 e1
-      | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____10108,uu____10109) ->
+      | FStar_Syntax_Syntax.Tm_uinst (e1,uu____10089) -> infer env1 e1
+      | FStar_Syntax_Syntax.Tm_meta (e1,uu____10095) -> infer env1 e1
+      | FStar_Syntax_Syntax.Tm_ascribed (e1,uu____10101,uu____10102) ->
           infer env1 e1
       | FStar_Syntax_Syntax.Tm_constant c ->
-          let uu____10151 =
-            let uu____10152 = env1.tc_const c  in N uu____10152  in
-          (uu____10151, e, e)
+          let uu____10144 =
+            let uu____10145 = env1.tc_const c  in N uu____10145  in
+          (uu____10144, e, e)
       | FStar_Syntax_Syntax.Tm_quoted (tm,qt) ->
           ((N FStar_Syntax_Syntax.t_term), e, e)
-      | FStar_Syntax_Syntax.Tm_let uu____10159 ->
-          let uu____10173 =
-            let uu____10175 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_let %s" uu____10175  in
-          failwith uu____10173
-      | FStar_Syntax_Syntax.Tm_type uu____10184 ->
+      | FStar_Syntax_Syntax.Tm_let uu____10152 ->
+          let uu____10166 =
+            let uu____10168 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_let %s" uu____10168  in
+          failwith uu____10166
+      | FStar_Syntax_Syntax.Tm_type uu____10177 ->
           failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_arrow uu____10192 ->
+      | FStar_Syntax_Syntax.Tm_arrow uu____10185 ->
           failwith "impossible (DM stratification)"
-      | FStar_Syntax_Syntax.Tm_refine uu____10214 ->
-          let uu____10221 =
-            let uu____10223 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_refine %s" uu____10223  in
-          failwith uu____10221
-      | FStar_Syntax_Syntax.Tm_uvar uu____10232 ->
-          let uu____10245 =
-            let uu____10247 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____10247  in
-          failwith uu____10245
-      | FStar_Syntax_Syntax.Tm_delayed uu____10256 ->
+      | FStar_Syntax_Syntax.Tm_refine uu____10207 ->
+          let uu____10214 =
+            let uu____10216 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_refine %s" uu____10216  in
+          failwith uu____10214
+      | FStar_Syntax_Syntax.Tm_uvar uu____10225 ->
+          let uu____10238 =
+            let uu____10240 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_uvar %s" uu____10240  in
+          failwith uu____10238
+      | FStar_Syntax_Syntax.Tm_delayed uu____10249 ->
           failwith "impossible (compressed)"
       | FStar_Syntax_Syntax.Tm_unknown  ->
-          let uu____10278 =
-            let uu____10280 = FStar_Syntax_Print.term_to_string e  in
-            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____10280  in
-          failwith uu____10278
+          let uu____10271 =
+            let uu____10273 = FStar_Syntax_Print.term_to_string e  in
+            FStar_Util.format1 "[infer]: Tm_unknown %s" uu____10273  in
+          failwith uu____10271
 
 and (mk_match :
   env ->
@@ -2965,65 +2950,62 @@ and (mk_match :
     fun e0  ->
       fun branches  ->
         fun f  ->
-          let mk x =
-            FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-              e0.FStar_Syntax_Syntax.pos
-             in
-          let uu____10329 = check_n env1 e0  in
-          match uu____10329 with
-          | (uu____10342,s_e0,u_e0) ->
-              let uu____10345 =
-                let uu____10374 =
+          let mk x = FStar_Syntax_Syntax.mk x e0.FStar_Syntax_Syntax.pos  in
+          let uu____10322 = check_n env1 e0  in
+          match uu____10322 with
+          | (uu____10335,s_e0,u_e0) ->
+              let uu____10338 =
+                let uu____10367 =
                   FStar_List.map
                     (fun b  ->
-                       let uu____10435 = FStar_Syntax_Subst.open_branch b  in
-                       match uu____10435 with
+                       let uu____10428 = FStar_Syntax_Subst.open_branch b  in
+                       match uu____10428 with
                        | (pat,FStar_Pervasives_Native.None ,body) ->
                            let env2 =
-                             let uu___1117_10477 = env1  in
-                             let uu____10478 =
-                               let uu____10479 =
+                             let uu___1117_10470 = env1  in
+                             let uu____10471 =
+                               let uu____10472 =
                                  FStar_Syntax_Syntax.pat_bvs pat  in
                                FStar_List.fold_left
                                  FStar_TypeChecker_Env.push_bv env1.tcenv
-                                 uu____10479
+                                 uu____10472
                                 in
                              {
-                               tcenv = uu____10478;
-                               subst = (uu___1117_10477.subst);
-                               tc_const = (uu___1117_10477.tc_const)
+                               tcenv = uu____10471;
+                               subst = (uu___1117_10470.subst);
+                               tc_const = (uu___1117_10470.tc_const)
                              }  in
-                           let uu____10482 = f env2 body  in
-                           (match uu____10482 with
+                           let uu____10475 = f env2 body  in
+                           (match uu____10475 with
                             | (nm1,s_body,u_body) ->
                                 (nm1,
                                   (pat, FStar_Pervasives_Native.None,
                                     (s_body, u_body, body))))
-                       | uu____10554 ->
+                       | uu____10547 ->
                            FStar_Errors.raise_err
                              (FStar_Errors.Fatal_WhenClauseNotSupported,
                                "No when clauses in the definition language"))
                     branches
                    in
-                FStar_List.split uu____10374  in
-              (match uu____10345 with
+                FStar_List.split uu____10367  in
+              (match uu____10338 with
                | (nms,branches1) ->
                    let t1 =
-                     let uu____10660 = FStar_List.hd nms  in
-                     match uu____10660 with | M t1 -> t1 | N t1 -> t1  in
+                     let uu____10653 = FStar_List.hd nms  in
+                     match uu____10653 with | M t1 -> t1 | N t1 -> t1  in
                    let has_m =
                      FStar_List.existsb
-                       (fun uu___10_10669  ->
-                          match uu___10_10669 with
-                          | M uu____10671 -> true
-                          | uu____10673 -> false) nms
+                       (fun uu___10_10662  ->
+                          match uu___10_10662 with
+                          | M uu____10664 -> true
+                          | uu____10666 -> false) nms
                       in
-                   let uu____10675 =
-                     let uu____10712 =
+                   let uu____10668 =
+                     let uu____10705 =
                        FStar_List.map2
                          (fun nm1  ->
-                            fun uu____10802  ->
-                              match uu____10802 with
+                            fun uu____10795  ->
+                              match uu____10795 with
                               | (pat,guard,(s_body,u_body,original_body)) ->
                                   (match (nm1, has_m) with
                                    | (N t2,false ) ->
@@ -3033,17 +3015,17 @@ and (mk_match :
                                        (nm1, (pat, guard, s_body),
                                          (pat, guard, u_body))
                                    | (N t2,true ) ->
-                                       let uu____10986 =
+                                       let uu____10979 =
                                          check env1 original_body (M t2)  in
-                                       (match uu____10986 with
-                                        | (uu____11023,s_body1,u_body1) ->
+                                       (match uu____10979 with
+                                        | (uu____11016,s_body1,u_body1) ->
                                             ((M t2), (pat, guard, s_body1),
                                               (pat, guard, u_body1)))
-                                   | (M uu____11062,false ) ->
+                                   | (M uu____11055,false ) ->
                                        failwith "impossible")) nms branches1
                         in
-                     FStar_List.unzip3 uu____10712  in
-                   (match uu____10675 with
+                     FStar_List.unzip3 uu____10705  in
+                   (match uu____10668 with
                     | (nms1,s_branches,u_branches) ->
                         if has_m
                         then
@@ -3054,29 +3036,29 @@ and (mk_match :
                              in
                           let s_branches1 =
                             FStar_List.map
-                              (fun uu____11251  ->
-                                 match uu____11251 with
+                              (fun uu____11244  ->
+                                 match uu____11244 with
                                  | (pat,guard,s_body) ->
                                      let s_body1 =
-                                       let uu____11302 =
-                                         let uu____11303 =
-                                           let uu____11320 =
-                                             let uu____11331 =
-                                               let uu____11340 =
+                                       let uu____11295 =
+                                         let uu____11296 =
+                                           let uu____11313 =
+                                             let uu____11324 =
+                                               let uu____11333 =
                                                  FStar_Syntax_Syntax.bv_to_name
                                                    p
                                                   in
-                                               let uu____11343 =
+                                               let uu____11336 =
                                                  FStar_Syntax_Syntax.as_implicit
                                                    false
                                                   in
-                                               (uu____11340, uu____11343)  in
-                                             [uu____11331]  in
-                                           (s_body, uu____11320)  in
+                                               (uu____11333, uu____11336)  in
+                                             [uu____11324]  in
+                                           (s_body, uu____11313)  in
                                          FStar_Syntax_Syntax.Tm_app
-                                           uu____11303
+                                           uu____11296
                                           in
-                                       mk uu____11302  in
+                                       mk uu____11295  in
                                      (pat, guard, s_body1)) s_branches
                              in
                           let s_branches2 =
@@ -3088,38 +3070,38 @@ and (mk_match :
                               u_branches
                              in
                           let s_e =
-                            let uu____11478 =
-                              let uu____11479 =
+                            let uu____11471 =
+                              let uu____11472 =
                                 FStar_Syntax_Syntax.mk_binder p  in
-                              [uu____11479]  in
-                            let uu____11498 =
+                              [uu____11472]  in
+                            let uu____11491 =
                               mk
                                 (FStar_Syntax_Syntax.Tm_match
                                    (s_e0, s_branches2))
                                in
-                            FStar_Syntax_Util.abs uu____11478 uu____11498
+                            FStar_Syntax_Util.abs uu____11471 uu____11491
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
                                     FStar_Syntax_Util.ktype0))
                              in
                           let t1_star =
-                            let uu____11522 =
-                              let uu____11531 =
-                                let uu____11538 =
+                            let uu____11515 =
+                              let uu____11524 =
+                                let uu____11531 =
                                   FStar_Syntax_Syntax.new_bv
                                     FStar_Pervasives_Native.None p_type
                                    in
                                 FStar_All.pipe_left
-                                  FStar_Syntax_Syntax.mk_binder uu____11538
+                                  FStar_Syntax_Syntax.mk_binder uu____11531
                                  in
-                              [uu____11531]  in
-                            let uu____11557 =
+                              [uu____11524]  in
+                            let uu____11550 =
                               FStar_Syntax_Syntax.mk_Total
                                 FStar_Syntax_Util.ktype0
                                in
-                            FStar_Syntax_Util.arrow uu____11522 uu____11557
+                            FStar_Syntax_Util.arrow uu____11515 uu____11550
                              in
-                          let uu____11560 =
+                          let uu____11553 =
                             mk
                               (FStar_Syntax_Syntax.Tm_ascribed
                                  (s_e,
@@ -3127,12 +3109,12 @@ and (mk_match :
                                      FStar_Pervasives_Native.None),
                                    FStar_Pervasives_Native.None))
                              in
-                          let uu____11599 =
+                          let uu____11592 =
                             mk
                               (FStar_Syntax_Syntax.Tm_match
                                  (u_e0, u_branches1))
                              in
-                          ((M t1), uu____11560, uu____11599)
+                          ((M t1), uu____11553, uu____11592)
                         else
                           (let s_branches1 =
                              FStar_List.map FStar_Syntax_Subst.close_branch
@@ -3143,28 +3125,28 @@ and (mk_match :
                                u_branches
                               in
                            let t1_star = t1  in
-                           let uu____11709 =
-                             let uu____11710 =
-                               let uu____11711 =
-                                 let uu____11738 =
+                           let uu____11702 =
+                             let uu____11703 =
+                               let uu____11704 =
+                                 let uu____11731 =
                                    mk
                                      (FStar_Syntax_Syntax.Tm_match
                                         (s_e0, s_branches1))
                                     in
-                                 (uu____11738,
+                                 (uu____11731,
                                    ((FStar_Util.Inl t1_star),
                                      FStar_Pervasives_Native.None),
                                    FStar_Pervasives_Native.None)
                                   in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____11711
+                               FStar_Syntax_Syntax.Tm_ascribed uu____11704
                                 in
-                             mk uu____11710  in
-                           let uu____11797 =
+                             mk uu____11703  in
+                           let uu____11790 =
                              mk
                                (FStar_Syntax_Syntax.Tm_match
                                   (u_e0, u_branches1))
                               in
-                           ((N t1), uu____11709, uu____11797))))
+                           ((N t1), uu____11702, uu____11790))))
 
 and (mk_let :
   env_ ->
@@ -3185,179 +3167,177 @@ and (mk_let :
       fun e2  ->
         fun proceed  ->
           fun ensure_m  ->
-            let mk x =
-              FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-                e2.FStar_Syntax_Syntax.pos
+            let mk x = FStar_Syntax_Syntax.mk x e2.FStar_Syntax_Syntax.pos
                in
             let e1 = binding.FStar_Syntax_Syntax.lbdef  in
             let x = FStar_Util.left binding.FStar_Syntax_Syntax.lbname  in
             let x_binders =
-              let uu____11862 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____11862]  in
-            let uu____11881 = FStar_Syntax_Subst.open_term x_binders e2  in
-            match uu____11881 with
+              let uu____11855 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____11855]  in
+            let uu____11874 = FStar_Syntax_Subst.open_term x_binders e2  in
+            match uu____11874 with
             | (x_binders1,e21) ->
-                let uu____11894 = infer env1 e1  in
-                (match uu____11894 with
+                let uu____11887 = infer env1 e1  in
+                (match uu____11887 with
                  | (N t1,s_e1,u_e1) ->
                      let u_binding =
-                       let uu____11911 = is_C t1  in
-                       if uu____11911
+                       let uu____11904 = is_C t1  in
+                       if uu____11904
                        then
-                         let uu___1203_11914 = binding  in
-                         let uu____11915 =
-                           let uu____11918 =
+                         let uu___1203_11907 = binding  in
+                         let uu____11908 =
+                           let uu____11911 =
                              FStar_Syntax_Subst.subst env1.subst s_e1  in
-                           trans_F_ env1 t1 uu____11918  in
+                           trans_F_ env1 t1 uu____11911  in
                          {
                            FStar_Syntax_Syntax.lbname =
-                             (uu___1203_11914.FStar_Syntax_Syntax.lbname);
+                             (uu___1203_11907.FStar_Syntax_Syntax.lbname);
                            FStar_Syntax_Syntax.lbunivs =
-                             (uu___1203_11914.FStar_Syntax_Syntax.lbunivs);
-                           FStar_Syntax_Syntax.lbtyp = uu____11915;
+                             (uu___1203_11907.FStar_Syntax_Syntax.lbunivs);
+                           FStar_Syntax_Syntax.lbtyp = uu____11908;
                            FStar_Syntax_Syntax.lbeff =
-                             (uu___1203_11914.FStar_Syntax_Syntax.lbeff);
+                             (uu___1203_11907.FStar_Syntax_Syntax.lbeff);
                            FStar_Syntax_Syntax.lbdef =
-                             (uu___1203_11914.FStar_Syntax_Syntax.lbdef);
+                             (uu___1203_11907.FStar_Syntax_Syntax.lbdef);
                            FStar_Syntax_Syntax.lbattrs =
-                             (uu___1203_11914.FStar_Syntax_Syntax.lbattrs);
+                             (uu___1203_11907.FStar_Syntax_Syntax.lbattrs);
                            FStar_Syntax_Syntax.lbpos =
-                             (uu___1203_11914.FStar_Syntax_Syntax.lbpos)
+                             (uu___1203_11907.FStar_Syntax_Syntax.lbpos)
                          }
                        else binding  in
                      let env2 =
-                       let uu___1206_11922 = env1  in
-                       let uu____11923 =
+                       let uu___1206_11915 = env1  in
+                       let uu____11916 =
                          FStar_TypeChecker_Env.push_bv env1.tcenv
-                           (let uu___1208_11925 = x  in
+                           (let uu___1208_11918 = x  in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___1208_11925.FStar_Syntax_Syntax.ppname);
+                                (uu___1208_11918.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___1208_11925.FStar_Syntax_Syntax.index);
+                                (uu___1208_11918.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             })
                           in
                        {
-                         tcenv = uu____11923;
-                         subst = (uu___1206_11922.subst);
-                         tc_const = (uu___1206_11922.tc_const)
+                         tcenv = uu____11916;
+                         subst = (uu___1206_11915.subst);
+                         tc_const = (uu___1206_11915.tc_const)
                        }  in
-                     let uu____11926 = proceed env2 e21  in
-                     (match uu____11926 with
+                     let uu____11919 = proceed env2 e21  in
+                     (match uu____11919 with
                       | (nm_rec,s_e2,u_e2) ->
                           let s_binding =
-                            let uu___1215_11943 = binding  in
-                            let uu____11944 =
+                            let uu___1215_11936 = binding  in
+                            let uu____11937 =
                               star_type' env2
                                 binding.FStar_Syntax_Syntax.lbtyp
                                in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___1215_11943.FStar_Syntax_Syntax.lbname);
+                                (uu___1215_11936.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___1215_11943.FStar_Syntax_Syntax.lbunivs);
-                              FStar_Syntax_Syntax.lbtyp = uu____11944;
+                                (uu___1215_11936.FStar_Syntax_Syntax.lbunivs);
+                              FStar_Syntax_Syntax.lbtyp = uu____11937;
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___1215_11943.FStar_Syntax_Syntax.lbeff);
+                                (uu___1215_11936.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef =
-                                (uu___1215_11943.FStar_Syntax_Syntax.lbdef);
+                                (uu___1215_11936.FStar_Syntax_Syntax.lbdef);
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___1215_11943.FStar_Syntax_Syntax.lbattrs);
+                                (uu___1215_11936.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___1215_11943.FStar_Syntax_Syntax.lbpos)
+                                (uu___1215_11936.FStar_Syntax_Syntax.lbpos)
                             }  in
-                          let uu____11947 =
-                            let uu____11948 =
-                              let uu____11949 =
-                                let uu____11963 =
+                          let uu____11940 =
+                            let uu____11941 =
+                              let uu____11942 =
+                                let uu____11956 =
                                   FStar_Syntax_Subst.close x_binders1 s_e2
                                    in
                                 ((false,
-                                   [(let uu___1218_11980 = s_binding  in
+                                   [(let uu___1218_11973 = s_binding  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1218_11980.FStar_Syntax_Syntax.lbname);
+                                         (uu___1218_11973.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1218_11980.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___1218_11973.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1218_11980.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___1218_11973.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1218_11980.FStar_Syntax_Syntax.lbeff);
+                                         (uu___1218_11973.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = s_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1218_11980.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___1218_11973.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1218_11980.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____11963)
+                                         (uu___1218_11973.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu____11956)
                                  in
-                              FStar_Syntax_Syntax.Tm_let uu____11949  in
-                            mk uu____11948  in
-                          let uu____11981 =
-                            let uu____11982 =
-                              let uu____11983 =
-                                let uu____11997 =
+                              FStar_Syntax_Syntax.Tm_let uu____11942  in
+                            mk uu____11941  in
+                          let uu____11974 =
+                            let uu____11975 =
+                              let uu____11976 =
+                                let uu____11990 =
                                   FStar_Syntax_Subst.close x_binders1 u_e2
                                    in
                                 ((false,
-                                   [(let uu___1220_12014 = u_binding  in
+                                   [(let uu___1220_12007 = u_binding  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1220_12014.FStar_Syntax_Syntax.lbname);
+                                         (uu___1220_12007.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1220_12014.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___1220_12007.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1220_12014.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___1220_12007.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1220_12014.FStar_Syntax_Syntax.lbeff);
+                                         (uu___1220_12007.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1220_12014.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___1220_12007.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1220_12014.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____11997)
+                                         (uu___1220_12007.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu____11990)
                                  in
-                              FStar_Syntax_Syntax.Tm_let uu____11983  in
-                            mk uu____11982  in
-                          (nm_rec, uu____11947, uu____11981))
+                              FStar_Syntax_Syntax.Tm_let uu____11976  in
+                            mk uu____11975  in
+                          (nm_rec, uu____11940, uu____11974))
                  | (M t1,s_e1,u_e1) ->
                      let u_binding =
-                       let uu___1227_12019 = binding  in
+                       let uu___1227_12012 = binding  in
                        {
                          FStar_Syntax_Syntax.lbname =
-                           (uu___1227_12019.FStar_Syntax_Syntax.lbname);
+                           (uu___1227_12012.FStar_Syntax_Syntax.lbname);
                          FStar_Syntax_Syntax.lbunivs =
-                           (uu___1227_12019.FStar_Syntax_Syntax.lbunivs);
+                           (uu___1227_12012.FStar_Syntax_Syntax.lbunivs);
                          FStar_Syntax_Syntax.lbtyp = t1;
                          FStar_Syntax_Syntax.lbeff =
                            FStar_Parser_Const.effect_PURE_lid;
                          FStar_Syntax_Syntax.lbdef =
-                           (uu___1227_12019.FStar_Syntax_Syntax.lbdef);
+                           (uu___1227_12012.FStar_Syntax_Syntax.lbdef);
                          FStar_Syntax_Syntax.lbattrs =
-                           (uu___1227_12019.FStar_Syntax_Syntax.lbattrs);
+                           (uu___1227_12012.FStar_Syntax_Syntax.lbattrs);
                          FStar_Syntax_Syntax.lbpos =
-                           (uu___1227_12019.FStar_Syntax_Syntax.lbpos)
+                           (uu___1227_12012.FStar_Syntax_Syntax.lbpos)
                        }  in
                      let env2 =
-                       let uu___1230_12021 = env1  in
-                       let uu____12022 =
+                       let uu___1230_12014 = env1  in
+                       let uu____12015 =
                          FStar_TypeChecker_Env.push_bv env1.tcenv
-                           (let uu___1232_12024 = x  in
+                           (let uu___1232_12017 = x  in
                             {
                               FStar_Syntax_Syntax.ppname =
-                                (uu___1232_12024.FStar_Syntax_Syntax.ppname);
+                                (uu___1232_12017.FStar_Syntax_Syntax.ppname);
                               FStar_Syntax_Syntax.index =
-                                (uu___1232_12024.FStar_Syntax_Syntax.index);
+                                (uu___1232_12017.FStar_Syntax_Syntax.index);
                               FStar_Syntax_Syntax.sort = t1
                             })
                           in
                        {
-                         tcenv = uu____12022;
-                         subst = (uu___1230_12021.subst);
-                         tc_const = (uu___1230_12021.tc_const)
+                         tcenv = uu____12015;
+                         subst = (uu___1230_12014.subst);
+                         tc_const = (uu___1230_12014.tc_const)
                        }  in
-                     let uu____12025 = ensure_m env2 e21  in
-                     (match uu____12025 with
+                     let uu____12018 = ensure_m env2 e21  in
+                     (match uu____12018 with
                       | (t2,s_e2,u_e2) ->
                           let p_type = mk_star_to_type mk env2 t2  in
                           let p =
@@ -3365,20 +3345,20 @@ and (mk_let :
                               FStar_Pervasives_Native.None p_type
                              in
                           let s_e21 =
-                            let uu____12049 =
-                              let uu____12050 =
-                                let uu____12067 =
-                                  let uu____12078 =
-                                    let uu____12087 =
+                            let uu____12042 =
+                              let uu____12043 =
+                                let uu____12060 =
+                                  let uu____12071 =
+                                    let uu____12080 =
                                       FStar_Syntax_Syntax.bv_to_name p  in
-                                    let uu____12090 =
+                                    let uu____12083 =
                                       FStar_Syntax_Syntax.as_implicit false
                                        in
-                                    (uu____12087, uu____12090)  in
-                                  [uu____12078]  in
-                                (s_e2, uu____12067)  in
-                              FStar_Syntax_Syntax.Tm_app uu____12050  in
-                            mk uu____12049  in
+                                    (uu____12080, uu____12083)  in
+                                  [uu____12071]  in
+                                (s_e2, uu____12060)  in
+                              FStar_Syntax_Syntax.Tm_app uu____12043  in
+                            mk uu____12042  in
                           let s_e22 =
                             FStar_Syntax_Util.abs x_binders1 s_e21
                               (FStar_Pervasives_Native.Some
@@ -3386,55 +3366,55 @@ and (mk_let :
                                     FStar_Syntax_Util.ktype0))
                              in
                           let body =
-                            let uu____12132 =
-                              let uu____12133 =
-                                let uu____12150 =
-                                  let uu____12161 =
-                                    let uu____12170 =
+                            let uu____12125 =
+                              let uu____12126 =
+                                let uu____12143 =
+                                  let uu____12154 =
+                                    let uu____12163 =
                                       FStar_Syntax_Syntax.as_implicit false
                                        in
-                                    (s_e22, uu____12170)  in
-                                  [uu____12161]  in
-                                (s_e1, uu____12150)  in
-                              FStar_Syntax_Syntax.Tm_app uu____12133  in
-                            mk uu____12132  in
-                          let uu____12206 =
-                            let uu____12207 =
-                              let uu____12208 =
+                                    (s_e22, uu____12163)  in
+                                  [uu____12154]  in
+                                (s_e1, uu____12143)  in
+                              FStar_Syntax_Syntax.Tm_app uu____12126  in
+                            mk uu____12125  in
+                          let uu____12199 =
+                            let uu____12200 =
+                              let uu____12201 =
                                 FStar_Syntax_Syntax.mk_binder p  in
-                              [uu____12208]  in
-                            FStar_Syntax_Util.abs uu____12207 body
+                              [uu____12201]  in
+                            FStar_Syntax_Util.abs uu____12200 body
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_tot
                                     FStar_Syntax_Util.ktype0))
                              in
-                          let uu____12227 =
-                            let uu____12228 =
-                              let uu____12229 =
-                                let uu____12243 =
+                          let uu____12220 =
+                            let uu____12221 =
+                              let uu____12222 =
+                                let uu____12236 =
                                   FStar_Syntax_Subst.close x_binders1 u_e2
                                    in
                                 ((false,
-                                   [(let uu___1244_12260 = u_binding  in
+                                   [(let uu___1244_12253 = u_binding  in
                                      {
                                        FStar_Syntax_Syntax.lbname =
-                                         (uu___1244_12260.FStar_Syntax_Syntax.lbname);
+                                         (uu___1244_12253.FStar_Syntax_Syntax.lbname);
                                        FStar_Syntax_Syntax.lbunivs =
-                                         (uu___1244_12260.FStar_Syntax_Syntax.lbunivs);
+                                         (uu___1244_12253.FStar_Syntax_Syntax.lbunivs);
                                        FStar_Syntax_Syntax.lbtyp =
-                                         (uu___1244_12260.FStar_Syntax_Syntax.lbtyp);
+                                         (uu___1244_12253.FStar_Syntax_Syntax.lbtyp);
                                        FStar_Syntax_Syntax.lbeff =
-                                         (uu___1244_12260.FStar_Syntax_Syntax.lbeff);
+                                         (uu___1244_12253.FStar_Syntax_Syntax.lbeff);
                                        FStar_Syntax_Syntax.lbdef = u_e1;
                                        FStar_Syntax_Syntax.lbattrs =
-                                         (uu___1244_12260.FStar_Syntax_Syntax.lbattrs);
+                                         (uu___1244_12253.FStar_Syntax_Syntax.lbattrs);
                                        FStar_Syntax_Syntax.lbpos =
-                                         (uu___1244_12260.FStar_Syntax_Syntax.lbpos)
-                                     })]), uu____12243)
+                                         (uu___1244_12253.FStar_Syntax_Syntax.lbpos)
+                                     })]), uu____12236)
                                  in
-                              FStar_Syntax_Syntax.Tm_let uu____12229  in
-                            mk uu____12228  in
-                          ((M t2), uu____12206, uu____12227)))
+                              FStar_Syntax_Syntax.Tm_let uu____12222  in
+                            mk uu____12221  in
+                          ((M t2), uu____12199, uu____12220)))
 
 and (check_n :
   env_ ->
@@ -3445,15 +3425,15 @@ and (check_n :
   fun env1  ->
     fun e  ->
       let mn =
-        let uu____12270 =
+        let uu____12263 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-            FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+            e.FStar_Syntax_Syntax.pos
            in
-        N uu____12270  in
-      let uu____12271 = check env1 e mn  in
-      match uu____12271 with
+        N uu____12263  in
+      let uu____12264 = check env1 e mn  in
+      match uu____12264 with
       | (N t,s_e,u_e) -> (t, s_e, u_e)
-      | uu____12287 -> failwith "[check_n]: impossible"
+      | uu____12280 -> failwith "[check_n]: impossible"
 
 and (check_m :
   env_ ->
@@ -3464,15 +3444,15 @@ and (check_m :
   fun env1  ->
     fun e  ->
       let mn =
-        let uu____12310 =
+        let uu____12303 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-            FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+            e.FStar_Syntax_Syntax.pos
            in
-        M uu____12310  in
-      let uu____12311 = check env1 e mn  in
-      match uu____12311 with
+        M uu____12303  in
+      let uu____12304 = check env1 e mn  in
+      match uu____12304 with
       | (M t,s_e,u_e) -> (t, s_e, u_e)
-      | uu____12327 -> failwith "[check_m]: impossible"
+      | uu____12320 -> failwith "[check_m]: impossible"
 
 and (comp_of_nm : nm_ -> FStar_Syntax_Syntax.comp) =
   fun nm1  ->
@@ -3503,188 +3483,185 @@ and (trans_F_ :
   fun env1  ->
     fun c  ->
       fun wp  ->
-        (let uu____12360 =
-           let uu____12362 = is_C c  in Prims.op_Negation uu____12362  in
-         if uu____12360
+        (let uu____12353 =
+           let uu____12355 = is_C c  in Prims.op_Negation uu____12355  in
+         if uu____12353
          then
-           let uu____12365 =
-             let uu____12371 =
-               let uu____12373 = FStar_Syntax_Print.term_to_string c  in
-               FStar_Util.format1 "Not a DM4F C-type: %s" uu____12373  in
-             (FStar_Errors.Error_UnexpectedDM4FType, uu____12371)  in
-           FStar_Errors.raise_error uu____12365 c.FStar_Syntax_Syntax.pos
+           let uu____12358 =
+             let uu____12364 =
+               let uu____12366 = FStar_Syntax_Print.term_to_string c  in
+               FStar_Util.format1 "Not a DM4F C-type: %s" uu____12366  in
+             (FStar_Errors.Error_UnexpectedDM4FType, uu____12364)  in
+           FStar_Errors.raise_error uu____12358 c.FStar_Syntax_Syntax.pos
          else ());
-        (let mk x =
-           FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-             c.FStar_Syntax_Syntax.pos
-            in
-         let uu____12387 =
-           let uu____12388 = FStar_Syntax_Subst.compress c  in
-           uu____12388.FStar_Syntax_Syntax.n  in
-         match uu____12387 with
+        (let mk x = FStar_Syntax_Syntax.mk x c.FStar_Syntax_Syntax.pos  in
+         let uu____12380 =
+           let uu____12381 = FStar_Syntax_Subst.compress c  in
+           uu____12381.FStar_Syntax_Syntax.n  in
+         match uu____12380 with
          | FStar_Syntax_Syntax.Tm_app (head,args) ->
-             let uu____12417 = FStar_Syntax_Util.head_and_args wp  in
-             (match uu____12417 with
+             let uu____12410 = FStar_Syntax_Util.head_and_args wp  in
+             (match uu____12410 with
               | (wp_head,wp_args) ->
-                  ((let uu____12461 =
+                  ((let uu____12454 =
                       (Prims.op_Negation
                          ((FStar_List.length wp_args) =
                             (FStar_List.length args)))
                         ||
-                        (let uu____12480 =
-                           let uu____12482 =
+                        (let uu____12473 =
+                           let uu____12475 =
                              FStar_Parser_Const.mk_tuple_data_lid
                                (FStar_List.length wp_args)
                                FStar_Range.dummyRange
                               in
                            FStar_Syntax_Util.is_constructor wp_head
-                             uu____12482
+                             uu____12475
                             in
-                         Prims.op_Negation uu____12480)
+                         Prims.op_Negation uu____12473)
                        in
-                    if uu____12461 then failwith "mismatch" else ());
-                   (let uu____12495 =
-                      let uu____12496 =
-                        let uu____12513 =
+                    if uu____12454 then failwith "mismatch" else ());
+                   (let uu____12488 =
+                      let uu____12489 =
+                        let uu____12506 =
                           FStar_List.map2
-                            (fun uu____12551  ->
-                               fun uu____12552  ->
-                                 match (uu____12551, uu____12552) with
+                            (fun uu____12544  ->
+                               fun uu____12545  ->
+                                 match (uu____12544, uu____12545) with
                                  | ((arg,q),(wp_arg,q')) ->
                                      let print_implicit q1 =
-                                       let uu____12614 =
+                                       let uu____12607 =
                                          FStar_Syntax_Syntax.is_implicit q1
                                           in
-                                       if uu____12614
+                                       if uu____12607
                                        then "implicit"
                                        else "explicit"  in
-                                     ((let uu____12623 =
-                                         let uu____12625 =
+                                     ((let uu____12616 =
+                                         let uu____12618 =
                                            FStar_Syntax_Util.eq_aqual q q'
                                             in
-                                         uu____12625 <>
+                                         uu____12618 <>
                                            FStar_Syntax_Util.Equal
                                           in
-                                       if uu____12623
+                                       if uu____12616
                                        then
-                                         let uu____12627 =
-                                           let uu____12633 =
-                                             let uu____12635 =
+                                         let uu____12620 =
+                                           let uu____12626 =
+                                             let uu____12628 =
                                                print_implicit q  in
-                                             let uu____12637 =
+                                             let uu____12630 =
                                                print_implicit q'  in
                                              FStar_Util.format2
                                                "Incoherent implicit qualifiers %s %s\n"
-                                               uu____12635 uu____12637
+                                               uu____12628 uu____12630
                                               in
                                            (FStar_Errors.Warning_IncoherentImplicitQualifier,
-                                             uu____12633)
+                                             uu____12626)
                                             in
                                          FStar_Errors.log_issue
                                            head.FStar_Syntax_Syntax.pos
-                                           uu____12627
+                                           uu____12620
                                        else ());
-                                      (let uu____12643 =
+                                      (let uu____12636 =
                                          trans_F_ env1 arg wp_arg  in
-                                       (uu____12643, q)))) args wp_args
+                                       (uu____12636, q)))) args wp_args
                            in
-                        (head, uu____12513)  in
-                      FStar_Syntax_Syntax.Tm_app uu____12496  in
-                    mk uu____12495)))
+                        (head, uu____12506)  in
+                      FStar_Syntax_Syntax.Tm_app uu____12489  in
+                    mk uu____12488)))
          | FStar_Syntax_Syntax.Tm_arrow (binders,comp) ->
              let binders1 = FStar_Syntax_Util.name_binders binders  in
-             let uu____12689 = FStar_Syntax_Subst.open_comp binders1 comp  in
-             (match uu____12689 with
+             let uu____12682 = FStar_Syntax_Subst.open_comp binders1 comp  in
+             (match uu____12682 with
               | (binders_orig,comp1) ->
-                  let uu____12696 =
-                    let uu____12713 =
+                  let uu____12689 =
+                    let uu____12706 =
                       FStar_List.map
-                        (fun uu____12753  ->
-                           match uu____12753 with
+                        (fun uu____12746  ->
+                           match uu____12746 with
                            | (bv,q) ->
                                let h = bv.FStar_Syntax_Syntax.sort  in
-                               let uu____12781 = is_C h  in
-                               if uu____12781
+                               let uu____12774 = is_C h  in
+                               if uu____12774
                                then
                                  let w' =
-                                   let uu____12797 =
-                                     let uu____12799 =
+                                   let uu____12790 =
+                                     let uu____12792 =
                                        FStar_Ident.text_of_id
                                          bv.FStar_Syntax_Syntax.ppname
                                         in
-                                     Prims.op_Hat uu____12799 "__w'"  in
-                                   let uu____12802 = star_type' env1 h  in
-                                   FStar_Syntax_Syntax.gen_bv uu____12797
-                                     FStar_Pervasives_Native.None uu____12802
+                                     Prims.op_Hat uu____12792 "__w'"  in
+                                   let uu____12795 = star_type' env1 h  in
+                                   FStar_Syntax_Syntax.gen_bv uu____12790
+                                     FStar_Pervasives_Native.None uu____12795
                                     in
-                                 let uu____12803 =
-                                   let uu____12812 =
-                                     let uu____12821 =
-                                       let uu____12828 =
-                                         let uu____12829 =
-                                           let uu____12830 =
+                                 let uu____12796 =
+                                   let uu____12805 =
+                                     let uu____12814 =
+                                       let uu____12821 =
+                                         let uu____12822 =
+                                           let uu____12823 =
                                              FStar_Syntax_Syntax.bv_to_name
                                                w'
                                               in
-                                           trans_F_ env1 h uu____12830  in
+                                           trans_F_ env1 h uu____12823  in
                                          FStar_Syntax_Syntax.null_bv
-                                           uu____12829
+                                           uu____12822
                                           in
-                                       (uu____12828, q)  in
-                                     [uu____12821]  in
-                                   (w', q) :: uu____12812  in
-                                 (w', uu____12803)
+                                       (uu____12821, q)  in
+                                     [uu____12814]  in
+                                   (w', q) :: uu____12805  in
+                                 (w', uu____12796)
                                else
                                  (let x =
-                                    let uu____12864 =
-                                      let uu____12866 =
+                                    let uu____12857 =
+                                      let uu____12859 =
                                         FStar_Ident.text_of_id
                                           bv.FStar_Syntax_Syntax.ppname
                                          in
-                                      Prims.op_Hat uu____12866 "__x"  in
-                                    let uu____12869 = star_type' env1 h  in
-                                    FStar_Syntax_Syntax.gen_bv uu____12864
+                                      Prims.op_Hat uu____12859 "__x"  in
+                                    let uu____12862 = star_type' env1 h  in
+                                    FStar_Syntax_Syntax.gen_bv uu____12857
                                       FStar_Pervasives_Native.None
-                                      uu____12869
+                                      uu____12862
                                      in
                                   (x, [(x, q)]))) binders_orig
                        in
-                    FStar_List.split uu____12713  in
-                  (match uu____12696 with
+                    FStar_List.split uu____12706  in
+                  (match uu____12689 with
                    | (bvs,binders2) ->
                        let binders3 = FStar_List.flatten binders2  in
                        let comp2 =
-                         let uu____12942 =
-                           let uu____12945 =
+                         let uu____12935 =
+                           let uu____12938 =
                              FStar_Syntax_Syntax.binders_of_list bvs  in
                            FStar_Syntax_Util.rename_binders binders_orig
-                             uu____12945
+                             uu____12938
                             in
-                         FStar_Syntax_Subst.subst_comp uu____12942 comp1  in
+                         FStar_Syntax_Subst.subst_comp uu____12935 comp1  in
                        let app =
-                         let uu____12949 =
-                           let uu____12950 =
-                             let uu____12967 =
+                         let uu____12942 =
+                           let uu____12943 =
+                             let uu____12960 =
                                FStar_List.map
                                  (fun bv  ->
-                                    let uu____12986 =
+                                    let uu____12979 =
                                       FStar_Syntax_Syntax.bv_to_name bv  in
-                                    let uu____12987 =
+                                    let uu____12980 =
                                       FStar_Syntax_Syntax.as_implicit false
                                        in
-                                    (uu____12986, uu____12987)) bvs
+                                    (uu____12979, uu____12980)) bvs
                                 in
-                             (wp, uu____12967)  in
-                           FStar_Syntax_Syntax.Tm_app uu____12950  in
-                         mk uu____12949  in
+                             (wp, uu____12960)  in
+                           FStar_Syntax_Syntax.Tm_app uu____12943  in
+                         mk uu____12942  in
                        let comp3 =
-                         let uu____13002 = type_of_comp comp2  in
-                         let uu____13003 = is_monadic_comp comp2  in
-                         trans_G env1 uu____13002 uu____13003 app  in
+                         let uu____12995 = type_of_comp comp2  in
+                         let uu____12996 = is_monadic_comp comp2  in
+                         trans_G env1 uu____12995 uu____12996 app  in
                        FStar_Syntax_Util.arrow binders3 comp3))
-         | FStar_Syntax_Syntax.Tm_ascribed (e,uu____13006,uu____13007) ->
+         | FStar_Syntax_Syntax.Tm_ascribed (e,uu____12999,uu____13000) ->
              trans_F_ env1 e wp
-         | uu____13048 -> failwith "impossible trans_F_")
+         | uu____13041 -> failwith "impossible trans_F_")
 
 and (trans_G :
   env_ ->
@@ -3697,26 +3674,26 @@ and (trans_G :
         fun wp  ->
           if is_monadic1
           then
-            let uu____13056 =
-              let uu____13057 = star_type' env1 h  in
-              let uu____13060 =
-                let uu____13071 =
-                  let uu____13080 = FStar_Syntax_Syntax.as_implicit false  in
-                  (wp, uu____13080)  in
-                [uu____13071]  in
+            let uu____13049 =
+              let uu____13050 = star_type' env1 h  in
+              let uu____13053 =
+                let uu____13064 =
+                  let uu____13073 = FStar_Syntax_Syntax.as_implicit false  in
+                  (wp, uu____13073)  in
+                [uu____13064]  in
               {
                 FStar_Syntax_Syntax.comp_univs =
                   [FStar_Syntax_Syntax.U_unknown];
                 FStar_Syntax_Syntax.effect_name =
                   FStar_Parser_Const.effect_PURE_lid;
-                FStar_Syntax_Syntax.result_typ = uu____13057;
-                FStar_Syntax_Syntax.effect_args = uu____13060;
+                FStar_Syntax_Syntax.result_typ = uu____13050;
+                FStar_Syntax_Syntax.effect_args = uu____13053;
                 FStar_Syntax_Syntax.flags = []
               }  in
-            FStar_Syntax_Syntax.mk_Comp uu____13056
+            FStar_Syntax_Syntax.mk_Comp uu____13049
           else
-            (let uu____13106 = trans_F_ env1 h wp  in
-             FStar_Syntax_Syntax.mk_Total uu____13106)
+            (let uu____13099 = trans_F_ env1 h wp  in
+             FStar_Syntax_Syntax.mk_Total uu____13099)
 
 let (n :
   FStar_TypeChecker_Env.env ->
@@ -3732,7 +3709,7 @@ let (n :
 let (star_type : env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
   fun env1  ->
     fun t  ->
-      let uu____13127 = n env1.tcenv t  in star_type' env1 uu____13127
+      let uu____13120 = n env1.tcenv t  in star_type' env1 uu____13120
   
 let (star_expr :
   env ->
@@ -3741,7 +3718,7 @@ let (star_expr :
         FStar_Syntax_Syntax.term))
   =
   fun env1  ->
-    fun t  -> let uu____13147 = n env1.tcenv t  in check_n env1 uu____13147
+    fun t  -> let uu____13140 = n env1.tcenv t  in check_n env1 uu____13140
   
 let (trans_F :
   env ->
@@ -3751,9 +3728,9 @@ let (trans_F :
   fun env1  ->
     fun c  ->
       fun wp  ->
-        let uu____13164 = n env1.tcenv c  in
-        let uu____13165 = n env1.tcenv wp  in
-        trans_F_ env1 uu____13164 uu____13165
+        let uu____13157 = n env1.tcenv c  in
+        let uu____13158 = n env1.tcenv wp  in
+        trans_F_ env1 uu____13157 uu____13158
   
 let (recheck_debug :
   Prims.string ->
@@ -3763,26 +3740,26 @@ let (recheck_debug :
   fun s  ->
     fun env1  ->
       fun t  ->
-        (let uu____13185 =
+        (let uu____13178 =
            FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED")  in
-         if uu____13185
+         if uu____13178
          then
-           let uu____13189 = FStar_Syntax_Print.term_to_string t  in
+           let uu____13182 = FStar_Syntax_Print.term_to_string t  in
            FStar_Util.print2
              "Term has been %s-transformed to:\n%s\n----------\n" s
-             uu____13189
+             uu____13182
          else ());
-        (let uu____13194 = FStar_TypeChecker_TcTerm.tc_term env1 t  in
-         match uu____13194 with
-         | (t',uu____13202,uu____13203) ->
-             ((let uu____13205 =
+        (let uu____13187 = FStar_TypeChecker_TcTerm.tc_term env1 t  in
+         match uu____13187 with
+         | (t',uu____13195,uu____13196) ->
+             ((let uu____13198 =
                  FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED")
                   in
-               if uu____13205
+               if uu____13198
                then
-                 let uu____13209 = FStar_Syntax_Print.term_to_string t'  in
+                 let uu____13202 = FStar_Syntax_Print.term_to_string t'  in
                  FStar_Util.print1 "Re-checked; got:\n%s\n----------\n"
-                   uu____13209
+                   uu____13202
                else ());
               t'))
   
@@ -3794,74 +3771,74 @@ let (cps_and_elaborate :
   =
   fun env1  ->
     fun ed  ->
-      let uu____13245 =
+      let uu____13238 =
         FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
           (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.signature)
          in
-      match uu____13245 with
+      match uu____13238 with
       | (effect_binders_un,signature_un) ->
-          let uu____13266 =
+          let uu____13259 =
             FStar_TypeChecker_TcTerm.tc_tparams env1 effect_binders_un  in
-          (match uu____13266 with
-           | (effect_binders,env2,uu____13285) ->
-               let uu____13286 =
+          (match uu____13259 with
+           | (effect_binders,env2,uu____13278) ->
+               let uu____13279 =
                  FStar_TypeChecker_TcTerm.tc_trivial_guard env2 signature_un
                   in
-               (match uu____13286 with
-                | (signature,uu____13302) ->
-                    let raise_error uu____13318 =
-                      match uu____13318 with
+               (match uu____13279 with
+                | (signature,uu____13295) ->
+                    let raise_error uu____13311 =
+                      match uu____13311 with
                       | (e,err_msg) ->
                           FStar_Errors.raise_error (e, err_msg)
                             signature.FStar_Syntax_Syntax.pos
                        in
                     let effect_binders1 =
                       FStar_List.map
-                        (fun uu____13354  ->
-                           match uu____13354 with
+                        (fun uu____13347  ->
+                           match uu____13347 with
                            | (bv,qual) ->
-                               let uu____13373 =
-                                 let uu___1370_13374 = bv  in
-                                 let uu____13375 =
+                               let uu____13366 =
+                                 let uu___1370_13367 = bv  in
+                                 let uu____13368 =
                                    FStar_TypeChecker_Normalize.normalize
                                      [FStar_TypeChecker_Env.EraseUniverses]
                                      env2 bv.FStar_Syntax_Syntax.sort
                                     in
                                  {
                                    FStar_Syntax_Syntax.ppname =
-                                     (uu___1370_13374.FStar_Syntax_Syntax.ppname);
+                                     (uu___1370_13367.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
-                                     (uu___1370_13374.FStar_Syntax_Syntax.index);
-                                   FStar_Syntax_Syntax.sort = uu____13375
+                                     (uu___1370_13367.FStar_Syntax_Syntax.index);
+                                   FStar_Syntax_Syntax.sort = uu____13368
                                  }  in
-                               (uu____13373, qual)) effect_binders
+                               (uu____13366, qual)) effect_binders
                        in
-                    let uu____13380 =
-                      let uu____13387 =
-                        let uu____13388 =
+                    let uu____13373 =
+                      let uu____13380 =
+                        let uu____13381 =
                           FStar_Syntax_Subst.compress signature_un  in
-                        uu____13388.FStar_Syntax_Syntax.n  in
-                      match uu____13387 with
+                        uu____13381.FStar_Syntax_Syntax.n  in
+                      match uu____13380 with
                       | FStar_Syntax_Syntax.Tm_arrow
-                          ((a,uu____13398)::[],effect_marker) ->
+                          ((a,uu____13391)::[],effect_marker) ->
                           (a, effect_marker)
-                      | uu____13430 ->
+                      | uu____13423 ->
                           raise_error
                             (FStar_Errors.Fatal_BadSignatureShape,
                               "bad shape for effect-for-free signature")
                        in
-                    (match uu____13380 with
+                    (match uu____13373 with
                      | (a,effect_marker) ->
                          let a1 =
-                           let uu____13456 = FStar_Syntax_Syntax.is_null_bv a
+                           let uu____13449 = FStar_Syntax_Syntax.is_null_bv a
                               in
-                           if uu____13456
+                           if uu____13449
                            then
-                             let uu____13459 =
-                               let uu____13462 =
+                             let uu____13452 =
+                               let uu____13455 =
                                  FStar_Syntax_Syntax.range_of_bv a  in
-                               FStar_Pervasives_Native.Some uu____13462  in
-                             FStar_Syntax_Syntax.gen_bv "a" uu____13459
+                               FStar_Pervasives_Native.Some uu____13455  in
+                             FStar_Syntax_Syntax.gen_bv "a" uu____13452
                                a.FStar_Syntax_Syntax.sort
                            else a  in
                          let open_and_check env3 other_binders t =
@@ -3871,42 +3848,41 @@ let (cps_and_elaborate :
                                   other_binders)
                               in
                            let t1 = FStar_Syntax_Subst.subst subst t  in
-                           let uu____13510 =
+                           let uu____13503 =
                              FStar_TypeChecker_TcTerm.tc_term env3 t1  in
-                           match uu____13510 with
-                           | (t2,comp,uu____13523) -> (t2, comp)  in
+                           match uu____13503 with
+                           | (t2,comp,uu____13516) -> (t2, comp)  in
                          let mk x =
                            FStar_Syntax_Syntax.mk x
-                             FStar_Pervasives_Native.None
                              signature.FStar_Syntax_Syntax.pos
                             in
-                         let uu____13532 =
-                           let uu____13537 =
-                             let uu____13538 =
-                               let uu____13547 =
+                         let uu____13525 =
+                           let uu____13530 =
+                             let uu____13531 =
+                               let uu____13540 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr
                                   in
-                               FStar_All.pipe_right uu____13547
+                               FStar_All.pipe_right uu____13540
                                  FStar_Util.must
                                 in
-                             FStar_All.pipe_right uu____13538
+                             FStar_All.pipe_right uu____13531
                                FStar_Pervasives_Native.snd
                               in
-                           open_and_check env2 [] uu____13537  in
-                         (match uu____13532 with
+                           open_and_check env2 [] uu____13530  in
+                         (match uu____13525 with
                           | (repr,_comp) ->
-                              ((let uu____13593 =
+                              ((let uu____13586 =
                                   FStar_TypeChecker_Env.debug env2
                                     (FStar_Options.Other "ED")
                                    in
-                                if uu____13593
+                                if uu____13586
                                 then
-                                  let uu____13597 =
+                                  let uu____13590 =
                                     FStar_Syntax_Print.term_to_string repr
                                      in
                                   FStar_Util.print1 "Representation is: %s\n"
-                                    uu____13597
+                                    uu____13590
                                 else ());
                                (let ed_range =
                                   FStar_TypeChecker_Env.get_range env2  in
@@ -3916,51 +3892,51 @@ let (cps_and_elaborate :
                                        env2 FStar_Range.dummyRange)
                                    in
                                 let wp_type = star_type dmff_env repr  in
-                                let uu____13605 =
+                                let uu____13598 =
                                   recheck_debug "*" env2 wp_type  in
                                 let wp_a =
-                                  let uu____13608 =
-                                    let uu____13609 =
-                                      let uu____13610 =
-                                        let uu____13627 =
-                                          let uu____13638 =
-                                            let uu____13647 =
+                                  let uu____13601 =
+                                    let uu____13602 =
+                                      let uu____13603 =
+                                        let uu____13620 =
+                                          let uu____13631 =
+                                            let uu____13640 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a1
                                                in
-                                            let uu____13650 =
+                                            let uu____13643 =
                                               FStar_Syntax_Syntax.as_implicit
                                                 false
                                                in
-                                            (uu____13647, uu____13650)  in
-                                          [uu____13638]  in
-                                        (wp_type, uu____13627)  in
-                                      FStar_Syntax_Syntax.Tm_app uu____13610
+                                            (uu____13640, uu____13643)  in
+                                          [uu____13631]  in
+                                        (wp_type, uu____13620)  in
+                                      FStar_Syntax_Syntax.Tm_app uu____13603
                                        in
-                                    mk uu____13609  in
+                                    mk uu____13602  in
                                   FStar_TypeChecker_Normalize.normalize
                                     [FStar_TypeChecker_Env.Beta] env2
-                                    uu____13608
+                                    uu____13601
                                    in
                                 let effect_signature =
                                   let binders =
-                                    let uu____13698 =
-                                      let uu____13705 =
+                                    let uu____13691 =
+                                      let uu____13698 =
                                         FStar_Syntax_Syntax.as_implicit false
                                          in
-                                      (a1, uu____13705)  in
-                                    let uu____13711 =
-                                      let uu____13720 =
-                                        let uu____13727 =
+                                      (a1, uu____13698)  in
+                                    let uu____13704 =
+                                      let uu____13713 =
+                                        let uu____13720 =
                                           FStar_Syntax_Syntax.gen_bv
                                             "dijkstra_wp"
                                             FStar_Pervasives_Native.None wp_a
                                            in
-                                        FStar_All.pipe_right uu____13727
+                                        FStar_All.pipe_right uu____13720
                                           FStar_Syntax_Syntax.mk_binder
                                          in
-                                      [uu____13720]  in
-                                    uu____13698 :: uu____13711  in
+                                      [uu____13713]  in
+                                    uu____13691 :: uu____13704  in
                                   let binders1 =
                                     FStar_Syntax_Subst.close_binders binders
                                      in
@@ -3968,7 +3944,7 @@ let (cps_and_elaborate :
                                     (FStar_Syntax_Syntax.Tm_arrow
                                        (binders1, effect_marker))
                                    in
-                                let uu____13764 =
+                                let uu____13757 =
                                   recheck_debug
                                     "turned into the effect signature" env2
                                     effect_signature
@@ -3979,87 +3955,87 @@ let (cps_and_elaborate :
                                 let elaborate_and_star dmff_env1
                                   other_binders item =
                                   let env3 = get_env dmff_env1  in
-                                  let uu____13830 = item  in
-                                  match uu____13830 with
+                                  let uu____13823 = item  in
+                                  match uu____13823 with
                                   | (u_item,item1) ->
-                                      let uu____13845 =
+                                      let uu____13838 =
                                         open_and_check env3 other_binders
                                           item1
                                          in
-                                      (match uu____13845 with
+                                      (match uu____13838 with
                                        | (item2,item_comp) ->
-                                           ((let uu____13861 =
-                                               let uu____13863 =
+                                           ((let uu____13854 =
+                                               let uu____13856 =
                                                  FStar_TypeChecker_Common.is_total_lcomp
                                                    item_comp
                                                   in
-                                               Prims.op_Negation uu____13863
+                                               Prims.op_Negation uu____13856
                                                 in
-                                             if uu____13861
+                                             if uu____13854
                                              then
-                                               let uu____13866 =
-                                                 let uu____13872 =
-                                                   let uu____13874 =
+                                               let uu____13859 =
+                                                 let uu____13865 =
+                                                   let uu____13867 =
                                                      FStar_Syntax_Print.term_to_string
                                                        item2
                                                       in
-                                                   let uu____13876 =
+                                                   let uu____13869 =
                                                      FStar_TypeChecker_Common.lcomp_to_string
                                                        item_comp
                                                       in
                                                    FStar_Util.format2
                                                      "Computation for [%s] is not total : %s !"
-                                                     uu____13874 uu____13876
+                                                     uu____13867 uu____13869
                                                     in
                                                  (FStar_Errors.Fatal_ComputationNotTotal,
-                                                   uu____13872)
+                                                   uu____13865)
                                                   in
                                                FStar_Errors.raise_err
-                                                 uu____13866
+                                                 uu____13859
                                              else ());
-                                            (let uu____13882 =
+                                            (let uu____13875 =
                                                star_expr dmff_env1 item2  in
-                                             match uu____13882 with
+                                             match uu____13875 with
                                              | (item_t,item_wp,item_elab) ->
-                                                 let uu____13900 =
+                                                 let uu____13893 =
                                                    recheck_debug "*" env3
                                                      item_wp
                                                     in
-                                                 let uu____13902 =
+                                                 let uu____13895 =
                                                    recheck_debug "_" env3
                                                      item_elab
                                                     in
                                                  (dmff_env1, item_t, item_wp,
                                                    item_elab))))
                                    in
-                                let uu____13904 =
-                                  let uu____13913 =
-                                    let uu____13918 =
+                                let uu____13897 =
+                                  let uu____13906 =
+                                    let uu____13911 =
                                       FStar_All.pipe_right ed
                                         FStar_Syntax_Util.get_bind_repr
                                        in
-                                    FStar_All.pipe_right uu____13918
+                                    FStar_All.pipe_right uu____13911
                                       FStar_Util.must
                                      in
-                                  elaborate_and_star dmff_env [] uu____13913
+                                  elaborate_and_star dmff_env [] uu____13906
                                    in
-                                match uu____13904 with
-                                | (dmff_env1,uu____13946,bind_wp,bind_elab)
+                                match uu____13897 with
+                                | (dmff_env1,uu____13939,bind_wp,bind_elab)
                                     ->
-                                    let uu____13949 =
-                                      let uu____13958 =
-                                        let uu____13963 =
+                                    let uu____13942 =
+                                      let uu____13951 =
+                                        let uu____13956 =
                                           FStar_All.pipe_right ed
                                             FStar_Syntax_Util.get_return_repr
                                            in
-                                        FStar_All.pipe_right uu____13963
+                                        FStar_All.pipe_right uu____13956
                                           FStar_Util.must
                                          in
                                       elaborate_and_star dmff_env1 []
-                                        uu____13958
+                                        uu____13951
                                        in
-                                    (match uu____13949 with
-                                     | (dmff_env2,uu____13991,return_wp,return_elab)
+                                    (match uu____13942 with
+                                     | (dmff_env2,uu____13984,return_wp,return_elab)
                                          ->
                                          let rc_gtot =
                                            {
@@ -4072,102 +4048,102 @@ let (cps_and_elaborate :
                                                = []
                                            }  in
                                          let lift_from_pure_wp =
-                                           let uu____14000 =
-                                             let uu____14001 =
+                                           let uu____13993 =
+                                             let uu____13994 =
                                                FStar_Syntax_Subst.compress
                                                  return_wp
                                                 in
-                                             uu____14001.FStar_Syntax_Syntax.n
+                                             uu____13994.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____14000 with
+                                           match uu____13993 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (b1::b2::bs,body,what) ->
-                                               let uu____14059 =
-                                                 let uu____14078 =
-                                                   let uu____14083 =
+                                               let uu____14052 =
+                                                 let uu____14071 =
+                                                   let uu____14076 =
                                                      FStar_Syntax_Util.abs bs
                                                        body
                                                        FStar_Pervasives_Native.None
                                                       in
                                                    FStar_Syntax_Subst.open_term
-                                                     [b1; b2] uu____14083
+                                                     [b1; b2] uu____14076
                                                     in
-                                                 match uu____14078 with
+                                                 match uu____14071 with
                                                  | (b11::b21::[],body1) ->
                                                      (b11, b21, body1)
-                                                 | uu____14165 ->
+                                                 | uu____14158 ->
                                                      failwith
                                                        "Impossible : open_term not preserving binders arity"
                                                   in
-                                               (match uu____14059 with
+                                               (match uu____14052 with
                                                 | (b11,b21,body1) ->
                                                     let env0 =
-                                                      let uu____14219 =
+                                                      let uu____14212 =
                                                         get_env dmff_env2  in
                                                       FStar_TypeChecker_Env.push_binders
-                                                        uu____14219
+                                                        uu____14212
                                                         [b11; b21]
                                                        in
                                                     let wp_b1 =
                                                       let raw_wp_b1 =
-                                                        let uu____14242 =
-                                                          let uu____14243 =
-                                                            let uu____14260 =
-                                                              let uu____14271
+                                                        let uu____14235 =
+                                                          let uu____14236 =
+                                                            let uu____14253 =
+                                                              let uu____14264
                                                                 =
-                                                                let uu____14280
+                                                                let uu____14273
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     (
                                                                     FStar_Pervasives_Native.fst
                                                                     b11)
                                                                    in
-                                                                let uu____14285
+                                                                let uu____14278
                                                                   =
                                                                   FStar_Syntax_Syntax.as_implicit
                                                                     false
                                                                    in
-                                                                (uu____14280,
-                                                                  uu____14285)
+                                                                (uu____14273,
+                                                                  uu____14278)
                                                                  in
-                                                              [uu____14271]
+                                                              [uu____14264]
                                                                in
                                                             (wp_type,
-                                                              uu____14260)
+                                                              uu____14253)
                                                              in
                                                           FStar_Syntax_Syntax.Tm_app
-                                                            uu____14243
+                                                            uu____14236
                                                            in
-                                                        mk uu____14242  in
+                                                        mk uu____14235  in
                                                       FStar_TypeChecker_Normalize.normalize
                                                         [FStar_TypeChecker_Env.Beta]
                                                         env0 raw_wp_b1
                                                        in
-                                                    let uu____14321 =
-                                                      let uu____14330 =
-                                                        let uu____14331 =
+                                                    let uu____14314 =
+                                                      let uu____14323 =
+                                                        let uu____14324 =
                                                           FStar_Syntax_Util.unascribe
                                                             wp_b1
                                                            in
                                                         FStar_TypeChecker_Normalize.eta_expand_with_type
                                                           env0 body1
-                                                          uu____14331
+                                                          uu____14324
                                                          in
                                                       FStar_All.pipe_left
                                                         FStar_Syntax_Util.abs_formals
-                                                        uu____14330
+                                                        uu____14323
                                                        in
-                                                    (match uu____14321 with
+                                                    (match uu____14314 with
                                                      | (bs1,body2,what') ->
-                                                         let fail uu____14354
+                                                         let fail uu____14347
                                                            =
                                                            let error_msg =
-                                                             let uu____14357
+                                                             let uu____14350
                                                                =
                                                                FStar_Syntax_Print.term_to_string
                                                                  body2
                                                                 in
-                                                             let uu____14359
+                                                             let uu____14352
                                                                =
                                                                match what'
                                                                with
@@ -4180,8 +4156,8 @@ let (cps_and_elaborate :
                                                                 in
                                                              FStar_Util.format2
                                                                "The body of return_wp (%s) should be of type Type0 but is of type %s"
-                                                               uu____14357
-                                                               uu____14359
+                                                               uu____14350
+                                                               uu____14352
                                                               in
                                                            raise_error
                                                              (FStar_Errors.Fatal_WrongBodyTypeForReturnWP,
@@ -4192,21 +4168,21 @@ let (cps_and_elaborate :
                                                                 -> fail ()
                                                            | FStar_Pervasives_Native.Some
                                                                rc ->
-                                                               ((let uu____14369
+                                                               ((let uu____14362
                                                                    =
-                                                                   let uu____14371
+                                                                   let uu____14364
                                                                     =
                                                                     FStar_Syntax_Util.is_pure_effect
                                                                     rc.FStar_Syntax_Syntax.residual_effect
                                                                      in
                                                                    Prims.op_Negation
-                                                                    uu____14371
+                                                                    uu____14364
                                                                     in
                                                                  if
-                                                                   uu____14369
+                                                                   uu____14362
                                                                  then fail ()
                                                                  else ());
-                                                                (let uu____14376
+                                                                (let uu____14369
                                                                    =
                                                                    FStar_Util.map_opt
                                                                     rc.FStar_Syntax_Syntax.residual_typ
@@ -4232,9 +4208,9 @@ let (cps_and_elaborate :
                                                                     fail ())
                                                                     in
                                                                  FStar_All.pipe_right
-                                                                   uu____14376
+                                                                   uu____14369
                                                                    (fun
-                                                                    uu____14394
+                                                                    uu____14387
                                                                      -> ()))));
                                                           (let wp =
                                                              let t2 =
@@ -4251,96 +4227,92 @@ let (cps_and_elaborate :
                                                                pure_wp_type
                                                               in
                                                            let body3 =
-                                                             let uu____14406
+                                                             let uu____14397
                                                                =
-                                                               let uu____14411
+                                                               FStar_Syntax_Syntax.bv_to_name
+                                                                 wp
+                                                                in
+                                                             let uu____14398
+                                                               =
+                                                               let uu____14399
                                                                  =
-                                                                 FStar_Syntax_Syntax.bv_to_name
-                                                                   wp
-                                                                  in
-                                                               let uu____14412
-                                                                 =
-                                                                 let uu____14413
+                                                                 let uu____14408
                                                                    =
-                                                                   let uu____14422
-                                                                    =
-                                                                    FStar_Syntax_Util.abs
+                                                                   FStar_Syntax_Util.abs
                                                                     [b21]
                                                                     body2
-                                                                    what'  in
-                                                                   (uu____14422,
-                                                                    FStar_Pervasives_Native.None)
+                                                                    what'
                                                                     in
-                                                                 [uu____14413]
+                                                                 (uu____14408,
+                                                                   FStar_Pervasives_Native.None)
                                                                   in
-                                                               FStar_Syntax_Syntax.mk_Tm_app
-                                                                 uu____14411
-                                                                 uu____14412
+                                                               [uu____14399]
                                                                 in
-                                                             uu____14406
-                                                               FStar_Pervasives_Native.None
+                                                             FStar_Syntax_Syntax.mk_Tm_app
+                                                               uu____14397
+                                                               uu____14398
                                                                ed_range
                                                               in
-                                                           let uu____14457 =
-                                                             let uu____14458
+                                                           let uu____14443 =
+                                                             let uu____14444
                                                                =
-                                                               let uu____14467
+                                                               let uu____14453
                                                                  =
                                                                  FStar_Syntax_Syntax.mk_binder
                                                                    wp
                                                                   in
-                                                               [uu____14467]
+                                                               [uu____14453]
                                                                 in
                                                              b11 ::
-                                                               uu____14458
+                                                               uu____14444
                                                               in
-                                                           let uu____14492 =
+                                                           let uu____14478 =
                                                              FStar_Syntax_Util.abs
                                                                bs1 body3 what
                                                               in
                                                            FStar_Syntax_Util.abs
-                                                             uu____14457
-                                                             uu____14492
+                                                             uu____14443
+                                                             uu____14478
                                                              (FStar_Pervasives_Native.Some
                                                                 rc_gtot)))))
-                                           | uu____14495 ->
+                                           | uu____14481 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedReturnShape,
                                                    "unexpected shape for return")
                                             in
                                          let return_wp1 =
-                                           let uu____14503 =
-                                             let uu____14504 =
+                                           let uu____14489 =
+                                             let uu____14490 =
                                                FStar_Syntax_Subst.compress
                                                  return_wp
                                                 in
-                                             uu____14504.FStar_Syntax_Syntax.n
+                                             uu____14490.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____14503 with
+                                           match uu____14489 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (b1::b2::bs,body,what) ->
-                                               let uu____14562 =
+                                               let uu____14548 =
                                                  FStar_Syntax_Util.abs bs
                                                    body what
                                                   in
                                                FStar_Syntax_Util.abs 
-                                                 [b1; b2] uu____14562
+                                                 [b1; b2] uu____14548
                                                  (FStar_Pervasives_Native.Some
                                                     rc_gtot)
-                                           | uu____14583 ->
+                                           | uu____14569 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedReturnShape,
                                                    "unexpected shape for return")
                                             in
                                          let bind_wp1 =
-                                           let uu____14591 =
-                                             let uu____14592 =
+                                           let uu____14577 =
+                                             let uu____14578 =
                                                FStar_Syntax_Subst.compress
                                                  bind_wp
                                                 in
-                                             uu____14592.FStar_Syntax_Syntax.n
+                                             uu____14578.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____14591 with
+                                           match uu____14577 with
                                            | FStar_Syntax_Syntax.Tm_abs
                                                (binders,body,what) ->
                                                let r =
@@ -4350,24 +4322,24 @@ let (cps_and_elaborate :
                                                       Prims.int_one)
                                                    FStar_Pervasives_Native.None
                                                   in
-                                               let uu____14626 =
-                                                 let uu____14627 =
-                                                   let uu____14636 =
-                                                     let uu____14643 =
+                                               let uu____14612 =
+                                                 let uu____14613 =
+                                                   let uu____14622 =
+                                                     let uu____14629 =
                                                        mk
                                                          (FStar_Syntax_Syntax.Tm_fvar
                                                             r)
                                                         in
                                                      FStar_Syntax_Syntax.null_binder
-                                                       uu____14643
+                                                       uu____14629
                                                       in
-                                                   [uu____14636]  in
+                                                   [uu____14622]  in
                                                  FStar_List.append
-                                                   uu____14627 binders
+                                                   uu____14613 binders
                                                   in
                                                FStar_Syntax_Util.abs
-                                                 uu____14626 body what
-                                           | uu____14662 ->
+                                                 uu____14612 body what
+                                           | uu____14648 ->
                                                raise_error
                                                  (FStar_Errors.Fatal_UnexpectedBindShape,
                                                    "unexpected shape for bind")
@@ -4379,24 +4351,24 @@ let (cps_and_elaborate :
                                                = Prims.int_zero
                                            then t
                                            else
-                                             (let uu____14692 =
-                                                let uu____14693 =
-                                                  let uu____14694 =
-                                                    let uu____14711 =
-                                                      let uu____14722 =
+                                             (let uu____14678 =
+                                                let uu____14679 =
+                                                  let uu____14680 =
+                                                    let uu____14697 =
+                                                      let uu____14708 =
                                                         FStar_Syntax_Util.args_of_binders
                                                           effect_binders1
                                                          in
                                                       FStar_Pervasives_Native.snd
-                                                        uu____14722
+                                                        uu____14708
                                                        in
-                                                    (t, uu____14711)  in
+                                                    (t, uu____14697)  in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____14694
+                                                    uu____14680
                                                    in
-                                                mk uu____14693  in
+                                                mk uu____14679  in
                                               FStar_Syntax_Subst.close
-                                                effect_binders1 uu____14692)
+                                                effect_binders1 uu____14678)
                                             in
                                          let rec apply_last f l =
                                            match l with
@@ -4404,12 +4376,12 @@ let (cps_and_elaborate :
                                                failwith
                                                  "impossible: empty path.."
                                            | a2::[] ->
-                                               let uu____14780 = f a2  in
-                                               [uu____14780]
+                                               let uu____14766 = f a2  in
+                                               [uu____14766]
                                            | x::xs ->
-                                               let uu____14791 =
+                                               let uu____14777 =
                                                  apply_last f xs  in
-                                               x :: uu____14791
+                                               x :: uu____14777
                                             in
                                          let register maybe_admit name item =
                                            let p =
@@ -4429,98 +4401,98 @@ let (cps_and_elaborate :
                                              FStar_Ident.lid_of_path p'
                                                ed_range
                                               in
-                                           let uu____14832 =
+                                           let uu____14818 =
                                              FStar_TypeChecker_Env.try_lookup_lid
                                                env2 l'
                                               in
-                                           match uu____14832 with
+                                           match uu____14818 with
                                            | FStar_Pervasives_Native.Some
                                                (_us,_t) ->
-                                               ((let uu____14862 =
+                                               ((let uu____14848 =
                                                    FStar_Options.debug_any ()
                                                     in
-                                                 if uu____14862
+                                                 if uu____14848
                                                  then
-                                                   let uu____14865 =
+                                                   let uu____14851 =
                                                      FStar_Ident.string_of_lid
                                                        l'
                                                       in
                                                    FStar_Util.print1
                                                      "DM4F: Applying override %s\n"
-                                                     uu____14865
+                                                     uu____14851
                                                  else ());
-                                                (let uu____14870 =
+                                                (let uu____14856 =
                                                    FStar_Syntax_Syntax.lid_as_fv
                                                      l'
                                                      FStar_Syntax_Syntax.delta_equational
                                                      FStar_Pervasives_Native.None
                                                     in
                                                  FStar_Syntax_Syntax.fv_to_tm
-                                                   uu____14870))
+                                                   uu____14856))
                                            | FStar_Pervasives_Native.None  ->
-                                               let uu____14879 =
-                                                 let uu____14884 =
+                                               let uu____14865 =
+                                                 let uu____14870 =
                                                    mk_lid name  in
-                                                 let uu____14885 =
+                                                 let uu____14871 =
                                                    FStar_Syntax_Util.abs
                                                      effect_binders1 item
                                                      FStar_Pervasives_Native.None
                                                     in
                                                  FStar_TypeChecker_Util.mk_toplevel_definition
-                                                   env2 uu____14884
-                                                   uu____14885
+                                                   env2 uu____14870
+                                                   uu____14871
                                                   in
-                                               (match uu____14879 with
+                                               (match uu____14865 with
                                                 | (sigelt,fv) ->
                                                     let sigelt1 =
                                                       if maybe_admit
                                                       then
-                                                        let uu___1544_14890 =
+                                                        let uu___1544_14876 =
                                                           sigelt  in
                                                         {
                                                           FStar_Syntax_Syntax.sigel
                                                             =
-                                                            (uu___1544_14890.FStar_Syntax_Syntax.sigel);
+                                                            (uu___1544_14876.FStar_Syntax_Syntax.sigel);
                                                           FStar_Syntax_Syntax.sigrng
                                                             =
-                                                            (uu___1544_14890.FStar_Syntax_Syntax.sigrng);
+                                                            (uu___1544_14876.FStar_Syntax_Syntax.sigrng);
                                                           FStar_Syntax_Syntax.sigquals
                                                             =
-                                                            (uu___1544_14890.FStar_Syntax_Syntax.sigquals);
+                                                            (uu___1544_14876.FStar_Syntax_Syntax.sigquals);
                                                           FStar_Syntax_Syntax.sigmeta
                                                             =
-                                                            (let uu___1546_14892
+                                                            (let uu___1546_14878
                                                                =
                                                                sigelt.FStar_Syntax_Syntax.sigmeta
                                                                 in
                                                              {
                                                                FStar_Syntax_Syntax.sigmeta_active
                                                                  =
-                                                                 (uu___1546_14892.FStar_Syntax_Syntax.sigmeta_active);
+                                                                 (uu___1546_14878.FStar_Syntax_Syntax.sigmeta_active);
                                                                FStar_Syntax_Syntax.sigmeta_fact_db_ids
                                                                  =
-                                                                 (uu___1546_14892.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
+                                                                 (uu___1546_14878.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
                                                                FStar_Syntax_Syntax.sigmeta_admit
                                                                  = true
                                                              });
                                                           FStar_Syntax_Syntax.sigattrs
                                                             =
-                                                            (uu___1544_14890.FStar_Syntax_Syntax.sigattrs);
+                                                            (uu___1544_14876.FStar_Syntax_Syntax.sigattrs);
                                                           FStar_Syntax_Syntax.sigopts
                                                             =
-                                                            (uu___1544_14890.FStar_Syntax_Syntax.sigopts)
+                                                            (uu___1544_14876.FStar_Syntax_Syntax.sigopts)
                                                         }
                                                       else sigelt  in
-                                                    ((let uu____14897 =
-                                                        let uu____14900 =
+                                                    ((let uu____14883 =
+                                                        let uu____14886 =
                                                           FStar_ST.op_Bang
                                                             sigelts
                                                            in
                                                         sigelt1 ::
-                                                          uu____14900
+                                                          uu____14886
                                                          in
                                                       FStar_ST.op_Colon_Equals
-                                                        sigelts uu____14897);
+                                                        sigelts uu____14883);
                                                      fv))
                                             in
                                          let register_admit = register true
@@ -4531,127 +4503,127 @@ let (cps_and_elaborate :
                                              lift_from_pure_wp
                                             in
                                          let mk_sigelt se =
-                                           let uu___1555_14983 =
+                                           let uu___1555_14969 =
                                              FStar_Syntax_Syntax.mk_sigelt se
                                               in
                                            {
                                              FStar_Syntax_Syntax.sigel =
-                                               (uu___1555_14983.FStar_Syntax_Syntax.sigel);
+                                               (uu___1555_14969.FStar_Syntax_Syntax.sigel);
                                              FStar_Syntax_Syntax.sigrng =
                                                ed_range;
                                              FStar_Syntax_Syntax.sigquals =
-                                               (uu___1555_14983.FStar_Syntax_Syntax.sigquals);
+                                               (uu___1555_14969.FStar_Syntax_Syntax.sigquals);
                                              FStar_Syntax_Syntax.sigmeta =
-                                               (uu___1555_14983.FStar_Syntax_Syntax.sigmeta);
+                                               (uu___1555_14969.FStar_Syntax_Syntax.sigmeta);
                                              FStar_Syntax_Syntax.sigattrs =
-                                               (uu___1555_14983.FStar_Syntax_Syntax.sigattrs);
+                                               (uu___1555_14969.FStar_Syntax_Syntax.sigattrs);
                                              FStar_Syntax_Syntax.sigopts =
-                                               (uu___1555_14983.FStar_Syntax_Syntax.sigopts)
+                                               (uu___1555_14969.FStar_Syntax_Syntax.sigopts)
                                            }  in
                                          let return_wp2 =
                                            register1 "return_wp" return_wp1
                                             in
-                                         ((let uu____14987 =
-                                             let uu____14990 =
+                                         ((let uu____14973 =
+                                             let uu____14976 =
                                                mk_sigelt
                                                  (FStar_Syntax_Syntax.Sig_pragma
                                                     (FStar_Syntax_Syntax.PushOptions
                                                        FStar_Pervasives_Native.None))
                                                 in
-                                             let uu____14992 =
+                                             let uu____14978 =
                                                FStar_ST.op_Bang sigelts  in
-                                             uu____14990 :: uu____14992  in
+                                             uu____14976 :: uu____14978  in
                                            FStar_ST.op_Colon_Equals sigelts
-                                             uu____14987);
+                                             uu____14973);
                                           (let return_elab1 =
                                              register_admit "return_elab"
                                                return_elab
                                               in
-                                           (let uu____15044 =
-                                              let uu____15047 =
+                                           (let uu____15030 =
+                                              let uu____15033 =
                                                 mk_sigelt
                                                   (FStar_Syntax_Syntax.Sig_pragma
                                                      FStar_Syntax_Syntax.PopOptions)
                                                  in
-                                              let uu____15048 =
+                                              let uu____15034 =
                                                 FStar_ST.op_Bang sigelts  in
-                                              uu____15047 :: uu____15048  in
+                                              uu____15033 :: uu____15034  in
                                             FStar_ST.op_Colon_Equals sigelts
-                                              uu____15044);
+                                              uu____15030);
                                            (let bind_wp2 =
                                               register1 "bind_wp" bind_wp1
                                                in
-                                            (let uu____15100 =
-                                               let uu____15103 =
+                                            (let uu____15086 =
+                                               let uu____15089 =
                                                  mk_sigelt
                                                    (FStar_Syntax_Syntax.Sig_pragma
                                                       (FStar_Syntax_Syntax.PushOptions
                                                          FStar_Pervasives_Native.None))
                                                   in
-                                               let uu____15105 =
+                                               let uu____15091 =
                                                  FStar_ST.op_Bang sigelts  in
-                                               uu____15103 :: uu____15105  in
+                                               uu____15089 :: uu____15091  in
                                              FStar_ST.op_Colon_Equals sigelts
-                                               uu____15100);
+                                               uu____15086);
                                             (let bind_elab1 =
                                                register_admit "bind_elab"
                                                  bind_elab
                                                 in
-                                             (let uu____15157 =
-                                                let uu____15160 =
+                                             (let uu____15143 =
+                                                let uu____15146 =
                                                   mk_sigelt
                                                     (FStar_Syntax_Syntax.Sig_pragma
                                                        FStar_Syntax_Syntax.PopOptions)
                                                    in
-                                                let uu____15161 =
+                                                let uu____15147 =
                                                   FStar_ST.op_Bang sigelts
                                                    in
-                                                uu____15160 :: uu____15161
+                                                uu____15146 :: uu____15147
                                                  in
                                               FStar_ST.op_Colon_Equals
-                                                sigelts uu____15157);
-                                             (let uu____15210 =
+                                                sigelts uu____15143);
+                                             (let uu____15196 =
                                                 FStar_List.fold_left
-                                                  (fun uu____15250  ->
+                                                  (fun uu____15236  ->
                                                      fun action  ->
-                                                       match uu____15250 with
+                                                       match uu____15236 with
                                                        | (dmff_env3,actions)
                                                            ->
                                                            let params_un =
                                                              FStar_Syntax_Subst.open_binders
                                                                action.FStar_Syntax_Syntax.action_params
                                                               in
-                                                           let uu____15271 =
-                                                             let uu____15278
+                                                           let uu____15257 =
+                                                             let uu____15264
                                                                =
                                                                get_env
                                                                  dmff_env3
                                                                 in
                                                              FStar_TypeChecker_TcTerm.tc_tparams
-                                                               uu____15278
+                                                               uu____15264
                                                                params_un
                                                               in
-                                                           (match uu____15271
+                                                           (match uu____15257
                                                             with
-                                                            | (action_params,env',uu____15287)
+                                                            | (action_params,env',uu____15273)
                                                                 ->
                                                                 let action_params1
                                                                   =
                                                                   FStar_List.map
                                                                     (
                                                                     fun
-                                                                    uu____15313
+                                                                    uu____15299
                                                                      ->
-                                                                    match uu____15313
+                                                                    match uu____15299
                                                                     with
                                                                     | 
                                                                     (bv,qual)
                                                                     ->
-                                                                    let uu____15332
+                                                                    let uu____15318
                                                                     =
-                                                                    let uu___1577_15333
+                                                                    let uu___1577_15319
                                                                     = bv  in
-                                                                    let uu____15334
+                                                                    let uu____15320
                                                                     =
                                                                     FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Env.EraseUniverses]
@@ -4661,15 +4633,15 @@ let (cps_and_elaborate :
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     =
-                                                                    (uu___1577_15333.FStar_Syntax_Syntax.ppname);
+                                                                    (uu___1577_15319.FStar_Syntax_Syntax.ppname);
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1577_15333.FStar_Syntax_Syntax.index);
+                                                                    (uu___1577_15319.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
-                                                                    uu____15334
+                                                                    uu____15320
                                                                     }  in
-                                                                    (uu____15332,
+                                                                    (uu____15318,
                                                                     qual))
                                                                     action_params
                                                                    in
@@ -4679,7 +4651,7 @@ let (cps_and_elaborate :
                                                                     dmff_env3
                                                                     env'
                                                                    in
-                                                                let uu____15340
+                                                                let uu____15326
                                                                   =
                                                                   elaborate_and_star
                                                                     dmff_env'
@@ -4687,19 +4659,19 @@ let (cps_and_elaborate :
                                                                     ((action.FStar_Syntax_Syntax.action_univs),
                                                                     (action.FStar_Syntax_Syntax.action_defn))
                                                                    in
-                                                                (match uu____15340
+                                                                (match uu____15326
                                                                  with
                                                                  | (dmff_env4,action_t,action_wp,action_elab)
                                                                     ->
                                                                     let name
                                                                     =
-                                                                    let uu____15361
+                                                                    let uu____15347
                                                                     =
                                                                     FStar_Ident.ident_of_lid
                                                                     action.FStar_Syntax_Syntax.action_name
                                                                      in
                                                                     FStar_Ident.text_of_id
-                                                                    uu____15361
+                                                                    uu____15347
                                                                      in
                                                                     let action_typ_with_wp
                                                                     =
@@ -4740,19 +4712,19 @@ let (cps_and_elaborate :
                                                                     [] ->
                                                                     action_typ_with_wp1
                                                                     | 
-                                                                    uu____15380
+                                                                    uu____15366
                                                                     ->
-                                                                    let uu____15381
+                                                                    let uu____15367
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     action_typ_with_wp1
                                                                      in
                                                                     FStar_Syntax_Util.flat_arrow
                                                                     action_params2
-                                                                    uu____15381
+                                                                    uu____15367
                                                                      in
                                                                     ((
-                                                                    let uu____15385
+                                                                    let uu____15371
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -4760,36 +4732,36 @@ let (cps_and_elaborate :
                                                                     (FStar_Options.Other
                                                                     "ED")  in
                                                                     if
-                                                                    uu____15385
+                                                                    uu____15371
                                                                     then
-                                                                    let uu____15390
+                                                                    let uu____15376
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
                                                                     params_un
                                                                      in
-                                                                    let uu____15393
+                                                                    let uu____15379
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ","
                                                                     action_params2
                                                                      in
-                                                                    let uu____15396
+                                                                    let uu____15382
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     action_typ_with_wp2
                                                                      in
-                                                                    let uu____15398
+                                                                    let uu____15384
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     action_elab2
                                                                      in
                                                                     FStar_Util.print4
                                                                     "original action_params %s, end action_params %s, type %s, term %s\n"
-                                                                    uu____15390
-                                                                    uu____15393
-                                                                    uu____15396
-                                                                    uu____15398
+                                                                    uu____15376
+                                                                    uu____15379
+                                                                    uu____15382
+                                                                    uu____15384
                                                                     else ());
                                                                     (let action_elab3
                                                                     =
@@ -4807,19 +4779,19 @@ let (cps_and_elaborate :
                                                                     "_complete_type")
                                                                     action_typ_with_wp2
                                                                      in
-                                                                    let uu____15407
+                                                                    let uu____15393
                                                                     =
-                                                                    let uu____15410
+                                                                    let uu____15396
                                                                     =
-                                                                    let uu___1599_15411
+                                                                    let uu___1599_15397
                                                                     = action
                                                                      in
-                                                                    let uu____15412
+                                                                    let uu____15398
                                                                     =
                                                                     apply_close
                                                                     action_elab3
                                                                      in
-                                                                    let uu____15413
+                                                                    let uu____15399
                                                                     =
                                                                     apply_close
                                                                     action_typ_with_wp3
@@ -4827,32 +4799,32 @@ let (cps_and_elaborate :
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___1599_15411.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___1599_15397.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___1599_15411.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___1599_15397.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     =
-                                                                    (uu___1599_15411.FStar_Syntax_Syntax.action_univs);
+                                                                    (uu___1599_15397.FStar_Syntax_Syntax.action_univs);
                                                                     FStar_Syntax_Syntax.action_params
                                                                     = [];
                                                                     FStar_Syntax_Syntax.action_defn
                                                                     =
-                                                                    uu____15412;
+                                                                    uu____15398;
                                                                     FStar_Syntax_Syntax.action_typ
                                                                     =
-                                                                    uu____15413
+                                                                    uu____15399
                                                                     }  in
-                                                                    uu____15410
+                                                                    uu____15396
                                                                     ::
                                                                     actions
                                                                      in
                                                                     (dmff_env4,
-                                                                    uu____15407))))))
+                                                                    uu____15393))))))
                                                   (dmff_env2, [])
                                                   ed.FStar_Syntax_Syntax.actions
                                                  in
-                                              match uu____15210 with
+                                              match uu____15196 with
                                               | (dmff_env3,actions) ->
                                                   let actions1 =
                                                     FStar_List.rev actions
@@ -4865,163 +4837,163 @@ let (cps_and_elaborate :
                                                         wp_a
                                                        in
                                                     let binders =
-                                                      let uu____15457 =
+                                                      let uu____15443 =
                                                         FStar_Syntax_Syntax.mk_binder
                                                           a1
                                                          in
-                                                      let uu____15464 =
-                                                        let uu____15473 =
+                                                      let uu____15450 =
+                                                        let uu____15459 =
                                                           FStar_Syntax_Syntax.mk_binder
                                                             wp
                                                            in
-                                                        [uu____15473]  in
-                                                      uu____15457 ::
-                                                        uu____15464
+                                                        [uu____15459]  in
+                                                      uu____15443 ::
+                                                        uu____15450
                                                        in
-                                                    let uu____15498 =
-                                                      let uu____15501 =
-                                                        let uu____15502 =
-                                                          let uu____15503 =
-                                                            let uu____15520 =
-                                                              let uu____15531
+                                                    let uu____15484 =
+                                                      let uu____15487 =
+                                                        let uu____15488 =
+                                                          let uu____15489 =
+                                                            let uu____15506 =
+                                                              let uu____15517
                                                                 =
-                                                                let uu____15540
+                                                                let uu____15526
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     a1
                                                                    in
-                                                                let uu____15543
+                                                                let uu____15529
                                                                   =
                                                                   FStar_Syntax_Syntax.as_implicit
                                                                     false
                                                                    in
-                                                                (uu____15540,
-                                                                  uu____15543)
+                                                                (uu____15526,
+                                                                  uu____15529)
                                                                  in
-                                                              [uu____15531]
+                                                              [uu____15517]
                                                                in
                                                             (repr,
-                                                              uu____15520)
+                                                              uu____15506)
                                                              in
                                                           FStar_Syntax_Syntax.Tm_app
-                                                            uu____15503
+                                                            uu____15489
                                                            in
-                                                        mk uu____15502  in
-                                                      let uu____15579 =
+                                                        mk uu____15488  in
+                                                      let uu____15565 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           wp
                                                          in
                                                       trans_F dmff_env3
-                                                        uu____15501
-                                                        uu____15579
+                                                        uu____15487
+                                                        uu____15565
                                                        in
                                                     FStar_Syntax_Util.abs
-                                                      binders uu____15498
+                                                      binders uu____15484
                                                       FStar_Pervasives_Native.None
                                                      in
-                                                  let uu____15580 =
+                                                  let uu____15566 =
                                                     recheck_debug "FC" env2
                                                       repr1
                                                      in
                                                   let repr2 =
                                                     register1 "repr" repr1
                                                      in
-                                                  let uu____15584 =
-                                                    let uu____15593 =
-                                                      let uu____15594 =
-                                                        let uu____15597 =
+                                                  let uu____15570 =
+                                                    let uu____15579 =
+                                                      let uu____15580 =
+                                                        let uu____15583 =
                                                           FStar_Syntax_Subst.compress
                                                             wp_type
                                                            in
                                                         FStar_All.pipe_left
                                                           FStar_Syntax_Util.unascribe
-                                                          uu____15597
+                                                          uu____15583
                                                          in
-                                                      uu____15594.FStar_Syntax_Syntax.n
+                                                      uu____15580.FStar_Syntax_Syntax.n
                                                        in
-                                                    match uu____15593 with
+                                                    match uu____15579 with
                                                     | FStar_Syntax_Syntax.Tm_abs
-                                                        (type_param::effect_param,arrow,uu____15611)
+                                                        (type_param::effect_param,arrow,uu____15597)
                                                         ->
-                                                        let uu____15648 =
-                                                          let uu____15669 =
+                                                        let uu____15634 =
+                                                          let uu____15655 =
                                                             FStar_Syntax_Subst.open_term
                                                               (type_param ::
                                                               effect_param)
                                                               arrow
                                                              in
-                                                          match uu____15669
+                                                          match uu____15655
                                                           with
                                                           | (b::bs,body) ->
                                                               (b, bs, body)
-                                                          | uu____15737 ->
+                                                          | uu____15723 ->
                                                               failwith
                                                                 "Impossible : open_term nt preserving binders arity"
                                                            in
-                                                        (match uu____15648
+                                                        (match uu____15634
                                                          with
                                                          | (type_param1,effect_param1,arrow1)
                                                              ->
-                                                             let uu____15802
+                                                             let uu____15788
                                                                =
-                                                               let uu____15803
+                                                               let uu____15789
                                                                  =
-                                                                 let uu____15806
+                                                                 let uu____15792
                                                                    =
                                                                    FStar_Syntax_Subst.compress
                                                                     arrow1
                                                                     in
                                                                  FStar_All.pipe_left
                                                                    FStar_Syntax_Util.unascribe
-                                                                   uu____15806
+                                                                   uu____15792
                                                                   in
-                                                               uu____15803.FStar_Syntax_Syntax.n
+                                                               uu____15789.FStar_Syntax_Syntax.n
                                                                 in
-                                                             (match uu____15802
+                                                             (match uu____15788
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_arrow
                                                                   (wp_binders,c)
                                                                   ->
-                                                                  let uu____15839
+                                                                  let uu____15825
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     wp_binders
                                                                     c  in
-                                                                  (match uu____15839
+                                                                  (match uu____15825
                                                                    with
                                                                    | 
                                                                    (wp_binders1,c1)
                                                                     ->
-                                                                    let uu____15854
+                                                                    let uu____15840
                                                                     =
                                                                     FStar_List.partition
                                                                     (fun
-                                                                    uu____15885
+                                                                    uu____15871
                                                                      ->
-                                                                    match uu____15885
+                                                                    match uu____15871
                                                                     with
                                                                     | 
-                                                                    (bv,uu____15894)
+                                                                    (bv,uu____15880)
                                                                     ->
-                                                                    let uu____15899
+                                                                    let uu____15885
                                                                     =
-                                                                    let uu____15901
+                                                                    let uu____15887
                                                                     =
                                                                     FStar_Syntax_Free.names
                                                                     bv.FStar_Syntax_Syntax.sort
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____15901
+                                                                    uu____15887
                                                                     (FStar_Util.set_mem
                                                                     (FStar_Pervasives_Native.fst
                                                                     type_param1))
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____15899
+                                                                    uu____15885
                                                                     Prims.op_Negation)
                                                                     wp_binders1
                                                                      in
-                                                                    (match uu____15854
+                                                                    (match uu____15840
                                                                     with
                                                                     | 
                                                                     (pre_args,post_args)
@@ -5037,42 +5009,42 @@ let (cps_and_elaborate :
                                                                     [] ->
                                                                     let err_msg
                                                                     =
-                                                                    let uu____15993
+                                                                    let uu____15979
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: no post candidate %s (Type variable does not appear)"
-                                                                    uu____15993
+                                                                    uu____15979
                                                                      in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
                                                                     err_msg)
                                                                     | 
-                                                                    uu____16003
+                                                                    uu____15989
                                                                     ->
                                                                     let err_msg
                                                                     =
-                                                                    let uu____16014
+                                                                    let uu____16000
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Impossible to generate DM effect: multiple post candidates %s"
-                                                                    uu____16014
+                                                                    uu____16000
                                                                      in
                                                                     FStar_Errors.raise_err
                                                                     (FStar_Errors.Fatal_ImpossibleToGenerateDMEffect,
                                                                     err_msg)
                                                                      in
-                                                                    let uu____16024
+                                                                    let uu____16010
                                                                     =
                                                                     FStar_Syntax_Util.arrow
                                                                     pre_args
                                                                     c1  in
-                                                                    let uu____16027
+                                                                    let uu____16013
                                                                     =
                                                                     FStar_Syntax_Util.abs
                                                                     (type_param1
@@ -5082,58 +5054,58 @@ let (cps_and_elaborate :
                                                                     post).FStar_Syntax_Syntax.sort
                                                                     FStar_Pervasives_Native.None
                                                                      in
-                                                                    (uu____16024,
-                                                                    uu____16027)))
-                                                              | uu____16042
+                                                                    (uu____16010,
+                                                                    uu____16013)))
+                                                              | uu____16028
                                                                   ->
-                                                                  let uu____16043
+                                                                  let uu____16029
                                                                     =
-                                                                    let uu____16049
+                                                                    let uu____16035
                                                                     =
-                                                                    let uu____16051
+                                                                    let uu____16037
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     arrow1
                                                                      in
                                                                     FStar_Util.format1
                                                                     "Impossible: pre/post arrow %s"
-                                                                    uu____16051
+                                                                    uu____16037
                                                                      in
                                                                     (FStar_Errors.Fatal_ImpossiblePrePostArrow,
-                                                                    uu____16049)
+                                                                    uu____16035)
                                                                      in
                                                                   raise_error
-                                                                    uu____16043))
-                                                    | uu____16063 ->
-                                                        let uu____16064 =
-                                                          let uu____16070 =
-                                                            let uu____16072 =
+                                                                    uu____16029))
+                                                    | uu____16049 ->
+                                                        let uu____16050 =
+                                                          let uu____16056 =
+                                                            let uu____16058 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 wp_type
                                                                in
                                                             FStar_Util.format1
                                                               "Impossible: pre/post abs %s"
-                                                              uu____16072
+                                                              uu____16058
                                                              in
                                                           (FStar_Errors.Fatal_ImpossiblePrePostAbs,
-                                                            uu____16070)
+                                                            uu____16056)
                                                            in
                                                         raise_error
-                                                          uu____16064
+                                                          uu____16050
                                                      in
-                                                  (match uu____15584 with
+                                                  (match uu____15570 with
                                                    | (pre,post) ->
-                                                       ((let uu____16105 =
+                                                       ((let uu____16091 =
                                                            register1 "pre"
                                                              pre
                                                             in
                                                          ());
-                                                        (let uu____16108 =
+                                                        (let uu____16094 =
                                                            register1 "post"
                                                              post
                                                             in
                                                          ());
-                                                        (let uu____16111 =
+                                                        (let uu____16097 =
                                                            register1 "wp"
                                                              wp_type
                                                             in
@@ -5143,177 +5115,177 @@ let (cps_and_elaborate :
                                                            with
                                                            | FStar_Syntax_Syntax.DM4F_eff
                                                                combs ->
-                                                               let uu____16115
+                                                               let uu____16101
                                                                  =
-                                                                 let uu___1657_16116
+                                                                 let uu___1657_16102
                                                                    = combs
                                                                     in
-                                                                 let uu____16117
+                                                                 let uu____16103
                                                                    =
-                                                                   let uu____16118
+                                                                   let uu____16104
                                                                     =
                                                                     apply_close
                                                                     return_wp2
                                                                      in
                                                                    ([],
-                                                                    uu____16118)
+                                                                    uu____16104)
                                                                     in
-                                                                 let uu____16125
+                                                                 let uu____16111
                                                                    =
-                                                                   let uu____16126
+                                                                   let uu____16112
                                                                     =
                                                                     apply_close
                                                                     bind_wp2
                                                                      in
                                                                    ([],
-                                                                    uu____16126)
+                                                                    uu____16112)
                                                                     in
-                                                                 let uu____16133
+                                                                 let uu____16119
                                                                    =
-                                                                   let uu____16136
+                                                                   let uu____16122
                                                                     =
-                                                                    let uu____16137
+                                                                    let uu____16123
                                                                     =
                                                                     apply_close
                                                                     repr2  in
                                                                     ([],
-                                                                    uu____16137)
+                                                                    uu____16123)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16136
+                                                                    uu____16122
                                                                     in
-                                                                 let uu____16144
+                                                                 let uu____16130
                                                                    =
-                                                                   let uu____16147
+                                                                   let uu____16133
                                                                     =
-                                                                    let uu____16148
+                                                                    let uu____16134
                                                                     =
                                                                     apply_close
                                                                     return_elab1
                                                                      in
                                                                     ([],
-                                                                    uu____16148)
+                                                                    uu____16134)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16147
+                                                                    uu____16133
                                                                     in
-                                                                 let uu____16155
+                                                                 let uu____16141
                                                                    =
-                                                                   let uu____16158
+                                                                   let uu____16144
                                                                     =
-                                                                    let uu____16159
+                                                                    let uu____16145
                                                                     =
                                                                     apply_close
                                                                     bind_elab1
                                                                      in
                                                                     ([],
-                                                                    uu____16159)
+                                                                    uu____16145)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16158
+                                                                    uu____16144
                                                                     in
                                                                  {
                                                                    FStar_Syntax_Syntax.ret_wp
                                                                     =
-                                                                    uu____16117;
+                                                                    uu____16103;
                                                                    FStar_Syntax_Syntax.bind_wp
                                                                     =
-                                                                    uu____16125;
+                                                                    uu____16111;
                                                                    FStar_Syntax_Syntax.stronger
                                                                     =
-                                                                    (uu___1657_16116.FStar_Syntax_Syntax.stronger);
+                                                                    (uu___1657_16102.FStar_Syntax_Syntax.stronger);
                                                                    FStar_Syntax_Syntax.if_then_else
                                                                     =
-                                                                    (uu___1657_16116.FStar_Syntax_Syntax.if_then_else);
+                                                                    (uu___1657_16102.FStar_Syntax_Syntax.if_then_else);
                                                                    FStar_Syntax_Syntax.ite_wp
                                                                     =
-                                                                    (uu___1657_16116.FStar_Syntax_Syntax.ite_wp);
+                                                                    (uu___1657_16102.FStar_Syntax_Syntax.ite_wp);
                                                                    FStar_Syntax_Syntax.close_wp
                                                                     =
-                                                                    (uu___1657_16116.FStar_Syntax_Syntax.close_wp);
+                                                                    (uu___1657_16102.FStar_Syntax_Syntax.close_wp);
                                                                    FStar_Syntax_Syntax.trivial
                                                                     =
-                                                                    (uu___1657_16116.FStar_Syntax_Syntax.trivial);
+                                                                    (uu___1657_16102.FStar_Syntax_Syntax.trivial);
                                                                    FStar_Syntax_Syntax.repr
                                                                     =
-                                                                    uu____16133;
+                                                                    uu____16119;
                                                                    FStar_Syntax_Syntax.return_repr
                                                                     =
-                                                                    uu____16144;
+                                                                    uu____16130;
                                                                    FStar_Syntax_Syntax.bind_repr
                                                                     =
-                                                                    uu____16155
+                                                                    uu____16141
                                                                  }  in
                                                                FStar_Syntax_Syntax.DM4F_eff
-                                                                 uu____16115
-                                                           | uu____16166 ->
+                                                                 uu____16101
+                                                           | uu____16152 ->
                                                                failwith
                                                                  "Impossible! For a DM4F effect combinators must be in DM4f_eff"
                                                             in
                                                          let ed1 =
-                                                           let uu___1661_16169
+                                                           let uu___1661_16155
                                                              = ed  in
-                                                           let uu____16170 =
+                                                           let uu____16156 =
                                                              FStar_Syntax_Subst.close_binders
                                                                effect_binders1
                                                               in
-                                                           let uu____16171 =
-                                                             let uu____16172
+                                                           let uu____16157 =
+                                                             let uu____16158
                                                                =
                                                                FStar_Syntax_Subst.close
                                                                  effect_binders1
                                                                  effect_signature
                                                                 in
                                                              ([],
-                                                               uu____16172)
+                                                               uu____16158)
                                                               in
                                                            {
                                                              FStar_Syntax_Syntax.mname
                                                                =
-                                                               (uu___1661_16169.FStar_Syntax_Syntax.mname);
+                                                               (uu___1661_16155.FStar_Syntax_Syntax.mname);
                                                              FStar_Syntax_Syntax.cattributes
                                                                =
-                                                               (uu___1661_16169.FStar_Syntax_Syntax.cattributes);
+                                                               (uu___1661_16155.FStar_Syntax_Syntax.cattributes);
                                                              FStar_Syntax_Syntax.univs
                                                                =
-                                                               (uu___1661_16169.FStar_Syntax_Syntax.univs);
+                                                               (uu___1661_16155.FStar_Syntax_Syntax.univs);
                                                              FStar_Syntax_Syntax.binders
-                                                               = uu____16170;
+                                                               = uu____16156;
                                                              FStar_Syntax_Syntax.signature
-                                                               = uu____16171;
+                                                               = uu____16157;
                                                              FStar_Syntax_Syntax.combinators
                                                                = ed_combs;
                                                              FStar_Syntax_Syntax.actions
                                                                = actions1;
                                                              FStar_Syntax_Syntax.eff_attrs
                                                                =
-                                                               (uu___1661_16169.FStar_Syntax_Syntax.eff_attrs)
+                                                               (uu___1661_16155.FStar_Syntax_Syntax.eff_attrs)
                                                            }  in
-                                                         let uu____16179 =
+                                                         let uu____16165 =
                                                            gen_wps_for_free
                                                              env2
                                                              effect_binders1
                                                              a1 wp_a ed1
                                                             in
-                                                         match uu____16179
+                                                         match uu____16165
                                                          with
                                                          | (sigelts',ed2) ->
-                                                             ((let uu____16197
+                                                             ((let uu____16183
                                                                  =
                                                                  FStar_TypeChecker_Env.debug
                                                                    env2
                                                                    (FStar_Options.Other
                                                                     "ED")
                                                                   in
-                                                               if uu____16197
+                                                               if uu____16183
                                                                then
-                                                                 let uu____16201
+                                                                 let uu____16187
                                                                    =
                                                                    FStar_Syntax_Print.eff_decl_to_string
                                                                     true ed2
                                                                     in
                                                                  FStar_Util.print_string
-                                                                   uu____16201
+                                                                   uu____16187
                                                                else ());
                                                               (let lift_from_pure_opt
                                                                  =
@@ -5325,20 +5297,20 @@ let (cps_and_elaborate :
                                                                  then
                                                                    let lift_from_pure
                                                                     =
-                                                                    let uu____16221
+                                                                    let uu____16207
                                                                     =
-                                                                    let uu____16224
+                                                                    let uu____16210
                                                                     =
-                                                                    let uu____16225
+                                                                    let uu____16211
                                                                     =
                                                                     apply_close
                                                                     lift_from_pure_wp1
                                                                      in
                                                                     ([],
-                                                                    uu____16225)
+                                                                    uu____16211)
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____16224
+                                                                    uu____16210
                                                                      in
                                                                     {
                                                                     FStar_Syntax_Syntax.source
@@ -5349,39 +5321,39 @@ let (cps_and_elaborate :
                                                                     (ed2.FStar_Syntax_Syntax.mname);
                                                                     FStar_Syntax_Syntax.lift_wp
                                                                     =
-                                                                    uu____16221;
+                                                                    uu____16207;
                                                                     FStar_Syntax_Syntax.lift
                                                                     =
                                                                     FStar_Pervasives_Native.None
                                                                     }  in
-                                                                   let uu____16232
+                                                                   let uu____16218
                                                                     =
                                                                     mk_sigelt
                                                                     (FStar_Syntax_Syntax.Sig_sub_effect
                                                                     lift_from_pure)
                                                                      in
                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____16232
+                                                                    uu____16218
                                                                  else
                                                                    FStar_Pervasives_Native.None
                                                                   in
-                                                               let uu____16235
+                                                               let uu____16221
                                                                  =
-                                                                 let uu____16238
+                                                                 let uu____16224
                                                                    =
-                                                                   let uu____16241
+                                                                   let uu____16227
                                                                     =
                                                                     FStar_ST.op_Bang
                                                                     sigelts
                                                                      in
                                                                    FStar_List.rev
-                                                                    uu____16241
+                                                                    uu____16227
                                                                     in
                                                                  FStar_List.append
-                                                                   uu____16238
+                                                                   uu____16224
                                                                    sigelts'
                                                                   in
-                                                               (uu____16235,
+                                                               (uu____16221,
                                                                  ed2,
                                                                  lift_from_pure_opt))))))))))))))))))
   

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -4222,23 +4222,20 @@ let effect_repr_aux :
                    (check_partial_application effect_name
                       c1.FStar_Syntax_Syntax.effect_args;
                     (let uu____23942 =
-                       let uu____23945 = get_range env1  in
-                       let uu____23946 =
-                         let uu____23953 =
-                           let uu____23954 =
-                             let uu____23971 =
-                               let uu____23982 =
-                                 FStar_All.pipe_right res_typ
-                                   FStar_Syntax_Syntax.as_arg
-                                  in
-                               uu____23982 ::
-                                 (c1.FStar_Syntax_Syntax.effect_args)
+                       let uu____23945 =
+                         let uu____23946 =
+                           let uu____23963 =
+                             let uu____23974 =
+                               FStar_All.pipe_right res_typ
+                                 FStar_Syntax_Syntax.as_arg
                                 in
-                             (repr, uu____23971)  in
-                           FStar_Syntax_Syntax.Tm_app uu____23954  in
-                         FStar_Syntax_Syntax.mk uu____23953  in
-                       uu____23946 FStar_Pervasives_Native.None uu____23945
-                        in
+                             uu____23974 ::
+                               (c1.FStar_Syntax_Syntax.effect_args)
+                              in
+                           (repr, uu____23963)  in
+                         FStar_Syntax_Syntax.Tm_app uu____23946  in
+                       let uu____24011 = get_range env1  in
+                       FStar_Syntax_Syntax.mk uu____23945 uu____24011  in
                      FStar_Pervasives_Native.Some uu____23942)))
   
 let (effect_repr :
@@ -4261,10 +4258,10 @@ let (is_user_reflectable_effect : env -> FStar_Ident.lident -> Prims.bool) =
       let quals = lookup_effect_quals env1 effect_lid1  in
       FStar_All.pipe_right quals
         (FStar_List.existsb
-           (fun uu___11_24082  ->
-              match uu___11_24082 with
-              | FStar_Syntax_Syntax.Reflectable uu____24084 -> true
-              | uu____24086 -> false))
+           (fun uu___11_24075  ->
+              match uu___11_24075 with
+              | FStar_Syntax_Syntax.Reflectable uu____24077 -> true
+              | uu____24079 -> false))
   
 let (is_total_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
@@ -4291,18 +4288,18 @@ let (is_reifiable_comp : env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
       match c.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Comp ct ->
           is_reifiable_effect env1 ct.FStar_Syntax_Syntax.effect_name
-      | uu____24146 -> false
+      | uu____24139 -> false
   
 let (is_reifiable_function : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env1  ->
     fun t  ->
-      let uu____24161 =
-        let uu____24162 = FStar_Syntax_Subst.compress t  in
-        uu____24162.FStar_Syntax_Syntax.n  in
-      match uu____24161 with
-      | FStar_Syntax_Syntax.Tm_arrow (uu____24166,c) ->
+      let uu____24154 =
+        let uu____24155 = FStar_Syntax_Subst.compress t  in
+        uu____24155.FStar_Syntax_Syntax.n  in
+      match uu____24154 with
+      | FStar_Syntax_Syntax.Tm_arrow (uu____24159,c) ->
           is_reifiable_comp env1 c
-      | uu____24188 -> false
+      | uu____24181 -> false
   
 let (reify_comp :
   env ->
@@ -4313,22 +4310,22 @@ let (reify_comp :
     fun c  ->
       fun u_c  ->
         let l = FStar_Syntax_Util.comp_effect_name c  in
-        (let uu____24208 =
-           let uu____24210 = is_reifiable_effect env1 l  in
-           Prims.op_Negation uu____24210  in
-         if uu____24208
+        (let uu____24201 =
+           let uu____24203 = is_reifiable_effect env1 l  in
+           Prims.op_Negation uu____24203  in
+         if uu____24201
          then
-           let uu____24213 =
-             let uu____24219 =
-               let uu____24221 = FStar_Ident.string_of_lid l  in
-               FStar_Util.format1 "Effect %s cannot be reified" uu____24221
+           let uu____24206 =
+             let uu____24212 =
+               let uu____24214 = FStar_Ident.string_of_lid l  in
+               FStar_Util.format1 "Effect %s cannot be reified" uu____24214
                 in
-             (FStar_Errors.Fatal_EffectCannotBeReified, uu____24219)  in
-           let uu____24225 = get_range env1  in
-           FStar_Errors.raise_error uu____24213 uu____24225
+             (FStar_Errors.Fatal_EffectCannotBeReified, uu____24212)  in
+           let uu____24218 = get_range env1  in
+           FStar_Errors.raise_error uu____24206 uu____24218
          else ());
-        (let uu____24228 = effect_repr_aux true env1 c u_c  in
-         match uu____24228 with
+        (let uu____24221 = effect_repr_aux true env1 c u_c  in
+         match uu____24221 with
          | FStar_Pervasives_Native.None  ->
              failwith "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
@@ -4338,55 +4335,55 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
     fun s  ->
       let sb = ((FStar_Syntax_Util.lids_of_sigelt s), s)  in
       let env2 =
-        let uu___1686_24264 = env1  in
+        let uu___1686_24257 = env1  in
         {
-          solver = (uu___1686_24264.solver);
-          range = (uu___1686_24264.range);
-          curmodule = (uu___1686_24264.curmodule);
-          gamma = (uu___1686_24264.gamma);
+          solver = (uu___1686_24257.solver);
+          range = (uu___1686_24257.range);
+          curmodule = (uu___1686_24257.curmodule);
+          gamma = (uu___1686_24257.gamma);
           gamma_sig = (sb :: (env1.gamma_sig));
-          gamma_cache = (uu___1686_24264.gamma_cache);
-          modules = (uu___1686_24264.modules);
-          expected_typ = (uu___1686_24264.expected_typ);
-          sigtab = (uu___1686_24264.sigtab);
-          attrtab = (uu___1686_24264.attrtab);
-          instantiate_imp = (uu___1686_24264.instantiate_imp);
-          effects = (uu___1686_24264.effects);
-          generalize = (uu___1686_24264.generalize);
-          letrecs = (uu___1686_24264.letrecs);
-          top_level = (uu___1686_24264.top_level);
-          check_uvars = (uu___1686_24264.check_uvars);
-          use_eq = (uu___1686_24264.use_eq);
-          use_eq_strict = (uu___1686_24264.use_eq_strict);
-          is_iface = (uu___1686_24264.is_iface);
-          admit = (uu___1686_24264.admit);
-          lax = (uu___1686_24264.lax);
-          lax_universes = (uu___1686_24264.lax_universes);
-          phase1 = (uu___1686_24264.phase1);
-          failhard = (uu___1686_24264.failhard);
-          nosynth = (uu___1686_24264.nosynth);
-          uvar_subtyping = (uu___1686_24264.uvar_subtyping);
-          tc_term = (uu___1686_24264.tc_term);
-          type_of = (uu___1686_24264.type_of);
-          universe_of = (uu___1686_24264.universe_of);
-          check_type_of = (uu___1686_24264.check_type_of);
-          use_bv_sorts = (uu___1686_24264.use_bv_sorts);
-          qtbl_name_and_index = (uu___1686_24264.qtbl_name_and_index);
-          normalized_eff_names = (uu___1686_24264.normalized_eff_names);
-          fv_delta_depths = (uu___1686_24264.fv_delta_depths);
-          proof_ns = (uu___1686_24264.proof_ns);
-          synth_hook = (uu___1686_24264.synth_hook);
+          gamma_cache = (uu___1686_24257.gamma_cache);
+          modules = (uu___1686_24257.modules);
+          expected_typ = (uu___1686_24257.expected_typ);
+          sigtab = (uu___1686_24257.sigtab);
+          attrtab = (uu___1686_24257.attrtab);
+          instantiate_imp = (uu___1686_24257.instantiate_imp);
+          effects = (uu___1686_24257.effects);
+          generalize = (uu___1686_24257.generalize);
+          letrecs = (uu___1686_24257.letrecs);
+          top_level = (uu___1686_24257.top_level);
+          check_uvars = (uu___1686_24257.check_uvars);
+          use_eq = (uu___1686_24257.use_eq);
+          use_eq_strict = (uu___1686_24257.use_eq_strict);
+          is_iface = (uu___1686_24257.is_iface);
+          admit = (uu___1686_24257.admit);
+          lax = (uu___1686_24257.lax);
+          lax_universes = (uu___1686_24257.lax_universes);
+          phase1 = (uu___1686_24257.phase1);
+          failhard = (uu___1686_24257.failhard);
+          nosynth = (uu___1686_24257.nosynth);
+          uvar_subtyping = (uu___1686_24257.uvar_subtyping);
+          tc_term = (uu___1686_24257.tc_term);
+          type_of = (uu___1686_24257.type_of);
+          universe_of = (uu___1686_24257.universe_of);
+          check_type_of = (uu___1686_24257.check_type_of);
+          use_bv_sorts = (uu___1686_24257.use_bv_sorts);
+          qtbl_name_and_index = (uu___1686_24257.qtbl_name_and_index);
+          normalized_eff_names = (uu___1686_24257.normalized_eff_names);
+          fv_delta_depths = (uu___1686_24257.fv_delta_depths);
+          proof_ns = (uu___1686_24257.proof_ns);
+          synth_hook = (uu___1686_24257.synth_hook);
           try_solve_implicits_hook =
-            (uu___1686_24264.try_solve_implicits_hook);
-          splice = (uu___1686_24264.splice);
-          mpreprocess = (uu___1686_24264.mpreprocess);
-          postprocess = (uu___1686_24264.postprocess);
-          identifier_info = (uu___1686_24264.identifier_info);
-          tc_hooks = (uu___1686_24264.tc_hooks);
-          dsenv = (uu___1686_24264.dsenv);
-          nbe = (uu___1686_24264.nbe);
-          strict_args_tab = (uu___1686_24264.strict_args_tab);
-          erasable_types_tab = (uu___1686_24264.erasable_types_tab)
+            (uu___1686_24257.try_solve_implicits_hook);
+          splice = (uu___1686_24257.splice);
+          mpreprocess = (uu___1686_24257.mpreprocess);
+          postprocess = (uu___1686_24257.postprocess);
+          identifier_info = (uu___1686_24257.identifier_info);
+          tc_hooks = (uu___1686_24257.tc_hooks);
+          dsenv = (uu___1686_24257.dsenv);
+          nbe = (uu___1686_24257.nbe);
+          strict_args_tab = (uu___1686_24257.strict_args_tab);
+          erasable_types_tab = (uu___1686_24257.erasable_types_tab)
         }  in
       add_sigelt env2 s;
       (env2.tc_hooks).tc_push_in_gamma_hook env2 (FStar_Util.Inr sb);
@@ -4398,66 +4395,66 @@ let (push_new_effect :
       -> env)
   =
   fun env1  ->
-    fun uu____24283  ->
-      match uu____24283 with
+    fun uu____24276  ->
+      match uu____24276 with
       | (ed,quals) ->
           let effects1 =
-            let uu___1695_24297 = env1.effects  in
+            let uu___1695_24290 = env1.effects  in
             {
               decls = ((ed, quals) :: ((env1.effects).decls));
-              order = (uu___1695_24297.order);
-              joins = (uu___1695_24297.joins);
-              polymonadic_binds = (uu___1695_24297.polymonadic_binds)
+              order = (uu___1695_24290.order);
+              joins = (uu___1695_24290.joins);
+              polymonadic_binds = (uu___1695_24290.polymonadic_binds)
             }  in
-          let uu___1698_24306 = env1  in
+          let uu___1698_24299 = env1  in
           {
-            solver = (uu___1698_24306.solver);
-            range = (uu___1698_24306.range);
-            curmodule = (uu___1698_24306.curmodule);
-            gamma = (uu___1698_24306.gamma);
-            gamma_sig = (uu___1698_24306.gamma_sig);
-            gamma_cache = (uu___1698_24306.gamma_cache);
-            modules = (uu___1698_24306.modules);
-            expected_typ = (uu___1698_24306.expected_typ);
-            sigtab = (uu___1698_24306.sigtab);
-            attrtab = (uu___1698_24306.attrtab);
-            instantiate_imp = (uu___1698_24306.instantiate_imp);
+            solver = (uu___1698_24299.solver);
+            range = (uu___1698_24299.range);
+            curmodule = (uu___1698_24299.curmodule);
+            gamma = (uu___1698_24299.gamma);
+            gamma_sig = (uu___1698_24299.gamma_sig);
+            gamma_cache = (uu___1698_24299.gamma_cache);
+            modules = (uu___1698_24299.modules);
+            expected_typ = (uu___1698_24299.expected_typ);
+            sigtab = (uu___1698_24299.sigtab);
+            attrtab = (uu___1698_24299.attrtab);
+            instantiate_imp = (uu___1698_24299.instantiate_imp);
             effects = effects1;
-            generalize = (uu___1698_24306.generalize);
-            letrecs = (uu___1698_24306.letrecs);
-            top_level = (uu___1698_24306.top_level);
-            check_uvars = (uu___1698_24306.check_uvars);
-            use_eq = (uu___1698_24306.use_eq);
-            use_eq_strict = (uu___1698_24306.use_eq_strict);
-            is_iface = (uu___1698_24306.is_iface);
-            admit = (uu___1698_24306.admit);
-            lax = (uu___1698_24306.lax);
-            lax_universes = (uu___1698_24306.lax_universes);
-            phase1 = (uu___1698_24306.phase1);
-            failhard = (uu___1698_24306.failhard);
-            nosynth = (uu___1698_24306.nosynth);
-            uvar_subtyping = (uu___1698_24306.uvar_subtyping);
-            tc_term = (uu___1698_24306.tc_term);
-            type_of = (uu___1698_24306.type_of);
-            universe_of = (uu___1698_24306.universe_of);
-            check_type_of = (uu___1698_24306.check_type_of);
-            use_bv_sorts = (uu___1698_24306.use_bv_sorts);
-            qtbl_name_and_index = (uu___1698_24306.qtbl_name_and_index);
-            normalized_eff_names = (uu___1698_24306.normalized_eff_names);
-            fv_delta_depths = (uu___1698_24306.fv_delta_depths);
-            proof_ns = (uu___1698_24306.proof_ns);
-            synth_hook = (uu___1698_24306.synth_hook);
+            generalize = (uu___1698_24299.generalize);
+            letrecs = (uu___1698_24299.letrecs);
+            top_level = (uu___1698_24299.top_level);
+            check_uvars = (uu___1698_24299.check_uvars);
+            use_eq = (uu___1698_24299.use_eq);
+            use_eq_strict = (uu___1698_24299.use_eq_strict);
+            is_iface = (uu___1698_24299.is_iface);
+            admit = (uu___1698_24299.admit);
+            lax = (uu___1698_24299.lax);
+            lax_universes = (uu___1698_24299.lax_universes);
+            phase1 = (uu___1698_24299.phase1);
+            failhard = (uu___1698_24299.failhard);
+            nosynth = (uu___1698_24299.nosynth);
+            uvar_subtyping = (uu___1698_24299.uvar_subtyping);
+            tc_term = (uu___1698_24299.tc_term);
+            type_of = (uu___1698_24299.type_of);
+            universe_of = (uu___1698_24299.universe_of);
+            check_type_of = (uu___1698_24299.check_type_of);
+            use_bv_sorts = (uu___1698_24299.use_bv_sorts);
+            qtbl_name_and_index = (uu___1698_24299.qtbl_name_and_index);
+            normalized_eff_names = (uu___1698_24299.normalized_eff_names);
+            fv_delta_depths = (uu___1698_24299.fv_delta_depths);
+            proof_ns = (uu___1698_24299.proof_ns);
+            synth_hook = (uu___1698_24299.synth_hook);
             try_solve_implicits_hook =
-              (uu___1698_24306.try_solve_implicits_hook);
-            splice = (uu___1698_24306.splice);
-            mpreprocess = (uu___1698_24306.mpreprocess);
-            postprocess = (uu___1698_24306.postprocess);
-            identifier_info = (uu___1698_24306.identifier_info);
-            tc_hooks = (uu___1698_24306.tc_hooks);
-            dsenv = (uu___1698_24306.dsenv);
-            nbe = (uu___1698_24306.nbe);
-            strict_args_tab = (uu___1698_24306.strict_args_tab);
-            erasable_types_tab = (uu___1698_24306.erasable_types_tab)
+              (uu___1698_24299.try_solve_implicits_hook);
+            splice = (uu___1698_24299.splice);
+            mpreprocess = (uu___1698_24299.mpreprocess);
+            postprocess = (uu___1698_24299.postprocess);
+            identifier_info = (uu___1698_24299.identifier_info);
+            tc_hooks = (uu___1698_24299.tc_hooks);
+            dsenv = (uu___1698_24299.dsenv);
+            nbe = (uu___1698_24299.nbe);
+            strict_args_tab = (uu___1698_24299.strict_args_tab);
+            erasable_types_tab = (uu___1698_24299.erasable_types_tab)
           }
   
 let (exists_polymonadic_bind :
@@ -4470,19 +4467,19 @@ let (exists_polymonadic_bind :
   fun env1  ->
     fun m  ->
       fun n  ->
-        let uu____24335 =
+        let uu____24328 =
           FStar_All.pipe_right (env1.effects).polymonadic_binds
             (FStar_Util.find_opt
-               (fun uu____24403  ->
-                  match uu____24403 with
-                  | (m1,n1,uu____24421,uu____24422) ->
+               (fun uu____24396  ->
+                  match uu____24396 with
+                  | (m1,n1,uu____24414,uu____24415) ->
                       (FStar_Ident.lid_equals m m1) &&
                         (FStar_Ident.lid_equals n n1)))
            in
-        match uu____24335 with
-        | FStar_Pervasives_Native.Some (uu____24447,uu____24448,p,t) ->
+        match uu____24328 with
+        | FStar_Pervasives_Native.Some (uu____24440,uu____24441,p,t) ->
             FStar_Pervasives_Native.Some (p, t)
-        | uu____24493 -> FStar_Pervasives_Native.None
+        | uu____24486 -> FStar_Pervasives_Native.None
   
 let (update_effect_lattice :
   env -> FStar_Ident.lident -> FStar_Ident.lident -> mlift -> env) =
@@ -4493,23 +4490,23 @@ let (update_effect_lattice :
           let compose_edges e1 e2 =
             let composed_lift =
               let mlift_wp env2 c =
-                let uu____24568 =
+                let uu____24561 =
                   FStar_All.pipe_right c ((e1.mlift).mlift_wp env2)  in
-                FStar_All.pipe_right uu____24568
-                  (fun uu____24589  ->
-                     match uu____24589 with
+                FStar_All.pipe_right uu____24561
+                  (fun uu____24582  ->
+                     match uu____24582 with
                      | (c1,g1) ->
-                         let uu____24600 =
+                         let uu____24593 =
                            FStar_All.pipe_right c1 ((e2.mlift).mlift_wp env2)
                             in
-                         FStar_All.pipe_right uu____24600
-                           (fun uu____24621  ->
-                              match uu____24621 with
+                         FStar_All.pipe_right uu____24593
+                           (fun uu____24614  ->
+                              match uu____24614 with
                               | (c2,g2) ->
-                                  let uu____24632 =
+                                  let uu____24625 =
                                     FStar_TypeChecker_Common.conj_guard g1 g2
                                      in
-                                  (c2, uu____24632)))
+                                  (c2, uu____24625)))
                  in
               let mlift_term =
                 match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
@@ -4519,9 +4516,9 @@ let (update_effect_lattice :
                       ((fun u  ->
                           fun t  ->
                             fun e  ->
-                              let uu____24754 = l1 u t e  in
-                              l2 u t uu____24754))
-                | uu____24755 -> FStar_Pervasives_Native.None  in
+                              let uu____24747 = l1 u t e  in
+                              l2 u t uu____24747))
+                | uu____24748 -> FStar_Pervasives_Native.None  in
               { mlift_wp; mlift_term }  in
             {
               msource = (e1.msource);
@@ -4535,19 +4532,19 @@ let (update_effect_lattice :
           let ms =
             FStar_All.pipe_right (env1.effects).decls
               (FStar_List.map
-                 (fun uu____24823  ->
-                    match uu____24823 with
-                    | (e,uu____24831) -> e.FStar_Syntax_Syntax.mname))
+                 (fun uu____24816  ->
+                    match uu____24816 with
+                    | (e,uu____24824) -> e.FStar_Syntax_Syntax.mname))
              in
-          let find_edge order1 uu____24854 =
-            match uu____24854 with
+          let find_edge order1 uu____24847 =
+            match uu____24847 with
             | (i,j) ->
-                let uu____24865 = FStar_Ident.lid_equals i j  in
-                if uu____24865
+                let uu____24858 = FStar_Ident.lid_equals i j  in
+                if uu____24858
                 then
                   FStar_All.pipe_right (id_edge i)
-                    (fun uu____24872  ->
-                       FStar_Pervasives_Native.Some uu____24872)
+                    (fun uu____24865  ->
+                       FStar_Pervasives_Native.Some uu____24865)
                 else
                   FStar_All.pipe_right order1
                     (FStar_Util.find_opt
@@ -4557,38 +4554,38 @@ let (update_effect_lattice :
              in
           let order1 =
             let fold_fun order1 k =
-              let uu____24901 =
+              let uu____24894 =
                 FStar_All.pipe_right ms
                   (FStar_List.collect
                      (fun i  ->
-                        let uu____24911 = FStar_Ident.lid_equals i k  in
-                        if uu____24911
+                        let uu____24904 = FStar_Ident.lid_equals i k  in
+                        if uu____24904
                         then []
                         else
                           FStar_All.pipe_right ms
                             (FStar_List.collect
                                (fun j  ->
-                                  let uu____24925 =
+                                  let uu____24918 =
                                     FStar_Ident.lid_equals j k  in
-                                  if uu____24925
+                                  if uu____24918
                                   then []
                                   else
-                                    (let uu____24932 =
-                                       let uu____24941 =
+                                    (let uu____24925 =
+                                       let uu____24934 =
                                          find_edge order1 (i, k)  in
-                                       let uu____24944 =
+                                       let uu____24937 =
                                          find_edge order1 (k, j)  in
-                                       (uu____24941, uu____24944)  in
-                                     match uu____24932 with
+                                       (uu____24934, uu____24937)  in
+                                     match uu____24925 with
                                      | (FStar_Pervasives_Native.Some
                                         e1,FStar_Pervasives_Native.Some e2)
                                          ->
-                                         let uu____24959 =
+                                         let uu____24952 =
                                            compose_edges e1 e2  in
-                                         [uu____24959]
-                                     | uu____24960 -> [])))))
+                                         [uu____24952]
+                                     | uu____24953 -> [])))))
                  in
-              FStar_List.append order1 uu____24901  in
+              FStar_List.append order1 uu____24894  in
             FStar_All.pipe_right ms (FStar_List.fold_left fold_fun order)  in
           let order2 =
             FStar_Util.remove_dups
@@ -4600,30 +4597,30 @@ let (update_effect_lattice :
           FStar_All.pipe_right order2
             (FStar_List.iter
                (fun edge2  ->
-                  let uu____24990 =
+                  let uu____24983 =
                     (FStar_Ident.lid_equals edge2.msource
                        FStar_Parser_Const.effect_DIV_lid)
                       &&
-                      (let uu____24993 =
+                      (let uu____24986 =
                          lookup_effect_quals env1 edge2.mtarget  in
-                       FStar_All.pipe_right uu____24993
+                       FStar_All.pipe_right uu____24986
                          (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
                      in
-                  if uu____24990
+                  if uu____24983
                   then
-                    let uu____25000 =
-                      let uu____25006 =
-                        let uu____25008 =
+                    let uu____24993 =
+                      let uu____24999 =
+                        let uu____25001 =
                           FStar_Ident.string_of_lid edge2.mtarget  in
                         FStar_Util.format1
                           "Divergent computations cannot be included in an effect %s marked 'total'"
-                          uu____25008
+                          uu____25001
                          in
                       (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                        uu____25006)
+                        uu____24999)
                        in
-                    let uu____25012 = get_range env1  in
-                    FStar_Errors.raise_error uu____25000 uu____25012
+                    let uu____25005 = get_range env1  in
+                    FStar_Errors.raise_error uu____24993 uu____25005
                   else ()));
           (let joins =
              FStar_All.pipe_right ms
@@ -4633,9 +4630,9 @@ let (update_effect_lattice :
                        (FStar_List.collect
                           (fun j  ->
                              let join_opt1 =
-                               let uu____25090 = FStar_Ident.lid_equals i j
+                               let uu____25083 = FStar_Ident.lid_equals i j
                                   in
-                               if uu____25090
+                               if uu____25083
                                then
                                  FStar_Pervasives_Native.Some
                                    (i, (id_edge i), (id_edge i))
@@ -4644,13 +4641,13 @@ let (update_effect_lattice :
                                    (FStar_List.fold_left
                                       (fun bopt  ->
                                          fun k  ->
-                                           let uu____25142 =
-                                             let uu____25151 =
+                                           let uu____25135 =
+                                             let uu____25144 =
                                                find_edge order2 (i, k)  in
-                                             let uu____25154 =
+                                             let uu____25147 =
                                                find_edge order2 (j, k)  in
-                                             (uu____25151, uu____25154)  in
-                                           match uu____25142 with
+                                             (uu____25144, uu____25147)  in
+                                           match uu____25135 with
                                            | (FStar_Pervasives_Native.Some
                                               ik,FStar_Pervasives_Native.Some
                                               jk) ->
@@ -4660,35 +4657,35 @@ let (update_effect_lattice :
                                                     FStar_Pervasives_Native.Some
                                                       (k, ik, jk)
                                                 | FStar_Pervasives_Native.Some
-                                                    (ub,uu____25196,uu____25197)
+                                                    (ub,uu____25189,uu____25190)
                                                     ->
-                                                    let uu____25204 =
-                                                      let uu____25211 =
-                                                        let uu____25213 =
+                                                    let uu____25197 =
+                                                      let uu____25204 =
+                                                        let uu____25206 =
                                                           find_edge order2
                                                             (k, ub)
                                                            in
                                                         FStar_Util.is_some
-                                                          uu____25213
+                                                          uu____25206
                                                          in
-                                                      let uu____25216 =
-                                                        let uu____25218 =
+                                                      let uu____25209 =
+                                                        let uu____25211 =
                                                           find_edge order2
                                                             (ub, k)
                                                            in
                                                         FStar_Util.is_some
-                                                          uu____25218
+                                                          uu____25211
                                                          in
-                                                      (uu____25211,
-                                                        uu____25216)
+                                                      (uu____25204,
+                                                        uu____25209)
                                                        in
-                                                    (match uu____25204 with
+                                                    (match uu____25197 with
                                                      | (true ,true ) ->
-                                                         let uu____25235 =
+                                                         let uu____25228 =
                                                            FStar_Ident.lid_equals
                                                              k ub
                                                             in
-                                                         if uu____25235
+                                                         if uu____25228
                                                          then
                                                            (FStar_Errors.log_issue
                                                               FStar_Range.dummyRange
@@ -4704,99 +4701,99 @@ let (update_effect_lattice :
                                                          FStar_Pervasives_Native.Some
                                                            (k, ik, jk)
                                                      | (false ,true ) -> bopt))
-                                           | uu____25278 -> bopt)
+                                           | uu____25271 -> bopt)
                                       FStar_Pervasives_Native.None)
                                 in
                              match join_opt1 with
                              | FStar_Pervasives_Native.None  -> []
                              | FStar_Pervasives_Native.Some (k,e1,e2) ->
-                                 let uu____25330 =
-                                   let uu____25332 =
+                                 let uu____25323 =
+                                   let uu____25325 =
                                      exists_polymonadic_bind env1 i j  in
-                                   FStar_All.pipe_right uu____25332
+                                   FStar_All.pipe_right uu____25325
                                      FStar_Util.is_some
                                     in
-                                 if uu____25330
+                                 if uu____25323
                                  then
-                                   let uu____25381 =
-                                     let uu____25387 =
-                                       let uu____25389 =
+                                   let uu____25374 =
+                                     let uu____25380 =
+                                       let uu____25382 =
                                          FStar_Ident.string_of_lid src  in
-                                       let uu____25391 =
+                                       let uu____25384 =
                                          FStar_Ident.string_of_lid tgt  in
-                                       let uu____25393 =
+                                       let uu____25386 =
                                          FStar_Ident.string_of_lid i  in
-                                       let uu____25395 =
+                                       let uu____25388 =
                                          FStar_Ident.string_of_lid j  in
                                        FStar_Util.format4
                                          "Updating effect lattice with a lift between %s and %s induces a path from %s and %s in the effect lattice, and this conflicts with a polymonadic bind between them"
-                                         uu____25389 uu____25391 uu____25393
-                                         uu____25395
+                                         uu____25382 uu____25384 uu____25386
+                                         uu____25388
                                         in
                                      (FStar_Errors.Fatal_PolymonadicBind_conflict,
-                                       uu____25387)
+                                       uu____25380)
                                       in
-                                   FStar_Errors.raise_error uu____25381
+                                   FStar_Errors.raise_error uu____25374
                                      env1.range
                                  else [(i, j, k, (e1.mlift), (e2.mlift))]))))
               in
            let effects1 =
-             let uu___1819_25434 = env1.effects  in
+             let uu___1819_25427 = env1.effects  in
              {
-               decls = (uu___1819_25434.decls);
+               decls = (uu___1819_25427.decls);
                order = order2;
                joins;
-               polymonadic_binds = (uu___1819_25434.polymonadic_binds)
+               polymonadic_binds = (uu___1819_25427.polymonadic_binds)
              }  in
-           let uu___1822_25435 = env1  in
+           let uu___1822_25428 = env1  in
            {
-             solver = (uu___1822_25435.solver);
-             range = (uu___1822_25435.range);
-             curmodule = (uu___1822_25435.curmodule);
-             gamma = (uu___1822_25435.gamma);
-             gamma_sig = (uu___1822_25435.gamma_sig);
-             gamma_cache = (uu___1822_25435.gamma_cache);
-             modules = (uu___1822_25435.modules);
-             expected_typ = (uu___1822_25435.expected_typ);
-             sigtab = (uu___1822_25435.sigtab);
-             attrtab = (uu___1822_25435.attrtab);
-             instantiate_imp = (uu___1822_25435.instantiate_imp);
+             solver = (uu___1822_25428.solver);
+             range = (uu___1822_25428.range);
+             curmodule = (uu___1822_25428.curmodule);
+             gamma = (uu___1822_25428.gamma);
+             gamma_sig = (uu___1822_25428.gamma_sig);
+             gamma_cache = (uu___1822_25428.gamma_cache);
+             modules = (uu___1822_25428.modules);
+             expected_typ = (uu___1822_25428.expected_typ);
+             sigtab = (uu___1822_25428.sigtab);
+             attrtab = (uu___1822_25428.attrtab);
+             instantiate_imp = (uu___1822_25428.instantiate_imp);
              effects = effects1;
-             generalize = (uu___1822_25435.generalize);
-             letrecs = (uu___1822_25435.letrecs);
-             top_level = (uu___1822_25435.top_level);
-             check_uvars = (uu___1822_25435.check_uvars);
-             use_eq = (uu___1822_25435.use_eq);
-             use_eq_strict = (uu___1822_25435.use_eq_strict);
-             is_iface = (uu___1822_25435.is_iface);
-             admit = (uu___1822_25435.admit);
-             lax = (uu___1822_25435.lax);
-             lax_universes = (uu___1822_25435.lax_universes);
-             phase1 = (uu___1822_25435.phase1);
-             failhard = (uu___1822_25435.failhard);
-             nosynth = (uu___1822_25435.nosynth);
-             uvar_subtyping = (uu___1822_25435.uvar_subtyping);
-             tc_term = (uu___1822_25435.tc_term);
-             type_of = (uu___1822_25435.type_of);
-             universe_of = (uu___1822_25435.universe_of);
-             check_type_of = (uu___1822_25435.check_type_of);
-             use_bv_sorts = (uu___1822_25435.use_bv_sorts);
-             qtbl_name_and_index = (uu___1822_25435.qtbl_name_and_index);
-             normalized_eff_names = (uu___1822_25435.normalized_eff_names);
-             fv_delta_depths = (uu___1822_25435.fv_delta_depths);
-             proof_ns = (uu___1822_25435.proof_ns);
-             synth_hook = (uu___1822_25435.synth_hook);
+             generalize = (uu___1822_25428.generalize);
+             letrecs = (uu___1822_25428.letrecs);
+             top_level = (uu___1822_25428.top_level);
+             check_uvars = (uu___1822_25428.check_uvars);
+             use_eq = (uu___1822_25428.use_eq);
+             use_eq_strict = (uu___1822_25428.use_eq_strict);
+             is_iface = (uu___1822_25428.is_iface);
+             admit = (uu___1822_25428.admit);
+             lax = (uu___1822_25428.lax);
+             lax_universes = (uu___1822_25428.lax_universes);
+             phase1 = (uu___1822_25428.phase1);
+             failhard = (uu___1822_25428.failhard);
+             nosynth = (uu___1822_25428.nosynth);
+             uvar_subtyping = (uu___1822_25428.uvar_subtyping);
+             tc_term = (uu___1822_25428.tc_term);
+             type_of = (uu___1822_25428.type_of);
+             universe_of = (uu___1822_25428.universe_of);
+             check_type_of = (uu___1822_25428.check_type_of);
+             use_bv_sorts = (uu___1822_25428.use_bv_sorts);
+             qtbl_name_and_index = (uu___1822_25428.qtbl_name_and_index);
+             normalized_eff_names = (uu___1822_25428.normalized_eff_names);
+             fv_delta_depths = (uu___1822_25428.fv_delta_depths);
+             proof_ns = (uu___1822_25428.proof_ns);
+             synth_hook = (uu___1822_25428.synth_hook);
              try_solve_implicits_hook =
-               (uu___1822_25435.try_solve_implicits_hook);
-             splice = (uu___1822_25435.splice);
-             mpreprocess = (uu___1822_25435.mpreprocess);
-             postprocess = (uu___1822_25435.postprocess);
-             identifier_info = (uu___1822_25435.identifier_info);
-             tc_hooks = (uu___1822_25435.tc_hooks);
-             dsenv = (uu___1822_25435.dsenv);
-             nbe = (uu___1822_25435.nbe);
-             strict_args_tab = (uu___1822_25435.strict_args_tab);
-             erasable_types_tab = (uu___1822_25435.erasable_types_tab)
+               (uu___1822_25428.try_solve_implicits_hook);
+             splice = (uu___1822_25428.splice);
+             mpreprocess = (uu___1822_25428.mpreprocess);
+             postprocess = (uu___1822_25428.postprocess);
+             identifier_info = (uu___1822_25428.identifier_info);
+             tc_hooks = (uu___1822_25428.tc_hooks);
+             dsenv = (uu___1822_25428.dsenv);
+             nbe = (uu___1822_25428.nbe);
+             strict_args_tab = (uu___1822_25428.strict_args_tab);
+             erasable_types_tab = (uu___1822_25428.erasable_types_tab)
            })
   
 let (add_polymonadic_bind :
@@ -4810,150 +4807,150 @@ let (add_polymonadic_bind :
         fun p  ->
           fun ty  ->
             let err_msg poly =
-              let uu____25483 = FStar_Ident.string_of_lid m  in
-              let uu____25485 = FStar_Ident.string_of_lid n  in
-              let uu____25487 = FStar_Ident.string_of_lid p  in
+              let uu____25476 = FStar_Ident.string_of_lid m  in
+              let uu____25478 = FStar_Ident.string_of_lid n  in
+              let uu____25480 = FStar_Ident.string_of_lid p  in
               FStar_Util.format4
                 "Polymonadic bind ((%s, %s) |> %s) conflicts with an already existing %s"
-                uu____25483 uu____25485 uu____25487
+                uu____25476 uu____25478 uu____25480
                 (if poly
                  then "polymonadic bind"
                  else "path in the effect lattice")
                in
-            let uu____25496 =
-              let uu____25498 = exists_polymonadic_bind env1 m n  in
-              FStar_All.pipe_right uu____25498 FStar_Util.is_some  in
-            if uu____25496
+            let uu____25489 =
+              let uu____25491 = exists_polymonadic_bind env1 m n  in
+              FStar_All.pipe_right uu____25491 FStar_Util.is_some  in
+            if uu____25489
             then
-              let uu____25535 =
-                let uu____25541 = err_msg true  in
-                (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25541)
+              let uu____25528 =
+                let uu____25534 = err_msg true  in
+                (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25534)
                  in
-              FStar_Errors.raise_error uu____25535 env1.range
+              FStar_Errors.raise_error uu____25528 env1.range
             else
-              (let uu____25547 =
-                 let uu____25549 = join_opt env1 m n  in
-                 FStar_All.pipe_right uu____25549 FStar_Util.is_some  in
-               if uu____25547
+              (let uu____25540 =
+                 let uu____25542 = join_opt env1 m n  in
+                 FStar_All.pipe_right uu____25542 FStar_Util.is_some  in
+               if uu____25540
                then
-                 let uu____25574 =
-                   let uu____25580 = err_msg false  in
-                   (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25580)
+                 let uu____25567 =
+                   let uu____25573 = err_msg false  in
+                   (FStar_Errors.Fatal_PolymonadicBind_conflict, uu____25573)
                     in
-                 FStar_Errors.raise_error uu____25574 env1.range
+                 FStar_Errors.raise_error uu____25567 env1.range
                else
-                 (let uu___1837_25586 = env1  in
+                 (let uu___1837_25579 = env1  in
                   {
-                    solver = (uu___1837_25586.solver);
-                    range = (uu___1837_25586.range);
-                    curmodule = (uu___1837_25586.curmodule);
-                    gamma = (uu___1837_25586.gamma);
-                    gamma_sig = (uu___1837_25586.gamma_sig);
-                    gamma_cache = (uu___1837_25586.gamma_cache);
-                    modules = (uu___1837_25586.modules);
-                    expected_typ = (uu___1837_25586.expected_typ);
-                    sigtab = (uu___1837_25586.sigtab);
-                    attrtab = (uu___1837_25586.attrtab);
-                    instantiate_imp = (uu___1837_25586.instantiate_imp);
+                    solver = (uu___1837_25579.solver);
+                    range = (uu___1837_25579.range);
+                    curmodule = (uu___1837_25579.curmodule);
+                    gamma = (uu___1837_25579.gamma);
+                    gamma_sig = (uu___1837_25579.gamma_sig);
+                    gamma_cache = (uu___1837_25579.gamma_cache);
+                    modules = (uu___1837_25579.modules);
+                    expected_typ = (uu___1837_25579.expected_typ);
+                    sigtab = (uu___1837_25579.sigtab);
+                    attrtab = (uu___1837_25579.attrtab);
+                    instantiate_imp = (uu___1837_25579.instantiate_imp);
                     effects =
-                      (let uu___1839_25588 = env1.effects  in
+                      (let uu___1839_25581 = env1.effects  in
                        {
-                         decls = (uu___1839_25588.decls);
-                         order = (uu___1839_25588.order);
-                         joins = (uu___1839_25588.joins);
+                         decls = (uu___1839_25581.decls);
+                         order = (uu___1839_25581.order);
+                         joins = (uu___1839_25581.joins);
                          polymonadic_binds = ((m, n, p, ty) ::
                            ((env1.effects).polymonadic_binds))
                        });
-                    generalize = (uu___1837_25586.generalize);
-                    letrecs = (uu___1837_25586.letrecs);
-                    top_level = (uu___1837_25586.top_level);
-                    check_uvars = (uu___1837_25586.check_uvars);
-                    use_eq = (uu___1837_25586.use_eq);
-                    use_eq_strict = (uu___1837_25586.use_eq_strict);
-                    is_iface = (uu___1837_25586.is_iface);
-                    admit = (uu___1837_25586.admit);
-                    lax = (uu___1837_25586.lax);
-                    lax_universes = (uu___1837_25586.lax_universes);
-                    phase1 = (uu___1837_25586.phase1);
-                    failhard = (uu___1837_25586.failhard);
-                    nosynth = (uu___1837_25586.nosynth);
-                    uvar_subtyping = (uu___1837_25586.uvar_subtyping);
-                    tc_term = (uu___1837_25586.tc_term);
-                    type_of = (uu___1837_25586.type_of);
-                    universe_of = (uu___1837_25586.universe_of);
-                    check_type_of = (uu___1837_25586.check_type_of);
-                    use_bv_sorts = (uu___1837_25586.use_bv_sorts);
+                    generalize = (uu___1837_25579.generalize);
+                    letrecs = (uu___1837_25579.letrecs);
+                    top_level = (uu___1837_25579.top_level);
+                    check_uvars = (uu___1837_25579.check_uvars);
+                    use_eq = (uu___1837_25579.use_eq);
+                    use_eq_strict = (uu___1837_25579.use_eq_strict);
+                    is_iface = (uu___1837_25579.is_iface);
+                    admit = (uu___1837_25579.admit);
+                    lax = (uu___1837_25579.lax);
+                    lax_universes = (uu___1837_25579.lax_universes);
+                    phase1 = (uu___1837_25579.phase1);
+                    failhard = (uu___1837_25579.failhard);
+                    nosynth = (uu___1837_25579.nosynth);
+                    uvar_subtyping = (uu___1837_25579.uvar_subtyping);
+                    tc_term = (uu___1837_25579.tc_term);
+                    type_of = (uu___1837_25579.type_of);
+                    universe_of = (uu___1837_25579.universe_of);
+                    check_type_of = (uu___1837_25579.check_type_of);
+                    use_bv_sorts = (uu___1837_25579.use_bv_sorts);
                     qtbl_name_and_index =
-                      (uu___1837_25586.qtbl_name_and_index);
+                      (uu___1837_25579.qtbl_name_and_index);
                     normalized_eff_names =
-                      (uu___1837_25586.normalized_eff_names);
-                    fv_delta_depths = (uu___1837_25586.fv_delta_depths);
-                    proof_ns = (uu___1837_25586.proof_ns);
-                    synth_hook = (uu___1837_25586.synth_hook);
+                      (uu___1837_25579.normalized_eff_names);
+                    fv_delta_depths = (uu___1837_25579.fv_delta_depths);
+                    proof_ns = (uu___1837_25579.proof_ns);
+                    synth_hook = (uu___1837_25579.synth_hook);
                     try_solve_implicits_hook =
-                      (uu___1837_25586.try_solve_implicits_hook);
-                    splice = (uu___1837_25586.splice);
-                    mpreprocess = (uu___1837_25586.mpreprocess);
-                    postprocess = (uu___1837_25586.postprocess);
-                    identifier_info = (uu___1837_25586.identifier_info);
-                    tc_hooks = (uu___1837_25586.tc_hooks);
-                    dsenv = (uu___1837_25586.dsenv);
-                    nbe = (uu___1837_25586.nbe);
-                    strict_args_tab = (uu___1837_25586.strict_args_tab);
-                    erasable_types_tab = (uu___1837_25586.erasable_types_tab)
+                      (uu___1837_25579.try_solve_implicits_hook);
+                    splice = (uu___1837_25579.splice);
+                    mpreprocess = (uu___1837_25579.mpreprocess);
+                    postprocess = (uu___1837_25579.postprocess);
+                    identifier_info = (uu___1837_25579.identifier_info);
+                    tc_hooks = (uu___1837_25579.tc_hooks);
+                    dsenv = (uu___1837_25579.dsenv);
+                    nbe = (uu___1837_25579.nbe);
+                    strict_args_tab = (uu___1837_25579.strict_args_tab);
+                    erasable_types_tab = (uu___1837_25579.erasable_types_tab)
                   }))
   
 let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
   fun env1  ->
     fun b  ->
-      let uu___1843_25660 = env1  in
+      let uu___1843_25653 = env1  in
       {
-        solver = (uu___1843_25660.solver);
-        range = (uu___1843_25660.range);
-        curmodule = (uu___1843_25660.curmodule);
+        solver = (uu___1843_25653.solver);
+        range = (uu___1843_25653.range);
+        curmodule = (uu___1843_25653.curmodule);
         gamma = (b :: (env1.gamma));
-        gamma_sig = (uu___1843_25660.gamma_sig);
-        gamma_cache = (uu___1843_25660.gamma_cache);
-        modules = (uu___1843_25660.modules);
-        expected_typ = (uu___1843_25660.expected_typ);
-        sigtab = (uu___1843_25660.sigtab);
-        attrtab = (uu___1843_25660.attrtab);
-        instantiate_imp = (uu___1843_25660.instantiate_imp);
-        effects = (uu___1843_25660.effects);
-        generalize = (uu___1843_25660.generalize);
-        letrecs = (uu___1843_25660.letrecs);
-        top_level = (uu___1843_25660.top_level);
-        check_uvars = (uu___1843_25660.check_uvars);
-        use_eq = (uu___1843_25660.use_eq);
-        use_eq_strict = (uu___1843_25660.use_eq_strict);
-        is_iface = (uu___1843_25660.is_iface);
-        admit = (uu___1843_25660.admit);
-        lax = (uu___1843_25660.lax);
-        lax_universes = (uu___1843_25660.lax_universes);
-        phase1 = (uu___1843_25660.phase1);
-        failhard = (uu___1843_25660.failhard);
-        nosynth = (uu___1843_25660.nosynth);
-        uvar_subtyping = (uu___1843_25660.uvar_subtyping);
-        tc_term = (uu___1843_25660.tc_term);
-        type_of = (uu___1843_25660.type_of);
-        universe_of = (uu___1843_25660.universe_of);
-        check_type_of = (uu___1843_25660.check_type_of);
-        use_bv_sorts = (uu___1843_25660.use_bv_sorts);
-        qtbl_name_and_index = (uu___1843_25660.qtbl_name_and_index);
-        normalized_eff_names = (uu___1843_25660.normalized_eff_names);
-        fv_delta_depths = (uu___1843_25660.fv_delta_depths);
-        proof_ns = (uu___1843_25660.proof_ns);
-        synth_hook = (uu___1843_25660.synth_hook);
-        try_solve_implicits_hook = (uu___1843_25660.try_solve_implicits_hook);
-        splice = (uu___1843_25660.splice);
-        mpreprocess = (uu___1843_25660.mpreprocess);
-        postprocess = (uu___1843_25660.postprocess);
-        identifier_info = (uu___1843_25660.identifier_info);
-        tc_hooks = (uu___1843_25660.tc_hooks);
-        dsenv = (uu___1843_25660.dsenv);
-        nbe = (uu___1843_25660.nbe);
-        strict_args_tab = (uu___1843_25660.strict_args_tab);
-        erasable_types_tab = (uu___1843_25660.erasable_types_tab)
+        gamma_sig = (uu___1843_25653.gamma_sig);
+        gamma_cache = (uu___1843_25653.gamma_cache);
+        modules = (uu___1843_25653.modules);
+        expected_typ = (uu___1843_25653.expected_typ);
+        sigtab = (uu___1843_25653.sigtab);
+        attrtab = (uu___1843_25653.attrtab);
+        instantiate_imp = (uu___1843_25653.instantiate_imp);
+        effects = (uu___1843_25653.effects);
+        generalize = (uu___1843_25653.generalize);
+        letrecs = (uu___1843_25653.letrecs);
+        top_level = (uu___1843_25653.top_level);
+        check_uvars = (uu___1843_25653.check_uvars);
+        use_eq = (uu___1843_25653.use_eq);
+        use_eq_strict = (uu___1843_25653.use_eq_strict);
+        is_iface = (uu___1843_25653.is_iface);
+        admit = (uu___1843_25653.admit);
+        lax = (uu___1843_25653.lax);
+        lax_universes = (uu___1843_25653.lax_universes);
+        phase1 = (uu___1843_25653.phase1);
+        failhard = (uu___1843_25653.failhard);
+        nosynth = (uu___1843_25653.nosynth);
+        uvar_subtyping = (uu___1843_25653.uvar_subtyping);
+        tc_term = (uu___1843_25653.tc_term);
+        type_of = (uu___1843_25653.type_of);
+        universe_of = (uu___1843_25653.universe_of);
+        check_type_of = (uu___1843_25653.check_type_of);
+        use_bv_sorts = (uu___1843_25653.use_bv_sorts);
+        qtbl_name_and_index = (uu___1843_25653.qtbl_name_and_index);
+        normalized_eff_names = (uu___1843_25653.normalized_eff_names);
+        fv_delta_depths = (uu___1843_25653.fv_delta_depths);
+        proof_ns = (uu___1843_25653.proof_ns);
+        synth_hook = (uu___1843_25653.synth_hook);
+        try_solve_implicits_hook = (uu___1843_25653.try_solve_implicits_hook);
+        splice = (uu___1843_25653.splice);
+        mpreprocess = (uu___1843_25653.mpreprocess);
+        postprocess = (uu___1843_25653.postprocess);
+        identifier_info = (uu___1843_25653.identifier_info);
+        tc_hooks = (uu___1843_25653.tc_hooks);
+        dsenv = (uu___1843_25653.dsenv);
+        nbe = (uu___1843_25653.nbe);
+        strict_args_tab = (uu___1843_25653.strict_args_tab);
+        erasable_types_tab = (uu___1843_25653.erasable_types_tab)
       }
   
 let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
@@ -4972,65 +4969,65 @@ let (pop_bv :
     | (FStar_Syntax_Syntax.Binding_var x)::rest ->
         FStar_Pervasives_Native.Some
           (x,
-            (let uu___1856_25718 = env1  in
+            (let uu___1856_25711 = env1  in
              {
-               solver = (uu___1856_25718.solver);
-               range = (uu___1856_25718.range);
-               curmodule = (uu___1856_25718.curmodule);
+               solver = (uu___1856_25711.solver);
+               range = (uu___1856_25711.range);
+               curmodule = (uu___1856_25711.curmodule);
                gamma = rest;
-               gamma_sig = (uu___1856_25718.gamma_sig);
-               gamma_cache = (uu___1856_25718.gamma_cache);
-               modules = (uu___1856_25718.modules);
-               expected_typ = (uu___1856_25718.expected_typ);
-               sigtab = (uu___1856_25718.sigtab);
-               attrtab = (uu___1856_25718.attrtab);
-               instantiate_imp = (uu___1856_25718.instantiate_imp);
-               effects = (uu___1856_25718.effects);
-               generalize = (uu___1856_25718.generalize);
-               letrecs = (uu___1856_25718.letrecs);
-               top_level = (uu___1856_25718.top_level);
-               check_uvars = (uu___1856_25718.check_uvars);
-               use_eq = (uu___1856_25718.use_eq);
-               use_eq_strict = (uu___1856_25718.use_eq_strict);
-               is_iface = (uu___1856_25718.is_iface);
-               admit = (uu___1856_25718.admit);
-               lax = (uu___1856_25718.lax);
-               lax_universes = (uu___1856_25718.lax_universes);
-               phase1 = (uu___1856_25718.phase1);
-               failhard = (uu___1856_25718.failhard);
-               nosynth = (uu___1856_25718.nosynth);
-               uvar_subtyping = (uu___1856_25718.uvar_subtyping);
-               tc_term = (uu___1856_25718.tc_term);
-               type_of = (uu___1856_25718.type_of);
-               universe_of = (uu___1856_25718.universe_of);
-               check_type_of = (uu___1856_25718.check_type_of);
-               use_bv_sorts = (uu___1856_25718.use_bv_sorts);
-               qtbl_name_and_index = (uu___1856_25718.qtbl_name_and_index);
-               normalized_eff_names = (uu___1856_25718.normalized_eff_names);
-               fv_delta_depths = (uu___1856_25718.fv_delta_depths);
-               proof_ns = (uu___1856_25718.proof_ns);
-               synth_hook = (uu___1856_25718.synth_hook);
+               gamma_sig = (uu___1856_25711.gamma_sig);
+               gamma_cache = (uu___1856_25711.gamma_cache);
+               modules = (uu___1856_25711.modules);
+               expected_typ = (uu___1856_25711.expected_typ);
+               sigtab = (uu___1856_25711.sigtab);
+               attrtab = (uu___1856_25711.attrtab);
+               instantiate_imp = (uu___1856_25711.instantiate_imp);
+               effects = (uu___1856_25711.effects);
+               generalize = (uu___1856_25711.generalize);
+               letrecs = (uu___1856_25711.letrecs);
+               top_level = (uu___1856_25711.top_level);
+               check_uvars = (uu___1856_25711.check_uvars);
+               use_eq = (uu___1856_25711.use_eq);
+               use_eq_strict = (uu___1856_25711.use_eq_strict);
+               is_iface = (uu___1856_25711.is_iface);
+               admit = (uu___1856_25711.admit);
+               lax = (uu___1856_25711.lax);
+               lax_universes = (uu___1856_25711.lax_universes);
+               phase1 = (uu___1856_25711.phase1);
+               failhard = (uu___1856_25711.failhard);
+               nosynth = (uu___1856_25711.nosynth);
+               uvar_subtyping = (uu___1856_25711.uvar_subtyping);
+               tc_term = (uu___1856_25711.tc_term);
+               type_of = (uu___1856_25711.type_of);
+               universe_of = (uu___1856_25711.universe_of);
+               check_type_of = (uu___1856_25711.check_type_of);
+               use_bv_sorts = (uu___1856_25711.use_bv_sorts);
+               qtbl_name_and_index = (uu___1856_25711.qtbl_name_and_index);
+               normalized_eff_names = (uu___1856_25711.normalized_eff_names);
+               fv_delta_depths = (uu___1856_25711.fv_delta_depths);
+               proof_ns = (uu___1856_25711.proof_ns);
+               synth_hook = (uu___1856_25711.synth_hook);
                try_solve_implicits_hook =
-                 (uu___1856_25718.try_solve_implicits_hook);
-               splice = (uu___1856_25718.splice);
-               mpreprocess = (uu___1856_25718.mpreprocess);
-               postprocess = (uu___1856_25718.postprocess);
-               identifier_info = (uu___1856_25718.identifier_info);
-               tc_hooks = (uu___1856_25718.tc_hooks);
-               dsenv = (uu___1856_25718.dsenv);
-               nbe = (uu___1856_25718.nbe);
-               strict_args_tab = (uu___1856_25718.strict_args_tab);
-               erasable_types_tab = (uu___1856_25718.erasable_types_tab)
+                 (uu___1856_25711.try_solve_implicits_hook);
+               splice = (uu___1856_25711.splice);
+               mpreprocess = (uu___1856_25711.mpreprocess);
+               postprocess = (uu___1856_25711.postprocess);
+               identifier_info = (uu___1856_25711.identifier_info);
+               tc_hooks = (uu___1856_25711.tc_hooks);
+               dsenv = (uu___1856_25711.dsenv);
+               nbe = (uu___1856_25711.nbe);
+               strict_args_tab = (uu___1856_25711.strict_args_tab);
+               erasable_types_tab = (uu___1856_25711.erasable_types_tab)
              }))
-    | uu____25719 -> FStar_Pervasives_Native.None
+    | uu____25712 -> FStar_Pervasives_Native.None
   
 let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
   fun env1  ->
     fun bs  ->
       FStar_List.fold_left
         (fun env2  ->
-           fun uu____25748  ->
-             match uu____25748 with | (x,uu____25756) -> push_bv env2 x) env1
+           fun uu____25741  ->
+             match uu____25741 with | (x,uu____25749) -> push_bv env2 x) env1
         bs
   
 let (binding_of_lb :
@@ -5043,12 +5040,12 @@ let (binding_of_lb :
       match x with
       | FStar_Util.Inl x1 ->
           let x2 =
-            let uu___1870_25791 = x1  in
+            let uu___1870_25784 = x1  in
             {
               FStar_Syntax_Syntax.ppname =
-                (uu___1870_25791.FStar_Syntax_Syntax.ppname);
+                (uu___1870_25784.FStar_Syntax_Syntax.ppname);
               FStar_Syntax_Syntax.index =
-                (uu___1870_25791.FStar_Syntax_Syntax.index);
+                (uu___1870_25784.FStar_Syntax_Syntax.index);
               FStar_Syntax_Syntax.sort = (FStar_Pervasives_Native.snd t)
             }  in
           FStar_Syntax_Syntax.Binding_var x2
@@ -5080,65 +5077,65 @@ let (open_universes_in :
   fun env1  ->
     fun uvs  ->
       fun terms  ->
-        let uu____25864 = FStar_Syntax_Subst.univ_var_opening uvs  in
-        match uu____25864 with
+        let uu____25857 = FStar_Syntax_Subst.univ_var_opening uvs  in
+        match uu____25857 with
         | (univ_subst,univ_vars) ->
             let env' = push_univ_vars env1 univ_vars  in
-            let uu____25892 =
+            let uu____25885 =
               FStar_List.map (FStar_Syntax_Subst.subst univ_subst) terms  in
-            (env', univ_vars, uu____25892)
+            (env', univ_vars, uu____25885)
   
 let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
   fun env1  ->
     fun t  ->
-      let uu___1891_25908 = env1  in
+      let uu___1891_25901 = env1  in
       {
-        solver = (uu___1891_25908.solver);
-        range = (uu___1891_25908.range);
-        curmodule = (uu___1891_25908.curmodule);
-        gamma = (uu___1891_25908.gamma);
-        gamma_sig = (uu___1891_25908.gamma_sig);
-        gamma_cache = (uu___1891_25908.gamma_cache);
-        modules = (uu___1891_25908.modules);
+        solver = (uu___1891_25901.solver);
+        range = (uu___1891_25901.range);
+        curmodule = (uu___1891_25901.curmodule);
+        gamma = (uu___1891_25901.gamma);
+        gamma_sig = (uu___1891_25901.gamma_sig);
+        gamma_cache = (uu___1891_25901.gamma_cache);
+        modules = (uu___1891_25901.modules);
         expected_typ = (FStar_Pervasives_Native.Some t);
-        sigtab = (uu___1891_25908.sigtab);
-        attrtab = (uu___1891_25908.attrtab);
-        instantiate_imp = (uu___1891_25908.instantiate_imp);
-        effects = (uu___1891_25908.effects);
-        generalize = (uu___1891_25908.generalize);
-        letrecs = (uu___1891_25908.letrecs);
-        top_level = (uu___1891_25908.top_level);
-        check_uvars = (uu___1891_25908.check_uvars);
+        sigtab = (uu___1891_25901.sigtab);
+        attrtab = (uu___1891_25901.attrtab);
+        instantiate_imp = (uu___1891_25901.instantiate_imp);
+        effects = (uu___1891_25901.effects);
+        generalize = (uu___1891_25901.generalize);
+        letrecs = (uu___1891_25901.letrecs);
+        top_level = (uu___1891_25901.top_level);
+        check_uvars = (uu___1891_25901.check_uvars);
         use_eq = false;
-        use_eq_strict = (uu___1891_25908.use_eq_strict);
-        is_iface = (uu___1891_25908.is_iface);
-        admit = (uu___1891_25908.admit);
-        lax = (uu___1891_25908.lax);
-        lax_universes = (uu___1891_25908.lax_universes);
-        phase1 = (uu___1891_25908.phase1);
-        failhard = (uu___1891_25908.failhard);
-        nosynth = (uu___1891_25908.nosynth);
-        uvar_subtyping = (uu___1891_25908.uvar_subtyping);
-        tc_term = (uu___1891_25908.tc_term);
-        type_of = (uu___1891_25908.type_of);
-        universe_of = (uu___1891_25908.universe_of);
-        check_type_of = (uu___1891_25908.check_type_of);
-        use_bv_sorts = (uu___1891_25908.use_bv_sorts);
-        qtbl_name_and_index = (uu___1891_25908.qtbl_name_and_index);
-        normalized_eff_names = (uu___1891_25908.normalized_eff_names);
-        fv_delta_depths = (uu___1891_25908.fv_delta_depths);
-        proof_ns = (uu___1891_25908.proof_ns);
-        synth_hook = (uu___1891_25908.synth_hook);
-        try_solve_implicits_hook = (uu___1891_25908.try_solve_implicits_hook);
-        splice = (uu___1891_25908.splice);
-        mpreprocess = (uu___1891_25908.mpreprocess);
-        postprocess = (uu___1891_25908.postprocess);
-        identifier_info = (uu___1891_25908.identifier_info);
-        tc_hooks = (uu___1891_25908.tc_hooks);
-        dsenv = (uu___1891_25908.dsenv);
-        nbe = (uu___1891_25908.nbe);
-        strict_args_tab = (uu___1891_25908.strict_args_tab);
-        erasable_types_tab = (uu___1891_25908.erasable_types_tab)
+        use_eq_strict = (uu___1891_25901.use_eq_strict);
+        is_iface = (uu___1891_25901.is_iface);
+        admit = (uu___1891_25901.admit);
+        lax = (uu___1891_25901.lax);
+        lax_universes = (uu___1891_25901.lax_universes);
+        phase1 = (uu___1891_25901.phase1);
+        failhard = (uu___1891_25901.failhard);
+        nosynth = (uu___1891_25901.nosynth);
+        uvar_subtyping = (uu___1891_25901.uvar_subtyping);
+        tc_term = (uu___1891_25901.tc_term);
+        type_of = (uu___1891_25901.type_of);
+        universe_of = (uu___1891_25901.universe_of);
+        check_type_of = (uu___1891_25901.check_type_of);
+        use_bv_sorts = (uu___1891_25901.use_bv_sorts);
+        qtbl_name_and_index = (uu___1891_25901.qtbl_name_and_index);
+        normalized_eff_names = (uu___1891_25901.normalized_eff_names);
+        fv_delta_depths = (uu___1891_25901.fv_delta_depths);
+        proof_ns = (uu___1891_25901.proof_ns);
+        synth_hook = (uu___1891_25901.synth_hook);
+        try_solve_implicits_hook = (uu___1891_25901.try_solve_implicits_hook);
+        splice = (uu___1891_25901.splice);
+        mpreprocess = (uu___1891_25901.mpreprocess);
+        postprocess = (uu___1891_25901.postprocess);
+        identifier_info = (uu___1891_25901.identifier_info);
+        tc_hooks = (uu___1891_25901.tc_hooks);
+        dsenv = (uu___1891_25901.dsenv);
+        nbe = (uu___1891_25901.nbe);
+        strict_args_tab = (uu___1891_25901.strict_args_tab);
+        erasable_types_tab = (uu___1891_25901.erasable_types_tab)
       }
   
 let (expected_typ :
@@ -5151,127 +5148,127 @@ let (expected_typ :
 let (clear_expected_typ :
   env -> (env * FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)) =
   fun env_  ->
-    let uu____25939 = expected_typ env_  in
-    ((let uu___1898_25945 = env_  in
+    let uu____25932 = expected_typ env_  in
+    ((let uu___1898_25938 = env_  in
       {
-        solver = (uu___1898_25945.solver);
-        range = (uu___1898_25945.range);
-        curmodule = (uu___1898_25945.curmodule);
-        gamma = (uu___1898_25945.gamma);
-        gamma_sig = (uu___1898_25945.gamma_sig);
-        gamma_cache = (uu___1898_25945.gamma_cache);
-        modules = (uu___1898_25945.modules);
+        solver = (uu___1898_25938.solver);
+        range = (uu___1898_25938.range);
+        curmodule = (uu___1898_25938.curmodule);
+        gamma = (uu___1898_25938.gamma);
+        gamma_sig = (uu___1898_25938.gamma_sig);
+        gamma_cache = (uu___1898_25938.gamma_cache);
+        modules = (uu___1898_25938.modules);
         expected_typ = FStar_Pervasives_Native.None;
-        sigtab = (uu___1898_25945.sigtab);
-        attrtab = (uu___1898_25945.attrtab);
-        instantiate_imp = (uu___1898_25945.instantiate_imp);
-        effects = (uu___1898_25945.effects);
-        generalize = (uu___1898_25945.generalize);
-        letrecs = (uu___1898_25945.letrecs);
-        top_level = (uu___1898_25945.top_level);
-        check_uvars = (uu___1898_25945.check_uvars);
+        sigtab = (uu___1898_25938.sigtab);
+        attrtab = (uu___1898_25938.attrtab);
+        instantiate_imp = (uu___1898_25938.instantiate_imp);
+        effects = (uu___1898_25938.effects);
+        generalize = (uu___1898_25938.generalize);
+        letrecs = (uu___1898_25938.letrecs);
+        top_level = (uu___1898_25938.top_level);
+        check_uvars = (uu___1898_25938.check_uvars);
         use_eq = false;
-        use_eq_strict = (uu___1898_25945.use_eq_strict);
-        is_iface = (uu___1898_25945.is_iface);
-        admit = (uu___1898_25945.admit);
-        lax = (uu___1898_25945.lax);
-        lax_universes = (uu___1898_25945.lax_universes);
-        phase1 = (uu___1898_25945.phase1);
-        failhard = (uu___1898_25945.failhard);
-        nosynth = (uu___1898_25945.nosynth);
-        uvar_subtyping = (uu___1898_25945.uvar_subtyping);
-        tc_term = (uu___1898_25945.tc_term);
-        type_of = (uu___1898_25945.type_of);
-        universe_of = (uu___1898_25945.universe_of);
-        check_type_of = (uu___1898_25945.check_type_of);
-        use_bv_sorts = (uu___1898_25945.use_bv_sorts);
-        qtbl_name_and_index = (uu___1898_25945.qtbl_name_and_index);
-        normalized_eff_names = (uu___1898_25945.normalized_eff_names);
-        fv_delta_depths = (uu___1898_25945.fv_delta_depths);
-        proof_ns = (uu___1898_25945.proof_ns);
-        synth_hook = (uu___1898_25945.synth_hook);
-        try_solve_implicits_hook = (uu___1898_25945.try_solve_implicits_hook);
-        splice = (uu___1898_25945.splice);
-        mpreprocess = (uu___1898_25945.mpreprocess);
-        postprocess = (uu___1898_25945.postprocess);
-        identifier_info = (uu___1898_25945.identifier_info);
-        tc_hooks = (uu___1898_25945.tc_hooks);
-        dsenv = (uu___1898_25945.dsenv);
-        nbe = (uu___1898_25945.nbe);
-        strict_args_tab = (uu___1898_25945.strict_args_tab);
-        erasable_types_tab = (uu___1898_25945.erasable_types_tab)
-      }), uu____25939)
+        use_eq_strict = (uu___1898_25938.use_eq_strict);
+        is_iface = (uu___1898_25938.is_iface);
+        admit = (uu___1898_25938.admit);
+        lax = (uu___1898_25938.lax);
+        lax_universes = (uu___1898_25938.lax_universes);
+        phase1 = (uu___1898_25938.phase1);
+        failhard = (uu___1898_25938.failhard);
+        nosynth = (uu___1898_25938.nosynth);
+        uvar_subtyping = (uu___1898_25938.uvar_subtyping);
+        tc_term = (uu___1898_25938.tc_term);
+        type_of = (uu___1898_25938.type_of);
+        universe_of = (uu___1898_25938.universe_of);
+        check_type_of = (uu___1898_25938.check_type_of);
+        use_bv_sorts = (uu___1898_25938.use_bv_sorts);
+        qtbl_name_and_index = (uu___1898_25938.qtbl_name_and_index);
+        normalized_eff_names = (uu___1898_25938.normalized_eff_names);
+        fv_delta_depths = (uu___1898_25938.fv_delta_depths);
+        proof_ns = (uu___1898_25938.proof_ns);
+        synth_hook = (uu___1898_25938.synth_hook);
+        try_solve_implicits_hook = (uu___1898_25938.try_solve_implicits_hook);
+        splice = (uu___1898_25938.splice);
+        mpreprocess = (uu___1898_25938.mpreprocess);
+        postprocess = (uu___1898_25938.postprocess);
+        identifier_info = (uu___1898_25938.identifier_info);
+        tc_hooks = (uu___1898_25938.tc_hooks);
+        dsenv = (uu___1898_25938.dsenv);
+        nbe = (uu___1898_25938.nbe);
+        strict_args_tab = (uu___1898_25938.strict_args_tab);
+        erasable_types_tab = (uu___1898_25938.erasable_types_tab)
+      }), uu____25932)
   
 let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
   let empty_lid =
-    let uu____25957 =
-      let uu____25958 = FStar_Ident.id_of_text ""  in [uu____25958]  in
-    FStar_Ident.lid_of_ids uu____25957  in
+    let uu____25950 =
+      let uu____25951 = FStar_Ident.id_of_text ""  in [uu____25951]  in
+    FStar_Ident.lid_of_ids uu____25950  in
   fun env1  ->
     fun m  ->
       let sigs =
-        let uu____25965 =
+        let uu____25958 =
           FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____25965
+        if uu____25958
         then
-          let uu____25970 =
+          let uu____25963 =
             FStar_All.pipe_right env1.gamma_sig
               (FStar_List.map FStar_Pervasives_Native.snd)
              in
-          FStar_All.pipe_right uu____25970 FStar_List.rev
+          FStar_All.pipe_right uu____25963 FStar_List.rev
         else m.FStar_Syntax_Syntax.exports  in
       add_sigelts env1 sigs;
-      (let uu___1906_25998 = env1  in
+      (let uu___1906_25991 = env1  in
        {
-         solver = (uu___1906_25998.solver);
-         range = (uu___1906_25998.range);
+         solver = (uu___1906_25991.solver);
+         range = (uu___1906_25991.range);
          curmodule = empty_lid;
          gamma = [];
          gamma_sig = [];
-         gamma_cache = (uu___1906_25998.gamma_cache);
+         gamma_cache = (uu___1906_25991.gamma_cache);
          modules = (m :: (env1.modules));
-         expected_typ = (uu___1906_25998.expected_typ);
-         sigtab = (uu___1906_25998.sigtab);
-         attrtab = (uu___1906_25998.attrtab);
-         instantiate_imp = (uu___1906_25998.instantiate_imp);
-         effects = (uu___1906_25998.effects);
-         generalize = (uu___1906_25998.generalize);
-         letrecs = (uu___1906_25998.letrecs);
-         top_level = (uu___1906_25998.top_level);
-         check_uvars = (uu___1906_25998.check_uvars);
-         use_eq = (uu___1906_25998.use_eq);
-         use_eq_strict = (uu___1906_25998.use_eq_strict);
-         is_iface = (uu___1906_25998.is_iface);
-         admit = (uu___1906_25998.admit);
-         lax = (uu___1906_25998.lax);
-         lax_universes = (uu___1906_25998.lax_universes);
-         phase1 = (uu___1906_25998.phase1);
-         failhard = (uu___1906_25998.failhard);
-         nosynth = (uu___1906_25998.nosynth);
-         uvar_subtyping = (uu___1906_25998.uvar_subtyping);
-         tc_term = (uu___1906_25998.tc_term);
-         type_of = (uu___1906_25998.type_of);
-         universe_of = (uu___1906_25998.universe_of);
-         check_type_of = (uu___1906_25998.check_type_of);
-         use_bv_sorts = (uu___1906_25998.use_bv_sorts);
-         qtbl_name_and_index = (uu___1906_25998.qtbl_name_and_index);
-         normalized_eff_names = (uu___1906_25998.normalized_eff_names);
-         fv_delta_depths = (uu___1906_25998.fv_delta_depths);
-         proof_ns = (uu___1906_25998.proof_ns);
-         synth_hook = (uu___1906_25998.synth_hook);
+         expected_typ = (uu___1906_25991.expected_typ);
+         sigtab = (uu___1906_25991.sigtab);
+         attrtab = (uu___1906_25991.attrtab);
+         instantiate_imp = (uu___1906_25991.instantiate_imp);
+         effects = (uu___1906_25991.effects);
+         generalize = (uu___1906_25991.generalize);
+         letrecs = (uu___1906_25991.letrecs);
+         top_level = (uu___1906_25991.top_level);
+         check_uvars = (uu___1906_25991.check_uvars);
+         use_eq = (uu___1906_25991.use_eq);
+         use_eq_strict = (uu___1906_25991.use_eq_strict);
+         is_iface = (uu___1906_25991.is_iface);
+         admit = (uu___1906_25991.admit);
+         lax = (uu___1906_25991.lax);
+         lax_universes = (uu___1906_25991.lax_universes);
+         phase1 = (uu___1906_25991.phase1);
+         failhard = (uu___1906_25991.failhard);
+         nosynth = (uu___1906_25991.nosynth);
+         uvar_subtyping = (uu___1906_25991.uvar_subtyping);
+         tc_term = (uu___1906_25991.tc_term);
+         type_of = (uu___1906_25991.type_of);
+         universe_of = (uu___1906_25991.universe_of);
+         check_type_of = (uu___1906_25991.check_type_of);
+         use_bv_sorts = (uu___1906_25991.use_bv_sorts);
+         qtbl_name_and_index = (uu___1906_25991.qtbl_name_and_index);
+         normalized_eff_names = (uu___1906_25991.normalized_eff_names);
+         fv_delta_depths = (uu___1906_25991.fv_delta_depths);
+         proof_ns = (uu___1906_25991.proof_ns);
+         synth_hook = (uu___1906_25991.synth_hook);
          try_solve_implicits_hook =
-           (uu___1906_25998.try_solve_implicits_hook);
-         splice = (uu___1906_25998.splice);
-         mpreprocess = (uu___1906_25998.mpreprocess);
-         postprocess = (uu___1906_25998.postprocess);
-         identifier_info = (uu___1906_25998.identifier_info);
-         tc_hooks = (uu___1906_25998.tc_hooks);
-         dsenv = (uu___1906_25998.dsenv);
-         nbe = (uu___1906_25998.nbe);
-         strict_args_tab = (uu___1906_25998.strict_args_tab);
-         erasable_types_tab = (uu___1906_25998.erasable_types_tab)
+           (uu___1906_25991.try_solve_implicits_hook);
+         splice = (uu___1906_25991.splice);
+         mpreprocess = (uu___1906_25991.mpreprocess);
+         postprocess = (uu___1906_25991.postprocess);
+         identifier_info = (uu___1906_25991.identifier_info);
+         tc_hooks = (uu___1906_25991.tc_hooks);
+         dsenv = (uu___1906_25991.dsenv);
+         nbe = (uu___1906_25991.nbe);
+         strict_args_tab = (uu___1906_25991.strict_args_tab);
+         erasable_types_tab = (uu___1906_25991.erasable_types_tab)
        })
   
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
@@ -5281,22 +5278,22 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____26050)::tl -> aux out tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____26054,(uu____26055,t)))::tl
+      | (FStar_Syntax_Syntax.Binding_univ uu____26043)::tl -> aux out tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu____26047,(uu____26048,t)))::tl
           ->
-          let uu____26076 =
-            let uu____26079 = FStar_Syntax_Free.uvars t  in
-            ext out uu____26079  in
-          aux uu____26076 tl
+          let uu____26069 =
+            let uu____26072 = FStar_Syntax_Free.uvars t  in
+            ext out uu____26072  in
+          aux uu____26069 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____26082;
-            FStar_Syntax_Syntax.index = uu____26083;
+          { FStar_Syntax_Syntax.ppname = uu____26075;
+            FStar_Syntax_Syntax.index = uu____26076;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____26091 =
-            let uu____26094 = FStar_Syntax_Free.uvars t  in
-            ext out uu____26094  in
-          aux uu____26091 tl
+          let uu____26084 =
+            let uu____26087 = FStar_Syntax_Free.uvars t  in
+            ext out uu____26087  in
+          aux uu____26084 tl
        in
     aux no_uvs env1.gamma
   
@@ -5307,22 +5304,22 @@ let (univ_vars : env -> FStar_Syntax_Syntax.universe_uvar FStar_Util.set) =
     let rec aux out g =
       match g with
       | [] -> out
-      | (FStar_Syntax_Syntax.Binding_univ uu____26152)::tl -> aux out tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____26156,(uu____26157,t)))::tl
+      | (FStar_Syntax_Syntax.Binding_univ uu____26145)::tl -> aux out tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu____26149,(uu____26150,t)))::tl
           ->
-          let uu____26178 =
-            let uu____26181 = FStar_Syntax_Free.univs t  in
-            ext out uu____26181  in
-          aux uu____26178 tl
+          let uu____26171 =
+            let uu____26174 = FStar_Syntax_Free.univs t  in
+            ext out uu____26174  in
+          aux uu____26171 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____26184;
-            FStar_Syntax_Syntax.index = uu____26185;
+          { FStar_Syntax_Syntax.ppname = uu____26177;
+            FStar_Syntax_Syntax.index = uu____26178;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____26193 =
-            let uu____26196 = FStar_Syntax_Free.univs t  in
-            ext out uu____26196  in
-          aux uu____26193 tl
+          let uu____26186 =
+            let uu____26189 = FStar_Syntax_Free.univs t  in
+            ext out uu____26189  in
+          aux uu____26186 tl
        in
     aux no_univs env1.gamma
   
@@ -5334,23 +5331,23 @@ let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Util.set) =
       match g with
       | [] -> out
       | (FStar_Syntax_Syntax.Binding_univ uname)::tl ->
-          let uu____26258 = FStar_Util.set_add uname out  in
-          aux uu____26258 tl
-      | (FStar_Syntax_Syntax.Binding_lid (uu____26261,(uu____26262,t)))::tl
+          let uu____26251 = FStar_Util.set_add uname out  in
+          aux uu____26251 tl
+      | (FStar_Syntax_Syntax.Binding_lid (uu____26254,(uu____26255,t)))::tl
           ->
-          let uu____26283 =
-            let uu____26286 = FStar_Syntax_Free.univnames t  in
-            ext out uu____26286  in
-          aux uu____26283 tl
+          let uu____26276 =
+            let uu____26279 = FStar_Syntax_Free.univnames t  in
+            ext out uu____26279  in
+          aux uu____26276 tl
       | (FStar_Syntax_Syntax.Binding_var
-          { FStar_Syntax_Syntax.ppname = uu____26289;
-            FStar_Syntax_Syntax.index = uu____26290;
+          { FStar_Syntax_Syntax.ppname = uu____26282;
+            FStar_Syntax_Syntax.index = uu____26283;
             FStar_Syntax_Syntax.sort = t;_})::tl
           ->
-          let uu____26298 =
-            let uu____26301 = FStar_Syntax_Free.univnames t  in
-            ext out uu____26301  in
-          aux uu____26298 tl
+          let uu____26291 =
+            let uu____26294 = FStar_Syntax_Free.univnames t  in
+            ext out uu____26294  in
+          aux uu____26291 tl
        in
     aux no_univ_names env1.gamma
   
@@ -5360,21 +5357,21 @@ let (bound_vars_of_bindings :
   fun bs  ->
     FStar_All.pipe_right bs
       (FStar_List.collect
-         (fun uu___12_26322  ->
-            match uu___12_26322 with
+         (fun uu___12_26315  ->
+            match uu___12_26315 with
             | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu____26326 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu____26339 -> []))
+            | FStar_Syntax_Syntax.Binding_lid uu____26319 -> []
+            | FStar_Syntax_Syntax.Binding_univ uu____26332 -> []))
   
 let (binders_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
   fun bs  ->
-    let uu____26350 =
-      let uu____26359 = bound_vars_of_bindings bs  in
-      FStar_All.pipe_right uu____26359
+    let uu____26343 =
+      let uu____26352 = bound_vars_of_bindings bs  in
+      FStar_All.pipe_right uu____26352
         (FStar_List.map FStar_Syntax_Syntax.mk_binder)
        in
-    FStar_All.pipe_right uu____26350 FStar_List.rev
+    FStar_All.pipe_right uu____26343 FStar_List.rev
   
 let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
   fun env1  -> bound_vars_of_bindings env1.gamma 
@@ -5382,39 +5379,39 @@ let (all_binders : env -> FStar_Syntax_Syntax.binders) =
   fun env1  -> binders_of_bindings env1.gamma 
 let (print_gamma : FStar_Syntax_Syntax.gamma -> Prims.string) =
   fun gamma  ->
-    let uu____26407 =
+    let uu____26400 =
       FStar_All.pipe_right gamma
         (FStar_List.map
-           (fun uu___13_26420  ->
-              match uu___13_26420 with
+           (fun uu___13_26413  ->
+              match uu___13_26413 with
               | FStar_Syntax_Syntax.Binding_var x ->
-                  let uu____26423 = FStar_Syntax_Print.bv_to_string x  in
-                  Prims.op_Hat "Binding_var " uu____26423
+                  let uu____26416 = FStar_Syntax_Print.bv_to_string x  in
+                  Prims.op_Hat "Binding_var " uu____26416
               | FStar_Syntax_Syntax.Binding_univ u ->
-                  let uu____26427 = FStar_Ident.text_of_id u  in
-                  Prims.op_Hat "Binding_univ " uu____26427
-              | FStar_Syntax_Syntax.Binding_lid (l,uu____26431) ->
-                  let uu____26448 = FStar_Ident.string_of_lid l  in
-                  Prims.op_Hat "Binding_lid " uu____26448))
+                  let uu____26420 = FStar_Ident.text_of_id u  in
+                  Prims.op_Hat "Binding_univ " uu____26420
+              | FStar_Syntax_Syntax.Binding_lid (l,uu____26424) ->
+                  let uu____26441 = FStar_Ident.string_of_lid l  in
+                  Prims.op_Hat "Binding_lid " uu____26441))
        in
-    FStar_All.pipe_right uu____26407 (FStar_String.concat "::\n")
+    FStar_All.pipe_right uu____26400 (FStar_String.concat "::\n")
   
 let (string_of_delta_level : delta_level -> Prims.string) =
-  fun uu___14_26462  ->
-    match uu___14_26462 with
+  fun uu___14_26455  ->
+    match uu___14_26455 with
     | NoDelta  -> "NoDelta"
     | InliningDelta  -> "Inlining"
     | Eager_unfolding_only  -> "Eager_unfolding_only"
     | Unfold d ->
-        let uu____26468 = FStar_Syntax_Print.delta_depth_to_string d  in
-        Prims.op_Hat "Unfold " uu____26468
+        let uu____26461 = FStar_Syntax_Print.delta_depth_to_string d  in
+        Prims.op_Hat "Unfold " uu____26461
   
 let (lidents : env -> FStar_Ident.lident Prims.list) =
   fun env1  ->
     let keys = FStar_List.collect FStar_Pervasives_Native.fst env1.gamma_sig
        in
     FStar_Util.smap_fold (sigtab env1)
-      (fun uu____26491  ->
+      (fun uu____26484  ->
          fun v  ->
            fun keys1  ->
              FStar_List.append (FStar_Syntax_Util.lids_of_sigelt v) keys1)
@@ -5425,80 +5422,80 @@ let (should_enc_path : env -> Prims.string Prims.list -> Prims.bool) =
     fun path  ->
       let rec str_i_prefix xs ys =
         match (xs, ys) with
-        | ([],uu____26546) -> true
+        | ([],uu____26539) -> true
         | (x::xs1,y::ys1) ->
             ((FStar_String.lowercase x) = (FStar_String.lowercase y)) &&
               (str_i_prefix xs1 ys1)
-        | (uu____26579,uu____26580) -> false  in
-      let uu____26594 =
+        | (uu____26572,uu____26573) -> false  in
+      let uu____26587 =
         FStar_List.tryFind
-          (fun uu____26616  ->
-             match uu____26616 with | (p,uu____26627) -> str_i_prefix p path)
+          (fun uu____26609  ->
+             match uu____26609 with | (p,uu____26620) -> str_i_prefix p path)
           env1.proof_ns
          in
-      match uu____26594 with
+      match uu____26587 with
       | FStar_Pervasives_Native.None  -> false
-      | FStar_Pervasives_Native.Some (uu____26646,b) -> b
+      | FStar_Pervasives_Native.Some (uu____26639,b) -> b
   
 let (should_enc_lid : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1  ->
     fun lid  ->
-      let uu____26676 = FStar_Ident.path_of_lid lid  in
-      should_enc_path env1 uu____26676
+      let uu____26669 = FStar_Ident.path_of_lid lid  in
+      should_enc_path env1 uu____26669
   
 let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
   fun b  ->
     fun e  ->
       fun path  ->
-        let uu___2049_26698 = e  in
+        let uu___2049_26691 = e  in
         {
-          solver = (uu___2049_26698.solver);
-          range = (uu___2049_26698.range);
-          curmodule = (uu___2049_26698.curmodule);
-          gamma = (uu___2049_26698.gamma);
-          gamma_sig = (uu___2049_26698.gamma_sig);
-          gamma_cache = (uu___2049_26698.gamma_cache);
-          modules = (uu___2049_26698.modules);
-          expected_typ = (uu___2049_26698.expected_typ);
-          sigtab = (uu___2049_26698.sigtab);
-          attrtab = (uu___2049_26698.attrtab);
-          instantiate_imp = (uu___2049_26698.instantiate_imp);
-          effects = (uu___2049_26698.effects);
-          generalize = (uu___2049_26698.generalize);
-          letrecs = (uu___2049_26698.letrecs);
-          top_level = (uu___2049_26698.top_level);
-          check_uvars = (uu___2049_26698.check_uvars);
-          use_eq = (uu___2049_26698.use_eq);
-          use_eq_strict = (uu___2049_26698.use_eq_strict);
-          is_iface = (uu___2049_26698.is_iface);
-          admit = (uu___2049_26698.admit);
-          lax = (uu___2049_26698.lax);
-          lax_universes = (uu___2049_26698.lax_universes);
-          phase1 = (uu___2049_26698.phase1);
-          failhard = (uu___2049_26698.failhard);
-          nosynth = (uu___2049_26698.nosynth);
-          uvar_subtyping = (uu___2049_26698.uvar_subtyping);
-          tc_term = (uu___2049_26698.tc_term);
-          type_of = (uu___2049_26698.type_of);
-          universe_of = (uu___2049_26698.universe_of);
-          check_type_of = (uu___2049_26698.check_type_of);
-          use_bv_sorts = (uu___2049_26698.use_bv_sorts);
-          qtbl_name_and_index = (uu___2049_26698.qtbl_name_and_index);
-          normalized_eff_names = (uu___2049_26698.normalized_eff_names);
-          fv_delta_depths = (uu___2049_26698.fv_delta_depths);
+          solver = (uu___2049_26691.solver);
+          range = (uu___2049_26691.range);
+          curmodule = (uu___2049_26691.curmodule);
+          gamma = (uu___2049_26691.gamma);
+          gamma_sig = (uu___2049_26691.gamma_sig);
+          gamma_cache = (uu___2049_26691.gamma_cache);
+          modules = (uu___2049_26691.modules);
+          expected_typ = (uu___2049_26691.expected_typ);
+          sigtab = (uu___2049_26691.sigtab);
+          attrtab = (uu___2049_26691.attrtab);
+          instantiate_imp = (uu___2049_26691.instantiate_imp);
+          effects = (uu___2049_26691.effects);
+          generalize = (uu___2049_26691.generalize);
+          letrecs = (uu___2049_26691.letrecs);
+          top_level = (uu___2049_26691.top_level);
+          check_uvars = (uu___2049_26691.check_uvars);
+          use_eq = (uu___2049_26691.use_eq);
+          use_eq_strict = (uu___2049_26691.use_eq_strict);
+          is_iface = (uu___2049_26691.is_iface);
+          admit = (uu___2049_26691.admit);
+          lax = (uu___2049_26691.lax);
+          lax_universes = (uu___2049_26691.lax_universes);
+          phase1 = (uu___2049_26691.phase1);
+          failhard = (uu___2049_26691.failhard);
+          nosynth = (uu___2049_26691.nosynth);
+          uvar_subtyping = (uu___2049_26691.uvar_subtyping);
+          tc_term = (uu___2049_26691.tc_term);
+          type_of = (uu___2049_26691.type_of);
+          universe_of = (uu___2049_26691.universe_of);
+          check_type_of = (uu___2049_26691.check_type_of);
+          use_bv_sorts = (uu___2049_26691.use_bv_sorts);
+          qtbl_name_and_index = (uu___2049_26691.qtbl_name_and_index);
+          normalized_eff_names = (uu___2049_26691.normalized_eff_names);
+          fv_delta_depths = (uu___2049_26691.fv_delta_depths);
           proof_ns = ((path, b) :: (e.proof_ns));
-          synth_hook = (uu___2049_26698.synth_hook);
+          synth_hook = (uu___2049_26691.synth_hook);
           try_solve_implicits_hook =
-            (uu___2049_26698.try_solve_implicits_hook);
-          splice = (uu___2049_26698.splice);
-          mpreprocess = (uu___2049_26698.mpreprocess);
-          postprocess = (uu___2049_26698.postprocess);
-          identifier_info = (uu___2049_26698.identifier_info);
-          tc_hooks = (uu___2049_26698.tc_hooks);
-          dsenv = (uu___2049_26698.dsenv);
-          nbe = (uu___2049_26698.nbe);
-          strict_args_tab = (uu___2049_26698.strict_args_tab);
-          erasable_types_tab = (uu___2049_26698.erasable_types_tab)
+            (uu___2049_26691.try_solve_implicits_hook);
+          splice = (uu___2049_26691.splice);
+          mpreprocess = (uu___2049_26691.mpreprocess);
+          postprocess = (uu___2049_26691.postprocess);
+          identifier_info = (uu___2049_26691.identifier_info);
+          tc_hooks = (uu___2049_26691.tc_hooks);
+          dsenv = (uu___2049_26691.dsenv);
+          nbe = (uu___2049_26691.nbe);
+          strict_args_tab = (uu___2049_26691.strict_args_tab);
+          erasable_types_tab = (uu___2049_26691.erasable_types_tab)
         }
   
 let (add_proof_ns : env -> name_prefix -> env) =
@@ -5509,91 +5506,91 @@ let (get_proof_ns : env -> proof_namespace) = fun e  -> e.proof_ns
 let (set_proof_ns : proof_namespace -> env -> env) =
   fun ns  ->
     fun e  ->
-      let uu___2058_26746 = e  in
+      let uu___2058_26739 = e  in
       {
-        solver = (uu___2058_26746.solver);
-        range = (uu___2058_26746.range);
-        curmodule = (uu___2058_26746.curmodule);
-        gamma = (uu___2058_26746.gamma);
-        gamma_sig = (uu___2058_26746.gamma_sig);
-        gamma_cache = (uu___2058_26746.gamma_cache);
-        modules = (uu___2058_26746.modules);
-        expected_typ = (uu___2058_26746.expected_typ);
-        sigtab = (uu___2058_26746.sigtab);
-        attrtab = (uu___2058_26746.attrtab);
-        instantiate_imp = (uu___2058_26746.instantiate_imp);
-        effects = (uu___2058_26746.effects);
-        generalize = (uu___2058_26746.generalize);
-        letrecs = (uu___2058_26746.letrecs);
-        top_level = (uu___2058_26746.top_level);
-        check_uvars = (uu___2058_26746.check_uvars);
-        use_eq = (uu___2058_26746.use_eq);
-        use_eq_strict = (uu___2058_26746.use_eq_strict);
-        is_iface = (uu___2058_26746.is_iface);
-        admit = (uu___2058_26746.admit);
-        lax = (uu___2058_26746.lax);
-        lax_universes = (uu___2058_26746.lax_universes);
-        phase1 = (uu___2058_26746.phase1);
-        failhard = (uu___2058_26746.failhard);
-        nosynth = (uu___2058_26746.nosynth);
-        uvar_subtyping = (uu___2058_26746.uvar_subtyping);
-        tc_term = (uu___2058_26746.tc_term);
-        type_of = (uu___2058_26746.type_of);
-        universe_of = (uu___2058_26746.universe_of);
-        check_type_of = (uu___2058_26746.check_type_of);
-        use_bv_sorts = (uu___2058_26746.use_bv_sorts);
-        qtbl_name_and_index = (uu___2058_26746.qtbl_name_and_index);
-        normalized_eff_names = (uu___2058_26746.normalized_eff_names);
-        fv_delta_depths = (uu___2058_26746.fv_delta_depths);
+        solver = (uu___2058_26739.solver);
+        range = (uu___2058_26739.range);
+        curmodule = (uu___2058_26739.curmodule);
+        gamma = (uu___2058_26739.gamma);
+        gamma_sig = (uu___2058_26739.gamma_sig);
+        gamma_cache = (uu___2058_26739.gamma_cache);
+        modules = (uu___2058_26739.modules);
+        expected_typ = (uu___2058_26739.expected_typ);
+        sigtab = (uu___2058_26739.sigtab);
+        attrtab = (uu___2058_26739.attrtab);
+        instantiate_imp = (uu___2058_26739.instantiate_imp);
+        effects = (uu___2058_26739.effects);
+        generalize = (uu___2058_26739.generalize);
+        letrecs = (uu___2058_26739.letrecs);
+        top_level = (uu___2058_26739.top_level);
+        check_uvars = (uu___2058_26739.check_uvars);
+        use_eq = (uu___2058_26739.use_eq);
+        use_eq_strict = (uu___2058_26739.use_eq_strict);
+        is_iface = (uu___2058_26739.is_iface);
+        admit = (uu___2058_26739.admit);
+        lax = (uu___2058_26739.lax);
+        lax_universes = (uu___2058_26739.lax_universes);
+        phase1 = (uu___2058_26739.phase1);
+        failhard = (uu___2058_26739.failhard);
+        nosynth = (uu___2058_26739.nosynth);
+        uvar_subtyping = (uu___2058_26739.uvar_subtyping);
+        tc_term = (uu___2058_26739.tc_term);
+        type_of = (uu___2058_26739.type_of);
+        universe_of = (uu___2058_26739.universe_of);
+        check_type_of = (uu___2058_26739.check_type_of);
+        use_bv_sorts = (uu___2058_26739.use_bv_sorts);
+        qtbl_name_and_index = (uu___2058_26739.qtbl_name_and_index);
+        normalized_eff_names = (uu___2058_26739.normalized_eff_names);
+        fv_delta_depths = (uu___2058_26739.fv_delta_depths);
         proof_ns = ns;
-        synth_hook = (uu___2058_26746.synth_hook);
-        try_solve_implicits_hook = (uu___2058_26746.try_solve_implicits_hook);
-        splice = (uu___2058_26746.splice);
-        mpreprocess = (uu___2058_26746.mpreprocess);
-        postprocess = (uu___2058_26746.postprocess);
-        identifier_info = (uu___2058_26746.identifier_info);
-        tc_hooks = (uu___2058_26746.tc_hooks);
-        dsenv = (uu___2058_26746.dsenv);
-        nbe = (uu___2058_26746.nbe);
-        strict_args_tab = (uu___2058_26746.strict_args_tab);
-        erasable_types_tab = (uu___2058_26746.erasable_types_tab)
+        synth_hook = (uu___2058_26739.synth_hook);
+        try_solve_implicits_hook = (uu___2058_26739.try_solve_implicits_hook);
+        splice = (uu___2058_26739.splice);
+        mpreprocess = (uu___2058_26739.mpreprocess);
+        postprocess = (uu___2058_26739.postprocess);
+        identifier_info = (uu___2058_26739.identifier_info);
+        tc_hooks = (uu___2058_26739.tc_hooks);
+        dsenv = (uu___2058_26739.dsenv);
+        nbe = (uu___2058_26739.nbe);
+        strict_args_tab = (uu___2058_26739.strict_args_tab);
+        erasable_types_tab = (uu___2058_26739.erasable_types_tab)
       }
   
 let (unbound_vars :
   env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set) =
   fun e  ->
     fun t  ->
-      let uu____26762 = FStar_Syntax_Free.names t  in
-      let uu____26765 = bound_vars e  in
+      let uu____26755 = FStar_Syntax_Free.names t  in
+      let uu____26758 = bound_vars e  in
       FStar_List.fold_left (fun s  -> fun bv  -> FStar_Util.set_remove bv s)
-        uu____26762 uu____26765
+        uu____26755 uu____26758
   
 let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e  ->
     fun t  ->
-      let uu____26788 = unbound_vars e t  in
-      FStar_Util.set_is_empty uu____26788
+      let uu____26781 = unbound_vars e t  in
+      FStar_Util.set_is_empty uu____26781
   
 let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____26798 = FStar_Syntax_Free.names t  in
-    FStar_Util.set_is_empty uu____26798
+    let uu____26791 = FStar_Syntax_Free.names t  in
+    FStar_Util.set_is_empty uu____26791
   
 let (string_of_proof_ns : env -> Prims.string) =
   fun env1  ->
-    let aux uu____26819 =
-      match uu____26819 with
+    let aux uu____26812 =
+      match uu____26812 with
       | (p,b) ->
           if (p = []) && b
           then "*"
           else
-            (let uu____26839 = FStar_Ident.text_of_path p  in
-             Prims.op_Hat (if b then "+" else "-") uu____26839)
+            (let uu____26832 = FStar_Ident.text_of_path p  in
+             Prims.op_Hat (if b then "+" else "-") uu____26832)
        in
-    let uu____26847 =
-      let uu____26851 = FStar_List.map aux env1.proof_ns  in
-      FStar_All.pipe_right uu____26851 FStar_List.rev  in
-    FStar_All.pipe_right uu____26847 (FStar_String.concat " ")
+    let uu____26840 =
+      let uu____26844 = FStar_List.map aux env1.proof_ns  in
+      FStar_All.pipe_right uu____26844 FStar_List.rev  in
+    FStar_All.pipe_right uu____26840 (FStar_String.concat " ")
   
 let (guard_of_guard_formula :
   FStar_TypeChecker_Common.guard_formula -> guard_t) =
@@ -5620,23 +5617,23 @@ let (is_trivial : guard_t -> Prims.bool) =
                 ((imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
                    = FStar_Syntax_Syntax.Allow_unresolved)
                   ||
-                  (let uu____26919 =
+                  (let uu____26912 =
                      FStar_Syntax_Unionfind.find
                        (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                       in
-                   match uu____26919 with
-                   | FStar_Pervasives_Native.Some uu____26923 -> true
+                   match uu____26912 with
+                   | FStar_Pervasives_Native.Some uu____26916 -> true
                    | FStar_Pervasives_Native.None  -> false)))
-    | uu____26926 -> false
+    | uu____26919 -> false
   
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g  ->
     match g with
     | { FStar_TypeChecker_Common.guard_f = FStar_TypeChecker_Common.Trivial ;
-        FStar_TypeChecker_Common.deferred = uu____26936;
-        FStar_TypeChecker_Common.univ_ineqs = uu____26937;
-        FStar_TypeChecker_Common.implicits = uu____26938;_} -> true
-    | uu____26948 -> false
+        FStar_TypeChecker_Common.deferred = uu____26929;
+        FStar_TypeChecker_Common.univ_ineqs = uu____26930;
+        FStar_TypeChecker_Common.implicits = uu____26931;_} -> true
+    | uu____26941 -> false
   
 let (trivial_guard : guard_t) = FStar_TypeChecker_Common.trivial_guard 
 let (abstract_guard_n :
@@ -5651,16 +5648,16 @@ let (abstract_guard_n :
               (FStar_Pervasives_Native.Some
                  (FStar_Syntax_Util.residual_tot FStar_Syntax_Util.ktype0))
              in
-          let uu___2102_26970 = g  in
+          let uu___2102_26963 = g  in
           {
             FStar_TypeChecker_Common.guard_f =
               (FStar_TypeChecker_Common.NonTrivial f');
             FStar_TypeChecker_Common.deferred =
-              (uu___2102_26970.FStar_TypeChecker_Common.deferred);
+              (uu___2102_26963.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2102_26970.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2102_26963.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2102_26970.FStar_TypeChecker_Common.implicits)
+              (uu___2102_26963.FStar_TypeChecker_Common.implicits)
           }
   
 let (abstract_guard : FStar_Syntax_Syntax.binder -> guard_t -> guard_t) =
@@ -5675,31 +5672,31 @@ let (def_check_vars_in_set :
     fun msg  ->
       fun vset  ->
         fun t  ->
-          let uu____27009 = FStar_Options.defensive ()  in
-          if uu____27009
+          let uu____27002 = FStar_Options.defensive ()  in
+          if uu____27002
           then
             let s = FStar_Syntax_Free.names t  in
-            let uu____27015 =
-              let uu____27017 =
-                let uu____27019 = FStar_Util.set_difference s vset  in
-                FStar_All.pipe_left FStar_Util.set_is_empty uu____27019  in
-              Prims.op_Negation uu____27017  in
-            (if uu____27015
+            let uu____27008 =
+              let uu____27010 =
+                let uu____27012 = FStar_Util.set_difference s vset  in
+                FStar_All.pipe_left FStar_Util.set_is_empty uu____27012  in
+              Prims.op_Negation uu____27010  in
+            (if uu____27008
              then
-               let uu____27026 =
-                 let uu____27032 =
-                   let uu____27034 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____27036 =
-                     let uu____27038 = FStar_Util.set_elements s  in
-                     FStar_All.pipe_right uu____27038
+               let uu____27019 =
+                 let uu____27025 =
+                   let uu____27027 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____27029 =
+                     let uu____27031 = FStar_Util.set_elements s  in
+                     FStar_All.pipe_right uu____27031
                        (FStar_Syntax_Print.bvs_to_string ",\n\t")
                       in
                    FStar_Util.format3
                      "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                     msg uu____27034 uu____27036
+                     msg uu____27027 uu____27029
                     in
-                 (FStar_Errors.Warning_Defensive, uu____27032)  in
-               FStar_Errors.log_issue rng uu____27026
+                 (FStar_Errors.Warning_Defensive, uu____27025)  in
+               FStar_Errors.log_issue rng uu____27019
              else ())
           else ()
   
@@ -5712,15 +5709,15 @@ let (def_check_closed_in :
     fun msg  ->
       fun l  ->
         fun t  ->
-          let uu____27078 =
-            let uu____27080 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____27080  in
-          if uu____27078
+          let uu____27071 =
+            let uu____27073 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____27073  in
+          if uu____27071
           then ()
           else
-            (let uu____27085 =
+            (let uu____27078 =
                FStar_Util.as_set l FStar_Syntax_Syntax.order_bv  in
-             def_check_vars_in_set rng msg uu____27085 t)
+             def_check_vars_in_set rng msg uu____27078 t)
   
 let (def_check_closed_in_env :
   FStar_Range.range ->
@@ -5730,14 +5727,14 @@ let (def_check_closed_in_env :
     fun msg  ->
       fun e  ->
         fun t  ->
-          let uu____27111 =
-            let uu____27113 = FStar_Options.defensive ()  in
-            Prims.op_Negation uu____27113  in
-          if uu____27111
+          let uu____27104 =
+            let uu____27106 = FStar_Options.defensive ()  in
+            Prims.op_Negation uu____27106  in
+          if uu____27104
           then ()
           else
-            (let uu____27118 = bound_vars e  in
-             def_check_closed_in rng msg uu____27118 t)
+            (let uu____27111 = bound_vars e  in
+             def_check_closed_in rng msg uu____27111 t)
   
 let (def_check_guard_wf :
   FStar_Range.range -> Prims.string -> env -> guard_t -> unit) =
@@ -5756,33 +5753,30 @@ let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2139_27157 = g  in
-          let uu____27158 =
-            let uu____27159 =
-              let uu____27160 =
-                let uu____27167 =
-                  let uu____27168 =
-                    let uu____27185 =
-                      let uu____27196 = FStar_Syntax_Syntax.as_arg e  in
-                      [uu____27196]  in
-                    (f, uu____27185)  in
-                  FStar_Syntax_Syntax.Tm_app uu____27168  in
-                FStar_Syntax_Syntax.mk uu____27167  in
-              uu____27160 FStar_Pervasives_Native.None
-                f.FStar_Syntax_Syntax.pos
+          let uu___2139_27150 = g  in
+          let uu____27151 =
+            let uu____27152 =
+              let uu____27153 =
+                let uu____27154 =
+                  let uu____27171 =
+                    let uu____27182 = FStar_Syntax_Syntax.as_arg e  in
+                    [uu____27182]  in
+                  (f, uu____27171)  in
+                FStar_Syntax_Syntax.Tm_app uu____27154  in
+              FStar_Syntax_Syntax.mk uu____27153 f.FStar_Syntax_Syntax.pos
                in
             FStar_All.pipe_left
-              (fun uu____27233  ->
-                 FStar_TypeChecker_Common.NonTrivial uu____27233) uu____27159
+              (fun uu____27219  ->
+                 FStar_TypeChecker_Common.NonTrivial uu____27219) uu____27152
              in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27158;
+            FStar_TypeChecker_Common.guard_f = uu____27151;
             FStar_TypeChecker_Common.deferred =
-              (uu___2139_27157.FStar_TypeChecker_Common.deferred);
+              (uu___2139_27150.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2139_27157.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2139_27150.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2139_27157.FStar_TypeChecker_Common.implicits)
+              (uu___2139_27150.FStar_TypeChecker_Common.implicits)
           }
   
 let (map_guard :
@@ -5794,18 +5788,18 @@ let (map_guard :
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2146_27251 = g  in
-          let uu____27252 =
-            let uu____27253 = map f  in
-            FStar_TypeChecker_Common.NonTrivial uu____27253  in
+          let uu___2146_27237 = g  in
+          let uu____27238 =
+            let uu____27239 = map f  in
+            FStar_TypeChecker_Common.NonTrivial uu____27239  in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27252;
+            FStar_TypeChecker_Common.guard_f = uu____27238;
             FStar_TypeChecker_Common.deferred =
-              (uu___2146_27251.FStar_TypeChecker_Common.deferred);
+              (uu___2146_27237.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2146_27251.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2146_27237.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2146_27251.FStar_TypeChecker_Common.implicits)
+              (uu___2146_27237.FStar_TypeChecker_Common.implicits)
           }
   
 let (always_map_guard :
@@ -5816,39 +5810,39 @@ let (always_map_guard :
     fun map  ->
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  ->
-          let uu___2151_27270 = g  in
-          let uu____27271 =
-            let uu____27272 = map FStar_Syntax_Util.t_true  in
-            FStar_TypeChecker_Common.NonTrivial uu____27272  in
+          let uu___2151_27256 = g  in
+          let uu____27257 =
+            let uu____27258 = map FStar_Syntax_Util.t_true  in
+            FStar_TypeChecker_Common.NonTrivial uu____27258  in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27271;
+            FStar_TypeChecker_Common.guard_f = uu____27257;
             FStar_TypeChecker_Common.deferred =
-              (uu___2151_27270.FStar_TypeChecker_Common.deferred);
+              (uu___2151_27256.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2151_27270.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2151_27256.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2151_27270.FStar_TypeChecker_Common.implicits)
+              (uu___2151_27256.FStar_TypeChecker_Common.implicits)
           }
       | FStar_TypeChecker_Common.NonTrivial f ->
-          let uu___2155_27274 = g  in
-          let uu____27275 =
-            let uu____27276 = map f  in
-            FStar_TypeChecker_Common.NonTrivial uu____27276  in
+          let uu___2155_27260 = g  in
+          let uu____27261 =
+            let uu____27262 = map f  in
+            FStar_TypeChecker_Common.NonTrivial uu____27262  in
           {
-            FStar_TypeChecker_Common.guard_f = uu____27275;
+            FStar_TypeChecker_Common.guard_f = uu____27261;
             FStar_TypeChecker_Common.deferred =
-              (uu___2155_27274.FStar_TypeChecker_Common.deferred);
+              (uu___2155_27260.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___2155_27274.FStar_TypeChecker_Common.univ_ineqs);
+              (uu___2155_27260.FStar_TypeChecker_Common.univ_ineqs);
             FStar_TypeChecker_Common.implicits =
-              (uu___2155_27274.FStar_TypeChecker_Common.implicits)
+              (uu___2155_27260.FStar_TypeChecker_Common.implicits)
           }
   
 let (trivial : FStar_TypeChecker_Common.guard_formula -> unit) =
   fun t  ->
     match t with
     | FStar_TypeChecker_Common.Trivial  -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu____27283 ->
+    | FStar_TypeChecker_Common.NonTrivial uu____27269 ->
         failwith "impossible"
   
 let (check_trivial :
@@ -5875,24 +5869,24 @@ let (close_guard_univs :
                 (fun u  ->
                    fun b  ->
                      fun f1  ->
-                       let uu____27360 = FStar_Syntax_Syntax.is_null_binder b
+                       let uu____27346 = FStar_Syntax_Syntax.is_null_binder b
                           in
-                       if uu____27360
+                       if uu____27346
                        then f1
                        else
                          FStar_Syntax_Util.mk_forall u
                            (FStar_Pervasives_Native.fst b) f1) us bs f
                in
-            let uu___2178_27367 = g  in
+            let uu___2178_27353 = g  in
             {
               FStar_TypeChecker_Common.guard_f =
                 (FStar_TypeChecker_Common.NonTrivial f1);
               FStar_TypeChecker_Common.deferred =
-                (uu___2178_27367.FStar_TypeChecker_Common.deferred);
+                (uu___2178_27353.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___2178_27367.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___2178_27353.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___2178_27367.FStar_TypeChecker_Common.implicits)
+                (uu___2178_27353.FStar_TypeChecker_Common.implicits)
             }
   
 let (close_forall :
@@ -5906,8 +5900,8 @@ let (close_forall :
         FStar_List.fold_right
           (fun b  ->
              fun f1  ->
-               let uu____27401 = FStar_Syntax_Syntax.is_null_binder b  in
-               if uu____27401
+               let uu____27387 = FStar_Syntax_Syntax.is_null_binder b  in
+               if uu____27387
                then f1
                else
                  (let u =
@@ -5925,18 +5919,18 @@ let (close_guard : env -> FStar_Syntax_Syntax.binders -> guard_t -> guard_t)
         match g.FStar_TypeChecker_Common.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___2193_27428 = g  in
-            let uu____27429 =
-              let uu____27430 = close_forall env1 binders f  in
-              FStar_TypeChecker_Common.NonTrivial uu____27430  in
+            let uu___2193_27414 = g  in
+            let uu____27415 =
+              let uu____27416 = close_forall env1 binders f  in
+              FStar_TypeChecker_Common.NonTrivial uu____27416  in
             {
-              FStar_TypeChecker_Common.guard_f = uu____27429;
+              FStar_TypeChecker_Common.guard_f = uu____27415;
               FStar_TypeChecker_Common.deferred =
-                (uu___2193_27428.FStar_TypeChecker_Common.deferred);
+                (uu___2193_27414.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___2193_27428.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___2193_27414.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___2193_27428.FStar_TypeChecker_Common.implicits)
+                (uu___2193_27414.FStar_TypeChecker_Common.implicits)
             }
   
 let (new_implicit_var_aux :
@@ -5956,27 +5950,27 @@ let (new_implicit_var_aux :
         fun k  ->
           fun should_check  ->
             fun meta  ->
-              let uu____27488 =
+              let uu____27474 =
                 FStar_Syntax_Util.destruct k FStar_Parser_Const.range_of_lid
                  in
-              match uu____27488 with
+              match uu____27474 with
               | FStar_Pervasives_Native.Some
-                  (uu____27513::(tm,uu____27515)::[]) ->
+                  (uu____27499::(tm,uu____27501)::[]) ->
                   let t =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant
                          (FStar_Const.Const_range
                             (tm.FStar_Syntax_Syntax.pos)))
-                      FStar_Pervasives_Native.None tm.FStar_Syntax_Syntax.pos
+                      tm.FStar_Syntax_Syntax.pos
                      in
                   (t, [], trivial_guard)
-              | uu____27579 ->
+              | uu____27565 ->
                   let binders = all_binders env1  in
                   let gamma = env1.gamma  in
                   let ctx_uvar =
-                    let uu____27597 = FStar_Syntax_Unionfind.fresh r  in
+                    let uu____27583 = FStar_Syntax_Unionfind.fresh r  in
                     {
-                      FStar_Syntax_Syntax.ctx_uvar_head = uu____27597;
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu____27583;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
@@ -5992,7 +5986,7 @@ let (new_implicit_var_aux :
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_uvar
                            (ctx_uvar, ([], FStar_Syntax_Syntax.NoUseRange)))
-                        FStar_Pervasives_Native.None r
+                        r
                        in
                     let imp =
                       {
@@ -6001,26 +5995,26 @@ let (new_implicit_var_aux :
                         FStar_TypeChecker_Common.imp_tm = t;
                         FStar_TypeChecker_Common.imp_range = r
                       }  in
-                    (let uu____27631 =
+                    (let uu____27617 =
                        debug env1 (FStar_Options.Other "ImplicitTrace")  in
-                     if uu____27631
+                     if uu____27617
                      then
-                       let uu____27635 =
+                       let uu____27621 =
                          FStar_Syntax_Print.uvar_to_string
                            ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head
                           in
                        FStar_Util.print1
-                         "Just created uvar for implicit {%s}\n" uu____27635
+                         "Just created uvar for implicit {%s}\n" uu____27621
                      else ());
                     (let g =
-                       let uu___2217_27641 = trivial_guard  in
+                       let uu___2217_27627 = trivial_guard  in
                        {
                          FStar_TypeChecker_Common.guard_f =
-                           (uu___2217_27641.FStar_TypeChecker_Common.guard_f);
+                           (uu___2217_27627.FStar_TypeChecker_Common.guard_f);
                          FStar_TypeChecker_Common.deferred =
-                           (uu___2217_27641.FStar_TypeChecker_Common.deferred);
+                           (uu___2217_27627.FStar_TypeChecker_Common.deferred);
                          FStar_TypeChecker_Common.univ_ineqs =
-                           (uu___2217_27641.FStar_TypeChecker_Common.univ_ineqs);
+                           (uu___2217_27627.FStar_TypeChecker_Common.univ_ineqs);
                          FStar_TypeChecker_Common.implicits = [imp]
                        }  in
                      (t, [(ctx_uvar, r)], g))))
@@ -6038,44 +6032,44 @@ let (uvars_for_binders :
       fun substs  ->
         fun reason  ->
           fun r  ->
-            let uu____27695 =
+            let uu____27681 =
               FStar_All.pipe_right bs
                 (FStar_List.fold_left
-                   (fun uu____27752  ->
+                   (fun uu____27738  ->
                       fun b  ->
-                        match uu____27752 with
+                        match uu____27738 with
                         | (substs1,uvars,g) ->
                             let sort =
                               FStar_Syntax_Subst.subst substs1
                                 (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                                in
-                            let uu____27794 =
-                              let uu____27807 = reason b  in
-                              new_implicit_var_aux uu____27807 r env1 sort
+                            let uu____27780 =
+                              let uu____27793 = reason b  in
+                              new_implicit_var_aux uu____27793 r env1 sort
                                 FStar_Syntax_Syntax.Allow_untyped
                                 FStar_Pervasives_Native.None
                                in
-                            (match uu____27794 with
-                             | (t,uu____27824,g_t) ->
-                                 let uu____27838 =
-                                   let uu____27841 =
-                                     let uu____27844 =
-                                       let uu____27845 =
-                                         let uu____27852 =
+                            (match uu____27780 with
+                             | (t,uu____27810,g_t) ->
+                                 let uu____27824 =
+                                   let uu____27827 =
+                                     let uu____27830 =
+                                       let uu____27831 =
+                                         let uu____27838 =
                                            FStar_All.pipe_right b
                                              FStar_Pervasives_Native.fst
                                             in
-                                         (uu____27852, t)  in
-                                       FStar_Syntax_Syntax.NT uu____27845  in
-                                     [uu____27844]  in
-                                   FStar_List.append substs1 uu____27841  in
-                                 let uu____27863 = conj_guard g g_t  in
-                                 (uu____27838, (FStar_List.append uvars [t]),
-                                   uu____27863))) (substs, [], trivial_guard))
+                                         (uu____27838, t)  in
+                                       FStar_Syntax_Syntax.NT uu____27831  in
+                                     [uu____27830]  in
+                                   FStar_List.append substs1 uu____27827  in
+                                 let uu____27849 = conj_guard g g_t  in
+                                 (uu____27824, (FStar_List.append uvars [t]),
+                                   uu____27849))) (substs, [], trivial_guard))
                in
-            FStar_All.pipe_right uu____27695
-              (fun uu____27892  ->
-                 match uu____27892 with | (uu____27909,uvars,g) -> (uvars, g))
+            FStar_All.pipe_right uu____27681
+              (fun uu____27878  ->
+                 match uu____27878 with | (uu____27895,uvars,g) -> (uvars, g))
   
 let (pure_precondition_for_trivial_post :
   env ->
@@ -6091,50 +6085,45 @@ let (pure_precondition_for_trivial_post :
           fun r  ->
             let trivial_post =
               let post_ts =
-                let uu____27950 =
+                let uu____27936 =
                   lookup_definition [NoDelta] env1
                     FStar_Parser_Const.trivial_pure_post_lid
                    in
-                FStar_All.pipe_right uu____27950 FStar_Util.must  in
-              let uu____27967 = inst_tscheme_with post_ts [u]  in
-              match uu____27967 with
-              | (uu____27972,post) ->
-                  let uu____27974 =
-                    let uu____27979 =
-                      let uu____27980 =
-                        FStar_All.pipe_right t FStar_Syntax_Syntax.as_arg  in
-                      [uu____27980]  in
-                    FStar_Syntax_Syntax.mk_Tm_app post uu____27979  in
-                  uu____27974 FStar_Pervasives_Native.None r
+                FStar_All.pipe_right uu____27936 FStar_Util.must  in
+              let uu____27953 = inst_tscheme_with post_ts [u]  in
+              match uu____27953 with
+              | (uu____27958,post) ->
+                  let uu____27960 =
+                    let uu____27961 =
+                      FStar_All.pipe_right t FStar_Syntax_Syntax.as_arg  in
+                    [uu____27961]  in
+                  FStar_Syntax_Syntax.mk_Tm_app post uu____27960 r
                in
-            let uu____28013 =
-              let uu____28018 =
-                let uu____28019 =
-                  FStar_All.pipe_right trivial_post
-                    FStar_Syntax_Syntax.as_arg
-                   in
-                [uu____28019]  in
-              FStar_Syntax_Syntax.mk_Tm_app wp uu____28018  in
-            uu____28013 FStar_Pervasives_Native.None r
+            let uu____27994 =
+              let uu____27995 =
+                FStar_All.pipe_right trivial_post FStar_Syntax_Syntax.as_arg
+                 in
+              [uu____27995]  in
+            FStar_Syntax_Syntax.mk_Tm_app wp uu____27994 r
   
 let (dummy_solver : solver_t) =
   {
-    init = (fun uu____28055  -> ());
-    push = (fun uu____28057  -> ());
-    pop = (fun uu____28060  -> ());
+    init = (fun uu____28031  -> ());
+    push = (fun uu____28033  -> ());
+    pop = (fun uu____28036  -> ());
     snapshot =
-      (fun uu____28063  ->
+      (fun uu____28039  ->
          ((Prims.int_zero, Prims.int_zero, Prims.int_zero), ()));
-    rollback = (fun uu____28082  -> fun uu____28083  -> ());
-    encode_sig = (fun uu____28098  -> fun uu____28099  -> ());
+    rollback = (fun uu____28058  -> fun uu____28059  -> ());
+    encode_sig = (fun uu____28074  -> fun uu____28075  -> ());
     preprocess =
       (fun e  ->
          fun g  ->
-           let uu____28105 =
-             let uu____28112 = FStar_Options.peek ()  in (e, g, uu____28112)
+           let uu____28081 =
+             let uu____28088 = FStar_Options.peek ()  in (e, g, uu____28088)
               in
-           [uu____28105]);
-    solve = (fun uu____28128  -> fun uu____28129  -> fun uu____28130  -> ());
-    finish = (fun uu____28137  -> ());
-    refresh = (fun uu____28139  -> ())
+           [uu____28081]);
+    solve = (fun uu____28104  -> fun uu____28105  -> fun uu____28106  -> ());
+    finish = (fun uu____28113  -> ());
+    refresh = (fun uu____28115  -> ())
   } 

--- a/src/ocaml-output/FStar_TypeChecker_NBE.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBE.ml
@@ -768,57 +768,57 @@ let rec (translate :
               | (head,uu____3031) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
-                      FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+                      e.FStar_Syntax_Syntax.pos
                      in
-                  let uu____3075 =
+                  let uu____3073 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
-                      FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+                      e.FStar_Syntax_Syntax.pos
                      in
-                  translate cfg bs uu____3075)
+                  translate cfg bs uu____3073)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____3084);
-                FStar_Syntax_Syntax.pos = uu____3085;
-                FStar_Syntax_Syntax.vars = uu____3086;_},arg::more::args)
+                  (FStar_Const.Const_reflect uu____3082);
+                FStar_Syntax_Syntax.pos = uu____3083;
+                FStar_Syntax_Syntax.vars = uu____3084;_},arg::more::args)
              ->
-             let uu____3146 = FStar_Syntax_Util.head_and_args e  in
-             (match uu____3146 with
-              | (head,uu____3164) ->
+             let uu____3144 = FStar_Syntax_Util.head_and_args e  in
+             (match uu____3144 with
+              | (head,uu____3162) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
-                      FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+                      e.FStar_Syntax_Syntax.pos
                      in
-                  let uu____3208 =
+                  let uu____3204 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
-                      FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+                      e.FStar_Syntax_Syntax.pos
                      in
-                  translate cfg bs uu____3208)
+                  translate cfg bs uu____3204)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____3217);
-                FStar_Syntax_Syntax.pos = uu____3218;
-                FStar_Syntax_Syntax.vars = uu____3219;_},arg::[])
+                  (FStar_Const.Const_reflect uu____3213);
+                FStar_Syntax_Syntax.pos = uu____3214;
+                FStar_Syntax_Syntax.vars = uu____3215;_},arg::[])
              when (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying ->
              let cfg1 = reifying_false cfg  in
              translate cfg1 bs (FStar_Pervasives_Native.fst arg)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                  (FStar_Const.Const_reflect uu____3264);
-                FStar_Syntax_Syntax.pos = uu____3265;
-                FStar_Syntax_Syntax.vars = uu____3266;_},arg::[])
+                  (FStar_Const.Const_reflect uu____3260);
+                FStar_Syntax_Syntax.pos = uu____3261;
+                FStar_Syntax_Syntax.vars = uu____3262;_},arg::[])
              ->
-             let uu____3306 =
+             let uu____3302 =
                translate cfg bs (FStar_Pervasives_Native.fst arg)  in
-             FStar_TypeChecker_NBETerm.Reflect uu____3306
+             FStar_TypeChecker_NBETerm.Reflect uu____3302
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify );
-                FStar_Syntax_Syntax.pos = uu____3311;
-                FStar_Syntax_Syntax.vars = uu____3312;_},arg::[])
+                FStar_Syntax_Syntax.pos = uu____3307;
+                FStar_Syntax_Syntax.vars = uu____3308;_},arg::[])
              when
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
              ->
@@ -826,175 +826,175 @@ let rec (translate :
              translate cfg1 bs (FStar_Pervasives_Native.fst arg)
          | FStar_Syntax_Syntax.Tm_app (head,args) ->
              (debug1
-                (fun uu____3391  ->
-                   let uu____3392 = FStar_Syntax_Print.term_to_string head
+                (fun uu____3387  ->
+                   let uu____3388 = FStar_Syntax_Print.term_to_string head
                       in
-                   let uu____3394 = FStar_Syntax_Print.args_to_string args
+                   let uu____3390 = FStar_Syntax_Print.args_to_string args
                       in
-                   FStar_Util.print2 "Application: %s @ %s\n" uu____3392
-                     uu____3394);
-              (let uu____3397 = translate cfg bs head  in
-               let uu____3398 =
+                   FStar_Util.print2 "Application: %s @ %s\n" uu____3388
+                     uu____3390);
+              (let uu____3393 = translate cfg bs head  in
+               let uu____3394 =
                  FStar_List.map
                    (fun x  ->
-                      let uu____3420 =
+                      let uu____3416 =
                         translate cfg bs (FStar_Pervasives_Native.fst x)  in
-                      (uu____3420, (FStar_Pervasives_Native.snd x))) args
+                      (uu____3416, (FStar_Pervasives_Native.snd x))) args
                   in
-               iapp cfg uu____3397 uu____3398))
+               iapp cfg uu____3393 uu____3394))
          | FStar_Syntax_Syntax.Tm_match (scrut,branches) ->
-             let make_branches uu____3472 =
+             let make_branches uu____3468 =
                let cfg1 = zeta_false cfg  in
                let rec process_pattern bs1 p =
-                 let uu____3503 =
+                 let uu____3499 =
                    match p.FStar_Syntax_Syntax.v with
                    | FStar_Syntax_Syntax.Pat_constant c ->
                        (bs1, (FStar_Syntax_Syntax.Pat_constant c))
                    | FStar_Syntax_Syntax.Pat_cons (fvar,args) ->
-                       let uu____3539 =
+                       let uu____3535 =
                          FStar_List.fold_left
-                           (fun uu____3580  ->
-                              fun uu____3581  ->
-                                match (uu____3580, uu____3581) with
+                           (fun uu____3576  ->
+                              fun uu____3577  ->
+                                match (uu____3576, uu____3577) with
                                 | ((bs2,args1),(arg,b)) ->
-                                    let uu____3673 = process_pattern bs2 arg
+                                    let uu____3669 = process_pattern bs2 arg
                                        in
-                                    (match uu____3673 with
+                                    (match uu____3669 with
                                      | (bs',arg') ->
                                          (bs', ((arg', b) :: args1))))
                            (bs1, []) args
                           in
-                       (match uu____3539 with
+                       (match uu____3535 with
                         | (bs',args') ->
                             (bs',
                               (FStar_Syntax_Syntax.Pat_cons
                                  (fvar, (FStar_List.rev args')))))
                    | FStar_Syntax_Syntax.Pat_var bvar ->
                        let x =
-                         let uu____3772 =
-                           let uu____3773 =
+                         let uu____3768 =
+                           let uu____3769 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback cfg1 uu____3773  in
+                           readback cfg1 uu____3769  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3772
+                           FStar_Pervasives_Native.None uu____3768
                           in
-                       let uu____3774 =
-                         let uu____3777 =
+                       let uu____3770 =
+                         let uu____3773 =
                            FStar_TypeChecker_NBETerm.mkAccuVar x  in
-                         uu____3777 :: bs1  in
-                       (uu____3774, (FStar_Syntax_Syntax.Pat_var x))
+                         uu____3773 :: bs1  in
+                       (uu____3770, (FStar_Syntax_Syntax.Pat_var x))
                    | FStar_Syntax_Syntax.Pat_wild bvar ->
                        let x =
-                         let uu____3782 =
-                           let uu____3783 =
+                         let uu____3778 =
+                           let uu____3779 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback cfg1 uu____3783  in
+                           readback cfg1 uu____3779  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3782
+                           FStar_Pervasives_Native.None uu____3778
                           in
-                       let uu____3784 =
-                         let uu____3787 =
+                       let uu____3780 =
+                         let uu____3783 =
                            FStar_TypeChecker_NBETerm.mkAccuVar x  in
-                         uu____3787 :: bs1  in
-                       (uu____3784, (FStar_Syntax_Syntax.Pat_wild x))
+                         uu____3783 :: bs1  in
+                       (uu____3780, (FStar_Syntax_Syntax.Pat_wild x))
                    | FStar_Syntax_Syntax.Pat_dot_term (bvar,tm) ->
                        let x =
-                         let uu____3797 =
-                           let uu____3798 =
+                         let uu____3793 =
+                           let uu____3794 =
                              translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort
                               in
-                           readback cfg1 uu____3798  in
+                           readback cfg1 uu____3794  in
                          FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu____3797
+                           FStar_Pervasives_Native.None uu____3793
                           in
-                       let uu____3799 =
-                         let uu____3800 =
-                           let uu____3807 =
-                             let uu____3810 = translate cfg1 bs1 tm  in
-                             readback cfg1 uu____3810  in
-                           (x, uu____3807)  in
-                         FStar_Syntax_Syntax.Pat_dot_term uu____3800  in
-                       (bs1, uu____3799)
+                       let uu____3795 =
+                         let uu____3796 =
+                           let uu____3803 =
+                             let uu____3806 = translate cfg1 bs1 tm  in
+                             readback cfg1 uu____3806  in
+                           (x, uu____3803)  in
+                         FStar_Syntax_Syntax.Pat_dot_term uu____3796  in
+                       (bs1, uu____3795)
                     in
-                 match uu____3503 with
+                 match uu____3499 with
                  | (bs2,p_new) ->
                      (bs2,
-                       (let uu___554_3830 = p  in
+                       (let uu___554_3826 = p  in
                         {
                           FStar_Syntax_Syntax.v = p_new;
                           FStar_Syntax_Syntax.p =
-                            (uu___554_3830.FStar_Syntax_Syntax.p)
+                            (uu___554_3826.FStar_Syntax_Syntax.p)
                         }))
                   in
                FStar_List.map
-                 (fun uu____3849  ->
-                    match uu____3849 with
+                 (fun uu____3845  ->
+                    match uu____3845 with
                     | (pat,when_clause,e1) ->
-                        let uu____3871 = process_pattern bs pat  in
-                        (match uu____3871 with
+                        let uu____3867 = process_pattern bs pat  in
+                        (match uu____3867 with
                          | (bs',pat') ->
-                             let uu____3884 =
-                               let uu____3885 =
-                                 let uu____3888 = translate cfg1 bs' e1  in
-                                 readback cfg1 uu____3888  in
-                               (pat', when_clause, uu____3885)  in
-                             FStar_Syntax_Util.branch uu____3884)) branches
+                             let uu____3880 =
+                               let uu____3881 =
+                                 let uu____3884 = translate cfg1 bs' e1  in
+                                 readback cfg1 uu____3884  in
+                               (pat', when_clause, uu____3881)  in
+                             FStar_Syntax_Util.branch uu____3880)) branches
                 in
              let scrut1 = translate cfg bs scrut  in
              (debug1
-                (fun uu____3905  ->
-                   let uu____3906 =
+                (fun uu____3901  ->
+                   let uu____3902 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos
                       in
-                   let uu____3908 = FStar_Syntax_Print.term_to_string e  in
-                   FStar_Util.print2 "%s: Translating match %s\n" uu____3906
-                     uu____3908);
+                   let uu____3904 = FStar_Syntax_Print.term_to_string e  in
+                   FStar_Util.print2 "%s: Translating match %s\n" uu____3902
+                     uu____3904);
               (let scrut2 = unlazy scrut1  in
                match scrut2 with
                | FStar_TypeChecker_NBETerm.Construct (c,us,args) ->
                    (debug1
-                      (fun uu____3936  ->
-                         let uu____3937 =
-                           let uu____3939 =
+                      (fun uu____3932  ->
+                         let uu____3933 =
+                           let uu____3935 =
                              FStar_All.pipe_right args
                                (FStar_List.map
-                                  (fun uu____3965  ->
-                                     match uu____3965 with
+                                  (fun uu____3961  ->
+                                     match uu____3961 with
                                      | (x,q) ->
-                                         let uu____3979 =
+                                         let uu____3975 =
                                            FStar_TypeChecker_NBETerm.t_to_string
                                              x
                                             in
                                          Prims.op_Hat
                                            (if FStar_Util.is_some q
                                             then "#"
-                                            else "") uu____3979))
+                                            else "") uu____3975))
                               in
-                           FStar_All.pipe_right uu____3939
+                           FStar_All.pipe_right uu____3935
                              (FStar_String.concat "; ")
                             in
-                         FStar_Util.print1 "Match args: %s\n" uu____3937);
-                    (let uu____3993 = pickBranch cfg scrut2 branches  in
-                     match uu____3993 with
+                         FStar_Util.print1 "Match args: %s\n" uu____3933);
+                    (let uu____3989 = pickBranch cfg scrut2 branches  in
+                     match uu____3989 with
                      | FStar_Pervasives_Native.Some (branch,args1) ->
-                         let uu____4014 =
+                         let uu____4010 =
                            FStar_List.fold_left
                              (fun bs1  -> fun x  -> x :: bs1) bs args1
                             in
-                         translate cfg uu____4014 branch
+                         translate cfg uu____4010 branch
                      | FStar_Pervasives_Native.None  ->
                          FStar_TypeChecker_NBETerm.mkAccuMatch scrut2
                            make_branches))
                | FStar_TypeChecker_NBETerm.Constant c ->
                    (debug1
-                      (fun uu____4037  ->
-                         let uu____4038 =
+                      (fun uu____4033  ->
+                         let uu____4034 =
                            FStar_TypeChecker_NBETerm.t_to_string scrut2  in
-                         FStar_Util.print1 "Match constant : %s\n" uu____4038);
-                    (let uu____4041 = pickBranch cfg scrut2 branches  in
-                     match uu____4041 with
+                         FStar_Util.print1 "Match constant : %s\n" uu____4034);
+                    (let uu____4037 = pickBranch cfg scrut2 branches  in
+                     match uu____4037 with
                      | FStar_Pervasives_Native.Some (branch,[]) ->
                          translate cfg bs branch
                      | FStar_Pervasives_Native.Some (branch,arg::[]) ->
@@ -1002,10 +1002,10 @@ let rec (translate :
                      | FStar_Pervasives_Native.None  ->
                          FStar_TypeChecker_NBETerm.mkAccuMatch scrut2
                            make_branches
-                     | FStar_Pervasives_Native.Some (uu____4075,hd::tl) ->
+                     | FStar_Pervasives_Native.Some (uu____4071,hd::tl) ->
                          failwith
                            "Impossible: Matching on constants cannot bind more than one variable"))
-               | uu____4089 ->
+               | uu____4085 ->
                    FStar_TypeChecker_NBETerm.mkAccuMatch scrut2 make_branches))
          | FStar_Syntax_Syntax.Tm_meta
              (e1,FStar_Syntax_Syntax.Meta_monadic (m,t)) when
@@ -1016,12 +1016,12 @@ let rec (translate :
              (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying ->
              translate_monadic_lift (m, m', t) cfg bs e1
          | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-             let uu____4134 =
+             let uu____4130 =
                FStar_TypeChecker_Cfg.should_reduce_local_let cfg.core_cfg lb
                 in
-             if uu____4134
+             if uu____4130
              then
-               let uu____4137 =
+               let uu____4133 =
                  (((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                     &&
                     (FStar_Syntax_Util.is_unit lb.FStar_Syntax_Syntax.lbtyp))
@@ -1029,7 +1029,7 @@ let rec (translate :
                    (FStar_Syntax_Util.is_pure_or_ghost_effect
                       lb.FStar_Syntax_Syntax.lbeff)
                   in
-               (if uu____4137
+               (if uu____4133
                 then
                   let bs1 =
                     (FStar_TypeChecker_NBETerm.Constant
@@ -1038,12 +1038,12 @@ let rec (translate :
                   translate cfg bs1 body
                 else
                   (let bs1 =
-                     let uu____4148 = translate_letbinding cfg bs lb  in
-                     uu____4148 :: bs  in
+                     let uu____4144 = translate_letbinding cfg bs lb  in
+                     uu____4144 :: bs  in
                    translate cfg bs1 body))
              else
-               (let def uu____4156 =
-                  let uu____4157 =
+               (let def uu____4152 =
+                  let uu____4153 =
                     (((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                        &&
                        (FStar_Syntax_Util.is_unit
@@ -1052,32 +1052,32 @@ let rec (translate :
                       (FStar_Syntax_Util.is_pure_or_ghost_effect
                          lb.FStar_Syntax_Syntax.lbeff)
                      in
-                  if uu____4157
+                  if uu____4153
                   then
                     FStar_TypeChecker_NBETerm.Constant
                       FStar_TypeChecker_NBETerm.Unit
                   else translate cfg bs lb.FStar_Syntax_Syntax.lbdef  in
-                let typ uu____4167 =
+                let typ uu____4163 =
                   translate cfg bs lb.FStar_Syntax_Syntax.lbtyp  in
                 let name =
-                  let uu____4169 =
+                  let uu____4165 =
                     FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                  FStar_Syntax_Syntax.freshen_bv uu____4169  in
+                  FStar_Syntax_Syntax.freshen_bv uu____4165  in
                 let bs1 =
                   (FStar_TypeChecker_NBETerm.Accu
                      ((FStar_TypeChecker_NBETerm.Var name), []))
                   :: bs  in
-                let body1 uu____4188 = translate cfg bs1 body  in
-                let uu____4189 =
-                  let uu____4200 =
-                    let uu____4201 =
-                      let uu____4218 = FStar_Thunk.mk typ  in
-                      let uu____4221 = FStar_Thunk.mk def  in
-                      let uu____4224 = FStar_Thunk.mk body1  in
-                      (name, uu____4218, uu____4221, uu____4224, lb)  in
-                    FStar_TypeChecker_NBETerm.UnreducedLet uu____4201  in
-                  (uu____4200, [])  in
-                FStar_TypeChecker_NBETerm.Accu uu____4189)
+                let body1 uu____4184 = translate cfg bs1 body  in
+                let uu____4185 =
+                  let uu____4196 =
+                    let uu____4197 =
+                      let uu____4214 = FStar_Thunk.mk typ  in
+                      let uu____4217 = FStar_Thunk.mk def  in
+                      let uu____4220 = FStar_Thunk.mk body1  in
+                      (name, uu____4214, uu____4217, uu____4220, lb)  in
+                    FStar_TypeChecker_NBETerm.UnreducedLet uu____4197  in
+                  (uu____4196, [])  in
+                FStar_TypeChecker_NBETerm.Accu uu____4185)
          | FStar_Syntax_Syntax.Tm_let ((_rec,lbs),body) ->
              if
                (Prims.op_Negation
@@ -1088,9 +1088,9 @@ let rec (translate :
                let vars =
                  FStar_List.map
                    (fun lb  ->
-                      let uu____4270 =
+                      let uu____4266 =
                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                      FStar_Syntax_Syntax.freshen_bv uu____4270) lbs
+                      FStar_Syntax_Syntax.freshen_bv uu____4266) lbs
                   in
                let typs =
                  FStar_List.map
@@ -1098,36 +1098,36 @@ let rec (translate :
                    lbs
                   in
                let rec_bs =
-                 let uu____4279 =
+                 let uu____4275 =
                    FStar_List.map
                      (fun v  ->
                         FStar_TypeChecker_NBETerm.Accu
                           ((FStar_TypeChecker_NBETerm.Var v), [])) vars
                     in
-                 FStar_List.append uu____4279 bs  in
+                 FStar_List.append uu____4275 bs  in
                let defs =
                  FStar_List.map
                    (fun lb  ->
                       translate cfg rec_bs lb.FStar_Syntax_Syntax.lbdef) lbs
                   in
                let body1 = translate cfg rec_bs body  in
-               let uu____4300 =
-                 let uu____4311 =
-                   let uu____4312 =
-                     let uu____4329 = FStar_List.zip3 vars typs defs  in
-                     (uu____4329, body1, lbs)  in
-                   FStar_TypeChecker_NBETerm.UnreducedLetRec uu____4312  in
-                 (uu____4311, [])  in
-               FStar_TypeChecker_NBETerm.Accu uu____4300
+               let uu____4296 =
+                 let uu____4307 =
+                   let uu____4308 =
+                     let uu____4325 = FStar_List.zip3 vars typs defs  in
+                     (uu____4325, body1, lbs)  in
+                   FStar_TypeChecker_NBETerm.UnreducedLetRec uu____4308  in
+                 (uu____4307, [])  in
+               FStar_TypeChecker_NBETerm.Accu uu____4296
              else
-               (let uu____4360 = make_rec_env lbs bs  in
-                translate cfg uu____4360 body)
-         | FStar_Syntax_Syntax.Tm_meta (e1,uu____4364) -> translate cfg bs e1
+               (let uu____4356 = make_rec_env lbs bs  in
+                translate cfg uu____4356 body)
+         | FStar_Syntax_Syntax.Tm_meta (e1,uu____4360) -> translate cfg bs e1
          | FStar_Syntax_Syntax.Tm_quoted (qt,qi) ->
              let close t =
                let bvs =
                  FStar_List.map
-                   (fun uu____4385  ->
+                   (fun uu____4381  ->
                       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                         FStar_Syntax_Syntax.tun) bs
                   in
@@ -1136,18 +1136,18 @@ let rec (translate :
                    (fun i  -> fun bv  -> FStar_Syntax_Syntax.DB (i, bv)) bvs
                   in
                let s2 =
-                 let uu____4398 = FStar_List.zip bvs bs  in
+                 let uu____4394 = FStar_List.zip bvs bs  in
                  FStar_List.map
-                   (fun uu____4413  ->
-                      match uu____4413 with
+                   (fun uu____4409  ->
+                      match uu____4409 with
                       | (bv,t1) ->
-                          let uu____4420 =
-                            let uu____4427 = readback cfg t1  in
-                            (bv, uu____4427)  in
-                          FStar_Syntax_Syntax.NT uu____4420) uu____4398
+                          let uu____4416 =
+                            let uu____4423 = readback cfg t1  in
+                            (bv, uu____4423)  in
+                          FStar_Syntax_Syntax.NT uu____4416) uu____4394
                   in
-               let uu____4432 = FStar_Syntax_Subst.subst s1 t  in
-               FStar_Syntax_Subst.subst s2 uu____4432  in
+               let uu____4428 = FStar_Syntax_Subst.subst s1 t  in
+               FStar_Syntax_Subst.subst s2 uu____4428  in
              (match qi.FStar_Syntax_Syntax.qkind with
               | FStar_Syntax_Syntax.Quote_dynamic  ->
                   let qt1 = close qt  in
@@ -1156,18 +1156,18 @@ let rec (translate :
                   let qi1 = FStar_Syntax_Syntax.on_antiquoted close qi  in
                   FStar_TypeChecker_NBETerm.Quote (qt, qi1))
          | FStar_Syntax_Syntax.Tm_lazy li ->
-             let f uu____4441 =
+             let f uu____4437 =
                let t = FStar_Syntax_Util.unfold_lazy li  in
                debug1
-                 (fun uu____4448  ->
-                    let uu____4449 = FStar_Syntax_Print.term_to_string t  in
+                 (fun uu____4444  ->
+                    let uu____4445 = FStar_Syntax_Print.term_to_string t  in
                     FStar_Util.print1 ">> Unfolding Tm_lazy to %s\n"
-                      uu____4449);
+                      uu____4445);
                translate cfg bs t  in
-             let uu____4452 =
-               let uu____4467 = FStar_Thunk.mk f  in
-               ((FStar_Util.Inl li), uu____4467)  in
-             FStar_TypeChecker_NBETerm.Lazy uu____4452)
+             let uu____4448 =
+               let uu____4463 = FStar_Thunk.mk f  in
+               ((FStar_Util.Inl li), uu____4463)  in
+             FStar_TypeChecker_NBETerm.Lazy uu____4448)
 
 and (translate_comp :
   config ->
@@ -1179,20 +1179,20 @@ and (translate_comp :
       fun c  ->
         match c.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Total (typ,u) ->
-            let uu____4499 =
-              let uu____4506 = translate cfg bs typ  in
-              let uu____4507 = fmap_opt (translate_univ cfg bs) u  in
-              (uu____4506, uu____4507)  in
-            FStar_TypeChecker_NBETerm.Tot uu____4499
+            let uu____4495 =
+              let uu____4502 = translate cfg bs typ  in
+              let uu____4503 = fmap_opt (translate_univ cfg bs) u  in
+              (uu____4502, uu____4503)  in
+            FStar_TypeChecker_NBETerm.Tot uu____4495
         | FStar_Syntax_Syntax.GTotal (typ,u) ->
-            let uu____4522 =
-              let uu____4529 = translate cfg bs typ  in
-              let uu____4530 = fmap_opt (translate_univ cfg bs) u  in
-              (uu____4529, uu____4530)  in
-            FStar_TypeChecker_NBETerm.GTot uu____4522
+            let uu____4518 =
+              let uu____4525 = translate cfg bs typ  in
+              let uu____4526 = fmap_opt (translate_univ cfg bs) u  in
+              (uu____4525, uu____4526)  in
+            FStar_TypeChecker_NBETerm.GTot uu____4518
         | FStar_Syntax_Syntax.Comp ctyp ->
-            let uu____4536 = translate_comp_typ cfg bs ctyp  in
-            FStar_TypeChecker_NBETerm.Comp uu____4536
+            let uu____4532 = translate_comp_typ cfg bs ctyp  in
+            FStar_TypeChecker_NBETerm.Comp uu____4532
 
 and (iapp :
   config ->
@@ -1212,13 +1212,13 @@ and (iapp :
               let binders1 =
                 match binders with
                 | FStar_Util.Inr raw_args ->
-                    let uu____4672 = FStar_List.splitAt m raw_args  in
-                    (match uu____4672 with
-                     | (uu____4713,raw_args1) -> FStar_Util.Inr raw_args1)
+                    let uu____4668 = FStar_List.splitAt m raw_args  in
+                    (match uu____4668 with
+                     | (uu____4709,raw_args1) -> FStar_Util.Inr raw_args1)
                 | FStar_Util.Inl (ctx,xs,rc) ->
-                    let uu____4782 = FStar_List.splitAt m xs  in
-                    (match uu____4782 with
-                     | (uu____4829,xs1) ->
+                    let uu____4778 = FStar_List.splitAt m xs  in
+                    (match uu____4778 with
+                     | (uu____4825,xs1) ->
                          let ctx1 = FStar_List.append arg_values_rev ctx  in
                          FStar_Util.Inl (ctx1, xs1, rc))
                  in
@@ -1232,36 +1232,36 @@ and (iapp :
                    map_rev FStar_Pervasives_Native.fst args  in
                  f1 arg_values_rev)
               else
-                (let uu____4929 = FStar_List.splitAt n args  in
-                 match uu____4929 with
+                (let uu____4925 = FStar_List.splitAt n args  in
+                 match uu____4925 with
                  | (args1,args') ->
-                     let uu____4976 =
-                       let uu____4977 =
+                     let uu____4972 =
+                       let uu____4973 =
                          map_rev FStar_Pervasives_Native.fst args1  in
-                       f1 uu____4977  in
-                     iapp cfg uu____4976 args')
+                       f1 uu____4973  in
+                     iapp cfg uu____4972 args')
         | FStar_TypeChecker_NBETerm.Accu (a,ts) ->
             FStar_TypeChecker_NBETerm.Accu
               (a, (FStar_List.rev_append args ts))
         | FStar_TypeChecker_NBETerm.Construct (i,us,ts) ->
             let rec aux args1 us1 ts1 =
               match args1 with
-              | (FStar_TypeChecker_NBETerm.Univ u,uu____5096)::args2 ->
+              | (FStar_TypeChecker_NBETerm.Univ u,uu____5092)::args2 ->
                   aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1)  in
-            let uu____5140 = aux args us ts  in
-            (match uu____5140 with
+            let uu____5136 = aux args us ts  in
+            (match uu____5136 with
              | (us',ts') -> FStar_TypeChecker_NBETerm.Construct (i, us', ts'))
         | FStar_TypeChecker_NBETerm.FV (i,us,ts) ->
             let rec aux args1 us1 ts1 =
               match args1 with
-              | (FStar_TypeChecker_NBETerm.Univ u,uu____5267)::args2 ->
+              | (FStar_TypeChecker_NBETerm.Univ u,uu____5263)::args2 ->
                   aux args2 (u :: us1) ts1
               | a::args2 -> aux args2 us1 (a :: ts1)
               | [] -> (us1, ts1)  in
-            let uu____5311 = aux args us ts  in
-            (match uu____5311 with
+            let uu____5307 = aux args us ts  in
+            (match uu____5307 with
              | (us',ts') -> FStar_TypeChecker_NBETerm.FV (i, us', ts'))
         | FStar_TypeChecker_NBETerm.TopLevelLet (lb,arity,args_rev) ->
             let args_rev1 = FStar_List.rev_append args args_rev  in
@@ -1269,85 +1269,85 @@ and (iapp :
             let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs
                in
             (debug cfg
-               (fun uu____5389  ->
-                  let uu____5390 =
+               (fun uu____5385  ->
+                  let uu____5386 =
                     FStar_Syntax_Print.lbname_to_string
                       lb.FStar_Syntax_Syntax.lbname
                      in
-                  let uu____5392 = FStar_Util.string_of_int arity  in
-                  let uu____5394 = FStar_Util.string_of_int n_args_rev  in
+                  let uu____5388 = FStar_Util.string_of_int arity  in
+                  let uu____5390 = FStar_Util.string_of_int n_args_rev  in
                   FStar_Util.print3
                     "Reached iapp for %s with arity %s and n_args = %s\n"
-                    uu____5390 uu____5392 uu____5394);
+                    uu____5386 uu____5388 uu____5390);
              if n_args_rev >= arity
              then
-               (let uu____5398 =
-                  let uu____5411 =
-                    let uu____5412 =
+               (let uu____5394 =
+                  let uu____5407 =
+                    let uu____5408 =
                       FStar_Syntax_Util.unascribe
                         lb.FStar_Syntax_Syntax.lbdef
                        in
-                    uu____5412.FStar_Syntax_Syntax.n  in
-                  match uu____5411 with
-                  | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____5429) ->
+                    uu____5408.FStar_Syntax_Syntax.n  in
+                  match uu____5407 with
+                  | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____5425) ->
                       (bs, body)
-                  | uu____5462 -> ([], (lb.FStar_Syntax_Syntax.lbdef))  in
-                match uu____5398 with
+                  | uu____5458 -> ([], (lb.FStar_Syntax_Syntax.lbdef))  in
+                match uu____5394 with
                 | (bs,body) ->
                     if (n_univs + (FStar_List.length bs)) = arity
                     then
-                      let uu____5503 =
+                      let uu____5499 =
                         FStar_Util.first_N (n_args_rev - arity) args_rev1  in
-                      (match uu____5503 with
+                      (match uu____5499 with
                        | (extra,args_rev2) ->
                            (debug cfg
-                              (fun uu____5555  ->
-                                 let uu____5556 =
+                              (fun uu____5551  ->
+                                 let uu____5552 =
                                    FStar_Syntax_Print.lbname_to_string
                                      lb.FStar_Syntax_Syntax.lbname
                                     in
-                                 let uu____5558 =
+                                 let uu____5554 =
                                    FStar_Syntax_Print.term_to_string body  in
-                                 let uu____5560 =
-                                   let uu____5562 =
+                                 let uu____5556 =
+                                   let uu____5558 =
                                      FStar_List.map
-                                       (fun uu____5574  ->
-                                          match uu____5574 with
-                                          | (x,uu____5581) ->
+                                       (fun uu____5570  ->
+                                          match uu____5570 with
+                                          | (x,uu____5577) ->
                                               FStar_TypeChecker_NBETerm.t_to_string
                                                 x) args_rev2
                                       in
-                                   FStar_All.pipe_right uu____5562
+                                   FStar_All.pipe_right uu____5558
                                      (FStar_String.concat ", ")
                                     in
                                  FStar_Util.print3
                                    "Reducing body of %s = %s,\n\twith args = %s\n"
-                                   uu____5556 uu____5558 uu____5560);
+                                   uu____5552 uu____5554 uu____5556);
                             (let t =
-                               let uu____5589 =
+                               let uu____5585 =
                                  FStar_List.map FStar_Pervasives_Native.fst
                                    args_rev2
                                   in
-                               translate cfg uu____5589 body  in
+                               translate cfg uu____5585 body  in
                              match extra with
                              | [] -> t
-                             | uu____5600 ->
+                             | uu____5596 ->
                                  iapp cfg t (FStar_List.rev extra))))
                     else
-                      (let uu____5613 =
+                      (let uu____5609 =
                          FStar_Util.first_N (n_args_rev - n_univs) args_rev1
                           in
-                       match uu____5613 with
+                       match uu____5609 with
                        | (extra,univs) ->
-                           let uu____5660 =
-                             let uu____5661 =
+                           let uu____5656 =
+                             let uu____5657 =
                                FStar_List.map FStar_Pervasives_Native.fst
                                  univs
                                 in
-                             translate cfg uu____5661
+                             translate cfg uu____5657
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           iapp cfg uu____5660 (FStar_List.rev extra)))
+                           iapp cfg uu____5656 (FStar_List.rev extra)))
              else
                FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, args_rev1))
         | FStar_TypeChecker_NBETerm.TopLevelRec
@@ -1355,52 +1355,52 @@ and (iapp :
             let args1 = FStar_List.append args' args  in
             if (FStar_List.length args1) >= arity
             then
-              let uu____5721 =
+              let uu____5717 =
                 should_reduce_recursive_definition args1 decreases_list  in
-              (match uu____5721 with
-               | (should_reduce,uu____5730,uu____5731) ->
+              (match uu____5717 with
+               | (should_reduce,uu____5726,uu____5727) ->
                    if Prims.op_Negation should_reduce
                    then
                      let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                         in
                      (debug cfg
-                        (fun uu____5739  ->
-                           let uu____5740 =
+                        (fun uu____5735  ->
+                           let uu____5736 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "Decided to not unfold recursive definition %s\n"
-                             uu____5740);
+                             uu____5736);
                       iapp cfg (FStar_TypeChecker_NBETerm.FV (fv, [], []))
                         args1)
                    else
                      (debug cfg
-                        (fun uu____5760  ->
-                           let uu____5761 =
-                             let uu____5763 =
+                        (fun uu____5756  ->
+                           let uu____5757 =
+                             let uu____5759 =
                                FStar_Util.right lb.FStar_Syntax_Syntax.lbname
                                 in
-                             FStar_Syntax_Print.fv_to_string uu____5763  in
+                             FStar_Syntax_Print.fv_to_string uu____5759  in
                            FStar_Util.print1
                              "Yes, Decided to unfold recursive definition %s\n"
-                             uu____5761);
-                      (let uu____5765 =
+                             uu____5757);
+                      (let uu____5761 =
                          FStar_Util.first_N
                            (FStar_List.length lb.FStar_Syntax_Syntax.lbunivs)
                            args1
                           in
-                       match uu____5765 with
+                       match uu____5761 with
                        | (univs,rest) ->
-                           let uu____5812 =
-                             let uu____5813 =
-                               let uu____5816 =
+                           let uu____5808 =
+                             let uu____5809 =
+                               let uu____5812 =
                                  FStar_List.map FStar_Pervasives_Native.fst
                                    univs
                                   in
-                               FStar_List.rev uu____5816  in
-                             translate cfg uu____5813
+                               FStar_List.rev uu____5812  in
+                             translate cfg uu____5809
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           iapp cfg uu____5812 rest)))
+                           iapp cfg uu____5808 rest)))
             else
               FStar_TypeChecker_NBETerm.TopLevelRec
                 (lb, arity, decreases_list, args1)
@@ -1423,11 +1423,11 @@ and (iapp :
                      (remaining_arity - n_args), decreases_list)
                else
                  (let args1 = FStar_List.append acc_args args  in
-                  let uu____5934 =
+                  let uu____5930 =
                     should_reduce_recursive_definition args1 decreases_list
                      in
-                  match uu____5934 with
-                  | (should_reduce,uu____5943,uu____5944) ->
+                  match uu____5930 with
+                  | (should_reduce,uu____5939,uu____5940) ->
                       if Prims.op_Negation should_reduce
                       then
                         FStar_TypeChecker_NBETerm.LocalLetRec
@@ -1436,37 +1436,37 @@ and (iapp :
                       else
                         (let env = make_rec_env mutual_lbs local_env  in
                          debug cfg
-                           (fun uu____5973  ->
-                              (let uu____5975 =
-                                 let uu____5977 =
+                           (fun uu____5969  ->
+                              (let uu____5971 =
+                                 let uu____5973 =
                                    FStar_List.map
                                      FStar_TypeChecker_NBETerm.t_to_string
                                      env
                                     in
-                                 FStar_String.concat ",\n\t " uu____5977  in
+                                 FStar_String.concat ",\n\t " uu____5973  in
                                FStar_Util.print1
-                                 "LocalLetRec Env = {\n\t%s\n}\n" uu____5975);
-                              (let uu____5984 =
-                                 let uu____5986 =
+                                 "LocalLetRec Env = {\n\t%s\n}\n" uu____5971);
+                              (let uu____5980 =
+                                 let uu____5982 =
                                    FStar_List.map
-                                     (fun uu____5998  ->
-                                        match uu____5998 with
-                                        | (t,uu____6005) ->
+                                     (fun uu____5994  ->
+                                        match uu____5994 with
+                                        | (t,uu____6001) ->
                                             FStar_TypeChecker_NBETerm.t_to_string
                                               t) args1
                                     in
-                                 FStar_String.concat ",\n\t " uu____5986  in
+                                 FStar_String.concat ",\n\t " uu____5982  in
                                FStar_Util.print1
-                                 "LocalLetRec Args = {\n\t%s\n}\n" uu____5984));
-                         (let uu____6008 =
+                                 "LocalLetRec Args = {\n\t%s\n}\n" uu____5980));
+                         (let uu____6004 =
                             translate cfg env lb.FStar_Syntax_Syntax.lbdef
                              in
-                          iapp cfg uu____6008 args1))))
-        | uu____6009 ->
-            let uu____6010 =
-              let uu____6012 = FStar_TypeChecker_NBETerm.t_to_string f  in
-              Prims.op_Hat "NBE ill-typed application: " uu____6012  in
-            failwith uu____6010
+                          iapp cfg uu____6004 args1))))
+        | uu____6005 ->
+            let uu____6006 =
+              let uu____6008 = FStar_TypeChecker_NBETerm.t_to_string f  in
+              Prims.op_Hat "NBE ill-typed application: " uu____6008  in
+            failwith uu____6006
 
 and (translate_fv :
   config ->
@@ -1478,31 +1478,31 @@ and (translate_fv :
       fun fvar  ->
         let debug1 = debug cfg  in
         let qninfo =
-          let uu____6029 = FStar_TypeChecker_Cfg.cfg_env cfg.core_cfg  in
-          let uu____6030 = FStar_Syntax_Syntax.lid_of_fv fvar  in
-          FStar_TypeChecker_Env.lookup_qname uu____6029 uu____6030  in
-        let uu____6031 = (is_constr qninfo) || (is_constr_fv fvar)  in
-        if uu____6031
+          let uu____6025 = FStar_TypeChecker_Cfg.cfg_env cfg.core_cfg  in
+          let uu____6026 = FStar_Syntax_Syntax.lid_of_fv fvar  in
+          FStar_TypeChecker_Env.lookup_qname uu____6025 uu____6026  in
+        let uu____6027 = (is_constr qninfo) || (is_constr_fv fvar)  in
+        if uu____6027
         then FStar_TypeChecker_NBETerm.mkConstruct fvar [] []
         else
-          (let uu____6040 =
+          (let uu____6036 =
              FStar_TypeChecker_Normalize.should_unfold cfg.core_cfg
-               (fun uu____6042  ->
+               (fun uu____6038  ->
                   (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying) fvar qninfo
               in
-           match uu____6040 with
+           match uu____6036 with
            | FStar_TypeChecker_Normalize.Should_unfold_fully  ->
                failwith "Not yet handled"
            | FStar_TypeChecker_Normalize.Should_unfold_no  ->
                (debug1
-                  (fun uu____6049  ->
-                     let uu____6050 = FStar_Syntax_Print.fv_to_string fvar
+                  (fun uu____6045  ->
+                     let uu____6046 = FStar_Syntax_Print.fv_to_string fvar
                         in
                      FStar_Util.print1 "(1) Decided to not unfold %s\n"
-                       uu____6050);
-                (let uu____6053 =
+                       uu____6046);
+                (let uu____6049 =
                    FStar_TypeChecker_Cfg.find_prim_step cfg.core_cfg fvar  in
-                 match uu____6053 with
+                 match uu____6049 with
                  | FStar_Pervasives_Native.Some prim_step when
                      prim_step.FStar_TypeChecker_Cfg.strong_reduction_ok ->
                      let arity =
@@ -1510,25 +1510,25 @@ and (translate_fv :
                          prim_step.FStar_TypeChecker_Cfg.univ_arity
                         in
                      (debug1
-                        (fun uu____6064  ->
-                           let uu____6065 =
+                        (fun uu____6060  ->
+                           let uu____6061 =
                              FStar_Syntax_Print.fv_to_string fvar  in
-                           FStar_Util.print1 "Found a primop %s\n" uu____6065);
-                      (let uu____6068 =
-                         let uu____6101 =
-                           let f uu____6134 =
-                             let uu____6136 =
+                           FStar_Util.print1 "Found a primop %s\n" uu____6061);
+                      (let uu____6064 =
+                         let uu____6097 =
+                           let f uu____6130 =
+                             let uu____6132 =
                                FStar_Syntax_Syntax.new_bv
                                  FStar_Pervasives_Native.None
                                  FStar_Syntax_Syntax.t_unit
                                 in
-                             (uu____6136, FStar_Pervasives_Native.None)  in
-                           let uu____6139 =
-                             let uu____6150 = FStar_Common.tabulate arity f
+                             (uu____6132, FStar_Pervasives_Native.None)  in
+                           let uu____6135 =
+                             let uu____6146 = FStar_Common.tabulate arity f
                                 in
-                             ([], uu____6150, FStar_Pervasives_Native.None)
+                             ([], uu____6146, FStar_Pervasives_Native.None)
                               in
-                           FStar_Util.Inl uu____6139  in
+                           FStar_Util.Inl uu____6135  in
                          ((fun args_rev  ->
                              let args' =
                                map_rev FStar_TypeChecker_NBETerm.as_arg
@@ -1540,68 +1540,68 @@ and (translate_fv :
                                  FStar_TypeChecker_NBETerm.translate =
                                    (translate cfg bs)
                                }  in
-                             let uu____6224 =
+                             let uu____6220 =
                                prim_step.FStar_TypeChecker_Cfg.interpretation_nbe
                                  callbacks args'
                                 in
-                             match uu____6224 with
+                             match uu____6220 with
                              | FStar_Pervasives_Native.Some x ->
                                  (debug1
-                                    (fun uu____6235  ->
-                                       let uu____6236 =
+                                    (fun uu____6231  ->
+                                       let uu____6232 =
                                          FStar_Syntax_Print.fv_to_string fvar
                                           in
-                                       let uu____6238 =
+                                       let uu____6234 =
                                          FStar_TypeChecker_NBETerm.t_to_string
                                            x
                                           in
                                        FStar_Util.print2
                                          "Primitive operator %s returned %s\n"
-                                         uu____6236 uu____6238);
+                                         uu____6232 uu____6234);
                                   x)
                              | FStar_Pervasives_Native.None  ->
                                  (debug1
-                                    (fun uu____6246  ->
-                                       let uu____6247 =
+                                    (fun uu____6242  ->
+                                       let uu____6243 =
                                          FStar_Syntax_Print.fv_to_string fvar
                                           in
                                        FStar_Util.print1
                                          "Primitive operator %s failed\n"
-                                         uu____6247);
-                                  (let uu____6250 =
+                                         uu____6243);
+                                  (let uu____6246 =
                                      FStar_TypeChecker_NBETerm.mkFV fvar []
                                        []
                                       in
-                                   iapp cfg uu____6250 args'))), uu____6101,
+                                   iapp cfg uu____6246 args'))), uu____6097,
                            arity)
                           in
-                       FStar_TypeChecker_NBETerm.Lam uu____6068))
-                 | FStar_Pervasives_Native.Some uu____6255 ->
+                       FStar_TypeChecker_NBETerm.Lam uu____6064))
+                 | FStar_Pervasives_Native.Some uu____6251 ->
                      (debug1
-                        (fun uu____6261  ->
-                           let uu____6262 =
+                        (fun uu____6257  ->
+                           let uu____6258 =
                              FStar_Syntax_Print.fv_to_string fvar  in
                            FStar_Util.print1 "(2) Decided to not unfold %s\n"
-                             uu____6262);
+                             uu____6258);
                       FStar_TypeChecker_NBETerm.mkFV fvar [] [])
-                 | uu____6269 ->
+                 | uu____6265 ->
                      (debug1
-                        (fun uu____6277  ->
-                           let uu____6278 =
+                        (fun uu____6273  ->
+                           let uu____6274 =
                              FStar_Syntax_Print.fv_to_string fvar  in
                            FStar_Util.print1 "(3) Decided to not unfold %s\n"
-                             uu____6278);
+                             uu____6274);
                       FStar_TypeChecker_NBETerm.mkFV fvar [] [])))
            | FStar_TypeChecker_Normalize.Should_unfold_reify  ->
                let t =
                  let is_qninfo_visible =
-                   let uu____6288 =
+                   let uu____6284 =
                      FStar_TypeChecker_Env.lookup_definition_qninfo
                        (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                        (fvar.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                        qninfo
                       in
-                   FStar_Option.isSome uu____6288  in
+                   FStar_Option.isSome uu____6284  in
                  if is_qninfo_visible
                  then
                    match qninfo with
@@ -1610,18 +1610,18 @@ and (translate_fv :
                         ({
                            FStar_Syntax_Syntax.sigel =
                              FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),names);
-                           FStar_Syntax_Syntax.sigrng = uu____6303;
-                           FStar_Syntax_Syntax.sigquals = uu____6304;
-                           FStar_Syntax_Syntax.sigmeta = uu____6305;
-                           FStar_Syntax_Syntax.sigattrs = uu____6306;
-                           FStar_Syntax_Syntax.sigopts = uu____6307;_},_us_opt),_rng)
+                           FStar_Syntax_Syntax.sigrng = uu____6299;
+                           FStar_Syntax_Syntax.sigquals = uu____6300;
+                           FStar_Syntax_Syntax.sigmeta = uu____6301;
+                           FStar_Syntax_Syntax.sigattrs = uu____6302;
+                           FStar_Syntax_Syntax.sigopts = uu____6303;_},_us_opt),_rng)
                        ->
                        (debug1
-                          (fun uu____6377  ->
-                             let uu____6378 =
+                          (fun uu____6373  ->
+                             let uu____6374 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1 "(1) Decided to unfold %s\n"
-                               uu____6378);
+                               uu____6374);
                         (let lbm = find_let lbs fvar  in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1629,43 +1629,43 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu____6386 = let_rec_arity lb  in
-                               (match uu____6386 with
+                               let uu____6382 = let_rec_arity lb  in
+                               (match uu____6382 with
                                 | (ar,lst) ->
                                     FStar_TypeChecker_NBETerm.TopLevelRec
                                       (lb, ar, lst, []))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None  ->
                              failwith "Could not find let binding"))
-                   | uu____6422 ->
+                   | uu____6418 ->
                        (debug1
-                          (fun uu____6428  ->
-                             let uu____6429 =
+                          (fun uu____6424  ->
+                             let uu____6425 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1
-                               "(1) qninfo is None for (%s)\n" uu____6429);
+                               "(1) qninfo is None for (%s)\n" uu____6425);
                         FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                  else
                    (debug1
-                      (fun uu____6443  ->
-                         let uu____6444 =
+                      (fun uu____6439  ->
+                         let uu____6440 =
                            FStar_Syntax_Print.fv_to_string fvar  in
                          FStar_Util.print1
                            "(1) qninfo is not visible at this level (%s)\n"
-                           uu____6444);
+                           uu____6440);
                     FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                   in
                (cache_add cfg fvar t; t)
            | FStar_TypeChecker_Normalize.Should_unfold_yes  ->
                let t =
                  let is_qninfo_visible =
-                   let uu____6455 =
+                   let uu____6451 =
                      FStar_TypeChecker_Env.lookup_definition_qninfo
                        (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                        (fvar.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                        qninfo
                       in
-                   FStar_Option.isSome uu____6455  in
+                   FStar_Option.isSome uu____6451  in
                  if is_qninfo_visible
                  then
                    match qninfo with
@@ -1674,18 +1674,18 @@ and (translate_fv :
                         ({
                            FStar_Syntax_Syntax.sigel =
                              FStar_Syntax_Syntax.Sig_let ((is_rec,lbs),names);
-                           FStar_Syntax_Syntax.sigrng = uu____6470;
-                           FStar_Syntax_Syntax.sigquals = uu____6471;
-                           FStar_Syntax_Syntax.sigmeta = uu____6472;
-                           FStar_Syntax_Syntax.sigattrs = uu____6473;
-                           FStar_Syntax_Syntax.sigopts = uu____6474;_},_us_opt),_rng)
+                           FStar_Syntax_Syntax.sigrng = uu____6466;
+                           FStar_Syntax_Syntax.sigquals = uu____6467;
+                           FStar_Syntax_Syntax.sigmeta = uu____6468;
+                           FStar_Syntax_Syntax.sigattrs = uu____6469;
+                           FStar_Syntax_Syntax.sigopts = uu____6470;_},_us_opt),_rng)
                        ->
                        (debug1
-                          (fun uu____6544  ->
-                             let uu____6545 =
+                          (fun uu____6540  ->
+                             let uu____6541 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1 "(1) Decided to unfold %s\n"
-                               uu____6545);
+                               uu____6541);
                         (let lbm = find_let lbs fvar  in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1693,30 +1693,30 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu____6553 = let_rec_arity lb  in
-                               (match uu____6553 with
+                               let uu____6549 = let_rec_arity lb  in
+                               (match uu____6549 with
                                 | (ar,lst) ->
                                     FStar_TypeChecker_NBETerm.TopLevelRec
                                       (lb, ar, lst, []))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None  ->
                              failwith "Could not find let binding"))
-                   | uu____6589 ->
+                   | uu____6585 ->
                        (debug1
-                          (fun uu____6595  ->
-                             let uu____6596 =
+                          (fun uu____6591  ->
+                             let uu____6592 =
                                FStar_Syntax_Print.fv_to_string fvar  in
                              FStar_Util.print1
-                               "(1) qninfo is None for (%s)\n" uu____6596);
+                               "(1) qninfo is None for (%s)\n" uu____6592);
                         FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                  else
                    (debug1
-                      (fun uu____6610  ->
-                         let uu____6611 =
+                      (fun uu____6606  ->
+                         let uu____6607 =
                            FStar_Syntax_Print.fv_to_string fvar  in
                          FStar_Util.print1
                            "(1) qninfo is not visible at this level (%s)\n"
-                           uu____6611);
+                           uu____6607);
                     FStar_TypeChecker_NBETerm.mkFV fvar [] [])
                   in
                (cache_add cfg fvar t; t))
@@ -1731,29 +1731,29 @@ and (translate_letbinding :
       fun lb  ->
         let debug1 = debug cfg  in
         let us = lb.FStar_Syntax_Syntax.lbunivs  in
-        let uu____6635 =
+        let uu____6631 =
           FStar_Syntax_Util.arrow_formals lb.FStar_Syntax_Syntax.lbtyp  in
-        match uu____6635 with
-        | (formals,uu____6643) ->
+        match uu____6631 with
+        | (formals,uu____6639) ->
             let arity = (FStar_List.length us) + (FStar_List.length formals)
                in
             if arity = Prims.int_zero
             then translate cfg bs lb.FStar_Syntax_Syntax.lbdef
             else
-              (let uu____6661 =
+              (let uu____6657 =
                  FStar_Util.is_right lb.FStar_Syntax_Syntax.lbname  in
-               if uu____6661
+               if uu____6657
                then
                  (debug1
-                    (fun uu____6671  ->
-                       let uu____6672 =
+                    (fun uu____6667  ->
+                       let uu____6668 =
                          FStar_Syntax_Print.lbname_to_string
                            lb.FStar_Syntax_Syntax.lbname
                           in
-                       let uu____6674 = FStar_Util.string_of_int arity  in
+                       let uu____6670 = FStar_Util.string_of_int arity  in
                        FStar_Util.print2
                          "Making TopLevelLet for %s with arity %s\n"
-                         uu____6672 uu____6674);
+                         uu____6668 uu____6670);
                   FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, []))
                else translate cfg bs lb.FStar_Syntax_Syntax.lbdef)
 
@@ -1767,8 +1767,8 @@ and (mkRec :
     fun b  ->
       fun bs  ->
         fun env  ->
-          let uu____6699 = let_rec_arity b  in
-          match uu____6699 with
+          let uu____6695 = let_rec_arity b  in
+          match uu____6695 with
           | (ar,ar_lst) ->
               FStar_TypeChecker_NBETerm.LocalLetRec
                 (i, b, bs, env, [], ar, ar_lst)
@@ -1793,13 +1793,13 @@ and (translate_constant :
     | FStar_Const.Const_unit  -> FStar_TypeChecker_NBETerm.Unit
     | FStar_Const.Const_bool b -> FStar_TypeChecker_NBETerm.Bool b
     | FStar_Const.Const_int (s,FStar_Pervasives_Native.None ) ->
-        let uu____6769 = FStar_BigInt.big_int_of_string s  in
-        FStar_TypeChecker_NBETerm.Int uu____6769
+        let uu____6765 = FStar_BigInt.big_int_of_string s  in
+        FStar_TypeChecker_NBETerm.Int uu____6765
     | FStar_Const.Const_string (s,r) ->
         FStar_TypeChecker_NBETerm.String (s, r)
     | FStar_Const.Const_char c1 -> FStar_TypeChecker_NBETerm.Char c1
     | FStar_Const.Const_range r -> FStar_TypeChecker_NBETerm.Range r
-    | uu____6778 -> FStar_TypeChecker_NBETerm.SConst c
+    | uu____6774 -> FStar_TypeChecker_NBETerm.SConst c
 
 and (readback_comp :
   config -> FStar_TypeChecker_NBETerm.comp -> FStar_Syntax_Syntax.comp) =
@@ -1808,19 +1808,18 @@ and (readback_comp :
       let c' =
         match c with
         | FStar_TypeChecker_NBETerm.Tot (typ,u) ->
-            let uu____6788 =
-              let uu____6797 = readback cfg typ  in (uu____6797, u)  in
-            FStar_Syntax_Syntax.Total uu____6788
+            let uu____6784 =
+              let uu____6793 = readback cfg typ  in (uu____6793, u)  in
+            FStar_Syntax_Syntax.Total uu____6784
         | FStar_TypeChecker_NBETerm.GTot (typ,u) ->
-            let uu____6810 =
-              let uu____6819 = readback cfg typ  in (uu____6819, u)  in
-            FStar_Syntax_Syntax.GTotal uu____6810
+            let uu____6806 =
+              let uu____6815 = readback cfg typ  in (uu____6815, u)  in
+            FStar_Syntax_Syntax.GTotal uu____6806
         | FStar_TypeChecker_NBETerm.Comp ctyp ->
-            let uu____6827 = readback_comp_typ cfg ctyp  in
-            FStar_Syntax_Syntax.Comp uu____6827
+            let uu____6823 = readback_comp_typ cfg ctyp  in
+            FStar_Syntax_Syntax.Comp uu____6823
          in
-      FStar_Syntax_Syntax.mk c' FStar_Pervasives_Native.None
-        FStar_Range.dummyRange
+      FStar_Syntax_Syntax.mk c' FStar_Range.dummyRange
 
 and (translate_comp_typ :
   config ->
@@ -1830,30 +1829,30 @@ and (translate_comp_typ :
   fun cfg  ->
     fun bs  ->
       fun c  ->
-        let uu____6833 = c  in
-        match uu____6833 with
+        let uu____6829 = c  in
+        match uu____6829 with
         | { FStar_Syntax_Syntax.comp_univs = comp_univs;
             FStar_Syntax_Syntax.effect_name = effect_name;
             FStar_Syntax_Syntax.result_typ = result_typ;
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags = flags;_} ->
-            let uu____6853 =
+            let uu____6849 =
               FStar_List.map (translate_univ cfg bs) comp_univs  in
-            let uu____6854 = translate cfg bs result_typ  in
-            let uu____6855 =
+            let uu____6850 = translate cfg bs result_typ  in
+            let uu____6851 =
               FStar_List.map
                 (fun x  ->
-                   let uu____6883 =
+                   let uu____6879 =
                      translate cfg bs (FStar_Pervasives_Native.fst x)  in
-                   (uu____6883, (FStar_Pervasives_Native.snd x))) effect_args
+                   (uu____6879, (FStar_Pervasives_Native.snd x))) effect_args
                in
-            let uu____6890 = FStar_List.map (translate_flag cfg bs) flags  in
+            let uu____6886 = FStar_List.map (translate_flag cfg bs) flags  in
             {
-              FStar_TypeChecker_NBETerm.comp_univs = uu____6853;
+              FStar_TypeChecker_NBETerm.comp_univs = uu____6849;
               FStar_TypeChecker_NBETerm.effect_name = effect_name;
-              FStar_TypeChecker_NBETerm.result_typ = uu____6854;
-              FStar_TypeChecker_NBETerm.effect_args = uu____6855;
-              FStar_TypeChecker_NBETerm.flags = uu____6890
+              FStar_TypeChecker_NBETerm.result_typ = uu____6850;
+              FStar_TypeChecker_NBETerm.effect_args = uu____6851;
+              FStar_TypeChecker_NBETerm.flags = uu____6886
             }
 
 and (readback_comp_typ :
@@ -1862,17 +1861,17 @@ and (readback_comp_typ :
   =
   fun cfg  ->
     fun c  ->
-      let uu____6895 = readback cfg c.FStar_TypeChecker_NBETerm.result_typ
+      let uu____6891 = readback cfg c.FStar_TypeChecker_NBETerm.result_typ
          in
-      let uu____6898 =
+      let uu____6894 =
         FStar_List.map
           (fun x  ->
-             let uu____6924 = readback cfg (FStar_Pervasives_Native.fst x)
+             let uu____6920 = readback cfg (FStar_Pervasives_Native.fst x)
                 in
-             (uu____6924, (FStar_Pervasives_Native.snd x)))
+             (uu____6920, (FStar_Pervasives_Native.snd x)))
           c.FStar_TypeChecker_NBETerm.effect_args
          in
-      let uu____6925 =
+      let uu____6921 =
         FStar_List.map (readback_flag cfg) c.FStar_TypeChecker_NBETerm.flags
          in
       {
@@ -1880,9 +1879,9 @@ and (readback_comp_typ :
           (c.FStar_TypeChecker_NBETerm.comp_univs);
         FStar_Syntax_Syntax.effect_name =
           (c.FStar_TypeChecker_NBETerm.effect_name);
-        FStar_Syntax_Syntax.result_typ = uu____6895;
-        FStar_Syntax_Syntax.effect_args = uu____6898;
-        FStar_Syntax_Syntax.flags = uu____6925
+        FStar_Syntax_Syntax.result_typ = uu____6891;
+        FStar_Syntax_Syntax.effect_args = uu____6894;
+        FStar_Syntax_Syntax.flags = uu____6921
       }
 
 and (translate_residual_comp :
@@ -1894,22 +1893,22 @@ and (translate_residual_comp :
   fun cfg  ->
     fun bs  ->
       fun c  ->
-        let uu____6933 = c  in
-        match uu____6933 with
+        let uu____6929 = c  in
+        match uu____6929 with
         | { FStar_Syntax_Syntax.residual_effect = residual_effect;
             FStar_Syntax_Syntax.residual_typ = residual_typ;
             FStar_Syntax_Syntax.residual_flags = residual_flags;_} ->
-            let uu____6943 =
+            let uu____6939 =
               if
                 ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
               then FStar_Pervasives_Native.None
               else FStar_Util.map_opt residual_typ (translate cfg bs)  in
-            let uu____6953 =
+            let uu____6949 =
               FStar_List.map (translate_flag cfg bs) residual_flags  in
             {
               FStar_TypeChecker_NBETerm.residual_effect = residual_effect;
-              FStar_TypeChecker_NBETerm.residual_typ = uu____6943;
-              FStar_TypeChecker_NBETerm.residual_flags = uu____6953
+              FStar_TypeChecker_NBETerm.residual_typ = uu____6939;
+              FStar_TypeChecker_NBETerm.residual_flags = uu____6949
             }
 
 and (readback_residual_comp :
@@ -1919,26 +1918,26 @@ and (readback_residual_comp :
   =
   fun cfg  ->
     fun c  ->
-      let uu____6958 =
+      let uu____6954 =
         FStar_Util.map_opt c.FStar_TypeChecker_NBETerm.residual_typ
           (fun x  ->
              debug cfg
-               (fun uu____6969  ->
-                  let uu____6970 = FStar_TypeChecker_NBETerm.t_to_string x
+               (fun uu____6965  ->
+                  let uu____6966 = FStar_TypeChecker_NBETerm.t_to_string x
                      in
                   FStar_Util.print1 "Reading back residualtype %s\n"
-                    uu____6970);
+                    uu____6966);
              readback cfg x)
          in
-      let uu____6973 =
+      let uu____6969 =
         FStar_List.map (readback_flag cfg)
           c.FStar_TypeChecker_NBETerm.residual_flags
          in
       {
         FStar_Syntax_Syntax.residual_effect =
           (c.FStar_TypeChecker_NBETerm.residual_effect);
-        FStar_Syntax_Syntax.residual_typ = uu____6958;
-        FStar_Syntax_Syntax.residual_flags = uu____6973
+        FStar_Syntax_Syntax.residual_typ = uu____6954;
+        FStar_Syntax_Syntax.residual_flags = uu____6969
       }
 
 and (translate_flag :
@@ -1964,8 +1963,8 @@ and (translate_flag :
         | FStar_Syntax_Syntax.LEMMA  -> FStar_TypeChecker_NBETerm.LEMMA
         | FStar_Syntax_Syntax.CPS  -> FStar_TypeChecker_NBETerm.CPS
         | FStar_Syntax_Syntax.DECREASES tm ->
-            let uu____6984 = translate cfg bs tm  in
-            FStar_TypeChecker_NBETerm.DECREASES uu____6984
+            let uu____6980 = translate cfg bs tm  in
+            FStar_TypeChecker_NBETerm.DECREASES uu____6980
 
 and (readback_flag :
   config -> FStar_TypeChecker_NBETerm.cflag -> FStar_Syntax_Syntax.cflag) =
@@ -1986,8 +1985,8 @@ and (readback_flag :
       | FStar_TypeChecker_NBETerm.LEMMA  -> FStar_Syntax_Syntax.LEMMA
       | FStar_TypeChecker_NBETerm.CPS  -> FStar_Syntax_Syntax.CPS
       | FStar_TypeChecker_NBETerm.DECREASES t ->
-          let uu____6988 = readback cfg t  in
-          FStar_Syntax_Syntax.DECREASES uu____6988
+          let uu____6984 = readback cfg t  in
+          FStar_Syntax_Syntax.DECREASES uu____6984
 
 and (translate_monadic :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.term'
@@ -1997,31 +1996,31 @@ and (translate_monadic :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____6991  ->
+  fun uu____6987  ->
     fun cfg  ->
       fun bs  ->
         fun e  ->
-          match uu____6991 with
+          match uu____6987 with
           | (m,ty) ->
               let e1 = FStar_Syntax_Util.unascribe e  in
               (match e1.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-                   let uu____7029 =
-                     let uu____7038 =
+                   let uu____7025 =
+                     let uu____7034 =
                        FStar_TypeChecker_Env.norm_eff_name
                          (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv m
                         in
                      FStar_TypeChecker_Env.effect_decl_opt
-                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7038
+                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7034
                       in
-                   (match uu____7029 with
+                   (match uu____7025 with
                     | FStar_Pervasives_Native.None  ->
-                        let uu____7045 =
-                          let uu____7047 = FStar_Ident.string_of_lid m  in
+                        let uu____7041 =
+                          let uu____7043 = FStar_Ident.string_of_lid m  in
                           FStar_Util.format1
-                            "Effect declaration not found: %s" uu____7047
+                            "Effect declaration not found: %s" uu____7043
                            in
-                        failwith uu____7045
+                        failwith uu____7041
                     | FStar_Pervasives_Native.Some (ed,q) ->
                         let cfg' = reifying_false cfg  in
                         let body_lam =
@@ -2032,80 +2031,77 @@ and (translate_monadic :
                                 (FStar_Pervasives_Native.Some ty);
                               FStar_Syntax_Syntax.residual_flags = []
                             }  in
-                          let uu____7069 =
-                            let uu____7076 =
-                              let uu____7077 =
-                                let uu____7096 =
-                                  let uu____7105 =
-                                    let uu____7112 =
-                                      FStar_Util.left
-                                        lb.FStar_Syntax_Syntax.lbname
-                                       in
-                                    (uu____7112,
-                                      FStar_Pervasives_Native.None)
+                          let uu____7065 =
+                            let uu____7066 =
+                              let uu____7085 =
+                                let uu____7094 =
+                                  let uu____7101 =
+                                    FStar_Util.left
+                                      lb.FStar_Syntax_Syntax.lbname
                                      in
-                                  [uu____7105]  in
-                                (uu____7096, body,
-                                  (FStar_Pervasives_Native.Some body_rc))
-                                 in
-                              FStar_Syntax_Syntax.Tm_abs uu____7077  in
-                            FStar_Syntax_Syntax.mk uu____7076  in
-                          uu____7069 FStar_Pervasives_Native.None
+                                  (uu____7101, FStar_Pervasives_Native.None)
+                                   in
+                                [uu____7094]  in
+                              (uu____7085, body,
+                                (FStar_Pervasives_Native.Some body_rc))
+                               in
+                            FStar_Syntax_Syntax.Tm_abs uu____7066  in
+                          FStar_Syntax_Syntax.mk uu____7065
                             body.FStar_Syntax_Syntax.pos
                            in
                         let maybe_range_arg =
-                          let uu____7146 =
+                          let uu____7135 =
                             FStar_Util.for_some
                               (FStar_Syntax_Util.attr_eq
                                  FStar_Syntax_Util.dm4f_bind_range_attr)
                               ed.FStar_Syntax_Syntax.eff_attrs
                              in
-                          if uu____7146
+                          if uu____7135
                           then
-                            let uu____7155 =
-                              let uu____7160 =
-                                let uu____7161 =
+                            let uu____7144 =
+                              let uu____7149 =
+                                let uu____7150 =
                                   FStar_TypeChecker_Cfg.embed_simple
                                     FStar_Syntax_Embeddings.e_range
                                     lb.FStar_Syntax_Syntax.lbpos
                                     lb.FStar_Syntax_Syntax.lbpos
                                    in
-                                translate cfg [] uu____7161  in
-                              (uu____7160, FStar_Pervasives_Native.None)  in
-                            let uu____7162 =
-                              let uu____7169 =
-                                let uu____7174 =
-                                  let uu____7175 =
+                                translate cfg [] uu____7150  in
+                              (uu____7149, FStar_Pervasives_Native.None)  in
+                            let uu____7151 =
+                              let uu____7158 =
+                                let uu____7163 =
+                                  let uu____7164 =
                                     FStar_TypeChecker_Cfg.embed_simple
                                       FStar_Syntax_Embeddings.e_range
                                       body.FStar_Syntax_Syntax.pos
                                       body.FStar_Syntax_Syntax.pos
                                      in
-                                  translate cfg [] uu____7175  in
-                                (uu____7174, FStar_Pervasives_Native.None)
+                                  translate cfg [] uu____7164  in
+                                (uu____7163, FStar_Pervasives_Native.None)
                                  in
-                              [uu____7169]  in
-                            uu____7155 :: uu____7162
+                              [uu____7158]  in
+                            uu____7144 :: uu____7151
                           else []  in
                         let t =
-                          let uu____7195 =
-                            let uu____7196 =
-                              let uu____7197 =
-                                let uu____7198 =
-                                  let uu____7199 =
-                                    let uu____7206 =
+                          let uu____7184 =
+                            let uu____7185 =
+                              let uu____7186 =
+                                let uu____7187 =
+                                  let uu____7188 =
+                                    let uu____7195 =
                                       FStar_All.pipe_right ed
                                         FStar_Syntax_Util.get_bind_repr
                                        in
-                                    FStar_All.pipe_right uu____7206
+                                    FStar_All.pipe_right uu____7195
                                       FStar_Util.must
                                      in
-                                  FStar_All.pipe_right uu____7199
+                                  FStar_All.pipe_right uu____7188
                                     FStar_Pervasives_Native.snd
                                    in
-                                FStar_Syntax_Util.un_uinst uu____7198  in
-                              translate cfg' [] uu____7197  in
-                            iapp cfg uu____7196
+                                FStar_Syntax_Util.un_uinst uu____7187  in
+                              translate cfg' [] uu____7186  in
+                            iapp cfg uu____7185
                               [((FStar_TypeChecker_NBETerm.Univ
                                    FStar_Syntax_Syntax.U_unknown),
                                  FStar_Pervasives_Native.None);
@@ -2113,167 +2109,161 @@ and (translate_monadic :
                                   FStar_Syntax_Syntax.U_unknown),
                                 FStar_Pervasives_Native.None)]
                              in
-                          let uu____7239 =
-                            let uu____7240 =
-                              let uu____7247 =
-                                let uu____7252 =
+                          let uu____7228 =
+                            let uu____7229 =
+                              let uu____7236 =
+                                let uu____7241 =
                                   translate cfg' bs
                                     lb.FStar_Syntax_Syntax.lbtyp
                                    in
-                                (uu____7252, FStar_Pervasives_Native.None)
+                                (uu____7241, FStar_Pervasives_Native.None)
                                  in
-                              let uu____7253 =
-                                let uu____7260 =
-                                  let uu____7265 = translate cfg' bs ty  in
-                                  (uu____7265, FStar_Pervasives_Native.None)
+                              let uu____7242 =
+                                let uu____7249 =
+                                  let uu____7254 = translate cfg' bs ty  in
+                                  (uu____7254, FStar_Pervasives_Native.None)
                                    in
-                                [uu____7260]  in
-                              uu____7247 :: uu____7253  in
-                            let uu____7278 =
-                              let uu____7285 =
-                                let uu____7292 =
-                                  let uu____7299 =
-                                    let uu____7304 =
+                                [uu____7249]  in
+                              uu____7236 :: uu____7242  in
+                            let uu____7267 =
+                              let uu____7274 =
+                                let uu____7281 =
+                                  let uu____7288 =
+                                    let uu____7293 =
                                       translate cfg bs
                                         lb.FStar_Syntax_Syntax.lbdef
                                        in
-                                    (uu____7304,
+                                    (uu____7293,
                                       FStar_Pervasives_Native.None)
                                      in
-                                  let uu____7305 =
-                                    let uu____7312 =
-                                      let uu____7319 =
-                                        let uu____7324 =
+                                  let uu____7294 =
+                                    let uu____7301 =
+                                      let uu____7308 =
+                                        let uu____7313 =
                                           translate cfg bs body_lam  in
-                                        (uu____7324,
+                                        (uu____7313,
                                           FStar_Pervasives_Native.None)
                                          in
-                                      [uu____7319]  in
+                                      [uu____7308]  in
                                     (FStar_TypeChecker_NBETerm.Unknown,
                                       FStar_Pervasives_Native.None) ::
-                                      uu____7312
+                                      uu____7301
                                      in
-                                  uu____7299 :: uu____7305  in
+                                  uu____7288 :: uu____7294  in
                                 (FStar_TypeChecker_NBETerm.Unknown,
-                                  FStar_Pervasives_Native.None) :: uu____7292
+                                  FStar_Pervasives_Native.None) :: uu____7281
                                  in
-                              FStar_List.append maybe_range_arg uu____7285
+                              FStar_List.append maybe_range_arg uu____7274
                                in
-                            FStar_List.append uu____7240 uu____7278  in
-                          iapp cfg uu____7195 uu____7239  in
+                            FStar_List.append uu____7229 uu____7267  in
+                          iapp cfg uu____7184 uu____7228  in
                         (debug cfg
-                           (fun uu____7356  ->
-                              let uu____7357 =
+                           (fun uu____7345  ->
+                              let uu____7346 =
                                 FStar_TypeChecker_NBETerm.t_to_string t  in
                               FStar_Util.print1 "translate_monadic: %s\n"
-                                uu____7357);
+                                uu____7346);
                          t))
                | FStar_Syntax_Syntax.Tm_app
                    ({
                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                        (FStar_Const.Const_reflect uu____7360);
-                      FStar_Syntax_Syntax.pos = uu____7361;
-                      FStar_Syntax_Syntax.vars = uu____7362;_},(e2,uu____7364)::[])
+                        (FStar_Const.Const_reflect uu____7349);
+                      FStar_Syntax_Syntax.pos = uu____7350;
+                      FStar_Syntax_Syntax.vars = uu____7351;_},(e2,uu____7353)::[])
                    ->
-                   let uu____7403 = reifying_false cfg  in
-                   translate uu____7403 bs e2
+                   let uu____7392 = reifying_false cfg  in
+                   translate uu____7392 bs e2
                | FStar_Syntax_Syntax.Tm_app (head,args) ->
                    (debug cfg
-                      (fun uu____7434  ->
-                         let uu____7435 =
+                      (fun uu____7423  ->
+                         let uu____7424 =
                            FStar_Syntax_Print.term_to_string head  in
-                         let uu____7437 =
+                         let uu____7426 =
                            FStar_Syntax_Print.args_to_string args  in
                          FStar_Util.print2
-                           "translate_monadic app (%s) @ (%s)\n" uu____7435
-                           uu____7437);
-                    (let fallback1 uu____7445 = translate cfg bs e1  in
-                     let fallback2 uu____7451 =
-                       let uu____7452 = reifying_false cfg  in
-                       let uu____7453 =
+                           "translate_monadic app (%s) @ (%s)\n" uu____7424
+                           uu____7426);
+                    (let fallback1 uu____7434 = translate cfg bs e1  in
+                     let fallback2 uu____7440 =
+                       let uu____7441 = reifying_false cfg  in
+                       let uu____7442 =
                          FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_meta
                               (e1,
                                 (FStar_Syntax_Syntax.Meta_monadic (m, ty))))
-                           FStar_Pervasives_Native.None
                            e1.FStar_Syntax_Syntax.pos
                           in
-                       translate uu____7452 bs uu____7453  in
-                     let uu____7458 =
-                       let uu____7459 = FStar_Syntax_Util.un_uinst head  in
-                       uu____7459.FStar_Syntax_Syntax.n  in
-                     match uu____7458 with
+                       translate uu____7441 bs uu____7442  in
+                     let uu____7447 =
+                       let uu____7448 = FStar_Syntax_Util.un_uinst head  in
+                       uu____7448.FStar_Syntax_Syntax.n  in
+                     match uu____7447 with
                      | FStar_Syntax_Syntax.Tm_fvar fv ->
                          let lid = FStar_Syntax_Syntax.lid_of_fv fv  in
                          let qninfo =
                            FStar_TypeChecker_Env.lookup_qname
                              (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv lid
                             in
-                         let uu____7465 =
-                           let uu____7467 =
+                         let uu____7454 =
+                           let uu____7456 =
                              FStar_TypeChecker_Env.is_action
                                (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv lid
                               in
-                           Prims.op_Negation uu____7467  in
-                         if uu____7465
+                           Prims.op_Negation uu____7456  in
+                         if uu____7454
                          then fallback1 ()
                          else
-                           (let uu____7472 =
-                              let uu____7474 =
+                           (let uu____7461 =
+                              let uu____7463 =
                                 FStar_TypeChecker_Env.lookup_definition_qninfo
                                   (cfg.core_cfg).FStar_TypeChecker_Cfg.delta_level
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   qninfo
                                  in
-                              FStar_Option.isNone uu____7474  in
-                            if uu____7472
+                              FStar_Option.isNone uu____7463  in
+                            if uu____7461
                             then fallback2 ()
                             else
                               (let e2 =
-                                 let uu____7491 =
-                                   let uu____7496 =
-                                     FStar_Syntax_Util.mk_reify head  in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____7496
-                                     args
-                                    in
-                                 uu____7491 FStar_Pervasives_Native.None
-                                   e1.FStar_Syntax_Syntax.pos
+                                 let uu____7478 =
+                                   FStar_Syntax_Util.mk_reify head  in
+                                 FStar_Syntax_Syntax.mk_Tm_app uu____7478
+                                   args e1.FStar_Syntax_Syntax.pos
                                   in
-                               let uu____7497 = reifying_false cfg  in
-                               translate uu____7497 bs e2))
-                     | uu____7498 -> fallback1 ()))
+                               let uu____7479 = reifying_false cfg  in
+                               translate uu____7479 bs e2))
+                     | uu____7480 -> fallback1 ()))
                | FStar_Syntax_Syntax.Tm_match (sc,branches) ->
                    let branches1 =
                      FStar_All.pipe_right branches
                        (FStar_List.map
-                          (fun uu____7619  ->
-                             match uu____7619 with
+                          (fun uu____7601  ->
+                             match uu____7601 with
                              | (pat,wopt,tm) ->
-                                 let uu____7667 =
+                                 let uu____7649 =
                                    FStar_Syntax_Util.mk_reify tm  in
-                                 (pat, wopt, uu____7667)))
+                                 (pat, wopt, uu____7649)))
                       in
                    let tm =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_match (sc, branches1))
-                       FStar_Pervasives_Native.None
                        e1.FStar_Syntax_Syntax.pos
                       in
-                   let uu____7699 = reifying_false cfg  in
-                   translate uu____7699 bs tm
+                   let uu____7681 = reifying_false cfg  in
+                   translate uu____7681 bs tm
                | FStar_Syntax_Syntax.Tm_meta
-                   (t,FStar_Syntax_Syntax.Meta_monadic uu____7701) ->
+                   (t,FStar_Syntax_Syntax.Meta_monadic uu____7683) ->
                    translate_monadic (m, ty) cfg bs e1
                | FStar_Syntax_Syntax.Tm_meta
                    (t,FStar_Syntax_Syntax.Meta_monadic_lift (msrc,mtgt,ty'))
                    -> translate_monadic_lift (msrc, mtgt, ty') cfg bs e1
-               | uu____7728 ->
-                   let uu____7729 =
-                     let uu____7731 = FStar_Syntax_Print.tag_of_term e1  in
+               | uu____7710 ->
+                   let uu____7711 =
+                     let uu____7713 = FStar_Syntax_Print.tag_of_term e1  in
                      FStar_Util.format1
-                       "Unexpected case in translate_monadic: %s" uu____7731
+                       "Unexpected case in translate_monadic: %s" uu____7713
                       in
-                   failwith uu____7729)
+                   failwith uu____7711)
 
 and (translate_monadic_lift :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.monad_name *
@@ -2283,115 +2273,114 @@ and (translate_monadic_lift :
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           FStar_TypeChecker_NBETerm.t)
   =
-  fun uu____7734  ->
+  fun uu____7716  ->
     fun cfg  ->
       fun bs  ->
         fun e  ->
-          match uu____7734 with
+          match uu____7716 with
           | (msrc,mtgt,ty) ->
               let e1 = FStar_Syntax_Util.unascribe e  in
-              let uu____7758 =
+              let uu____7740 =
                 (FStar_Syntax_Util.is_pure_effect msrc) ||
                   (FStar_Syntax_Util.is_div_effect msrc)
                  in
-              if uu____7758
+              if uu____7740
               then
                 let ed =
-                  let uu____7762 =
+                  let uu____7744 =
                     FStar_TypeChecker_Env.norm_eff_name
                       (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv mtgt
                      in
                   FStar_TypeChecker_Env.get_effect_decl
-                    (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7762
+                    (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv uu____7744
                    in
                 let ret =
-                  let uu____7764 =
-                    let uu____7765 =
-                      let uu____7768 =
-                        let uu____7769 =
-                          let uu____7776 =
+                  let uu____7746 =
+                    let uu____7747 =
+                      let uu____7750 =
+                        let uu____7751 =
+                          let uu____7758 =
                             FStar_All.pipe_right ed
                               FStar_Syntax_Util.get_return_repr
                              in
-                          FStar_All.pipe_right uu____7776 FStar_Util.must  in
-                        FStar_All.pipe_right uu____7769
+                          FStar_All.pipe_right uu____7758 FStar_Util.must  in
+                        FStar_All.pipe_right uu____7751
                           FStar_Pervasives_Native.snd
                          in
-                      FStar_Syntax_Subst.compress uu____7768  in
-                    uu____7765.FStar_Syntax_Syntax.n  in
-                  match uu____7764 with
-                  | FStar_Syntax_Syntax.Tm_uinst (ret,uu____7822::[]) ->
+                      FStar_Syntax_Subst.compress uu____7750  in
+                    uu____7747.FStar_Syntax_Syntax.n  in
+                  match uu____7746 with
+                  | FStar_Syntax_Syntax.Tm_uinst (ret,uu____7804::[]) ->
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_uinst
                            (ret, [FStar_Syntax_Syntax.U_unknown]))
-                        FStar_Pervasives_Native.None
                         e1.FStar_Syntax_Syntax.pos
-                  | uu____7829 ->
+                  | uu____7811 ->
                       failwith "NYI: Reification of indexed effect (NBE)"
                    in
                 let cfg' = reifying_false cfg  in
                 let t =
-                  let uu____7833 =
-                    let uu____7834 = translate cfg' [] ret  in
-                    iapp cfg' uu____7834
+                  let uu____7815 =
+                    let uu____7816 = translate cfg' [] ret  in
+                    iapp cfg' uu____7816
                       [((FStar_TypeChecker_NBETerm.Univ
                            FStar_Syntax_Syntax.U_unknown),
                          FStar_Pervasives_Native.None)]
                      in
-                  let uu____7843 =
-                    let uu____7844 =
-                      let uu____7849 = translate cfg' bs ty  in
-                      (uu____7849, FStar_Pervasives_Native.None)  in
-                    let uu____7850 =
-                      let uu____7857 =
-                        let uu____7862 = translate cfg' bs e1  in
-                        (uu____7862, FStar_Pervasives_Native.None)  in
-                      [uu____7857]  in
-                    uu____7844 :: uu____7850  in
-                  iapp cfg' uu____7833 uu____7843  in
+                  let uu____7825 =
+                    let uu____7826 =
+                      let uu____7831 = translate cfg' bs ty  in
+                      (uu____7831, FStar_Pervasives_Native.None)  in
+                    let uu____7832 =
+                      let uu____7839 =
+                        let uu____7844 = translate cfg' bs e1  in
+                        (uu____7844, FStar_Pervasives_Native.None)  in
+                      [uu____7839]  in
+                    uu____7826 :: uu____7832  in
+                  iapp cfg' uu____7815 uu____7825  in
                 (debug cfg
-                   (fun uu____7878  ->
-                      let uu____7879 =
+                   (fun uu____7860  ->
+                      let uu____7861 =
                         FStar_TypeChecker_NBETerm.t_to_string t  in
                       FStar_Util.print1 "translate_monadic_lift(1): %s\n"
-                        uu____7879);
+                        uu____7861);
                  t)
               else
-                (let uu____7884 =
+                (let uu____7866 =
                    FStar_TypeChecker_Env.monad_leq
                      (cfg.core_cfg).FStar_TypeChecker_Cfg.tcenv msrc mtgt
                     in
-                 match uu____7884 with
+                 match uu____7866 with
                  | FStar_Pervasives_Native.None  ->
-                     let uu____7887 =
-                       let uu____7889 = FStar_Ident.string_of_lid msrc  in
-                       let uu____7891 = FStar_Ident.string_of_lid mtgt  in
+                     let uu____7869 =
+                       let uu____7871 = FStar_Ident.string_of_lid msrc  in
+                       let uu____7873 = FStar_Ident.string_of_lid mtgt  in
                        FStar_Util.format2
                          "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                         uu____7889 uu____7891
+                         uu____7871 uu____7873
                         in
-                     failwith uu____7887
+                     failwith uu____7869
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____7894;
-                       FStar_TypeChecker_Env.mtarget = uu____7895;
+                     { FStar_TypeChecker_Env.msource = uu____7876;
+                       FStar_TypeChecker_Env.mtarget = uu____7877;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____7896;
+                         { FStar_TypeChecker_Env.mlift_wp = uu____7878;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.None ;_};_}
                      ->
-                     let uu____7916 =
-                       let uu____7918 = FStar_Ident.string_of_lid msrc  in
-                       let uu____7920 = FStar_Ident.string_of_lid mtgt  in
+                     let uu____7898 =
+                       let uu____7900 = FStar_Ident.string_of_lid msrc  in
+                       let uu____7902 = FStar_Ident.string_of_lid mtgt  in
                        FStar_Util.format2
                          "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                         uu____7918 uu____7920
+                         uu____7900 uu____7902
                         in
-                     failwith uu____7916
+                     failwith uu____7898
                  | FStar_Pervasives_Native.Some
-                     { FStar_TypeChecker_Env.msource = uu____7923;
-                       FStar_TypeChecker_Env.mtarget = uu____7924;
+                     { FStar_TypeChecker_Env.msource = uu____7905;
+                       FStar_TypeChecker_Env.mtarget = uu____7906;
                        FStar_TypeChecker_Env.mlift =
-                         { FStar_TypeChecker_Env.mlift_wp = uu____7925;
+                         { FStar_TypeChecker_Env.mlift_wp = uu____7907;
                            FStar_TypeChecker_Env.mlift_term =
                              FStar_Pervasives_Native.Some lift;_};_}
                      ->
@@ -2401,29 +2390,29 @@ and (translate_monadic_lift :
                            FStar_Pervasives_Native.None
                            FStar_Syntax_Syntax.tun
                           in
-                       let uu____7959 =
-                         let uu____7962 = FStar_Syntax_Syntax.bv_to_name x
+                       let uu____7941 =
+                         let uu____7944 = FStar_Syntax_Syntax.bv_to_name x
                             in
-                         lift FStar_Syntax_Syntax.U_unknown ty uu____7962  in
+                         lift FStar_Syntax_Syntax.U_unknown ty uu____7944  in
                        FStar_Syntax_Util.abs
-                         [(x, FStar_Pervasives_Native.None)] uu____7959
+                         [(x, FStar_Pervasives_Native.None)] uu____7941
                          FStar_Pervasives_Native.None
                         in
                      let cfg' = reifying_false cfg  in
                      let t =
-                       let uu____7979 = translate cfg' [] lift_lam  in
-                       let uu____7980 =
-                         let uu____7981 =
-                           let uu____7986 = translate cfg bs e1  in
-                           (uu____7986, FStar_Pervasives_Native.None)  in
-                         [uu____7981]  in
-                       iapp cfg uu____7979 uu____7980  in
+                       let uu____7961 = translate cfg' [] lift_lam  in
+                       let uu____7962 =
+                         let uu____7963 =
+                           let uu____7968 = translate cfg bs e1  in
+                           (uu____7968, FStar_Pervasives_Native.None)  in
+                         [uu____7963]  in
+                       iapp cfg uu____7961 uu____7962  in
                      (debug cfg
-                        (fun uu____7998  ->
-                           let uu____7999 =
+                        (fun uu____7980  ->
+                           let uu____7981 =
                              FStar_TypeChecker_NBETerm.t_to_string t  in
                            FStar_Util.print1
-                             "translate_monadic_lift(2): %s\n" uu____7999);
+                             "translate_monadic_lift(2): %s\n" uu____7981);
                       t))
 
 and (readback :
@@ -2433,21 +2422,21 @@ and (readback :
       let debug1 = debug cfg  in
       let readback_args cfg1 args =
         map_rev
-          (fun uu____8053  ->
-             match uu____8053 with
+          (fun uu____8035  ->
+             match uu____8035 with
              | (x1,q) ->
-                 let uu____8064 = readback cfg1 x1  in (uu____8064, q)) args
+                 let uu____8046 = readback cfg1 x1  in (uu____8046, q)) args
          in
       debug1
-        (fun uu____8070  ->
-           let uu____8071 = FStar_TypeChecker_NBETerm.t_to_string x  in
-           FStar_Util.print1 "Readback: %s\n" uu____8071);
+        (fun uu____8052  ->
+           let uu____8053 = FStar_TypeChecker_NBETerm.t_to_string x  in
+           FStar_Util.print1 "Readback: %s\n" uu____8053);
       (match x with
        | FStar_TypeChecker_NBETerm.Univ u ->
            failwith "Readback of universes should not occur"
        | FStar_TypeChecker_NBETerm.Unknown  ->
            FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
+             FStar_Range.dummyRange
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Unit )
            -> FStar_Syntax_Syntax.unit_const
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Bool
@@ -2456,14 +2445,13 @@ and (readback :
            (false )) -> FStar_Syntax_Util.exp_false_bool
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Int i)
            ->
-           let uu____8079 = FStar_BigInt.string_of_big_int i  in
-           FStar_All.pipe_right uu____8079 FStar_Syntax_Util.exp_int
+           let uu____8061 = FStar_BigInt.string_of_big_int i  in
+           FStar_All.pipe_right uu____8061 FStar_Syntax_Util.exp_int
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.String
            (s,r)) ->
            FStar_Syntax_Syntax.mk
              (FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_string (s, r)))
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
+                (FStar_Const.Const_string (s, r))) FStar_Range.dummyRange
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Char
            c) -> FStar_Syntax_Util.exp_char c
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.Range
@@ -2473,34 +2461,34 @@ and (readback :
        | FStar_TypeChecker_NBETerm.Constant (FStar_TypeChecker_NBETerm.SConst
            c) ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant c)
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
+             FStar_Range.dummyRange
        | FStar_TypeChecker_NBETerm.Type_t u ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
+             FStar_Range.dummyRange
        | FStar_TypeChecker_NBETerm.Lam (f,binders,arity) ->
-           let uu____8147 =
+           let uu____8129 =
              match binders with
              | FStar_Util.Inl (ctx,binders1,rc) ->
-                 let uu____8195 =
+                 let uu____8177 =
                    FStar_List.fold_left
-                     (fun uu____8249  ->
-                        fun uu____8250  ->
-                          match (uu____8249, uu____8250) with
+                     (fun uu____8231  ->
+                        fun uu____8232  ->
+                          match (uu____8231, uu____8232) with
                           | ((ctx1,binders_rev,accus_rev),(x1,q)) ->
                               let tnorm =
-                                let uu____8375 =
+                                let uu____8357 =
                                   translate cfg ctx1
                                     x1.FStar_Syntax_Syntax.sort
                                    in
-                                readback cfg uu____8375  in
+                                readback cfg uu____8357  in
                               let x2 =
-                                let uu___1227_8377 =
+                                let uu___1227_8359 =
                                   FStar_Syntax_Syntax.freshen_bv x1  in
                                 {
                                   FStar_Syntax_Syntax.ppname =
-                                    (uu___1227_8377.FStar_Syntax_Syntax.ppname);
+                                    (uu___1227_8359.FStar_Syntax_Syntax.ppname);
                                   FStar_Syntax_Syntax.index =
-                                    (uu___1227_8377.FStar_Syntax_Syntax.index);
+                                    (uu___1227_8359.FStar_Syntax_Syntax.index);
                                   FStar_Syntax_Syntax.sort = tnorm
                                 }  in
                               let ax = FStar_TypeChecker_NBETerm.mkAccuVar x2
@@ -2509,73 +2497,73 @@ and (readback :
                               (ctx2, ((x2, q) :: binders_rev), (ax ::
                                 accus_rev))) (ctx, [], []) binders1
                     in
-                 (match uu____8195 with
+                 (match uu____8177 with
                   | (ctx1,binders_rev,accus_rev) ->
                       let rc1 =
                         match rc with
                         | FStar_Pervasives_Native.None  ->
                             FStar_Pervasives_Native.None
                         | FStar_Pervasives_Native.Some rc1 ->
-                            let uu____8463 =
-                              let uu____8464 =
+                            let uu____8445 =
+                              let uu____8446 =
                                 translate_residual_comp cfg ctx1 rc1  in
-                              readback_residual_comp cfg uu____8464  in
-                            FStar_Pervasives_Native.Some uu____8463
+                              readback_residual_comp cfg uu____8446  in
+                            FStar_Pervasives_Native.Some uu____8445
                          in
                       ((FStar_List.rev binders_rev), accus_rev, rc1))
              | FStar_Util.Inr args ->
-                 let uu____8498 =
+                 let uu____8480 =
                    FStar_List.fold_right
-                     (fun uu____8539  ->
-                        fun uu____8540  ->
-                          match (uu____8539, uu____8540) with
-                          | ((t,uu____8592),(binders1,accus)) ->
+                     (fun uu____8521  ->
+                        fun uu____8522  ->
+                          match (uu____8521, uu____8522) with
+                          | ((t,uu____8574),(binders1,accus)) ->
                               let x1 =
-                                let uu____8634 = readback cfg t  in
+                                let uu____8616 = readback cfg t  in
                                 FStar_Syntax_Syntax.new_bv
-                                  FStar_Pervasives_Native.None uu____8634
+                                  FStar_Pervasives_Native.None uu____8616
                                  in
-                              let uu____8635 =
-                                let uu____8638 =
+                              let uu____8617 =
+                                let uu____8620 =
                                   FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-                                uu____8638 :: accus  in
+                                uu____8620 :: accus  in
                               (((x1, FStar_Pervasives_Native.None) ::
-                                binders1), uu____8635)) args ([], [])
+                                binders1), uu____8617)) args ([], [])
                     in
-                 (match uu____8498 with
+                 (match uu____8480 with
                   | (binders1,accus) ->
                       (binders1, (FStar_List.rev accus),
                         FStar_Pervasives_Native.None))
               in
-           (match uu____8147 with
+           (match uu____8129 with
             | (binders1,accus_rev,rc) ->
                 let body =
-                  let uu____8721 = f accus_rev  in readback cfg uu____8721
+                  let uu____8703 = f accus_rev  in readback cfg uu____8703
                    in
                 FStar_Syntax_Util.abs binders1 body rc)
        | FStar_TypeChecker_NBETerm.Refinement (f,targ) ->
            if
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
            then
-             let uu____8745 =
-               let uu____8746 = targ ()  in
-               FStar_Pervasives_Native.fst uu____8746  in
-             readback cfg uu____8745
+             let uu____8727 =
+               let uu____8728 = targ ()  in
+               FStar_Pervasives_Native.fst uu____8728  in
+             readback cfg uu____8727
            else
              (let x1 =
-                let uu____8754 =
-                  let uu____8755 =
-                    let uu____8756 = targ ()  in
-                    FStar_Pervasives_Native.fst uu____8756  in
-                  readback cfg uu____8755  in
+                let uu____8736 =
+                  let uu____8737 =
+                    let uu____8738 = targ ()  in
+                    FStar_Pervasives_Native.fst uu____8738  in
+                  readback cfg uu____8737  in
                 FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                  uu____8754
+                  uu____8736
                  in
               let body =
-                let uu____8762 =
-                  let uu____8763 = FStar_TypeChecker_NBETerm.mkAccuVar x1  in
-                  f uu____8763  in
-                readback cfg uu____8762  in
+                let uu____8744 =
+                  let uu____8745 = FStar_TypeChecker_NBETerm.mkAccuVar x1  in
+                  f uu____8745  in
+                readback cfg uu____8744  in
               let refinement = FStar_Syntax_Util.refine x1 body  in
               if
                 ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
@@ -2591,8 +2579,8 @@ and (readback :
        | FStar_TypeChecker_NBETerm.Arrow (FStar_Util.Inr (args,c)) ->
            let binders =
              FStar_List.map
-               (fun uu____8833  ->
-                  match uu____8833 with
+               (fun uu____8815  ->
+                  match uu____8815 with
                   | (t,q) ->
                       let t1 = readback cfg t  in
                       let x1 =
@@ -2606,38 +2594,38 @@ and (readback :
        | FStar_TypeChecker_NBETerm.Construct (fv,us,args) ->
            let args1 =
              map_rev
-               (fun uu____8885  ->
-                  match uu____8885 with
+               (fun uu____8867  ->
+                  match uu____8867 with
                   | (x1,q) ->
-                      let uu____8896 = readback cfg x1  in (uu____8896, q))
+                      let uu____8878 = readback cfg x1  in (uu____8878, q))
                args
               in
            let fv1 =
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-               FStar_Pervasives_Native.None FStar_Range.dummyRange
+               FStar_Range.dummyRange
               in
            let app =
-             let uu____8903 =
+             let uu____8885 =
                FStar_Syntax_Syntax.mk_Tm_uinst fv1 (FStar_List.rev us)  in
-             FStar_Syntax_Util.mk_app uu____8903 args1  in
+             FStar_Syntax_Util.mk_app uu____8885 args1  in
            app
        | FStar_TypeChecker_NBETerm.FV (fv,us,args) ->
            let args1 =
              map_rev
-               (fun uu____8944  ->
-                  match uu____8944 with
+               (fun uu____8926  ->
+                  match uu____8926 with
                   | (x1,q) ->
-                      let uu____8955 = readback cfg x1  in (uu____8955, q))
+                      let uu____8937 = readback cfg x1  in (uu____8937, q))
                args
               in
            let fv1 =
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-               FStar_Pervasives_Native.None FStar_Range.dummyRange
+               FStar_Range.dummyRange
               in
            let app =
-             let uu____8962 =
+             let uu____8944 =
                FStar_Syntax_Syntax.mk_Tm_uinst fv1 (FStar_List.rev us)  in
-             FStar_Syntax_Util.mk_app uu____8962 args1  in
+             FStar_Syntax_Util.mk_app uu____8944 args1  in
            if
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
            then
@@ -2651,8 +2639,8 @@ and (readback :
            (FStar_TypeChecker_NBETerm.Var bv,args) ->
            let args1 = readback_args cfg args  in
            let app =
-             let uu____9003 = FStar_Syntax_Syntax.bv_to_name bv  in
-             FStar_Syntax_Util.mk_app uu____9003 args1  in
+             let uu____8985 = FStar_Syntax_Syntax.bv_to_name bv  in
+             FStar_Syntax_Util.mk_app uu____8985 args1  in
            if
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
            then
@@ -2668,7 +2656,7 @@ and (readback :
              let branches_new = make_branches ()  in
              FStar_Syntax_Syntax.mk
                (FStar_Syntax_Syntax.Tm_match (scrut_new, branches_new))
-               FStar_Pervasives_Native.None FStar_Range.dummyRange
+               FStar_Range.dummyRange
               in
            let app = FStar_Syntax_Util.mk_app head args1  in
            if
@@ -2683,49 +2671,49 @@ and (readback :
             (var,typ,defn,body,lb),args)
            ->
            let typ1 =
-             let uu____9103 = FStar_Thunk.force typ  in
-             readback cfg uu____9103  in
+             let uu____9085 = FStar_Thunk.force typ  in
+             readback cfg uu____9085  in
            let defn1 =
-             let uu____9105 = FStar_Thunk.force defn  in
-             readback cfg uu____9105  in
+             let uu____9087 = FStar_Thunk.force defn  in
+             readback cfg uu____9087  in
            let body1 =
-             let uu____9107 =
-               let uu____9108 = FStar_Thunk.force body  in
-               readback cfg uu____9108  in
+             let uu____9089 =
+               let uu____9090 = FStar_Thunk.force body  in
+               readback cfg uu____9090  in
              FStar_Syntax_Subst.close [(var, FStar_Pervasives_Native.None)]
-               uu____9107
+               uu____9089
               in
            let lbname =
-             let uu____9128 =
-               let uu___1346_9129 =
+             let uu____9110 =
+               let uu___1346_9111 =
                  FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
                {
                  FStar_Syntax_Syntax.ppname =
-                   (uu___1346_9129.FStar_Syntax_Syntax.ppname);
+                   (uu___1346_9111.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
-                   (uu___1346_9129.FStar_Syntax_Syntax.index);
+                   (uu___1346_9111.FStar_Syntax_Syntax.index);
                  FStar_Syntax_Syntax.sort = typ1
                }  in
-             FStar_Util.Inl uu____9128  in
+             FStar_Util.Inl uu____9110  in
            let lb1 =
-             let uu___1349_9131 = lb  in
+             let uu___1349_9113 = lb  in
              {
                FStar_Syntax_Syntax.lbname = lbname;
                FStar_Syntax_Syntax.lbunivs =
-                 (uu___1349_9131.FStar_Syntax_Syntax.lbunivs);
+                 (uu___1349_9113.FStar_Syntax_Syntax.lbunivs);
                FStar_Syntax_Syntax.lbtyp = typ1;
                FStar_Syntax_Syntax.lbeff =
-                 (uu___1349_9131.FStar_Syntax_Syntax.lbeff);
+                 (uu___1349_9113.FStar_Syntax_Syntax.lbeff);
                FStar_Syntax_Syntax.lbdef = defn1;
                FStar_Syntax_Syntax.lbattrs =
-                 (uu___1349_9131.FStar_Syntax_Syntax.lbattrs);
+                 (uu___1349_9113.FStar_Syntax_Syntax.lbattrs);
                FStar_Syntax_Syntax.lbpos =
-                 (uu___1349_9131.FStar_Syntax_Syntax.lbpos)
+                 (uu___1349_9113.FStar_Syntax_Syntax.lbpos)
              }  in
            let hd =
              FStar_Syntax_Syntax.mk
                (FStar_Syntax_Syntax.Tm_let ((false, [lb1]), body1))
-               FStar_Pervasives_Native.None FStar_Range.dummyRange
+               FStar_Range.dummyRange
               in
            let args1 = readback_args cfg args  in
            FStar_Syntax_Util.mk_app hd args1
@@ -2735,44 +2723,44 @@ and (readback :
            ->
            let lbs1 =
              FStar_List.map2
-               (fun uu____9209  ->
+               (fun uu____9191  ->
                   fun lb  ->
-                    match uu____9209 with
+                    match uu____9191 with
                     | (v,t,d) ->
                         let t1 = readback cfg t  in
                         let def = readback cfg d  in
                         let v1 =
-                          let uu___1369_9223 = v  in
+                          let uu___1369_9205 = v  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___1369_9223.FStar_Syntax_Syntax.ppname);
+                              (uu___1369_9205.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___1369_9223.FStar_Syntax_Syntax.index);
+                              (uu___1369_9205.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t1
                           }  in
-                        let uu___1372_9224 = lb  in
+                        let uu___1372_9206 = lb  in
                         {
                           FStar_Syntax_Syntax.lbname = (FStar_Util.Inl v1);
                           FStar_Syntax_Syntax.lbunivs =
-                            (uu___1372_9224.FStar_Syntax_Syntax.lbunivs);
+                            (uu___1372_9206.FStar_Syntax_Syntax.lbunivs);
                           FStar_Syntax_Syntax.lbtyp = t1;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___1372_9224.FStar_Syntax_Syntax.lbeff);
+                            (uu___1372_9206.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef = def;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___1372_9224.FStar_Syntax_Syntax.lbattrs);
+                            (uu___1372_9206.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___1372_9224.FStar_Syntax_Syntax.lbpos)
+                            (uu___1372_9206.FStar_Syntax_Syntax.lbpos)
                         }) vars_typs_defns lbs
               in
            let body1 = readback cfg body  in
-           let uu____9226 = FStar_Syntax_Subst.close_let_rec lbs1 body1  in
-           (match uu____9226 with
+           let uu____9208 = FStar_Syntax_Subst.close_let_rec lbs1 body1  in
+           (match uu____9208 with
             | (lbs2,body2) ->
                 let hd =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_let ((true, lbs2), body2))
-                    FStar_Pervasives_Native.None FStar_Range.dummyRange
+                    FStar_Range.dummyRange
                    in
                 let args1 = readback_args cfg args  in
                 FStar_Syntax_Util.mk_app hd args1)
@@ -2784,114 +2772,114 @@ and (readback :
        | FStar_TypeChecker_NBETerm.TopLevelLet (lb,arity,args_rev) ->
            let n_univs = FStar_List.length lb.FStar_Syntax_Syntax.lbunivs  in
            let n_args = FStar_List.length args_rev  in
-           let uu____9309 = FStar_Util.first_N (n_args - n_univs) args_rev
+           let uu____9291 = FStar_Util.first_N (n_args - n_univs) args_rev
               in
-           (match uu____9309 with
+           (match uu____9291 with
             | (args_rev1,univs) ->
-                let uu____9356 =
-                  let uu____9357 =
-                    let uu____9358 =
+                let uu____9338 =
+                  let uu____9339 =
+                    let uu____9340 =
                       FStar_List.map FStar_Pervasives_Native.fst univs  in
-                    translate cfg uu____9358 lb.FStar_Syntax_Syntax.lbdef  in
-                  iapp cfg uu____9357 (FStar_List.rev args_rev1)  in
-                readback cfg uu____9356)
+                    translate cfg uu____9340 lb.FStar_Syntax_Syntax.lbdef  in
+                  iapp cfg uu____9339 (FStar_List.rev args_rev1)  in
+                readback cfg uu____9338)
        | FStar_TypeChecker_NBETerm.TopLevelRec
-           (lb,uu____9370,uu____9371,args) ->
+           (lb,uu____9352,uu____9353,args) ->
            let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
            let head =
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-               FStar_Pervasives_Native.None FStar_Range.dummyRange
+               FStar_Range.dummyRange
               in
            let args1 =
              FStar_List.map
-               (fun uu____9416  ->
-                  match uu____9416 with
+               (fun uu____9398  ->
+                  match uu____9398 with
                   | (t,q) ->
-                      let uu____9427 = readback cfg t  in (uu____9427, q))
+                      let uu____9409 = readback cfg t  in (uu____9409, q))
                args
               in
            FStar_Syntax_Util.mk_app head args1
        | FStar_TypeChecker_NBETerm.LocalLetRec
-           (i,uu____9429,lbs,bs,args,_ar,_ar_lst) ->
+           (i,uu____9411,lbs,bs,args,_ar,_ar_lst) ->
            let lbnames =
              FStar_List.map
                (fun lb  ->
-                  let uu____9471 =
-                    let uu____9473 =
-                      let uu____9474 =
+                  let uu____9453 =
+                    let uu____9455 =
+                      let uu____9456 =
                         FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                      uu____9474.FStar_Syntax_Syntax.ppname  in
-                    FStar_Ident.text_of_id uu____9473  in
-                  FStar_Syntax_Syntax.gen_bv uu____9471
+                      uu____9456.FStar_Syntax_Syntax.ppname  in
+                    FStar_Ident.text_of_id uu____9455  in
+                  FStar_Syntax_Syntax.gen_bv uu____9453
                     FStar_Pervasives_Native.None lb.FStar_Syntax_Syntax.lbtyp)
                lbs
               in
            let let_rec_env =
-             let uu____9478 =
+             let uu____9460 =
                FStar_List.map
                  (fun x1  ->
                     FStar_TypeChecker_NBETerm.Accu
                       ((FStar_TypeChecker_NBETerm.Var x1), [])) lbnames
                 in
-             FStar_List.rev_append uu____9478 bs  in
+             FStar_List.rev_append uu____9460 bs  in
            let lbs1 =
              FStar_List.map2
                (fun lb  ->
                   fun lbname  ->
                     let lbdef =
-                      let uu____9504 =
+                      let uu____9486 =
                         translate cfg let_rec_env
                           lb.FStar_Syntax_Syntax.lbdef
                          in
-                      readback cfg uu____9504  in
+                      readback cfg uu____9486  in
                     let lbtyp =
-                      let uu____9506 =
+                      let uu____9488 =
                         translate cfg bs lb.FStar_Syntax_Syntax.lbtyp  in
-                      readback cfg uu____9506  in
-                    let uu___1427_9507 = lb  in
+                      readback cfg uu____9488  in
+                    let uu___1427_9489 = lb  in
                     {
                       FStar_Syntax_Syntax.lbname = (FStar_Util.Inl lbname);
                       FStar_Syntax_Syntax.lbunivs =
-                        (uu___1427_9507.FStar_Syntax_Syntax.lbunivs);
+                        (uu___1427_9489.FStar_Syntax_Syntax.lbunivs);
                       FStar_Syntax_Syntax.lbtyp = lbtyp;
                       FStar_Syntax_Syntax.lbeff =
-                        (uu___1427_9507.FStar_Syntax_Syntax.lbeff);
+                        (uu___1427_9489.FStar_Syntax_Syntax.lbeff);
                       FStar_Syntax_Syntax.lbdef = lbdef;
                       FStar_Syntax_Syntax.lbattrs =
-                        (uu___1427_9507.FStar_Syntax_Syntax.lbattrs);
+                        (uu___1427_9489.FStar_Syntax_Syntax.lbattrs);
                       FStar_Syntax_Syntax.lbpos =
-                        (uu___1427_9507.FStar_Syntax_Syntax.lbpos)
+                        (uu___1427_9489.FStar_Syntax_Syntax.lbpos)
                     }) lbs lbnames
               in
            let body =
-             let uu____9509 = FStar_List.nth lbnames i  in
-             FStar_Syntax_Syntax.bv_to_name uu____9509  in
-           let uu____9510 = FStar_Syntax_Subst.close_let_rec lbs1 body  in
-           (match uu____9510 with
+             let uu____9491 = FStar_List.nth lbnames i  in
+             FStar_Syntax_Syntax.bv_to_name uu____9491  in
+           let uu____9492 = FStar_Syntax_Subst.close_let_rec lbs1 body  in
+           (match uu____9492 with
             | (lbs2,body1) ->
                 let head =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_let ((true, lbs2), body1))
-                    FStar_Pervasives_Native.None FStar_Range.dummyRange
+                    FStar_Range.dummyRange
                    in
                 let args1 =
                   FStar_List.map
-                    (fun uu____9558  ->
-                       match uu____9558 with
+                    (fun uu____9540  ->
+                       match uu____9540 with
                        | (x1,q) ->
-                           let uu____9569 = readback cfg x1  in
-                           (uu____9569, q)) args
+                           let uu____9551 = readback cfg x1  in
+                           (uu____9551, q)) args
                    in
                 FStar_Syntax_Util.mk_app head args1)
        | FStar_TypeChecker_NBETerm.Quote (qt,qi) ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_quoted (qt, qi))
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
-       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li,uu____9575) ->
+             FStar_Range.dummyRange
+       | FStar_TypeChecker_NBETerm.Lazy (FStar_Util.Inl li,uu____9557) ->
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_lazy li)
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
-       | FStar_TypeChecker_NBETerm.Lazy (uu____9592,thunk) ->
-           let uu____9614 = FStar_Thunk.force thunk  in
-           readback cfg uu____9614)
+             FStar_Range.dummyRange
+       | FStar_TypeChecker_NBETerm.Lazy (uu____9574,thunk) ->
+           let uu____9596 = FStar_Thunk.force thunk  in
+           readback cfg uu____9596)
 
 type step =
   | Primops 
@@ -2902,37 +2890,37 @@ type step =
   | Reify 
 let (uu___is_Primops : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Primops  -> true | uu____9643 -> false
+    match projectee with | Primops  -> true | uu____9625 -> false
   
 let (uu___is_UnfoldUntil : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldUntil _0 -> true | uu____9655 -> false
+    match projectee with | UnfoldUntil _0 -> true | uu____9637 -> false
   
 let (__proj__UnfoldUntil__item___0 : step -> FStar_Syntax_Syntax.delta_depth)
   = fun projectee  -> match projectee with | UnfoldUntil _0 -> _0 
 let (uu___is_UnfoldOnly : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldOnly _0 -> true | uu____9676 -> false
+    match projectee with | UnfoldOnly _0 -> true | uu____9658 -> false
   
 let (__proj__UnfoldOnly__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldOnly _0 -> _0 
 let (uu___is_UnfoldAttr : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldAttr _0 -> true | uu____9703 -> false
+    match projectee with | UnfoldAttr _0 -> true | uu____9685 -> false
   
 let (__proj__UnfoldAttr__item___0 : step -> FStar_Ident.lid Prims.list) =
   fun projectee  -> match projectee with | UnfoldAttr _0 -> _0 
 let (uu___is_UnfoldTac : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UnfoldTac  -> true | uu____9727 -> false
+    match projectee with | UnfoldTac  -> true | uu____9709 -> false
   
 let (uu___is_Reify : step -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Reify  -> true | uu____9738 -> false
+    match projectee with | Reify  -> true | uu____9720 -> false
   
 let (step_as_normalizer_step : step -> FStar_TypeChecker_Env.step) =
-  fun uu___2_9745  ->
-    match uu___2_9745 with
+  fun uu___2_9727  ->
+    match uu___2_9727 with
     | Primops  -> FStar_TypeChecker_Env.Primops
     | UnfoldUntil d -> FStar_TypeChecker_Env.UnfoldUntil d
     | UnfoldOnly lids -> FStar_TypeChecker_Env.UnfoldOnly lids
@@ -2947,7 +2935,7 @@ let (reduce_application :
   =
   fun cfg  ->
     fun t  ->
-      fun args  -> let uu____9769 = new_config cfg  in iapp uu____9769 t args
+      fun args  -> let uu____9751 = new_config cfg  in iapp uu____9751 t args
   
 let (normalize :
   FStar_TypeChecker_Cfg.primitive_step Prims.list ->
@@ -2961,105 +2949,105 @@ let (normalize :
         fun e  ->
           let cfg = FStar_TypeChecker_Cfg.config' psteps steps env  in
           let cfg1 =
-            let uu___1473_9801 = cfg  in
+            let uu___1473_9783 = cfg  in
             {
               FStar_TypeChecker_Cfg.steps =
-                (let uu___1475_9804 = cfg.FStar_TypeChecker_Cfg.steps  in
+                (let uu___1475_9786 = cfg.FStar_TypeChecker_Cfg.steps  in
                  {
                    FStar_TypeChecker_Cfg.beta =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.beta);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.beta);
                    FStar_TypeChecker_Cfg.iota =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.iota);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.iota);
                    FStar_TypeChecker_Cfg.zeta =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.zeta);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.zeta);
                    FStar_TypeChecker_Cfg.zeta_full =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.zeta_full);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.zeta_full);
                    FStar_TypeChecker_Cfg.weak =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.weak);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.weak);
                    FStar_TypeChecker_Cfg.hnf =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.hnf);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.hnf);
                    FStar_TypeChecker_Cfg.primops =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.primops);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.primops);
                    FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                    FStar_TypeChecker_Cfg.unfold_until =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.unfold_until);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.unfold_until);
                    FStar_TypeChecker_Cfg.unfold_only =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.unfold_only);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.unfold_only);
                    FStar_TypeChecker_Cfg.unfold_fully =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.unfold_fully);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.unfold_fully);
                    FStar_TypeChecker_Cfg.unfold_attr =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.unfold_attr);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.unfold_attr);
                    FStar_TypeChecker_Cfg.unfold_tac =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.unfold_tac);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.unfold_tac);
                    FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                    FStar_TypeChecker_Cfg.simplify =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.simplify);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.simplify);
                    FStar_TypeChecker_Cfg.erase_universes =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.erase_universes);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.erase_universes);
                    FStar_TypeChecker_Cfg.allow_unbound_universes =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.allow_unbound_universes);
                    FStar_TypeChecker_Cfg.reify_ = true;
                    FStar_TypeChecker_Cfg.compress_uvars =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.compress_uvars);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.compress_uvars);
                    FStar_TypeChecker_Cfg.no_full_norm =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.no_full_norm);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.no_full_norm);
                    FStar_TypeChecker_Cfg.check_no_uvars =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.check_no_uvars);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.check_no_uvars);
                    FStar_TypeChecker_Cfg.unmeta =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.unmeta);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.unmeta);
                    FStar_TypeChecker_Cfg.unascribe =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.unascribe);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.unascribe);
                    FStar_TypeChecker_Cfg.in_full_norm_request =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.in_full_norm_request);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.in_full_norm_request);
                    FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                    FStar_TypeChecker_Cfg.nbe_step =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.nbe_step);
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.nbe_step);
                    FStar_TypeChecker_Cfg.for_extraction =
-                     (uu___1475_9804.FStar_TypeChecker_Cfg.for_extraction)
+                     (uu___1475_9786.FStar_TypeChecker_Cfg.for_extraction)
                  });
               FStar_TypeChecker_Cfg.tcenv =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.tcenv);
+                (uu___1473_9783.FStar_TypeChecker_Cfg.tcenv);
               FStar_TypeChecker_Cfg.debug =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.debug);
+                (uu___1473_9783.FStar_TypeChecker_Cfg.debug);
               FStar_TypeChecker_Cfg.delta_level =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.delta_level);
+                (uu___1473_9783.FStar_TypeChecker_Cfg.delta_level);
               FStar_TypeChecker_Cfg.primitive_steps =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.primitive_steps);
+                (uu___1473_9783.FStar_TypeChecker_Cfg.primitive_steps);
               FStar_TypeChecker_Cfg.strong =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.strong);
+                (uu___1473_9783.FStar_TypeChecker_Cfg.strong);
               FStar_TypeChecker_Cfg.memoize_lazy =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.memoize_lazy);
+                (uu___1473_9783.FStar_TypeChecker_Cfg.memoize_lazy);
               FStar_TypeChecker_Cfg.normalize_pure_lets =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                (uu___1473_9783.FStar_TypeChecker_Cfg.normalize_pure_lets);
               FStar_TypeChecker_Cfg.reifying =
-                (uu___1473_9801.FStar_TypeChecker_Cfg.reifying)
+                (uu___1473_9783.FStar_TypeChecker_Cfg.reifying)
             }  in
-          (let uu____9807 =
+          (let uu____9789 =
              (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBETop"))
                ||
                (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBE"))
               in
-           if uu____9807
+           if uu____9789
            then
-             let uu____9812 = FStar_Syntax_Print.term_to_string e  in
-             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9812
+             let uu____9794 = FStar_Syntax_Print.term_to_string e  in
+             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9794
            else ());
           (let cfg2 = new_config cfg1  in
            let r =
-             let uu____9819 = translate cfg2 [] e  in
-             readback cfg2 uu____9819  in
-           (let uu____9821 =
+             let uu____9801 = translate cfg2 [] e  in
+             readback cfg2 uu____9801  in
+           (let uu____9803 =
               (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBETop"))
                 ||
                 (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBE"))
                in
-            if uu____9821
+            if uu____9803
             then
-              let uu____9826 = FStar_Syntax_Print.term_to_string r  in
-              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9826
+              let uu____9808 = FStar_Syntax_Print.term_to_string r  in
+              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9808
             else ());
            r)
   
@@ -3073,93 +3061,93 @@ let (normalize_for_unit_test :
       fun e  ->
         let cfg = FStar_TypeChecker_Cfg.config steps env  in
         let cfg1 =
-          let uu___1491_9853 = cfg  in
+          let uu___1491_9835 = cfg  in
           {
             FStar_TypeChecker_Cfg.steps =
-              (let uu___1493_9856 = cfg.FStar_TypeChecker_Cfg.steps  in
+              (let uu___1493_9838 = cfg.FStar_TypeChecker_Cfg.steps  in
                {
                  FStar_TypeChecker_Cfg.beta =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.beta);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.beta);
                  FStar_TypeChecker_Cfg.iota =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.iota);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.iota);
                  FStar_TypeChecker_Cfg.zeta =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.zeta);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.zeta);
                  FStar_TypeChecker_Cfg.zeta_full =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.zeta_full);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.zeta_full);
                  FStar_TypeChecker_Cfg.weak =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.weak);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.weak);
                  FStar_TypeChecker_Cfg.hnf =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.hnf);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.hnf);
                  FStar_TypeChecker_Cfg.primops =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.primops);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.primops);
                  FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                  FStar_TypeChecker_Cfg.unfold_until =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.unfold_until);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.unfold_until);
                  FStar_TypeChecker_Cfg.unfold_only =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.unfold_only);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.unfold_only);
                  FStar_TypeChecker_Cfg.unfold_fully =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.unfold_fully);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.unfold_fully);
                  FStar_TypeChecker_Cfg.unfold_attr =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.unfold_attr);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.unfold_attr);
                  FStar_TypeChecker_Cfg.unfold_tac =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.unfold_tac);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.unfold_tac);
                  FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                  FStar_TypeChecker_Cfg.simplify =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.simplify);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.simplify);
                  FStar_TypeChecker_Cfg.erase_universes =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.erase_universes);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.erase_universes);
                  FStar_TypeChecker_Cfg.allow_unbound_universes =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.allow_unbound_universes);
                  FStar_TypeChecker_Cfg.reify_ = true;
                  FStar_TypeChecker_Cfg.compress_uvars =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.compress_uvars);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.compress_uvars);
                  FStar_TypeChecker_Cfg.no_full_norm =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.no_full_norm);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.no_full_norm);
                  FStar_TypeChecker_Cfg.check_no_uvars =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.check_no_uvars);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.check_no_uvars);
                  FStar_TypeChecker_Cfg.unmeta =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.unmeta);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.unmeta);
                  FStar_TypeChecker_Cfg.unascribe =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.unascribe);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.unascribe);
                  FStar_TypeChecker_Cfg.in_full_norm_request =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.in_full_norm_request);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.in_full_norm_request);
                  FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                  FStar_TypeChecker_Cfg.nbe_step =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.nbe_step);
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.nbe_step);
                  FStar_TypeChecker_Cfg.for_extraction =
-                   (uu___1493_9856.FStar_TypeChecker_Cfg.for_extraction)
+                   (uu___1493_9838.FStar_TypeChecker_Cfg.for_extraction)
                });
             FStar_TypeChecker_Cfg.tcenv =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.tcenv);
+              (uu___1491_9835.FStar_TypeChecker_Cfg.tcenv);
             FStar_TypeChecker_Cfg.debug =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.debug);
+              (uu___1491_9835.FStar_TypeChecker_Cfg.debug);
             FStar_TypeChecker_Cfg.delta_level =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.delta_level);
+              (uu___1491_9835.FStar_TypeChecker_Cfg.delta_level);
             FStar_TypeChecker_Cfg.primitive_steps =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.primitive_steps);
+              (uu___1491_9835.FStar_TypeChecker_Cfg.primitive_steps);
             FStar_TypeChecker_Cfg.strong =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.strong);
+              (uu___1491_9835.FStar_TypeChecker_Cfg.strong);
             FStar_TypeChecker_Cfg.memoize_lazy =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.memoize_lazy);
+              (uu___1491_9835.FStar_TypeChecker_Cfg.memoize_lazy);
             FStar_TypeChecker_Cfg.normalize_pure_lets =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.normalize_pure_lets);
+              (uu___1491_9835.FStar_TypeChecker_Cfg.normalize_pure_lets);
             FStar_TypeChecker_Cfg.reifying =
-              (uu___1491_9853.FStar_TypeChecker_Cfg.reifying)
+              (uu___1491_9835.FStar_TypeChecker_Cfg.reifying)
           }  in
         let cfg2 = new_config cfg1  in
         debug cfg2
-          (fun uu____9862  ->
-             let uu____9863 = FStar_Syntax_Print.term_to_string e  in
-             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9863);
+          (fun uu____9844  ->
+             let uu____9845 = FStar_Syntax_Print.term_to_string e  in
+             FStar_Util.print1 "Calling NBE with (%s) {\n" uu____9845);
         (let r =
-           let uu____9867 = translate cfg2 [] e  in readback cfg2 uu____9867
+           let uu____9849 = translate cfg2 [] e  in readback cfg2 uu____9849
             in
          debug cfg2
-           (fun uu____9871  ->
-              let uu____9872 = FStar_Syntax_Print.term_to_string r  in
-              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9872);
+           (fun uu____9853  ->
+              let uu____9854 = FStar_Syntax_Print.term_to_string r  in
+              FStar_Util.print1 "}\nNBE returned (%s)\n" uu____9854);
          r)
   

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -160,12 +160,6 @@ let (head_of : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
     let uu____982 = FStar_Syntax_Util.head_and_args' t  in
     match uu____982 with | (hd,uu____998) -> hd
   
-let mk :
-  'uuuuuu1026 .
-    'uuuuuu1026 ->
-      FStar_Range.range -> 'uuuuuu1026 FStar_Syntax_Syntax.syntax
-  =
-  fun t  -> fun r  -> FStar_Syntax_Syntax.mk t FStar_Pervasives_Native.None r 
 let set_memo :
   'a . FStar_TypeChecker_Cfg.cfg -> 'a FStar_Syntax_Syntax.memo -> 'a -> unit
   =
@@ -174,25 +168,25 @@ let set_memo :
       fun t  ->
         if cfg.FStar_TypeChecker_Cfg.memoize_lazy
         then
-          let uu____1069 = FStar_ST.op_Bang r  in
-          match uu____1069 with
-          | FStar_Pervasives_Native.Some uu____1095 ->
+          let uu____1049 = FStar_ST.op_Bang r  in
+          match uu____1049 with
+          | FStar_Pervasives_Native.Some uu____1075 ->
               failwith "Unexpected set_memo: thunk already evaluated"
           | FStar_Pervasives_Native.None  ->
               FStar_ST.op_Colon_Equals r (FStar_Pervasives_Native.Some t)
         else ()
   
 let (closure_to_string : closure -> Prims.string) =
-  fun uu___1_1128  ->
-    match uu___1_1128 with
-    | Clos (env1,t,uu____1132,uu____1133) ->
-        let uu____1180 =
+  fun uu___1_1108  ->
+    match uu___1_1108 with
+    | Clos (env1,t,uu____1112,uu____1113) ->
+        let uu____1160 =
           FStar_All.pipe_right (FStar_List.length env1)
             FStar_Util.string_of_int
            in
-        let uu____1190 = FStar_Syntax_Print.term_to_string t  in
-        FStar_Util.format2 "(env=%s elts; %s)" uu____1180 uu____1190
-    | Univ uu____1193 -> "Univ"
+        let uu____1170 = FStar_Syntax_Print.term_to_string t  in
+        FStar_Util.format2 "(env=%s elts; %s)" uu____1160 uu____1170
+    | Univ uu____1173 -> "Univ"
     | Dummy  -> "dummy"
   
 let (env_to_string :
@@ -200,57 +194,57 @@ let (env_to_string :
     Prims.list -> Prims.string)
   =
   fun env1  ->
-    let uu____1219 =
+    let uu____1199 =
       FStar_List.map
-        (fun uu____1235  ->
-           match uu____1235 with
+        (fun uu____1215  ->
+           match uu____1215 with
            | (bopt,c) ->
-               let uu____1249 =
+               let uu____1229 =
                  match bopt with
                  | FStar_Pervasives_Native.None  -> "."
                  | FStar_Pervasives_Native.Some x ->
                      FStar_Syntax_Print.binder_to_string x
                   in
-               let uu____1254 = closure_to_string c  in
-               FStar_Util.format2 "(%s, %s)" uu____1249 uu____1254) env1
+               let uu____1234 = closure_to_string c  in
+               FStar_Util.format2 "(%s, %s)" uu____1229 uu____1234) env1
        in
-    FStar_All.pipe_right uu____1219 (FStar_String.concat "; ")
+    FStar_All.pipe_right uu____1199 (FStar_String.concat "; ")
   
 let (stack_elt_to_string : stack_elt -> Prims.string) =
-  fun uu___2_1268  ->
-    match uu___2_1268 with
-    | Arg (c,uu____1271,uu____1272) ->
-        let uu____1273 = closure_to_string c  in
-        FStar_Util.format1 "Closure %s" uu____1273
-    | MemoLazy uu____1276 -> "MemoLazy"
-    | Abs (uu____1284,bs,uu____1286,uu____1287,uu____1288) ->
-        let uu____1293 =
+  fun uu___2_1248  ->
+    match uu___2_1248 with
+    | Arg (c,uu____1251,uu____1252) ->
+        let uu____1253 = closure_to_string c  in
+        FStar_Util.format1 "Closure %s" uu____1253
+    | MemoLazy uu____1256 -> "MemoLazy"
+    | Abs (uu____1264,bs,uu____1266,uu____1267,uu____1268) ->
+        let uu____1273 =
           FStar_All.pipe_left FStar_Util.string_of_int (FStar_List.length bs)
            in
-        FStar_Util.format1 "Abs %s" uu____1293
-    | UnivArgs uu____1304 -> "UnivArgs"
-    | Match uu____1312 -> "Match"
-    | App (uu____1322,t,uu____1324,uu____1325) ->
-        let uu____1326 = FStar_Syntax_Print.term_to_string t  in
-        FStar_Util.format1 "App %s" uu____1326
-    | CBVApp (uu____1329,t,uu____1331,uu____1332) ->
-        let uu____1333 = FStar_Syntax_Print.term_to_string t  in
-        FStar_Util.format1 "CBVApp %s" uu____1333
-    | Meta (uu____1336,m,uu____1338) -> "Meta"
-    | Let uu____1340 -> "Let"
-    | Cfg uu____1350 -> "Cfg"
-    | Debug (t,uu____1353) ->
-        let uu____1354 = FStar_Syntax_Print.term_to_string t  in
-        FStar_Util.format1 "Debug %s" uu____1354
+        FStar_Util.format1 "Abs %s" uu____1273
+    | UnivArgs uu____1284 -> "UnivArgs"
+    | Match uu____1292 -> "Match"
+    | App (uu____1302,t,uu____1304,uu____1305) ->
+        let uu____1306 = FStar_Syntax_Print.term_to_string t  in
+        FStar_Util.format1 "App %s" uu____1306
+    | CBVApp (uu____1309,t,uu____1311,uu____1312) ->
+        let uu____1313 = FStar_Syntax_Print.term_to_string t  in
+        FStar_Util.format1 "CBVApp %s" uu____1313
+    | Meta (uu____1316,m,uu____1318) -> "Meta"
+    | Let uu____1320 -> "Let"
+    | Cfg uu____1330 -> "Cfg"
+    | Debug (t,uu____1333) ->
+        let uu____1334 = FStar_Syntax_Print.term_to_string t  in
+        FStar_Util.format1 "Debug %s" uu____1334
   
 let (stack_to_string : stack_elt Prims.list -> Prims.string) =
   fun s  ->
-    let uu____1368 = FStar_List.map stack_elt_to_string s  in
-    FStar_All.pipe_right uu____1368 (FStar_String.concat "; ")
+    let uu____1348 = FStar_List.map stack_elt_to_string s  in
+    FStar_All.pipe_right uu____1348 (FStar_String.concat "; ")
   
-let is_empty : 'uuuuuu1383 . 'uuuuuu1383 Prims.list -> Prims.bool =
-  fun uu___3_1391  ->
-    match uu___3_1391 with | [] -> true | uu____1395 -> false
+let is_empty : 'uuuuuu1363 . 'uuuuuu1363 Prims.list -> Prims.bool =
+  fun uu___3_1371  ->
+    match uu___3_1371 with | [] -> true | uu____1375 -> false
   
 let (lookup_bvar :
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
@@ -259,38 +253,38 @@ let (lookup_bvar :
   fun env1  ->
     fun x  ->
       try
-        (fun uu___121_1428  ->
+        (fun uu___119_1408  ->
            match () with
            | () ->
-               let uu____1429 =
+               let uu____1409 =
                  FStar_List.nth env1 x.FStar_Syntax_Syntax.index  in
-               FStar_Pervasives_Native.snd uu____1429) ()
+               FStar_Pervasives_Native.snd uu____1409) ()
       with
-      | uu___120_1446 ->
-          let uu____1447 =
-            let uu____1449 = FStar_Syntax_Print.db_to_string x  in
-            let uu____1451 = env_to_string env1  in
-            FStar_Util.format2 "Failed to find %s\nEnv is %s\n" uu____1449
-              uu____1451
+      | uu___118_1426 ->
+          let uu____1427 =
+            let uu____1429 = FStar_Syntax_Print.db_to_string x  in
+            let uu____1431 = env_to_string env1  in
+            FStar_Util.format2 "Failed to find %s\nEnv is %s\n" uu____1429
+              uu____1431
              in
-          failwith uu____1447
+          failwith uu____1427
   
 let (downgrade_ghost_effect_name :
   FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option) =
   fun l  ->
-    let uu____1462 =
+    let uu____1442 =
       FStar_Ident.lid_equals l FStar_Parser_Const.effect_Ghost_lid  in
-    if uu____1462
+    if uu____1442
     then FStar_Pervasives_Native.Some FStar_Parser_Const.effect_Pure_lid
     else
-      (let uu____1469 =
+      (let uu____1449 =
          FStar_Ident.lid_equals l FStar_Parser_Const.effect_GTot_lid  in
-       if uu____1469
+       if uu____1449
        then FStar_Pervasives_Native.Some FStar_Parser_Const.effect_Tot_lid
        else
-         (let uu____1476 =
+         (let uu____1456 =
             FStar_Ident.lid_equals l FStar_Parser_Const.effect_GHOST_lid  in
-          if uu____1476
+          if uu____1456
           then
             FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
           else FStar_Pervasives_Native.None))
@@ -305,116 +299,116 @@ let (norm_universe :
         let norm_univs_for_max us =
           let us1 = FStar_Util.sort_with FStar_Syntax_Util.compare_univs us
              in
-          let uu____1514 =
+          let uu____1494 =
             FStar_List.fold_left
-              (fun uu____1540  ->
+              (fun uu____1520  ->
                  fun u1  ->
-                   match uu____1540 with
+                   match uu____1520 with
                    | (cur_kernel,cur_max,out) ->
-                       let uu____1565 = FStar_Syntax_Util.univ_kernel u1  in
-                       (match uu____1565 with
+                       let uu____1545 = FStar_Syntax_Util.univ_kernel u1  in
+                       (match uu____1545 with
                         | (k_u,n) ->
-                            let uu____1583 =
+                            let uu____1563 =
                               FStar_Syntax_Util.eq_univs cur_kernel k_u  in
-                            if uu____1583
+                            if uu____1563
                             then (cur_kernel, u1, out)
                             else (k_u, u1, (cur_max :: out))))
               (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero, [])
               us1
              in
-          match uu____1514 with
-          | (uu____1604,u1,out) -> FStar_List.rev (u1 :: out)  in
+          match uu____1494 with
+          | (uu____1584,u1,out) -> FStar_List.rev (u1 :: out)  in
         let rec aux u1 =
           let u2 = FStar_Syntax_Subst.compress_univ u1  in
           match u2 with
           | FStar_Syntax_Syntax.U_bvar x ->
               (try
-                 (fun uu___155_1632  ->
+                 (fun uu___153_1612  ->
                     match () with
                     | () ->
-                        let uu____1635 =
-                          let uu____1636 = FStar_List.nth env1 x  in
-                          FStar_Pervasives_Native.snd uu____1636  in
-                        (match uu____1635 with
+                        let uu____1615 =
+                          let uu____1616 = FStar_List.nth env1 x  in
+                          FStar_Pervasives_Native.snd uu____1616  in
+                        (match uu____1615 with
                          | Univ u3 ->
-                             ((let uu____1655 =
+                             ((let uu____1635 =
                                  FStar_All.pipe_left
                                    (FStar_TypeChecker_Env.debug
                                       cfg.FStar_TypeChecker_Cfg.tcenv)
                                    (FStar_Options.Other "univ_norm")
                                   in
-                               if uu____1655
+                               if uu____1635
                                then
-                                 let uu____1660 =
+                                 let uu____1640 =
                                    FStar_Syntax_Print.univ_to_string u3  in
                                  FStar_Util.print1
-                                   "Univ (in norm_universe): %s\n" uu____1660
+                                   "Univ (in norm_universe): %s\n" uu____1640
                                else ());
                               aux u3)
                          | Dummy  -> [u2]
-                         | uu____1665 ->
-                             let uu____1666 =
-                               let uu____1668 = FStar_Util.string_of_int x
+                         | uu____1645 ->
+                             let uu____1646 =
+                               let uu____1648 = FStar_Util.string_of_int x
                                   in
                                FStar_Util.format1
                                  "Impossible: universe variable u@%s bound to a term"
-                                 uu____1668
+                                 uu____1648
                                 in
-                             failwith uu____1666)) ()
+                             failwith uu____1646)) ()
                with
-               | uu____1678 ->
+               | uu____1658 ->
                    if
                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
                    then [FStar_Syntax_Syntax.U_unknown]
                    else
-                     (let uu____1684 =
-                        let uu____1686 = FStar_Util.string_of_int x  in
+                     (let uu____1664 =
+                        let uu____1666 = FStar_Util.string_of_int x  in
                         FStar_String.op_Hat "Universe variable not found: u@"
-                          uu____1686
+                          uu____1666
                          in
-                      failwith uu____1684))
-          | FStar_Syntax_Syntax.U_unif uu____1691 when
+                      failwith uu____1664))
+          | FStar_Syntax_Syntax.U_unif uu____1671 when
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
               -> [FStar_Syntax_Syntax.U_zero]
           | FStar_Syntax_Syntax.U_zero  -> [u2]
-          | FStar_Syntax_Syntax.U_unif uu____1702 -> [u2]
-          | FStar_Syntax_Syntax.U_name uu____1713 -> [u2]
+          | FStar_Syntax_Syntax.U_unif uu____1682 -> [u2]
+          | FStar_Syntax_Syntax.U_name uu____1693 -> [u2]
           | FStar_Syntax_Syntax.U_unknown  -> [u2]
           | FStar_Syntax_Syntax.U_max [] -> [FStar_Syntax_Syntax.U_zero]
           | FStar_Syntax_Syntax.U_max us ->
               let us1 =
-                let uu____1720 = FStar_List.collect aux us  in
-                FStar_All.pipe_right uu____1720 norm_univs_for_max  in
+                let uu____1700 = FStar_List.collect aux us  in
+                FStar_All.pipe_right uu____1700 norm_univs_for_max  in
               (match us1 with
                | u_k::hd::rest ->
                    let rest1 = hd :: rest  in
-                   let uu____1737 = FStar_Syntax_Util.univ_kernel u_k  in
-                   (match uu____1737 with
+                   let uu____1717 = FStar_Syntax_Util.univ_kernel u_k  in
+                   (match uu____1717 with
                     | (FStar_Syntax_Syntax.U_zero ,n) ->
-                        let uu____1748 =
+                        let uu____1728 =
                           FStar_All.pipe_right rest1
                             (FStar_List.for_all
                                (fun u3  ->
-                                  let uu____1758 =
+                                  let uu____1738 =
                                     FStar_Syntax_Util.univ_kernel u3  in
-                                  match uu____1758 with
-                                  | (uu____1765,m) -> n <= m))
+                                  match uu____1738 with
+                                  | (uu____1745,m) -> n <= m))
                            in
-                        if uu____1748 then rest1 else us1
-                    | uu____1774 -> us1)
-               | uu____1780 -> us1)
+                        if uu____1728 then rest1 else us1
+                    | uu____1754 -> us1)
+               | uu____1760 -> us1)
           | FStar_Syntax_Syntax.U_succ u3 ->
-              let uu____1784 = aux u3  in
+              let uu____1764 = aux u3  in
               FStar_List.map
-                (fun uu____1787  -> FStar_Syntax_Syntax.U_succ uu____1787)
-                uu____1784
+                (fun uu____1767  -> FStar_Syntax_Syntax.U_succ uu____1767)
+                uu____1764
            in
         if
           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
         then FStar_Syntax_Syntax.U_unknown
         else
-          (let uu____1791 = aux u  in
-           match uu____1791 with
+          (let uu____1771 = aux u  in
+           match uu____1771 with
            | [] -> FStar_Syntax_Syntax.U_zero
            | (FStar_Syntax_Syntax.U_zero )::[] -> FStar_Syntax_Syntax.U_zero
            | (FStar_Syntax_Syntax.U_zero )::u1::[] -> u1
@@ -435,31 +429,31 @@ let rec (inline_closure_env :
       fun stack1  ->
         fun t  ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____1952  ->
-               let uu____1953 = FStar_Syntax_Print.tag_of_term t  in
-               let uu____1955 = env_to_string env1  in
-               let uu____1957 = FStar_Syntax_Print.term_to_string t  in
+            (fun uu____1932  ->
+               let uu____1933 = FStar_Syntax_Print.tag_of_term t  in
+               let uu____1935 = env_to_string env1  in
+               let uu____1937 = FStar_Syntax_Print.term_to_string t  in
                FStar_Util.print3 ">>> %s (env=%s)\nClosure_as_term %s\n"
-                 uu____1953 uu____1955 uu____1957);
+                 uu____1933 uu____1935 uu____1937);
           (match env1 with
            | [] when
                FStar_All.pipe_left Prims.op_Negation
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                -> rebuild_closure cfg env1 stack1 t
-           | uu____1970 ->
+           | uu____1950 ->
                (match t.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_delayed uu____1973 ->
-                    let uu____1988 = FStar_Syntax_Subst.compress t  in
-                    inline_closure_env cfg env1 stack1 uu____1988
+                | FStar_Syntax_Syntax.Tm_delayed uu____1953 ->
+                    let uu____1968 = FStar_Syntax_Subst.compress t  in
+                    inline_closure_env cfg env1 stack1 uu____1968
                 | FStar_Syntax_Syntax.Tm_unknown  ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_constant uu____1989 ->
+                | FStar_Syntax_Syntax.Tm_constant uu____1969 ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_name uu____1990 ->
+                | FStar_Syntax_Syntax.Tm_name uu____1970 ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_lazy uu____1991 ->
+                | FStar_Syntax_Syntax.Tm_lazy uu____1971 ->
                     rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_fvar uu____1992 ->
+                | FStar_Syntax_Syntax.Tm_fvar uu____1972 ->
                     rebuild_closure cfg env1 stack1 t
                 | FStar_Syntax_Syntax.Tm_uvar (uv,s) ->
                     if
@@ -467,20 +461,20 @@ let rec (inline_closure_env :
                     then
                       let t1 = FStar_Syntax_Subst.compress t  in
                       (match t1.FStar_Syntax_Syntax.n with
-                       | FStar_Syntax_Syntax.Tm_uvar uu____2017 ->
-                           let uu____2030 =
-                             let uu____2032 =
+                       | FStar_Syntax_Syntax.Tm_uvar uu____1997 ->
+                           let uu____2010 =
+                             let uu____2012 =
                                FStar_Range.string_of_range
                                  t1.FStar_Syntax_Syntax.pos
                                 in
-                             let uu____2034 =
+                             let uu____2014 =
                                FStar_Syntax_Print.term_to_string t1  in
                              FStar_Util.format2
                                "(%s): CheckNoUvars: Unexpected unification variable remains: %s"
-                               uu____2032 uu____2034
+                               uu____2012 uu____2014
                               in
-                           failwith uu____2030
-                       | uu____2039 -> inline_closure_env cfg env1 stack1 t1)
+                           failwith uu____2010
+                       | uu____2019 -> inline_closure_env cfg env1 stack1 t1)
                     else
                       (let s' =
                          FStar_All.pipe_right (FStar_Pervasives_Native.fst s)
@@ -488,30 +482,30 @@ let rec (inline_closure_env :
                               (fun s1  ->
                                  FStar_All.pipe_right s1
                                    (FStar_List.map
-                                      (fun uu___4_2075  ->
-                                         match uu___4_2075 with
+                                      (fun uu___4_2055  ->
+                                         match uu___4_2055 with
                                          | FStar_Syntax_Syntax.NT (x,t1) ->
-                                             let uu____2082 =
-                                               let uu____2089 =
+                                             let uu____2062 =
+                                               let uu____2069 =
                                                  inline_closure_env cfg env1
                                                    [] t1
                                                   in
-                                               (x, uu____2089)  in
+                                               (x, uu____2069)  in
                                              FStar_Syntax_Syntax.NT
-                                               uu____2082
+                                               uu____2062
                                          | FStar_Syntax_Syntax.NM (x,i) ->
                                              let x_i =
                                                FStar_Syntax_Syntax.bv_to_tm
-                                                 (let uu___249_2101 = x  in
+                                                 (let uu___247_2081 = x  in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___249_2101.FStar_Syntax_Syntax.ppname);
+                                                      (uu___247_2081.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       = i;
                                                     FStar_Syntax_Syntax.sort
                                                       =
-                                                      (uu___249_2101.FStar_Syntax_Syntax.sort)
+                                                      (uu___247_2081.FStar_Syntax_Syntax.sort)
                                                   })
                                                 in
                                              let t1 =
@@ -525,85 +519,88 @@ let rec (inline_closure_env :
                                                   FStar_Syntax_Syntax.NM
                                                     (x,
                                                       (x_j.FStar_Syntax_Syntax.index))
-                                              | uu____2107 ->
+                                              | uu____2087 ->
                                                   FStar_Syntax_Syntax.NT
                                                     (x, t1))
-                                         | uu____2110 ->
+                                         | uu____2090 ->
                                              failwith
                                                "Impossible: subst invariant of uvar nodes"))))
                           in
                        let t1 =
-                         let uu___258_2115 = t  in
+                         let uu___256_2095 = t  in
                          {
                            FStar_Syntax_Syntax.n =
                              (FStar_Syntax_Syntax.Tm_uvar
                                 (uv, (s', (FStar_Pervasives_Native.snd s))));
                            FStar_Syntax_Syntax.pos =
-                             (uu___258_2115.FStar_Syntax_Syntax.pos);
+                             (uu___256_2095.FStar_Syntax_Syntax.pos);
                            FStar_Syntax_Syntax.vars =
-                             (uu___258_2115.FStar_Syntax_Syntax.vars)
+                             (uu___256_2095.FStar_Syntax_Syntax.vars)
                          }  in
                        rebuild_closure cfg env1 stack1 t1)
                 | FStar_Syntax_Syntax.Tm_type u ->
                     let t1 =
-                      let uu____2136 =
-                        let uu____2137 = norm_universe cfg env1 u  in
-                        FStar_Syntax_Syntax.Tm_type uu____2137  in
-                      mk uu____2136 t.FStar_Syntax_Syntax.pos  in
+                      let uu____2116 =
+                        let uu____2117 = norm_universe cfg env1 u  in
+                        FStar_Syntax_Syntax.Tm_type uu____2117  in
+                      FStar_Syntax_Syntax.mk uu____2116
+                        t.FStar_Syntax_Syntax.pos
+                       in
                     rebuild_closure cfg env1 stack1 t1
                 | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
                     let t1 =
-                      let uu____2145 =
+                      let uu____2125 =
                         FStar_List.map (norm_universe cfg env1) us  in
-                      FStar_Syntax_Syntax.mk_Tm_uinst t' uu____2145  in
+                      FStar_Syntax_Syntax.mk_Tm_uinst t' uu____2125  in
                     rebuild_closure cfg env1 stack1 t1
                 | FStar_Syntax_Syntax.Tm_bvar x ->
-                    let uu____2147 = lookup_bvar env1 x  in
-                    (match uu____2147 with
-                     | Univ uu____2150 ->
+                    let uu____2127 = lookup_bvar env1 x  in
+                    (match uu____2127 with
+                     | Univ uu____2130 ->
                          failwith
                            "Impossible: term variable is bound to a universe"
                      | Dummy  ->
                          let x1 =
-                           let uu___274_2155 = x  in
+                           let uu___272_2135 = x  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___274_2155.FStar_Syntax_Syntax.ppname);
+                               (uu___272_2135.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___274_2155.FStar_Syntax_Syntax.index);
+                               (uu___272_2135.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort =
                                FStar_Syntax_Syntax.tun
                            }  in
                          let t1 =
-                           mk (FStar_Syntax_Syntax.Tm_bvar x1)
+                           FStar_Syntax_Syntax.mk
+                             (FStar_Syntax_Syntax.Tm_bvar x1)
                              t.FStar_Syntax_Syntax.pos
                             in
                          rebuild_closure cfg env1 stack1 t1
-                     | Clos (env2,t0,uu____2161,uu____2162) ->
+                     | Clos (env2,t0,uu____2141,uu____2142) ->
                          inline_closure_env cfg env2 stack1 t0)
                 | FStar_Syntax_Syntax.Tm_app (head,args) ->
                     let stack2 =
                       FStar_All.pipe_right stack1
                         (FStar_List.fold_right
-                           (fun uu____2253  ->
+                           (fun uu____2233  ->
                               fun stack2  ->
-                                match uu____2253 with
+                                match uu____2233 with
                                 | (a,aq) ->
-                                    let uu____2265 =
-                                      let uu____2266 =
-                                        let uu____2273 =
-                                          let uu____2274 =
-                                            let uu____2306 =
+                                    let uu____2245 =
+                                      let uu____2246 =
+                                        let uu____2253 =
+                                          let uu____2254 =
+                                            let uu____2286 =
                                               FStar_Util.mk_ref
                                                 FStar_Pervasives_Native.None
                                                in
-                                            (env1, a, uu____2306, false)  in
-                                          Clos uu____2274  in
-                                        (uu____2273, aq,
+                                            (env1, a, uu____2286, false)  in
+                                          Clos uu____2254  in
+                                        (uu____2253, aq,
                                           (t.FStar_Syntax_Syntax.pos))
                                          in
-                                      Arg uu____2266  in
-                                    uu____2265 :: stack2) args)
+                                      Arg uu____2246  in
+                                    uu____2245 :: stack2) args)
                        in
                     inline_closure_env cfg env1 stack2 head
                 | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
@@ -621,83 +618,90 @@ let rec (inline_closure_env :
                       :: stack1  in
                     inline_closure_env cfg env' stack2 body
                 | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                    let uu____2474 = close_binders cfg env1 bs  in
-                    (match uu____2474 with
+                    let uu____2454 = close_binders cfg env1 bs  in
+                    (match uu____2454 with
                      | (bs1,env') ->
                          let c1 = close_comp cfg env' c  in
                          let t1 =
-                           mk (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
+                           FStar_Syntax_Syntax.mk
+                             (FStar_Syntax_Syntax.Tm_arrow (bs1, c1))
                              t.FStar_Syntax_Syntax.pos
                             in
                          rebuild_closure cfg env1 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_refine (x,uu____2524) when
+                | FStar_Syntax_Syntax.Tm_refine (x,uu____2504) when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                     ->
                     inline_closure_env cfg env1 stack1
                       x.FStar_Syntax_Syntax.sort
                 | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-                    let uu____2535 =
-                      let uu____2548 =
-                        let uu____2557 = FStar_Syntax_Syntax.mk_binder x  in
-                        [uu____2557]  in
-                      close_binders cfg env1 uu____2548  in
-                    (match uu____2535 with
+                    let uu____2515 =
+                      let uu____2528 =
+                        let uu____2537 = FStar_Syntax_Syntax.mk_binder x  in
+                        [uu____2537]  in
+                      close_binders cfg env1 uu____2528  in
+                    (match uu____2515 with
                      | (x1,env2) ->
                          let phi1 = non_tail_inline_closure_env cfg env2 phi
                             in
                          let t1 =
-                           let uu____2602 =
-                             let uu____2603 =
-                               let uu____2610 =
-                                 let uu____2611 = FStar_List.hd x1  in
-                                 FStar_All.pipe_right uu____2611
+                           let uu____2582 =
+                             let uu____2583 =
+                               let uu____2590 =
+                                 let uu____2591 = FStar_List.hd x1  in
+                                 FStar_All.pipe_right uu____2591
                                    FStar_Pervasives_Native.fst
                                   in
-                               (uu____2610, phi1)  in
-                             FStar_Syntax_Syntax.Tm_refine uu____2603  in
-                           mk uu____2602 t.FStar_Syntax_Syntax.pos  in
+                               (uu____2590, phi1)  in
+                             FStar_Syntax_Syntax.Tm_refine uu____2583  in
+                           FStar_Syntax_Syntax.mk uu____2582
+                             t.FStar_Syntax_Syntax.pos
+                            in
                          rebuild_closure cfg env2 stack1 t1)
                 | FStar_Syntax_Syntax.Tm_ascribed (t1,(annot,tacopt),lopt) ->
                     let annot1 =
                       match annot with
                       | FStar_Util.Inl t2 ->
-                          let uu____2710 =
+                          let uu____2690 =
                             non_tail_inline_closure_env cfg env1 t2  in
-                          FStar_Util.Inl uu____2710
+                          FStar_Util.Inl uu____2690
                       | FStar_Util.Inr c ->
-                          let uu____2724 = close_comp cfg env1 c  in
-                          FStar_Util.Inr uu____2724
+                          let uu____2704 = close_comp cfg env1 c  in
+                          FStar_Util.Inr uu____2704
                        in
                     let tacopt1 =
                       FStar_Util.map_opt tacopt
                         (non_tail_inline_closure_env cfg env1)
                        in
                     let t2 =
-                      let uu____2743 =
-                        let uu____2744 =
-                          let uu____2771 =
+                      let uu____2723 =
+                        let uu____2724 =
+                          let uu____2751 =
                             non_tail_inline_closure_env cfg env1 t1  in
-                          (uu____2771, (annot1, tacopt1), lopt)  in
-                        FStar_Syntax_Syntax.Tm_ascribed uu____2744  in
-                      mk uu____2743 t.FStar_Syntax_Syntax.pos  in
+                          (uu____2751, (annot1, tacopt1), lopt)  in
+                        FStar_Syntax_Syntax.Tm_ascribed uu____2724  in
+                      FStar_Syntax_Syntax.mk uu____2723
+                        t.FStar_Syntax_Syntax.pos
+                       in
                     rebuild_closure cfg env1 stack1 t2
                 | FStar_Syntax_Syntax.Tm_quoted (t',qi) ->
                     let t1 =
                       match qi.FStar_Syntax_Syntax.qkind with
                       | FStar_Syntax_Syntax.Quote_dynamic  ->
-                          let uu____2817 =
-                            let uu____2818 =
-                              let uu____2825 =
+                          let uu____2797 =
+                            let uu____2798 =
+                              let uu____2805 =
                                 non_tail_inline_closure_env cfg env1 t'  in
-                              (uu____2825, qi)  in
-                            FStar_Syntax_Syntax.Tm_quoted uu____2818  in
-                          mk uu____2817 t.FStar_Syntax_Syntax.pos
+                              (uu____2805, qi)  in
+                            FStar_Syntax_Syntax.Tm_quoted uu____2798  in
+                          FStar_Syntax_Syntax.mk uu____2797
+                            t.FStar_Syntax_Syntax.pos
                       | FStar_Syntax_Syntax.Quote_static  ->
                           let qi1 =
                             FStar_Syntax_Syntax.on_antiquoted
                               (non_tail_inline_closure_env cfg env1) qi
                              in
-                          mk (FStar_Syntax_Syntax.Tm_quoted (t', qi1))
+                          FStar_Syntax_Syntax.mk
+                            (FStar_Syntax_Syntax.Tm_quoted (t', qi1))
                             t.FStar_Syntax_Syntax.pos
                        in
                     rebuild_closure cfg env1 stack1 t1
@@ -710,7 +714,7 @@ let rec (inline_closure_env :
                     let env0 = env1  in
                     let env2 =
                       FStar_List.fold_left
-                        (fun env2  -> fun uu____2880  -> dummy :: env2) env1
+                        (fun env2  -> fun uu____2860  -> dummy :: env2) env1
                         lb.FStar_Syntax_Syntax.lbunivs
                        in
                     let typ =
@@ -721,29 +725,29 @@ let rec (inline_closure_env :
                       non_tail_inline_closure_env cfg env2
                         lb.FStar_Syntax_Syntax.lbdef
                        in
-                    let uu____2901 =
-                      let uu____2912 = FStar_Syntax_Syntax.is_top_level [lb]
+                    let uu____2881 =
+                      let uu____2892 = FStar_Syntax_Syntax.is_top_level [lb]
                          in
-                      if uu____2912
+                      if uu____2892
                       then ((lb.FStar_Syntax_Syntax.lbname), body)
                       else
                         (let x =
                            FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                         let uu____2934 =
+                         let uu____2914 =
                            non_tail_inline_closure_env cfg (dummy :: env0)
                              body
                             in
                          ((FStar_Util.Inl
-                             (let uu___366_2950 = x  in
+                             (let uu___364_2930 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___366_2950.FStar_Syntax_Syntax.ppname);
+                                  (uu___364_2930.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___366_2950.FStar_Syntax_Syntax.index);
+                                  (uu___364_2930.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = typ
-                              })), uu____2934))
+                              })), uu____2914))
                        in
-                    (match uu____2901 with
+                    (match uu____2881 with
                      | (nm,body1) ->
                          let attrs =
                            FStar_List.map
@@ -751,41 +755,41 @@ let rec (inline_closure_env :
                              lb.FStar_Syntax_Syntax.lbattrs
                             in
                          let lb1 =
-                           let uu___372_2977 = lb  in
+                           let uu___370_2957 = lb  in
                            {
                              FStar_Syntax_Syntax.lbname = nm;
                              FStar_Syntax_Syntax.lbunivs =
-                               (uu___372_2977.FStar_Syntax_Syntax.lbunivs);
+                               (uu___370_2957.FStar_Syntax_Syntax.lbunivs);
                              FStar_Syntax_Syntax.lbtyp = typ;
                              FStar_Syntax_Syntax.lbeff =
-                               (uu___372_2977.FStar_Syntax_Syntax.lbeff);
+                               (uu___370_2957.FStar_Syntax_Syntax.lbeff);
                              FStar_Syntax_Syntax.lbdef = def;
                              FStar_Syntax_Syntax.lbattrs = attrs;
                              FStar_Syntax_Syntax.lbpos =
-                               (uu___372_2977.FStar_Syntax_Syntax.lbpos)
+                               (uu___370_2957.FStar_Syntax_Syntax.lbpos)
                            }  in
                          let t1 =
-                           mk
+                           FStar_Syntax_Syntax.mk
                              (FStar_Syntax_Syntax.Tm_let
                                 ((false, [lb1]), body1))
                              t.FStar_Syntax_Syntax.pos
                             in
                          rebuild_closure cfg env0 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_let ((uu____2994,lbs),body) ->
+                | FStar_Syntax_Syntax.Tm_let ((uu____2974,lbs),body) ->
                     let norm_one_lb env2 lb =
                       let env_univs =
                         FStar_List.fold_right
-                          (fun uu____3060  -> fun env3  -> dummy :: env3)
+                          (fun uu____3040  -> fun env3  -> dummy :: env3)
                           lb.FStar_Syntax_Syntax.lbunivs env2
                          in
                       let env3 =
-                        let uu____3077 = FStar_Syntax_Syntax.is_top_level lbs
+                        let uu____3057 = FStar_Syntax_Syntax.is_top_level lbs
                            in
-                        if uu____3077
+                        if uu____3057
                         then env_univs
                         else
                           FStar_List.fold_right
-                            (fun uu____3092  -> fun env3  -> dummy :: env3)
+                            (fun uu____3072  -> fun env3  -> dummy :: env3)
                             lbs env_univs
                          in
                       let ty =
@@ -793,41 +797,41 @@ let rec (inline_closure_env :
                           lb.FStar_Syntax_Syntax.lbtyp
                          in
                       let nm =
-                        let uu____3116 = FStar_Syntax_Syntax.is_top_level lbs
+                        let uu____3096 = FStar_Syntax_Syntax.is_top_level lbs
                            in
-                        if uu____3116
+                        if uu____3096
                         then lb.FStar_Syntax_Syntax.lbname
                         else
                           (let x =
                              FStar_Util.left lb.FStar_Syntax_Syntax.lbname
                               in
                            FStar_Util.Inl
-                             (let uu___395_3127 = x  in
+                             (let uu___393_3107 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___395_3127.FStar_Syntax_Syntax.ppname);
+                                  (uu___393_3107.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___395_3127.FStar_Syntax_Syntax.index);
+                                  (uu___393_3107.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = ty
                               }))
                          in
-                      let uu___398_3128 = lb  in
-                      let uu____3129 =
+                      let uu___396_3108 = lb  in
+                      let uu____3109 =
                         non_tail_inline_closure_env cfg env3
                           lb.FStar_Syntax_Syntax.lbdef
                          in
                       {
                         FStar_Syntax_Syntax.lbname = nm;
                         FStar_Syntax_Syntax.lbunivs =
-                          (uu___398_3128.FStar_Syntax_Syntax.lbunivs);
+                          (uu___396_3108.FStar_Syntax_Syntax.lbunivs);
                         FStar_Syntax_Syntax.lbtyp = ty;
                         FStar_Syntax_Syntax.lbeff =
-                          (uu___398_3128.FStar_Syntax_Syntax.lbeff);
-                        FStar_Syntax_Syntax.lbdef = uu____3129;
+                          (uu___396_3108.FStar_Syntax_Syntax.lbeff);
+                        FStar_Syntax_Syntax.lbdef = uu____3109;
                         FStar_Syntax_Syntax.lbattrs =
-                          (uu___398_3128.FStar_Syntax_Syntax.lbattrs);
+                          (uu___396_3108.FStar_Syntax_Syntax.lbattrs);
                         FStar_Syntax_Syntax.lbpos =
-                          (uu___398_3128.FStar_Syntax_Syntax.lbpos)
+                          (uu___396_3108.FStar_Syntax_Syntax.lbpos)
                       }  in
                     let lbs1 =
                       FStar_All.pipe_right lbs
@@ -836,12 +840,13 @@ let rec (inline_closure_env :
                     let body1 =
                       let body_env =
                         FStar_List.fold_right
-                          (fun uu____3161  -> fun env2  -> dummy :: env2)
+                          (fun uu____3141  -> fun env2  -> dummy :: env2)
                           lbs1 env1
                          in
                       non_tail_inline_closure_env cfg body_env body  in
                     let t1 =
-                      mk (FStar_Syntax_Syntax.Tm_let ((true, lbs1), body1))
+                      FStar_Syntax_Syntax.mk
+                        (FStar_Syntax_Syntax.Tm_let ((true, lbs1), body1))
                         t.FStar_Syntax_Syntax.pos
                        in
                     rebuild_closure cfg env1 stack1 t1
@@ -871,216 +876,214 @@ and (rebuild_closure :
       fun stack1  ->
         fun t  ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____3253  ->
-               let uu____3254 = FStar_Syntax_Print.tag_of_term t  in
-               let uu____3256 = env_to_string env1  in
-               let uu____3258 = stack_to_string stack1  in
-               let uu____3260 = FStar_Syntax_Print.term_to_string t  in
+            (fun uu____3233  ->
+               let uu____3234 = FStar_Syntax_Print.tag_of_term t  in
+               let uu____3236 = env_to_string env1  in
+               let uu____3238 = stack_to_string stack1  in
+               let uu____3240 = FStar_Syntax_Print.term_to_string t  in
                FStar_Util.print4
                  ">>> %s (env=%s, stack=%s)\nRebuild closure_as_term %s\n"
-                 uu____3254 uu____3256 uu____3258 uu____3260);
+                 uu____3234 uu____3236 uu____3238 uu____3240);
           (match stack1 with
            | [] -> t
-           | (Arg (Clos (env_arg,tm,uu____3267,uu____3268),aq,r))::stack2 ->
+           | (Arg (Clos (env_arg,tm,uu____3247,uu____3248),aq,r))::stack2 ->
                let stack3 = (App (env1, t, aq, r)) :: stack2  in
                inline_closure_env cfg env_arg stack3 tm
            | (App (env2,head,aq,r))::stack2 ->
-               let t1 =
-                 FStar_Syntax_Syntax.extend_app head (t, aq)
-                   FStar_Pervasives_Native.None r
-                  in
+               let t1 = FStar_Syntax_Syntax.extend_app head (t, aq) r  in
                rebuild_closure cfg env2 stack2 t1
            | (CBVApp (env2,head,aq,r))::stack2 ->
-               let t1 =
-                 FStar_Syntax_Syntax.extend_app head (t, aq)
-                   FStar_Pervasives_Native.None r
-                  in
+               let t1 = FStar_Syntax_Syntax.extend_app head (t, aq) r  in
                rebuild_closure cfg env2 stack2 t1
            | (Abs (env',bs,env'',lopt,r))::stack2 ->
-               let uu____3363 = close_binders cfg env' bs  in
-               (match uu____3363 with
-                | (bs1,uu____3379) ->
+               let uu____3339 = close_binders cfg env' bs  in
+               (match uu____3339 with
+                | (bs1,uu____3355) ->
                     let lopt1 = close_lcomp_opt cfg env'' lopt  in
-                    let uu____3399 =
-                      let uu___465_3402 = FStar_Syntax_Util.abs bs1 t lopt1
+                    let uu____3375 =
+                      let uu___463_3378 = FStar_Syntax_Util.abs bs1 t lopt1
                          in
                       {
                         FStar_Syntax_Syntax.n =
-                          (uu___465_3402.FStar_Syntax_Syntax.n);
+                          (uu___463_3378.FStar_Syntax_Syntax.n);
                         FStar_Syntax_Syntax.pos = r;
                         FStar_Syntax_Syntax.vars =
-                          (uu___465_3402.FStar_Syntax_Syntax.vars)
+                          (uu___463_3378.FStar_Syntax_Syntax.vars)
                       }  in
-                    rebuild_closure cfg env1 stack2 uu____3399)
+                    rebuild_closure cfg env1 stack2 uu____3375)
            | (Match (env2,branches1,cfg1,r))::stack2 ->
-               let close_one_branch env3 uu____3458 =
-                 match uu____3458 with
+               let close_one_branch env3 uu____3434 =
+                 match uu____3434 with
                  | (pat,w_opt,tm) ->
                      let rec norm_pat env4 p =
                        match p.FStar_Syntax_Syntax.v with
-                       | FStar_Syntax_Syntax.Pat_constant uu____3573 ->
+                       | FStar_Syntax_Syntax.Pat_constant uu____3549 ->
                            (p, env4)
                        | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-                           let uu____3604 =
+                           let uu____3580 =
                              FStar_All.pipe_right pats
                                (FStar_List.fold_left
-                                  (fun uu____3693  ->
-                                     fun uu____3694  ->
-                                       match (uu____3693, uu____3694) with
+                                  (fun uu____3669  ->
+                                     fun uu____3670  ->
+                                       match (uu____3669, uu____3670) with
                                        | ((pats1,env5),(p1,b)) ->
-                                           let uu____3844 = norm_pat env5 p1
+                                           let uu____3820 = norm_pat env5 p1
                                               in
-                                           (match uu____3844 with
+                                           (match uu____3820 with
                                             | (p2,env6) ->
                                                 (((p2, b) :: pats1), env6)))
                                   ([], env4))
                               in
-                           (match uu____3604 with
+                           (match uu____3580 with
                             | (pats1,env5) ->
-                                ((let uu___502_4014 = p  in
+                                ((let uu___500_3990 = p  in
                                   {
                                     FStar_Syntax_Syntax.v =
                                       (FStar_Syntax_Syntax.Pat_cons
                                          (fv, (FStar_List.rev pats1)));
                                     FStar_Syntax_Syntax.p =
-                                      (uu___502_4014.FStar_Syntax_Syntax.p)
+                                      (uu___500_3990.FStar_Syntax_Syntax.p)
                                   }), env5))
                        | FStar_Syntax_Syntax.Pat_var x ->
                            let x1 =
-                             let uu___506_4035 = x  in
-                             let uu____4036 =
+                             let uu___504_4011 = x  in
+                             let uu____4012 =
                                non_tail_inline_closure_env cfg1 env4
                                  x.FStar_Syntax_Syntax.sort
                                 in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___506_4035.FStar_Syntax_Syntax.ppname);
+                                 (uu___504_4011.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___506_4035.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu____4036
+                                 (uu___504_4011.FStar_Syntax_Syntax.index);
+                               FStar_Syntax_Syntax.sort = uu____4012
                              }  in
-                           ((let uu___509_4050 = p  in
+                           ((let uu___507_4026 = p  in
                              {
                                FStar_Syntax_Syntax.v =
                                  (FStar_Syntax_Syntax.Pat_var x1);
                                FStar_Syntax_Syntax.p =
-                                 (uu___509_4050.FStar_Syntax_Syntax.p)
+                                 (uu___507_4026.FStar_Syntax_Syntax.p)
                              }), (dummy :: env4))
                        | FStar_Syntax_Syntax.Pat_wild x ->
                            let x1 =
-                             let uu___513_4061 = x  in
-                             let uu____4062 =
+                             let uu___511_4037 = x  in
+                             let uu____4038 =
                                non_tail_inline_closure_env cfg1 env4
                                  x.FStar_Syntax_Syntax.sort
                                 in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___513_4061.FStar_Syntax_Syntax.ppname);
+                                 (uu___511_4037.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___513_4061.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu____4062
+                                 (uu___511_4037.FStar_Syntax_Syntax.index);
+                               FStar_Syntax_Syntax.sort = uu____4038
                              }  in
-                           ((let uu___516_4076 = p  in
+                           ((let uu___514_4052 = p  in
                              {
                                FStar_Syntax_Syntax.v =
                                  (FStar_Syntax_Syntax.Pat_wild x1);
                                FStar_Syntax_Syntax.p =
-                                 (uu___516_4076.FStar_Syntax_Syntax.p)
+                                 (uu___514_4052.FStar_Syntax_Syntax.p)
                              }), (dummy :: env4))
                        | FStar_Syntax_Syntax.Pat_dot_term (x,t1) ->
                            let x1 =
-                             let uu___522_4092 = x  in
-                             let uu____4093 =
+                             let uu___520_4068 = x  in
+                             let uu____4069 =
                                non_tail_inline_closure_env cfg1 env4
                                  x.FStar_Syntax_Syntax.sort
                                 in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___522_4092.FStar_Syntax_Syntax.ppname);
+                                 (uu___520_4068.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___522_4092.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu____4093
+                                 (uu___520_4068.FStar_Syntax_Syntax.index);
+                               FStar_Syntax_Syntax.sort = uu____4069
                              }  in
                            let t2 = non_tail_inline_closure_env cfg1 env4 t1
                               in
-                           ((let uu___526_4110 = p  in
+                           ((let uu___524_4086 = p  in
                              {
                                FStar_Syntax_Syntax.v =
                                  (FStar_Syntax_Syntax.Pat_dot_term (x1, t2));
                                FStar_Syntax_Syntax.p =
-                                 (uu___526_4110.FStar_Syntax_Syntax.p)
+                                 (uu___524_4086.FStar_Syntax_Syntax.p)
                              }), env4)
                         in
-                     let uu____4115 = norm_pat env3 pat  in
-                     (match uu____4115 with
+                     let uu____4091 = norm_pat env3 pat  in
+                     (match uu____4091 with
                       | (pat1,env4) ->
                           let w_opt1 =
                             match w_opt with
                             | FStar_Pervasives_Native.None  ->
                                 FStar_Pervasives_Native.None
                             | FStar_Pervasives_Native.Some w ->
-                                let uu____4184 =
+                                let uu____4160 =
                                   non_tail_inline_closure_env cfg1 env4 w  in
-                                FStar_Pervasives_Native.Some uu____4184
+                                FStar_Pervasives_Native.Some uu____4160
                              in
                           let tm1 = non_tail_inline_closure_env cfg1 env4 tm
                              in
                           (pat1, w_opt1, tm1))
                   in
                let t1 =
-                 let uu____4203 =
-                   let uu____4204 =
-                     let uu____4227 =
+                 let uu____4179 =
+                   let uu____4180 =
+                     let uu____4203 =
                        FStar_All.pipe_right branches1
                          (FStar_List.map (close_one_branch env2))
                         in
-                     (t, uu____4227)  in
-                   FStar_Syntax_Syntax.Tm_match uu____4204  in
-                 mk uu____4203 t.FStar_Syntax_Syntax.pos  in
+                     (t, uu____4203)  in
+                   FStar_Syntax_Syntax.Tm_match uu____4180  in
+                 FStar_Syntax_Syntax.mk uu____4179 t.FStar_Syntax_Syntax.pos
+                  in
                rebuild_closure cfg1 env2 stack2 t1
            | (Meta (env_m,m,r))::stack2 ->
                let m1 =
                  match m with
                  | FStar_Syntax_Syntax.Meta_pattern (names,args) ->
-                     let uu____4363 =
-                       let uu____4384 =
+                     let uu____4339 =
+                       let uu____4360 =
                          FStar_All.pipe_right names
                            (FStar_List.map
                               (non_tail_inline_closure_env cfg env_m))
                           in
-                       let uu____4401 =
+                       let uu____4377 =
                          FStar_All.pipe_right args
                            (FStar_List.map
                               (fun args1  ->
                                  FStar_All.pipe_right args1
                                    (FStar_List.map
-                                      (fun uu____4510  ->
-                                         match uu____4510 with
+                                      (fun uu____4486  ->
+                                         match uu____4486 with
                                          | (a,q) ->
-                                             let uu____4537 =
+                                             let uu____4513 =
                                                non_tail_inline_closure_env
                                                  cfg env_m a
                                                 in
-                                             (uu____4537, q)))))
+                                             (uu____4513, q)))))
                           in
-                       (uu____4384, uu____4401)  in
-                     FStar_Syntax_Syntax.Meta_pattern uu____4363
+                       (uu____4360, uu____4377)  in
+                     FStar_Syntax_Syntax.Meta_pattern uu____4339
                  | FStar_Syntax_Syntax.Meta_monadic (m1,tbody) ->
-                     let uu____4566 =
-                       let uu____4573 =
+                     let uu____4542 =
+                       let uu____4549 =
                          non_tail_inline_closure_env cfg env_m tbody  in
-                       (m1, uu____4573)  in
-                     FStar_Syntax_Syntax.Meta_monadic uu____4566
+                       (m1, uu____4549)  in
+                     FStar_Syntax_Syntax.Meta_monadic uu____4542
                  | FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,tbody) ->
-                     let uu____4585 =
-                       let uu____4594 =
+                     let uu____4561 =
+                       let uu____4570 =
                          non_tail_inline_closure_env cfg env_m tbody  in
-                       (m1, m2, uu____4594)  in
-                     FStar_Syntax_Syntax.Meta_monadic_lift uu____4585
-                 | uu____4599 -> m  in
-               let t1 = mk (FStar_Syntax_Syntax.Tm_meta (t, m1)) r  in
+                       (m1, m2, uu____4570)  in
+                     FStar_Syntax_Syntax.Meta_monadic_lift uu____4561
+                 | uu____4575 -> m  in
+               let t1 =
+                 FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_meta (t, m1))
+                   r
+                  in
                rebuild_closure cfg env1 stack2 t1
-           | uu____4605 -> failwith "Impossible: unexpected stack element")
+           | uu____4581 -> failwith "Impossible: unexpected stack element")
 
 and (close_imp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1093,10 +1096,10 @@ and (close_imp :
       fun imp  ->
         match imp with
         | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-            let uu____4621 =
-              let uu____4622 = inline_closure_env cfg env1 [] t  in
-              FStar_Syntax_Syntax.Meta uu____4622  in
-            FStar_Pervasives_Native.Some uu____4621
+            let uu____4597 =
+              let uu____4598 = inline_closure_env cfg env1 [] t  in
+              FStar_Syntax_Syntax.Meta uu____4598  in
+            FStar_Pervasives_Native.Some uu____4597
         | i -> i
 
 and (close_binders :
@@ -1110,31 +1113,31 @@ and (close_binders :
   fun cfg  ->
     fun env1  ->
       fun bs  ->
-        let uu____4639 =
+        let uu____4615 =
           FStar_All.pipe_right bs
             (FStar_List.fold_left
-               (fun uu____4723  ->
-                  fun uu____4724  ->
-                    match (uu____4723, uu____4724) with
+               (fun uu____4699  ->
+                  fun uu____4700  ->
+                    match (uu____4699, uu____4700) with
                     | ((env2,out),(b,imp)) ->
                         let b1 =
-                          let uu___581_4864 = b  in
-                          let uu____4865 =
+                          let uu___579_4840 = b  in
+                          let uu____4841 =
                             inline_closure_env cfg env2 []
                               b.FStar_Syntax_Syntax.sort
                              in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___581_4864.FStar_Syntax_Syntax.ppname);
+                              (uu___579_4840.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___581_4864.FStar_Syntax_Syntax.index);
-                            FStar_Syntax_Syntax.sort = uu____4865
+                              (uu___579_4840.FStar_Syntax_Syntax.index);
+                            FStar_Syntax_Syntax.sort = uu____4841
                           }  in
                         let imp1 = close_imp cfg env2 imp  in
                         let env3 = dummy :: env2  in
                         (env3, ((b1, imp1) :: out))) (env1, []))
            in
-        match uu____4639 with | (env2,bs1) -> ((FStar_List.rev bs1), env2)
+        match uu____4615 with | (env2,bs1) -> ((FStar_List.rev bs1), env2)
 
 and (close_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1150,18 +1153,18 @@ and (close_comp :
             FStar_All.pipe_left Prims.op_Negation
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
             -> c
-        | uu____5007 ->
+        | uu____4983 ->
             (match c.FStar_Syntax_Syntax.n with
              | FStar_Syntax_Syntax.Total (t,uopt) ->
-                 let uu____5020 = inline_closure_env cfg env1 [] t  in
-                 let uu____5021 =
+                 let uu____4996 = inline_closure_env cfg env1 [] t  in
+                 let uu____4997 =
                    FStar_Option.map (norm_universe cfg env1) uopt  in
-                 FStar_Syntax_Syntax.mk_Total' uu____5020 uu____5021
+                 FStar_Syntax_Syntax.mk_Total' uu____4996 uu____4997
              | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-                 let uu____5034 = inline_closure_env cfg env1 [] t  in
-                 let uu____5035 =
+                 let uu____5010 = inline_closure_env cfg env1 [] t  in
+                 let uu____5011 =
                    FStar_Option.map (norm_universe cfg env1) uopt  in
-                 FStar_Syntax_Syntax.mk_GTotal' uu____5034 uu____5035
+                 FStar_Syntax_Syntax.mk_GTotal' uu____5010 uu____5011
              | FStar_Syntax_Syntax.Comp c1 ->
                  let rt =
                    inline_closure_env cfg env1 []
@@ -1170,39 +1173,39 @@ and (close_comp :
                  let args =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.effect_args
                      (FStar_List.map
-                        (fun uu____5089  ->
-                           match uu____5089 with
+                        (fun uu____5065  ->
+                           match uu____5065 with
                            | (a,q) ->
-                               let uu____5110 =
+                               let uu____5086 =
                                  inline_closure_env cfg env1 [] a  in
-                               (uu____5110, q)))
+                               (uu____5086, q)))
                     in
                  let flags =
                    FStar_All.pipe_right c1.FStar_Syntax_Syntax.flags
                      (FStar_List.map
-                        (fun uu___5_5127  ->
-                           match uu___5_5127 with
+                        (fun uu___5_5103  ->
+                           match uu___5_5103 with
                            | FStar_Syntax_Syntax.DECREASES t ->
-                               let uu____5131 =
+                               let uu____5107 =
                                  inline_closure_env cfg env1 [] t  in
-                               FStar_Syntax_Syntax.DECREASES uu____5131
+                               FStar_Syntax_Syntax.DECREASES uu____5107
                            | f -> f))
                     in
-                 let uu____5135 =
-                   let uu___614_5136 = c1  in
-                   let uu____5137 =
+                 let uu____5111 =
+                   let uu___612_5112 = c1  in
+                   let uu____5113 =
                      FStar_List.map (norm_universe cfg env1)
                        c1.FStar_Syntax_Syntax.comp_univs
                       in
                    {
-                     FStar_Syntax_Syntax.comp_univs = uu____5137;
+                     FStar_Syntax_Syntax.comp_univs = uu____5113;
                      FStar_Syntax_Syntax.effect_name =
-                       (uu___614_5136.FStar_Syntax_Syntax.effect_name);
+                       (uu___612_5112.FStar_Syntax_Syntax.effect_name);
                      FStar_Syntax_Syntax.result_typ = rt;
                      FStar_Syntax_Syntax.effect_args = args;
                      FStar_Syntax_Syntax.flags = flags
                    }  in
-                 FStar_Syntax_Syntax.mk_Comp uu____5135)
+                 FStar_Syntax_Syntax.mk_Comp uu____5111)
 
 and (close_lcomp_opt :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1218,25 +1221,25 @@ and (close_lcomp_opt :
             let flags =
               FStar_All.pipe_right rc.FStar_Syntax_Syntax.residual_flags
                 (FStar_List.filter
-                   (fun uu___6_5155  ->
-                      match uu___6_5155 with
-                      | FStar_Syntax_Syntax.DECREASES uu____5157 -> false
-                      | uu____5161 -> true))
+                   (fun uu___6_5131  ->
+                      match uu___6_5131 with
+                      | FStar_Syntax_Syntax.DECREASES uu____5133 -> false
+                      | uu____5137 -> true))
                in
             let rc1 =
-              let uu___626_5164 = rc  in
-              let uu____5165 =
+              let uu___624_5140 = rc  in
+              let uu____5141 =
                 FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
                   (inline_closure_env cfg env1 [])
                  in
               {
                 FStar_Syntax_Syntax.residual_effect =
-                  (uu___626_5164.FStar_Syntax_Syntax.residual_effect);
-                FStar_Syntax_Syntax.residual_typ = uu____5165;
+                  (uu___624_5140.FStar_Syntax_Syntax.residual_effect);
+                FStar_Syntax_Syntax.residual_typ = uu____5141;
                 FStar_Syntax_Syntax.residual_flags = flags
               }  in
             FStar_Pervasives_Native.Some rc1
-        | uu____5174 -> lopt
+        | uu____5150 -> lopt
 
 let (filter_out_lcomp_cflags :
   FStar_Syntax_Syntax.cflag Prims.list ->
@@ -1245,10 +1248,10 @@ let (filter_out_lcomp_cflags :
   fun flags  ->
     FStar_All.pipe_right flags
       (FStar_List.filter
-         (fun uu___7_5195  ->
-            match uu___7_5195 with
-            | FStar_Syntax_Syntax.DECREASES uu____5197 -> false
-            | uu____5201 -> true))
+         (fun uu___7_5171  ->
+            match uu___7_5171 with
+            | FStar_Syntax_Syntax.DECREASES uu____5173 -> false
+            | uu____5177 -> true))
   
 let (closure_as_term :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1263,11 +1266,11 @@ let (unembed_binder :
     FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____5248 = FStar_ST.op_Bang unembed_binder_knot  in
-    match uu____5248 with
+    let uu____5224 = FStar_ST.op_Bang unembed_binder_knot  in
+    match uu____5224 with
     | FStar_Pervasives_Native.Some e ->
-        let uu____5287 = FStar_Syntax_Embeddings.unembed e t  in
-        uu____5287 false FStar_Syntax_Embeddings.id_norm_cb
+        let uu____5263 = FStar_Syntax_Embeddings.unembed e t  in
+        uu____5263 false FStar_Syntax_Embeddings.id_norm_cb
     | FStar_Pervasives_Native.None  ->
         (FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos
            (FStar_Errors.Warning_UnembedBinderKnot,
@@ -1275,94 +1278,94 @@ let (unembed_binder :
          FStar_Pervasives_Native.None)
   
 let mk_psc_subst :
-  'uuuuuu5307 .
+  'uuuuuu5283 .
     FStar_TypeChecker_Cfg.cfg ->
-      ((FStar_Syntax_Syntax.bv * 'uuuuuu5307) FStar_Pervasives_Native.option
+      ((FStar_Syntax_Syntax.bv * 'uuuuuu5283) FStar_Pervasives_Native.option
         * closure) Prims.list -> FStar_Syntax_Syntax.subst_elt Prims.list
   =
   fun cfg  ->
     fun env1  ->
       FStar_List.fold_right
-        (fun uu____5369  ->
+        (fun uu____5345  ->
            fun subst  ->
-             match uu____5369 with
+             match uu____5345 with
              | (binder_opt,closure1) ->
                  (match (binder_opt, closure1) with
                   | (FStar_Pervasives_Native.Some b,Clos
-                     (env2,term,uu____5410,uu____5411)) ->
-                      let uu____5472 = b  in
-                      (match uu____5472 with
-                       | (bv,uu____5480) ->
-                           let uu____5481 =
-                             let uu____5483 =
+                     (env2,term,uu____5386,uu____5387)) ->
+                      let uu____5448 = b  in
+                      (match uu____5448 with
+                       | (bv,uu____5456) ->
+                           let uu____5457 =
+                             let uu____5459 =
                                FStar_Syntax_Util.is_constructed_typ
                                  bv.FStar_Syntax_Syntax.sort
                                  FStar_Parser_Const.binder_lid
                                 in
-                             Prims.op_Negation uu____5483  in
-                           if uu____5481
+                             Prims.op_Negation uu____5459  in
+                           if uu____5457
                            then subst
                            else
                              (let term1 = closure_as_term cfg env2 term  in
-                              let uu____5491 = unembed_binder term1  in
-                              match uu____5491 with
+                              let uu____5467 = unembed_binder term1  in
+                              match uu____5467 with
                               | FStar_Pervasives_Native.None  -> subst
                               | FStar_Pervasives_Native.Some x ->
                                   let b1 =
-                                    let uu____5498 =
-                                      let uu___666_5499 = bv  in
-                                      let uu____5500 =
+                                    let uu____5474 =
+                                      let uu___664_5475 = bv  in
+                                      let uu____5476 =
                                         FStar_Syntax_Subst.subst subst
                                           (FStar_Pervasives_Native.fst x).FStar_Syntax_Syntax.sort
                                          in
                                       {
                                         FStar_Syntax_Syntax.ppname =
-                                          (uu___666_5499.FStar_Syntax_Syntax.ppname);
+                                          (uu___664_5475.FStar_Syntax_Syntax.ppname);
                                         FStar_Syntax_Syntax.index =
-                                          (uu___666_5499.FStar_Syntax_Syntax.index);
-                                        FStar_Syntax_Syntax.sort = uu____5500
+                                          (uu___664_5475.FStar_Syntax_Syntax.index);
+                                        FStar_Syntax_Syntax.sort = uu____5476
                                       }  in
-                                    FStar_Syntax_Syntax.freshen_bv uu____5498
+                                    FStar_Syntax_Syntax.freshen_bv uu____5474
                                      in
                                   let b_for_x =
-                                    let uu____5506 =
-                                      let uu____5513 =
+                                    let uu____5482 =
+                                      let uu____5489 =
                                         FStar_Syntax_Syntax.bv_to_name b1  in
                                       ((FStar_Pervasives_Native.fst x),
-                                        uu____5513)
+                                        uu____5489)
                                        in
-                                    FStar_Syntax_Syntax.NT uu____5506  in
+                                    FStar_Syntax_Syntax.NT uu____5482  in
                                   let subst1 =
                                     FStar_List.filter
-                                      (fun uu___8_5529  ->
-                                         match uu___8_5529 with
+                                      (fun uu___8_5505  ->
+                                         match uu___8_5505 with
                                          | FStar_Syntax_Syntax.NT
-                                             (uu____5531,{
+                                             (uu____5507,{
                                                            FStar_Syntax_Syntax.n
                                                              =
                                                              FStar_Syntax_Syntax.Tm_name
                                                              b';
                                                            FStar_Syntax_Syntax.pos
-                                                             = uu____5533;
+                                                             = uu____5509;
                                                            FStar_Syntax_Syntax.vars
-                                                             = uu____5534;_})
+                                                             = uu____5510;_})
                                              ->
-                                             let uu____5539 =
+                                             let uu____5515 =
                                                FStar_Ident.ident_equals
                                                  b1.FStar_Syntax_Syntax.ppname
                                                  b'.FStar_Syntax_Syntax.ppname
                                                 in
-                                             Prims.op_Negation uu____5539
-                                         | uu____5541 -> true) subst
+                                             Prims.op_Negation uu____5515
+                                         | uu____5517 -> true) subst
                                      in
                                   b_for_x :: subst1))
-                  | uu____5543 -> subst)) env1 []
+                  | uu____5519 -> subst)) env1 []
   
 let reduce_primops :
-  'uuuuuu5565 .
+  'uuuuuu5541 .
     FStar_Syntax_Embeddings.norm_cb ->
       FStar_TypeChecker_Cfg.cfg ->
-        ((FStar_Syntax_Syntax.bv * 'uuuuuu5565)
+        ((FStar_Syntax_Syntax.bv * 'uuuuuu5541)
           FStar_Pervasives_Native.option * closure) Prims.list ->
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
@@ -1376,17 +1379,17 @@ let reduce_primops :
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.primops
           then tm
           else
-            (let uu____5617 = FStar_Syntax_Util.head_and_args tm  in
-             match uu____5617 with
+            (let uu____5593 = FStar_Syntax_Util.head_and_args tm  in
+             match uu____5593 with
              | (head,args) ->
-                 let uu____5662 =
-                   let uu____5663 = FStar_Syntax_Util.un_uinst head  in
-                   uu____5663.FStar_Syntax_Syntax.n  in
-                 (match uu____5662 with
+                 let uu____5638 =
+                   let uu____5639 = FStar_Syntax_Util.un_uinst head  in
+                   uu____5639.FStar_Syntax_Syntax.n  in
+                 (match uu____5638 with
                   | FStar_Syntax_Syntax.Tm_fvar fv ->
-                      let uu____5669 =
+                      let uu____5645 =
                         FStar_TypeChecker_Cfg.find_prim_step cfg fv  in
-                      (match uu____5669 with
+                      (match uu____5645 with
                        | FStar_Pervasives_Native.Some prim_step when
                            prim_step.FStar_TypeChecker_Cfg.strong_reduction_ok
                              ||
@@ -1397,23 +1400,23 @@ let reduce_primops :
                            if l < prim_step.FStar_TypeChecker_Cfg.arity
                            then
                              (FStar_TypeChecker_Cfg.log_primops cfg
-                                (fun uu____5692  ->
-                                   let uu____5693 =
+                                (fun uu____5668  ->
+                                   let uu____5669 =
                                      FStar_Syntax_Print.lid_to_string
                                        prim_step.FStar_TypeChecker_Cfg.name
                                       in
-                                   let uu____5695 =
+                                   let uu____5671 =
                                      FStar_Util.string_of_int l  in
-                                   let uu____5697 =
+                                   let uu____5673 =
                                      FStar_Util.string_of_int
                                        prim_step.FStar_TypeChecker_Cfg.arity
                                       in
                                    FStar_Util.print3
                                      "primop: found partially applied %s (%s/%s args)\n"
-                                     uu____5693 uu____5695 uu____5697);
+                                     uu____5669 uu____5671 uu____5673);
                               tm)
                            else
-                             (let uu____5702 =
+                             (let uu____5678 =
                                 if l = prim_step.FStar_TypeChecker_Cfg.arity
                                 then (args, [])
                                 else
@@ -1421,23 +1424,23 @@ let reduce_primops :
                                     prim_step.FStar_TypeChecker_Cfg.arity
                                     args
                                  in
-                              match uu____5702 with
+                              match uu____5678 with
                               | (args_1,args_2) ->
                                   (FStar_TypeChecker_Cfg.log_primops cfg
-                                     (fun uu____5788  ->
-                                        let uu____5789 =
+                                     (fun uu____5764  ->
+                                        let uu____5765 =
                                           FStar_Syntax_Print.term_to_string
                                             tm
                                            in
                                         FStar_Util.print1
                                           "primop: trying to reduce <%s>\n"
-                                          uu____5789);
+                                          uu____5765);
                                    (let psc =
                                       {
                                         FStar_TypeChecker_Cfg.psc_range =
                                           (head.FStar_Syntax_Syntax.pos);
                                         FStar_TypeChecker_Cfg.psc_subst =
-                                          (fun uu____5794  ->
+                                          (fun uu____5770  ->
                                              if
                                                prim_step.FStar_TypeChecker_Cfg.requires_binder_substitution
                                              then mk_psc_subst cfg env1
@@ -1451,85 +1454,85 @@ let reduce_primops :
                                     | FStar_Pervasives_Native.None  ->
                                         (FStar_TypeChecker_Cfg.log_primops
                                            cfg
-                                           (fun uu____5808  ->
-                                              let uu____5809 =
+                                           (fun uu____5784  ->
+                                              let uu____5785 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tm
                                                  in
                                               FStar_Util.print1
                                                 "primop: <%s> did not reduce\n"
-                                                uu____5809);
+                                                uu____5785);
                                          tm)
                                     | FStar_Pervasives_Native.Some reduced ->
                                         (FStar_TypeChecker_Cfg.log_primops
                                            cfg
-                                           (fun uu____5817  ->
-                                              let uu____5818 =
+                                           (fun uu____5793  ->
+                                              let uu____5794 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tm
                                                  in
-                                              let uu____5820 =
+                                              let uu____5796 =
                                                 FStar_Syntax_Print.term_to_string
                                                   reduced
                                                  in
                                               FStar_Util.print2
                                                 "primop: <%s> reduced to <%s>\n"
-                                                uu____5818 uu____5820);
+                                                uu____5794 uu____5796);
                                          FStar_Syntax_Util.mk_app reduced
                                            args_2))))
-                       | FStar_Pervasives_Native.Some uu____5823 ->
+                       | FStar_Pervasives_Native.Some uu____5799 ->
                            (FStar_TypeChecker_Cfg.log_primops cfg
-                              (fun uu____5827  ->
-                                 let uu____5828 =
+                              (fun uu____5803  ->
+                                 let uu____5804 =
                                    FStar_Syntax_Print.term_to_string tm  in
                                  FStar_Util.print1
                                    "primop: not reducing <%s> since we're doing strong reduction\n"
-                                   uu____5828);
+                                   uu____5804);
                             tm)
                        | FStar_Pervasives_Native.None  -> tm)
                   | FStar_Syntax_Syntax.Tm_constant
                       (FStar_Const.Const_range_of ) when
                       Prims.op_Negation cfg.FStar_TypeChecker_Cfg.strong ->
                       (FStar_TypeChecker_Cfg.log_primops cfg
-                         (fun uu____5834  ->
-                            let uu____5835 =
+                         (fun uu____5810  ->
+                            let uu____5811 =
                               FStar_Syntax_Print.term_to_string tm  in
                             FStar_Util.print1 "primop: reducing <%s>\n"
-                              uu____5835);
+                              uu____5811);
                        (match args with
-                        | (a1,uu____5841)::[] ->
+                        | (a1,uu____5817)::[] ->
                             FStar_TypeChecker_Cfg.embed_simple
                               FStar_Syntax_Embeddings.e_range
                               a1.FStar_Syntax_Syntax.pos
                               tm.FStar_Syntax_Syntax.pos
-                        | uu____5866 -> tm))
+                        | uu____5842 -> tm))
                   | FStar_Syntax_Syntax.Tm_constant
                       (FStar_Const.Const_set_range_of ) when
                       Prims.op_Negation cfg.FStar_TypeChecker_Cfg.strong ->
                       (FStar_TypeChecker_Cfg.log_primops cfg
-                         (fun uu____5880  ->
-                            let uu____5881 =
+                         (fun uu____5856  ->
+                            let uu____5857 =
                               FStar_Syntax_Print.term_to_string tm  in
                             FStar_Util.print1 "primop: reducing <%s>\n"
-                              uu____5881);
+                              uu____5857);
                        (match args with
-                        | (t,uu____5887)::(r,uu____5889)::[] ->
-                            let uu____5930 =
+                        | (t,uu____5863)::(r,uu____5865)::[] ->
+                            let uu____5906 =
                               FStar_TypeChecker_Cfg.try_unembed_simple
                                 FStar_Syntax_Embeddings.e_range r
                                in
-                            (match uu____5930 with
+                            (match uu____5906 with
                              | FStar_Pervasives_Native.Some rng ->
                                  FStar_Syntax_Subst.set_use_range rng t
                              | FStar_Pervasives_Native.None  -> tm)
-                        | uu____5936 -> tm))
-                  | uu____5947 -> tm))
+                        | uu____5912 -> tm))
+                  | uu____5923 -> tm))
   
 let reduce_equality :
-  'uuuuuu5958 .
+  'uuuuuu5934 .
     FStar_Syntax_Embeddings.norm_cb ->
       FStar_TypeChecker_Cfg.cfg ->
-        ((FStar_Syntax_Syntax.bv * 'uuuuuu5958)
+        ((FStar_Syntax_Syntax.bv * 'uuuuuu5934)
           FStar_Pervasives_Native.option * closure) Prims.list ->
           FStar_Syntax_Syntax.term ->
             FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
@@ -1538,81 +1541,81 @@ let reduce_equality :
     fun cfg  ->
       fun tm  ->
         reduce_primops norm_cb
-          (let uu___754_6007 = cfg  in
+          (let uu___752_5983 = cfg  in
            {
              FStar_TypeChecker_Cfg.steps =
-               (let uu___756_6010 = FStar_TypeChecker_Cfg.default_steps  in
+               (let uu___754_5986 = FStar_TypeChecker_Cfg.default_steps  in
                 {
                   FStar_TypeChecker_Cfg.beta =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.beta);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.beta);
                   FStar_TypeChecker_Cfg.iota =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.iota);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.iota);
                   FStar_TypeChecker_Cfg.zeta =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.zeta);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.zeta);
                   FStar_TypeChecker_Cfg.zeta_full =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.zeta_full);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.zeta_full);
                   FStar_TypeChecker_Cfg.weak =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.weak);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.weak);
                   FStar_TypeChecker_Cfg.hnf =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.hnf);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.hnf);
                   FStar_TypeChecker_Cfg.primops = true;
                   FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                   FStar_TypeChecker_Cfg.unfold_until =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.unfold_until);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.unfold_until);
                   FStar_TypeChecker_Cfg.unfold_only =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.unfold_only);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.unfold_only);
                   FStar_TypeChecker_Cfg.unfold_fully =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.unfold_fully);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.unfold_fully);
                   FStar_TypeChecker_Cfg.unfold_attr =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.unfold_attr);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.unfold_attr);
                   FStar_TypeChecker_Cfg.unfold_tac =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.unfold_tac);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.unfold_tac);
                   FStar_TypeChecker_Cfg.pure_subterms_within_computations =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                   FStar_TypeChecker_Cfg.simplify =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.simplify);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.simplify);
                   FStar_TypeChecker_Cfg.erase_universes =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.erase_universes);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.erase_universes);
                   FStar_TypeChecker_Cfg.allow_unbound_universes =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.allow_unbound_universes);
                   FStar_TypeChecker_Cfg.reify_ =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.reify_);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.reify_);
                   FStar_TypeChecker_Cfg.compress_uvars =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.compress_uvars);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.compress_uvars);
                   FStar_TypeChecker_Cfg.no_full_norm =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.no_full_norm);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.no_full_norm);
                   FStar_TypeChecker_Cfg.check_no_uvars =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.check_no_uvars);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.check_no_uvars);
                   FStar_TypeChecker_Cfg.unmeta =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.unmeta);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.unmeta);
                   FStar_TypeChecker_Cfg.unascribe =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.unascribe);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.unascribe);
                   FStar_TypeChecker_Cfg.in_full_norm_request =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.in_full_norm_request);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.in_full_norm_request);
                   FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                   FStar_TypeChecker_Cfg.nbe_step =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.nbe_step);
+                    (uu___754_5986.FStar_TypeChecker_Cfg.nbe_step);
                   FStar_TypeChecker_Cfg.for_extraction =
-                    (uu___756_6010.FStar_TypeChecker_Cfg.for_extraction)
+                    (uu___754_5986.FStar_TypeChecker_Cfg.for_extraction)
                 });
              FStar_TypeChecker_Cfg.tcenv =
-               (uu___754_6007.FStar_TypeChecker_Cfg.tcenv);
+               (uu___752_5983.FStar_TypeChecker_Cfg.tcenv);
              FStar_TypeChecker_Cfg.debug =
-               (uu___754_6007.FStar_TypeChecker_Cfg.debug);
+               (uu___752_5983.FStar_TypeChecker_Cfg.debug);
              FStar_TypeChecker_Cfg.delta_level =
-               (uu___754_6007.FStar_TypeChecker_Cfg.delta_level);
+               (uu___752_5983.FStar_TypeChecker_Cfg.delta_level);
              FStar_TypeChecker_Cfg.primitive_steps =
                FStar_TypeChecker_Cfg.equality_ops;
              FStar_TypeChecker_Cfg.strong =
-               (uu___754_6007.FStar_TypeChecker_Cfg.strong);
+               (uu___752_5983.FStar_TypeChecker_Cfg.strong);
              FStar_TypeChecker_Cfg.memoize_lazy =
-               (uu___754_6007.FStar_TypeChecker_Cfg.memoize_lazy);
+               (uu___752_5983.FStar_TypeChecker_Cfg.memoize_lazy);
              FStar_TypeChecker_Cfg.normalize_pure_lets =
-               (uu___754_6007.FStar_TypeChecker_Cfg.normalize_pure_lets);
+               (uu___752_5983.FStar_TypeChecker_Cfg.normalize_pure_lets);
              FStar_TypeChecker_Cfg.reifying =
-               (uu___754_6007.FStar_TypeChecker_Cfg.reifying)
+               (uu___752_5983.FStar_TypeChecker_Cfg.reifying)
            }) tm
   
 type norm_request_t =
@@ -1621,25 +1624,25 @@ type norm_request_t =
   | Norm_request_requires_rejig 
 let (uu___is_Norm_request_none : norm_request_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Norm_request_none  -> true | uu____6021 -> false
+    match projectee with | Norm_request_none  -> true | uu____5997 -> false
   
 let (uu___is_Norm_request_ready : norm_request_t -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Norm_request_ready  -> true | uu____6032 -> false
+    match projectee with | Norm_request_ready  -> true | uu____6008 -> false
   
 let (uu___is_Norm_request_requires_rejig : norm_request_t -> Prims.bool) =
   fun projectee  ->
     match projectee with
     | Norm_request_requires_rejig  -> true
-    | uu____6043 -> false
+    | uu____6019 -> false
   
 let (is_norm_request :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.args -> norm_request_t) =
   fun hd  ->
     fun args  ->
       let aux min_args =
-        let uu____6064 = FStar_All.pipe_right args FStar_List.length  in
-        FStar_All.pipe_right uu____6064
+        let uu____6040 = FStar_All.pipe_right args FStar_List.length  in
+        FStar_All.pipe_right uu____6040
           (fun n  ->
              if n < min_args
              then Norm_request_none
@@ -1648,10 +1651,10 @@ let (is_norm_request :
                then Norm_request_ready
                else Norm_request_requires_rejig)
          in
-      let uu____6096 =
-        let uu____6097 = FStar_Syntax_Util.un_uinst hd  in
-        uu____6097.FStar_Syntax_Syntax.n  in
-      match uu____6096 with
+      let uu____6072 =
+        let uu____6073 = FStar_Syntax_Util.un_uinst hd  in
+        uu____6073.FStar_Syntax_Syntax.n  in
+      match uu____6072 with
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize_term
           -> aux (Prims.of_int (2))
@@ -1661,7 +1664,7 @@ let (is_norm_request :
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.norm ->
           aux (Prims.of_int (3))
-      | uu____6106 -> Norm_request_none
+      | uu____6082 -> Norm_request_none
   
 let (should_consider_norm_requests : FStar_TypeChecker_Cfg.cfg -> Prims.bool)
   =
@@ -1669,12 +1672,12 @@ let (should_consider_norm_requests : FStar_TypeChecker_Cfg.cfg -> Prims.bool)
     (Prims.op_Negation
        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.no_full_norm)
       &&
-      (let uu____6115 =
+      (let uu____6091 =
          FStar_Ident.lid_equals
            (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.curmodule
            FStar_Parser_Const.prims_lid
           in
-       Prims.op_Negation uu____6115)
+       Prims.op_Negation uu____6091)
   
 let (rejig_norm_request :
   FStar_Syntax_Syntax.term ->
@@ -1682,27 +1685,27 @@ let (rejig_norm_request :
   =
   fun hd  ->
     fun args  ->
-      let uu____6128 =
-        let uu____6129 = FStar_Syntax_Util.un_uinst hd  in
-        uu____6129.FStar_Syntax_Syntax.n  in
-      match uu____6128 with
+      let uu____6104 =
+        let uu____6105 = FStar_Syntax_Util.un_uinst hd  in
+        uu____6105.FStar_Syntax_Syntax.n  in
+      match uu____6104 with
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize_term
           ->
           (match args with
            | t1::t2::rest when (FStar_List.length rest) > Prims.int_zero ->
-               let uu____6187 = FStar_Syntax_Util.mk_app hd [t1; t2]  in
-               FStar_Syntax_Util.mk_app uu____6187 rest
-           | uu____6214 ->
+               let uu____6163 = FStar_Syntax_Util.mk_app hd [t1; t2]  in
+               FStar_Syntax_Util.mk_app uu____6163 rest
+           | uu____6190 ->
                failwith
                  "Impossible! invalid rejig_norm_request for normalize_term")
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize ->
           (match args with
            | t::rest when (FStar_List.length rest) > Prims.int_zero ->
-               let uu____6254 = FStar_Syntax_Util.mk_app hd [t]  in
-               FStar_Syntax_Util.mk_app uu____6254 rest
-           | uu____6273 ->
+               let uu____6230 = FStar_Syntax_Util.mk_app hd [t]  in
+               FStar_Syntax_Util.mk_app uu____6230 rest
+           | uu____6249 ->
                failwith
                  "Impossible! invalid rejig_norm_request for normalize")
       | FStar_Syntax_Syntax.Tm_fvar fv when
@@ -1710,17 +1713,17 @@ let (rejig_norm_request :
           (match args with
            | t1::t2::t3::rest when (FStar_List.length rest) > Prims.int_zero
                ->
-               let uu____6347 = FStar_Syntax_Util.mk_app hd [t1; t2; t3]  in
-               FStar_Syntax_Util.mk_app uu____6347 rest
-           | uu____6382 ->
+               let uu____6323 = FStar_Syntax_Util.mk_app hd [t1; t2; t3]  in
+               FStar_Syntax_Util.mk_app uu____6323 rest
+           | uu____6358 ->
                failwith "Impossible! invalid rejig_norm_request for norm")
-      | uu____6384 ->
-          let uu____6385 =
-            let uu____6387 = FStar_Syntax_Print.term_to_string hd  in
+      | uu____6360 ->
+          let uu____6361 =
+            let uu____6363 = FStar_Syntax_Print.term_to_string hd  in
             FStar_String.op_Hat
-              "Impossible! invalid rejig_norm_request for: %s" uu____6387
+              "Impossible! invalid rejig_norm_request for: %s" uu____6363
              in
-          failwith uu____6385
+          failwith uu____6361
   
 let (is_nbe_request : FStar_TypeChecker_Env.step Prims.list -> Prims.bool) =
   fun s  ->
@@ -1730,8 +1733,8 @@ let (is_nbe_request : FStar_TypeChecker_Env.step Prims.list -> Prims.bool) =
 let (tr_norm_step :
   FStar_Syntax_Embeddings.norm_step -> FStar_TypeChecker_Env.step Prims.list)
   =
-  fun uu___9_6408  ->
-    match uu___9_6408 with
+  fun uu___9_6384  ->
+    match uu___9_6384 with
     | FStar_Syntax_Embeddings.Zeta  -> [FStar_TypeChecker_Env.Zeta]
     | FStar_Syntax_Embeddings.ZetaFull  -> [FStar_TypeChecker_Env.ZetaFull]
     | FStar_Syntax_Embeddings.Iota  -> [FStar_TypeChecker_Env.Iota]
@@ -1743,29 +1746,29 @@ let (tr_norm_step :
     | FStar_Syntax_Embeddings.Primops  -> [FStar_TypeChecker_Env.Primops]
     | FStar_Syntax_Embeddings.Reify  -> [FStar_TypeChecker_Env.Reify]
     | FStar_Syntax_Embeddings.UnfoldOnly names ->
+        let uu____6391 =
+          let uu____6394 =
+            let uu____6395 = FStar_List.map FStar_Ident.lid_of_str names  in
+            FStar_TypeChecker_Env.UnfoldOnly uu____6395  in
+          [uu____6394]  in
+        (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
+          :: uu____6391
+    | FStar_Syntax_Embeddings.UnfoldFully names ->
+        let uu____6403 =
+          let uu____6406 =
+            let uu____6407 = FStar_List.map FStar_Ident.lid_of_str names  in
+            FStar_TypeChecker_Env.UnfoldFully uu____6407  in
+          [uu____6406]  in
+        (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
+          :: uu____6403
+    | FStar_Syntax_Embeddings.UnfoldAttr names ->
         let uu____6415 =
           let uu____6418 =
             let uu____6419 = FStar_List.map FStar_Ident.lid_of_str names  in
-            FStar_TypeChecker_Env.UnfoldOnly uu____6419  in
+            FStar_TypeChecker_Env.UnfoldAttr uu____6419  in
           [uu____6418]  in
         (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
           :: uu____6415
-    | FStar_Syntax_Embeddings.UnfoldFully names ->
-        let uu____6427 =
-          let uu____6430 =
-            let uu____6431 = FStar_List.map FStar_Ident.lid_of_str names  in
-            FStar_TypeChecker_Env.UnfoldFully uu____6431  in
-          [uu____6430]  in
-        (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
-          :: uu____6427
-    | FStar_Syntax_Embeddings.UnfoldAttr names ->
-        let uu____6439 =
-          let uu____6442 =
-            let uu____6443 = FStar_List.map FStar_Ident.lid_of_str names  in
-            FStar_TypeChecker_Env.UnfoldAttr uu____6443  in
-          [uu____6442]  in
-        (FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant)
-          :: uu____6439
     | FStar_Syntax_Embeddings.NBE  -> [FStar_TypeChecker_Env.NBE]
   
 let (tr_norm_steps :
@@ -1775,18 +1778,18 @@ let (tr_norm_steps :
   fun s  ->
     let s1 = FStar_List.concatMap tr_norm_step s  in
     let add_exclude s2 z =
-      let uu____6479 =
+      let uu____6455 =
         FStar_Util.for_some (FStar_TypeChecker_Env.eq_step z) s2  in
-      if uu____6479 then s2 else (FStar_TypeChecker_Env.Exclude z) :: s2  in
+      if uu____6455 then s2 else (FStar_TypeChecker_Env.Exclude z) :: s2  in
     let s2 = FStar_TypeChecker_Env.Beta :: s1  in
     let s3 = add_exclude s2 FStar_TypeChecker_Env.Zeta  in
     let s4 = add_exclude s3 FStar_TypeChecker_Env.Iota  in s4
   
 let get_norm_request :
-  'uuuuuu6504 .
+  'uuuuuu6480 .
     FStar_TypeChecker_Cfg.cfg ->
       (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu6504) Prims.list ->
+        (FStar_Syntax_Syntax.term * 'uuuuuu6480) Prims.list ->
           (FStar_TypeChecker_Env.step Prims.list * FStar_Syntax_Syntax.term)
             FStar_Pervasives_Native.option
   =
@@ -1794,16 +1797,16 @@ let get_norm_request :
     fun full_norm  ->
       fun args  ->
         let parse_steps s =
-          let uu____6555 =
-            let uu____6560 =
+          let uu____6531 =
+            let uu____6536 =
               FStar_Syntax_Embeddings.e_list
                 FStar_Syntax_Embeddings.e_norm_step
                in
-            FStar_TypeChecker_Cfg.try_unembed_simple uu____6560 s  in
-          match uu____6555 with
+            FStar_TypeChecker_Cfg.try_unembed_simple uu____6536 s  in
+          match uu____6531 with
           | FStar_Pervasives_Native.Some steps ->
-              let uu____6576 = tr_norm_steps steps  in
-              FStar_Pervasives_Native.Some uu____6576
+              let uu____6552 = tr_norm_steps steps  in
+              FStar_Pervasives_Native.Some uu____6552
           | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None  in
         let inherited_steps =
           FStar_List.append
@@ -1822,7 +1825,7 @@ let get_norm_request :
                 else []))
            in
         match args with
-        | uu____6611::(tm,uu____6613)::[] ->
+        | uu____6587::(tm,uu____6589)::[] ->
             let s =
               [FStar_TypeChecker_Env.Beta;
               FStar_TypeChecker_Env.Zeta;
@@ -1833,7 +1836,7 @@ let get_norm_request :
               FStar_TypeChecker_Env.Reify]  in
             FStar_Pervasives_Native.Some
               ((FStar_List.append inherited_steps s), tm)
-        | (tm,uu____6642)::[] ->
+        | (tm,uu____6618)::[] ->
             let s =
               [FStar_TypeChecker_Env.Beta;
               FStar_TypeChecker_Env.Zeta;
@@ -1844,15 +1847,15 @@ let get_norm_request :
               FStar_TypeChecker_Env.Reify]  in
             FStar_Pervasives_Native.Some
               ((FStar_List.append inherited_steps s), tm)
-        | (steps,uu____6663)::uu____6664::(tm,uu____6666)::[] ->
-            let uu____6687 =
-              let uu____6692 = full_norm steps  in parse_steps uu____6692  in
-            (match uu____6687 with
+        | (steps,uu____6639)::uu____6640::(tm,uu____6642)::[] ->
+            let uu____6663 =
+              let uu____6668 = full_norm steps  in parse_steps uu____6668  in
+            (match uu____6663 with
              | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
              | FStar_Pervasives_Native.Some s ->
                  FStar_Pervasives_Native.Some
                    ((FStar_List.append inherited_steps s), tm))
-        | uu____6722 -> FStar_Pervasives_Native.None
+        | uu____6698 -> FStar_Pervasives_Native.None
   
 let (nbe_eval :
   FStar_TypeChecker_Cfg.cfg ->
@@ -1863,40 +1866,40 @@ let (nbe_eval :
     fun s  ->
       fun tm  ->
         let delta_level =
-          let uu____6754 =
+          let uu____6730 =
             FStar_All.pipe_right s
               (FStar_Util.for_some
-                 (fun uu___10_6761  ->
-                    match uu___10_6761 with
-                    | FStar_TypeChecker_Env.UnfoldUntil uu____6763 -> true
-                    | FStar_TypeChecker_Env.UnfoldOnly uu____6765 -> true
-                    | FStar_TypeChecker_Env.UnfoldFully uu____6769 -> true
-                    | uu____6773 -> false))
+                 (fun uu___10_6737  ->
+                    match uu___10_6737 with
+                    | FStar_TypeChecker_Env.UnfoldUntil uu____6739 -> true
+                    | FStar_TypeChecker_Env.UnfoldOnly uu____6741 -> true
+                    | FStar_TypeChecker_Env.UnfoldFully uu____6745 -> true
+                    | uu____6749 -> false))
              in
-          if uu____6754
+          if uu____6730
           then
             [FStar_TypeChecker_Env.Unfold FStar_Syntax_Syntax.delta_constant]
           else [FStar_TypeChecker_Env.NoDelta]  in
         FStar_TypeChecker_Cfg.log_nbe cfg
-          (fun uu____6783  ->
-             let uu____6784 = FStar_Syntax_Print.term_to_string tm  in
-             FStar_Util.print1 "Invoking NBE with  %s\n" uu____6784);
+          (fun uu____6759  ->
+             let uu____6760 = FStar_Syntax_Print.term_to_string tm  in
+             FStar_Util.print1 "Invoking NBE with  %s\n" uu____6760);
         (let tm_norm =
-           let uu____6788 =
-             let uu____6803 = FStar_TypeChecker_Cfg.cfg_env cfg  in
-             uu____6803.FStar_TypeChecker_Env.nbe  in
-           uu____6788 s cfg.FStar_TypeChecker_Cfg.tcenv tm  in
+           let uu____6764 =
+             let uu____6779 = FStar_TypeChecker_Cfg.cfg_env cfg  in
+             uu____6779.FStar_TypeChecker_Env.nbe  in
+           uu____6764 s cfg.FStar_TypeChecker_Cfg.tcenv tm  in
          FStar_TypeChecker_Cfg.log_nbe cfg
-           (fun uu____6807  ->
-              let uu____6808 = FStar_Syntax_Print.term_to_string tm_norm  in
-              FStar_Util.print1 "Result of NBE is  %s\n" uu____6808);
+           (fun uu____6783  ->
+              let uu____6784 = FStar_Syntax_Print.term_to_string tm_norm  in
+              FStar_Util.print1 "Result of NBE is  %s\n" uu____6784);
          tm_norm)
   
 let firstn :
-  'uuuuuu6818 .
+  'uuuuuu6794 .
     Prims.int ->
-      'uuuuuu6818 Prims.list ->
-        ('uuuuuu6818 Prims.list * 'uuuuuu6818 Prims.list)
+      'uuuuuu6794 Prims.list ->
+        ('uuuuuu6794 Prims.list * 'uuuuuu6794 Prims.list)
   =
   fun k  ->
     fun l  ->
@@ -1906,64 +1909,64 @@ let (should_reify :
   FStar_TypeChecker_Cfg.cfg -> stack_elt Prims.list -> Prims.bool) =
   fun cfg  ->
     fun stack1  ->
-      let rec drop_irrel uu___11_6875 =
-        match uu___11_6875 with
-        | (MemoLazy uu____6880)::s -> drop_irrel s
-        | (UnivArgs uu____6890)::s -> drop_irrel s
+      let rec drop_irrel uu___11_6851 =
+        match uu___11_6851 with
+        | (MemoLazy uu____6856)::s -> drop_irrel s
+        | (UnivArgs uu____6866)::s -> drop_irrel s
         | s -> s  in
-      let uu____6903 = drop_irrel stack1  in
-      match uu____6903 with
+      let uu____6879 = drop_irrel stack1  in
+      match uu____6879 with
       | (App
-          (uu____6907,{
+          (uu____6883,{
                         FStar_Syntax_Syntax.n =
                           FStar_Syntax_Syntax.Tm_constant
                           (FStar_Const.Const_reify );
-                        FStar_Syntax_Syntax.pos = uu____6908;
-                        FStar_Syntax_Syntax.vars = uu____6909;_},uu____6910,uu____6911))::uu____6912
+                        FStar_Syntax_Syntax.pos = uu____6884;
+                        FStar_Syntax_Syntax.vars = uu____6885;_},uu____6886,uu____6887))::uu____6888
           -> (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
-      | uu____6917 -> false
+      | uu____6893 -> false
   
 let rec (maybe_weakly_reduced :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun tm  ->
     let aux_comp c =
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.GTotal (t,uu____6946) -> maybe_weakly_reduced t
-      | FStar_Syntax_Syntax.Total (t,uu____6956) -> maybe_weakly_reduced t
+      | FStar_Syntax_Syntax.GTotal (t,uu____6922) -> maybe_weakly_reduced t
+      | FStar_Syntax_Syntax.Total (t,uu____6932) -> maybe_weakly_reduced t
       | FStar_Syntax_Syntax.Comp ct ->
           (maybe_weakly_reduced ct.FStar_Syntax_Syntax.result_typ) ||
             (FStar_Util.for_some
-               (fun uu____6977  ->
-                  match uu____6977 with
-                  | (a,uu____6988) -> maybe_weakly_reduced a)
+               (fun uu____6953  ->
+                  match uu____6953 with
+                  | (a,uu____6964) -> maybe_weakly_reduced a)
                ct.FStar_Syntax_Syntax.effect_args)
        in
     let t = FStar_Syntax_Subst.compress tm  in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____6999 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_name uu____7016 -> false
-    | FStar_Syntax_Syntax.Tm_uvar uu____7018 -> false
-    | FStar_Syntax_Syntax.Tm_type uu____7032 -> false
-    | FStar_Syntax_Syntax.Tm_bvar uu____7034 -> false
-    | FStar_Syntax_Syntax.Tm_fvar uu____7036 -> false
-    | FStar_Syntax_Syntax.Tm_constant uu____7038 -> false
-    | FStar_Syntax_Syntax.Tm_lazy uu____7040 -> false
+    | FStar_Syntax_Syntax.Tm_delayed uu____6975 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_name uu____6992 -> false
+    | FStar_Syntax_Syntax.Tm_uvar uu____6994 -> false
+    | FStar_Syntax_Syntax.Tm_type uu____7008 -> false
+    | FStar_Syntax_Syntax.Tm_bvar uu____7010 -> false
+    | FStar_Syntax_Syntax.Tm_fvar uu____7012 -> false
+    | FStar_Syntax_Syntax.Tm_constant uu____7014 -> false
+    | FStar_Syntax_Syntax.Tm_lazy uu____7016 -> false
     | FStar_Syntax_Syntax.Tm_unknown  -> false
-    | FStar_Syntax_Syntax.Tm_uinst uu____7043 -> false
-    | FStar_Syntax_Syntax.Tm_quoted uu____7051 -> false
-    | FStar_Syntax_Syntax.Tm_let uu____7059 -> true
-    | FStar_Syntax_Syntax.Tm_abs uu____7074 -> true
-    | FStar_Syntax_Syntax.Tm_arrow uu____7094 -> true
-    | FStar_Syntax_Syntax.Tm_refine uu____7110 -> true
-    | FStar_Syntax_Syntax.Tm_match uu____7118 -> true
+    | FStar_Syntax_Syntax.Tm_uinst uu____7019 -> false
+    | FStar_Syntax_Syntax.Tm_quoted uu____7027 -> false
+    | FStar_Syntax_Syntax.Tm_let uu____7035 -> true
+    | FStar_Syntax_Syntax.Tm_abs uu____7050 -> true
+    | FStar_Syntax_Syntax.Tm_arrow uu____7070 -> true
+    | FStar_Syntax_Syntax.Tm_refine uu____7086 -> true
+    | FStar_Syntax_Syntax.Tm_match uu____7094 -> true
     | FStar_Syntax_Syntax.Tm_app (t1,args) ->
         (maybe_weakly_reduced t1) ||
           (FStar_All.pipe_right args
              (FStar_Util.for_some
-                (fun uu____7190  ->
-                   match uu____7190 with
-                   | (a,uu____7201) -> maybe_weakly_reduced a)))
-    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____7212) ->
+                (fun uu____7166  ->
+                   match uu____7166 with
+                   | (a,uu____7177) -> maybe_weakly_reduced a)))
+    | FStar_Syntax_Syntax.Tm_ascribed (t1,asc,uu____7188) ->
         ((maybe_weakly_reduced t1) ||
            (match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> maybe_weakly_reduced t2
@@ -1975,19 +1978,19 @@ let rec (maybe_weakly_reduced :
     | FStar_Syntax_Syntax.Tm_meta (t1,m) ->
         (maybe_weakly_reduced t1) ||
           ((match m with
-            | FStar_Syntax_Syntax.Meta_pattern (uu____7311,args) ->
+            | FStar_Syntax_Syntax.Meta_pattern (uu____7287,args) ->
                 FStar_Util.for_some
                   (FStar_Util.for_some
-                     (fun uu____7366  ->
-                        match uu____7366 with
-                        | (a,uu____7377) -> maybe_weakly_reduced a)) args
+                     (fun uu____7342  ->
+                        match uu____7342 with
+                        | (a,uu____7353) -> maybe_weakly_reduced a)) args
             | FStar_Syntax_Syntax.Meta_monadic_lift
-                (uu____7386,uu____7387,t') -> maybe_weakly_reduced t'
-            | FStar_Syntax_Syntax.Meta_monadic (uu____7393,t') ->
+                (uu____7362,uu____7363,t') -> maybe_weakly_reduced t'
+            | FStar_Syntax_Syntax.Meta_monadic (uu____7369,t') ->
                 maybe_weakly_reduced t'
-            | FStar_Syntax_Syntax.Meta_labeled uu____7399 -> false
-            | FStar_Syntax_Syntax.Meta_desugared uu____7409 -> false
-            | FStar_Syntax_Syntax.Meta_named uu____7411 -> false))
+            | FStar_Syntax_Syntax.Meta_labeled uu____7375 -> false
+            | FStar_Syntax_Syntax.Meta_desugared uu____7385 -> false
+            | FStar_Syntax_Syntax.Meta_named uu____7387 -> false))
   
 type should_unfold_res =
   | Should_unfold_no 
@@ -1996,19 +1999,19 @@ type should_unfold_res =
   | Should_unfold_reify 
 let (uu___is_Should_unfold_no : should_unfold_res -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Should_unfold_no  -> true | uu____7422 -> false
+    match projectee with | Should_unfold_no  -> true | uu____7398 -> false
   
 let (uu___is_Should_unfold_yes : should_unfold_res -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Should_unfold_yes  -> true | uu____7433 -> false
+    match projectee with | Should_unfold_yes  -> true | uu____7409 -> false
   
 let (uu___is_Should_unfold_fully : should_unfold_res -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Should_unfold_fully  -> true | uu____7444 -> false
+    match projectee with | Should_unfold_fully  -> true | uu____7420 -> false
   
 let (uu___is_Should_unfold_reify : should_unfold_res -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Should_unfold_reify  -> true | uu____7455 -> false
+    match projectee with | Should_unfold_reify  -> true | uu____7431 -> false
   
 let (should_unfold :
   FStar_TypeChecker_Cfg.cfg ->
@@ -2021,8 +2024,8 @@ let (should_unfold :
       fun fv  ->
         fun qninfo  ->
           let attrs =
-            let uu____7488 = FStar_TypeChecker_Env.attrs_of_qninfo qninfo  in
-            match uu____7488 with
+            let uu____7464 = FStar_TypeChecker_Env.attrs_of_qninfo qninfo  in
+            match uu____7464 with
             | FStar_Pervasives_Native.None  -> []
             | FStar_Pervasives_Native.Some ats -> ats  in
           let yes = (true, false, false)  in
@@ -2033,41 +2036,41 @@ let (should_unfold :
           let fullyno b = if b then fully else no  in
           let comb_or l =
             FStar_List.fold_right
-              (fun uu____7687  ->
-                 fun uu____7688  ->
-                   match (uu____7687, uu____7688) with
+              (fun uu____7663  ->
+                 fun uu____7664  ->
+                   match (uu____7663, uu____7664) with
                    | ((a,b,c),(x,y,z)) -> ((a || x), (b || y), (c || z))) l
               (false, false, false)
              in
-          let string_of_res uu____7794 =
-            match uu____7794 with
+          let string_of_res uu____7770 =
+            match uu____7770 with
             | (x,y,z) ->
-                let uu____7814 = FStar_Util.string_of_bool x  in
-                let uu____7816 = FStar_Util.string_of_bool y  in
-                let uu____7818 = FStar_Util.string_of_bool z  in
-                FStar_Util.format3 "(%s,%s,%s)" uu____7814 uu____7816
-                  uu____7818
+                let uu____7790 = FStar_Util.string_of_bool x  in
+                let uu____7792 = FStar_Util.string_of_bool y  in
+                let uu____7794 = FStar_Util.string_of_bool z  in
+                FStar_Util.format3 "(%s,%s,%s)" uu____7790 uu____7792
+                  uu____7794
              in
           let res =
             if FStar_TypeChecker_Env.qninfo_is_action qninfo
             then
               let b = should_reify1 cfg  in
               (FStar_TypeChecker_Cfg.log_unfolding cfg
-                 (fun uu____7846  ->
-                    let uu____7847 = FStar_Syntax_Print.fv_to_string fv  in
-                    let uu____7849 = FStar_Util.string_of_bool b  in
+                 (fun uu____7822  ->
+                    let uu____7823 = FStar_Syntax_Print.fv_to_string fv  in
+                    let uu____7825 = FStar_Util.string_of_bool b  in
                     FStar_Util.print2
                       "should_unfold: For DM4F action %s, should_reify = %s\n"
-                      uu____7847 uu____7849);
+                      uu____7823 uu____7825);
                if b then reif else no)
             else
               if
-                (let uu____7864 = FStar_TypeChecker_Cfg.find_prim_step cfg fv
+                (let uu____7840 = FStar_TypeChecker_Cfg.find_prim_step cfg fv
                     in
-                 FStar_Option.isSome uu____7864)
+                 FStar_Option.isSome uu____7840)
               then
                 (FStar_TypeChecker_Cfg.log_unfolding cfg
-                   (fun uu____7869  ->
+                   (fun uu____7845  ->
                       FStar_Util.print_string
                         " >> It's a primop, not unfolding\n");
                  no)
@@ -2082,22 +2085,22 @@ let (should_unfold :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let
-                          ((is_rec,uu____7904),uu____7905);
-                        FStar_Syntax_Syntax.sigrng = uu____7906;
+                          ((is_rec,uu____7880),uu____7881);
+                        FStar_Syntax_Syntax.sigrng = uu____7882;
                         FStar_Syntax_Syntax.sigquals = qs;
-                        FStar_Syntax_Syntax.sigmeta = uu____7908;
-                        FStar_Syntax_Syntax.sigattrs = uu____7909;
-                        FStar_Syntax_Syntax.sigopts = uu____7910;_},uu____7911),uu____7912),uu____7913,uu____7914,uu____7915)
+                        FStar_Syntax_Syntax.sigmeta = uu____7884;
+                        FStar_Syntax_Syntax.sigattrs = uu____7885;
+                        FStar_Syntax_Syntax.sigopts = uu____7886;_},uu____7887),uu____7888),uu____7889,uu____7890,uu____7891)
                      when
                      FStar_List.contains FStar_Syntax_Syntax.HasMaskedEffect
                        qs
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8024  ->
+                        (fun uu____8000  ->
                            FStar_Util.print_string
                              " >> HasMaskedEffect, not unfolding\n");
                       no)
-                 | (uu____8026,uu____8027,uu____8028,uu____8029) when
+                 | (uu____8002,uu____8003,uu____8004,uu____8005) when
                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_tac
                        &&
                        (FStar_Util.for_some
@@ -2105,7 +2108,7 @@ let (should_unfold :
                              FStar_Syntax_Util.tac_opaque_attr) attrs)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8096  ->
+                        (fun uu____8072  ->
                            FStar_Util.print_string
                              " >> tac_opaque, not unfolding\n");
                       no)
@@ -2114,12 +2117,12 @@ let (should_unfold :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let
-                          ((is_rec,uu____8099),uu____8100);
-                        FStar_Syntax_Syntax.sigrng = uu____8101;
+                          ((is_rec,uu____8075),uu____8076);
+                        FStar_Syntax_Syntax.sigrng = uu____8077;
                         FStar_Syntax_Syntax.sigquals = qs;
-                        FStar_Syntax_Syntax.sigmeta = uu____8103;
-                        FStar_Syntax_Syntax.sigattrs = uu____8104;
-                        FStar_Syntax_Syntax.sigopts = uu____8105;_},uu____8106),uu____8107),uu____8108,uu____8109,uu____8110)
+                        FStar_Syntax_Syntax.sigmeta = uu____8079;
+                        FStar_Syntax_Syntax.sigattrs = uu____8080;
+                        FStar_Syntax_Syntax.sigopts = uu____8081;_},uu____8082),uu____8083),uu____8084,uu____8085,uu____8086)
                      when
                      (is_rec &&
                         (Prims.op_Negation
@@ -2129,38 +2132,38 @@ let (should_unfold :
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8219  ->
+                        (fun uu____8195  ->
                            FStar_Util.print_string
                              " >> It's a recursive definition but we're not doing Zeta, not unfolding\n");
                       no)
-                 | (uu____8221,FStar_Pervasives_Native.Some
-                    uu____8222,uu____8223,uu____8224) ->
+                 | (uu____8197,FStar_Pervasives_Native.Some
+                    uu____8198,uu____8199,uu____8200) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8292  ->
-                           let uu____8293 =
+                        (fun uu____8268  ->
+                           let uu____8269 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____8293);
-                      (let uu____8296 =
-                         let uu____8308 =
+                             uu____8269);
+                      (let uu____8272 =
+                         let uu____8284 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None  -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____8334 =
+                               let uu____8310 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids
                                   in
-                               FStar_All.pipe_left yesno uu____8334
+                               FStar_All.pipe_left yesno uu____8310
                             in
-                         let uu____8346 =
-                           let uu____8358 =
+                         let uu____8322 =
+                           let uu____8334 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None  -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8384 =
+                                 let uu____8360 =
                                    FStar_Util.for_some
                                      (fun at  ->
                                         FStar_Util.for_some
@@ -2168,53 +2171,53 @@ let (should_unfold :
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs
                                     in
-                                 FStar_All.pipe_left yesno uu____8384
+                                 FStar_All.pipe_left yesno uu____8360
                               in
-                           let uu____8400 =
-                             let uu____8412 =
+                           let uu____8376 =
+                             let uu____8388 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None  -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8438 =
+                                   let uu____8414 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids
                                       in
-                                   FStar_All.pipe_left fullyno uu____8438
+                                   FStar_All.pipe_left fullyno uu____8414
                                 in
-                             [uu____8412]  in
-                           uu____8358 :: uu____8400  in
-                         uu____8308 :: uu____8346  in
-                       comb_or uu____8296))
-                 | (uu____8486,uu____8487,FStar_Pervasives_Native.Some
-                    uu____8488,uu____8489) ->
+                             [uu____8388]  in
+                           uu____8334 :: uu____8376  in
+                         uu____8284 :: uu____8322  in
+                       comb_or uu____8272))
+                 | (uu____8462,uu____8463,FStar_Pervasives_Native.Some
+                    uu____8464,uu____8465) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8557  ->
-                           let uu____8558 =
+                        (fun uu____8533  ->
+                           let uu____8534 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____8558);
-                      (let uu____8561 =
-                         let uu____8573 =
+                             uu____8534);
+                      (let uu____8537 =
+                         let uu____8549 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None  -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____8599 =
+                               let uu____8575 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids
                                   in
-                               FStar_All.pipe_left yesno uu____8599
+                               FStar_All.pipe_left yesno uu____8575
                             in
-                         let uu____8611 =
-                           let uu____8623 =
+                         let uu____8587 =
+                           let uu____8599 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None  -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8649 =
+                                 let uu____8625 =
                                    FStar_Util.for_some
                                      (fun at  ->
                                         FStar_Util.for_some
@@ -2222,53 +2225,53 @@ let (should_unfold :
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs
                                     in
-                                 FStar_All.pipe_left yesno uu____8649
+                                 FStar_All.pipe_left yesno uu____8625
                               in
-                           let uu____8665 =
-                             let uu____8677 =
+                           let uu____8641 =
+                             let uu____8653 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None  -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8703 =
+                                   let uu____8679 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids
                                       in
-                                   FStar_All.pipe_left fullyno uu____8703
+                                   FStar_All.pipe_left fullyno uu____8679
                                 in
-                             [uu____8677]  in
-                           uu____8623 :: uu____8665  in
-                         uu____8573 :: uu____8611  in
-                       comb_or uu____8561))
-                 | (uu____8751,uu____8752,uu____8753,FStar_Pervasives_Native.Some
-                    uu____8754) ->
+                             [uu____8653]  in
+                           uu____8599 :: uu____8641  in
+                         uu____8549 :: uu____8587  in
+                       comb_or uu____8537))
+                 | (uu____8727,uu____8728,uu____8729,FStar_Pervasives_Native.Some
+                    uu____8730) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8822  ->
-                           let uu____8823 =
+                        (fun uu____8798  ->
+                           let uu____8799 =
                              FStar_Syntax_Print.fv_to_string fv  in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____8823);
-                      (let uu____8826 =
-                         let uu____8838 =
+                             uu____8799);
+                      (let uu____8802 =
+                         let uu____8814 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None  -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____8864 =
+                               let uu____8840 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids
                                   in
-                               FStar_All.pipe_left yesno uu____8864
+                               FStar_All.pipe_left yesno uu____8840
                             in
-                         let uu____8876 =
-                           let uu____8888 =
+                         let uu____8852 =
+                           let uu____8864 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None  -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8914 =
+                                 let uu____8890 =
                                    FStar_Util.for_some
                                      (fun at  ->
                                         FStar_Util.for_some
@@ -2276,92 +2279,92 @@ let (should_unfold :
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs
                                     in
-                                 FStar_All.pipe_left yesno uu____8914
+                                 FStar_All.pipe_left yesno uu____8890
                               in
-                           let uu____8930 =
-                             let uu____8942 =
+                           let uu____8906 =
+                             let uu____8918 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None  -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8968 =
+                                   let uu____8944 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids
                                       in
-                                   FStar_All.pipe_left fullyno uu____8968
+                                   FStar_All.pipe_left fullyno uu____8944
                                 in
-                             [uu____8942]  in
-                           uu____8888 :: uu____8930  in
-                         uu____8838 :: uu____8876  in
-                       comb_or uu____8826))
-                 | uu____9016 ->
+                             [uu____8918]  in
+                           uu____8864 :: uu____8906  in
+                         uu____8814 :: uu____8852  in
+                       comb_or uu____8802))
+                 | uu____8992 ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____9062  ->
-                           let uu____9063 =
+                        (fun uu____9038  ->
+                           let uu____9039 =
                              FStar_Syntax_Print.fv_to_string fv  in
-                           let uu____9065 =
+                           let uu____9041 =
                              FStar_Syntax_Print.delta_depth_to_string
                                fv.FStar_Syntax_Syntax.fv_delta
                               in
-                           let uu____9067 =
+                           let uu____9043 =
                              FStar_Common.string_of_list
                                FStar_TypeChecker_Env.string_of_delta_level
                                cfg.FStar_TypeChecker_Cfg.delta_level
                               in
                            FStar_Util.print3
                              "should_unfold: Reached a %s with delta_depth = %s\n >> Our delta_level is %s\n"
-                             uu____9063 uu____9065 uu____9067);
-                      (let uu____9070 =
+                             uu____9039 uu____9041 uu____9043);
+                      (let uu____9046 =
                          FStar_All.pipe_right
                            cfg.FStar_TypeChecker_Cfg.delta_level
                            (FStar_Util.for_some
-                              (fun uu___12_9076  ->
-                                 match uu___12_9076 with
+                              (fun uu___12_9052  ->
+                                 match uu___12_9052 with
                                  | FStar_TypeChecker_Env.NoDelta  -> false
                                  | FStar_TypeChecker_Env.InliningDelta  ->
                                      true
                                  | FStar_TypeChecker_Env.Eager_unfolding_only
                                       -> true
                                  | FStar_TypeChecker_Env.Unfold l ->
-                                     let uu____9082 =
+                                     let uu____9058 =
                                        FStar_TypeChecker_Env.delta_depth_of_fv
                                          cfg.FStar_TypeChecker_Cfg.tcenv fv
                                         in
                                      FStar_TypeChecker_Common.delta_depth_greater_than
-                                       uu____9082 l))
+                                       uu____9058 l))
                           in
-                       FStar_All.pipe_left yesno uu____9070)))
+                       FStar_All.pipe_left yesno uu____9046)))
              in
           FStar_TypeChecker_Cfg.log_unfolding cfg
-            (fun uu____9098  ->
-               let uu____9099 = FStar_Syntax_Print.fv_to_string fv  in
-               let uu____9101 =
-                 let uu____9103 = FStar_Syntax_Syntax.range_of_fv fv  in
-                 FStar_Range.string_of_range uu____9103  in
-               let uu____9104 = string_of_res res  in
+            (fun uu____9074  ->
+               let uu____9075 = FStar_Syntax_Print.fv_to_string fv  in
+               let uu____9077 =
+                 let uu____9079 = FStar_Syntax_Syntax.range_of_fv fv  in
+                 FStar_Range.string_of_range uu____9079  in
+               let uu____9080 = string_of_res res  in
                FStar_Util.print3
                  "should_unfold: For %s (%s), unfolding res = %s\n"
-                 uu____9099 uu____9101 uu____9104);
+                 uu____9075 uu____9077 uu____9080);
           (match res with
-           | (false ,uu____9107,uu____9108) -> Should_unfold_no
+           | (false ,uu____9083,uu____9084) -> Should_unfold_no
            | (true ,false ,false ) -> Should_unfold_yes
            | (true ,true ,false ) -> Should_unfold_fully
            | (true ,false ,true ) -> Should_unfold_reify
-           | uu____9133 ->
-               let uu____9143 =
-                 let uu____9145 = string_of_res res  in
+           | uu____9109 ->
+               let uu____9119 =
+                 let uu____9121 = string_of_res res  in
                  FStar_Util.format1 "Unexpected unfolding result: %s"
-                   uu____9145
+                   uu____9121
                   in
-               FStar_All.pipe_left failwith uu____9143)
+               FStar_All.pipe_left failwith uu____9119)
   
 let decide_unfolding :
-  'uuuuuu9164 .
+  'uuuuuu9140 .
     FStar_TypeChecker_Cfg.cfg ->
       env ->
         stack_elt Prims.list ->
-          'uuuuuu9164 ->
+          'uuuuuu9140 ->
             FStar_Syntax_Syntax.fv ->
               FStar_TypeChecker_Env.qninfo ->
                 (FStar_TypeChecker_Cfg.cfg * stack_elt Prims.list)
@@ -2383,28 +2386,28 @@ let decide_unfolding :
                   FStar_Pervasives_Native.Some (cfg, stack1)
               | Should_unfold_fully  ->
                   let cfg' =
-                    let uu___1165_9233 = cfg  in
+                    let uu___1163_9209 = cfg  in
                     {
                       FStar_TypeChecker_Cfg.steps =
-                        (let uu___1167_9236 = cfg.FStar_TypeChecker_Cfg.steps
+                        (let uu___1165_9212 = cfg.FStar_TypeChecker_Cfg.steps
                             in
                          {
                            FStar_TypeChecker_Cfg.beta =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.beta);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.beta);
                            FStar_TypeChecker_Cfg.iota =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.iota);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.iota);
                            FStar_TypeChecker_Cfg.zeta =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.zeta);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.zeta);
                            FStar_TypeChecker_Cfg.zeta_full =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.zeta_full);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.zeta_full);
                            FStar_TypeChecker_Cfg.weak =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.weak);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.weak);
                            FStar_TypeChecker_Cfg.hnf =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.hnf);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.hnf);
                            FStar_TypeChecker_Cfg.primops =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.primops);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.primops);
                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                            FStar_TypeChecker_Cfg.unfold_until =
                              (FStar_Pervasives_Native.Some
                                 FStar_Syntax_Syntax.delta_constant);
@@ -2415,53 +2418,53 @@ let decide_unfolding :
                            FStar_TypeChecker_Cfg.unfold_attr =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.unfold_tac);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.unfold_tac);
                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                              =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                            FStar_TypeChecker_Cfg.simplify =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.simplify);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.simplify);
                            FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.erase_universes);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.erase_universes);
                            FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.allow_unbound_universes);
                            FStar_TypeChecker_Cfg.reify_ =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.reify_);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.reify_);
                            FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.compress_uvars);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.compress_uvars);
                            FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.no_full_norm);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.no_full_norm);
                            FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.check_no_uvars);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.check_no_uvars);
                            FStar_TypeChecker_Cfg.unmeta =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.unmeta);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.unmeta);
                            FStar_TypeChecker_Cfg.unascribe =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.unascribe);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.unascribe);
                            FStar_TypeChecker_Cfg.in_full_norm_request =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.in_full_norm_request);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.in_full_norm_request);
                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                            FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.nbe_step);
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___1167_9236.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___1165_9212.FStar_TypeChecker_Cfg.for_extraction)
                          });
                       FStar_TypeChecker_Cfg.tcenv =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.tcenv);
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.tcenv);
                       FStar_TypeChecker_Cfg.debug =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.debug);
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.debug);
                       FStar_TypeChecker_Cfg.delta_level =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.delta_level);
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.delta_level);
                       FStar_TypeChecker_Cfg.primitive_steps =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.primitive_steps);
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.primitive_steps);
                       FStar_TypeChecker_Cfg.strong =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.strong);
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.strong);
                       FStar_TypeChecker_Cfg.memoize_lazy =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.memoize_lazy);
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.memoize_lazy);
                       FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.normalize_pure_lets);
                       FStar_TypeChecker_Cfg.reifying =
-                        (uu___1165_9233.FStar_TypeChecker_Cfg.reifying)
+                        (uu___1163_9209.FStar_TypeChecker_Cfg.reifying)
                     }  in
                   let stack' =
                     match stack1 with
@@ -2474,20 +2477,16 @@ let decide_unfolding :
                     match s with
                     | [] -> [e]
                     | (UnivArgs (us,r))::t ->
-                        let uu____9298 = push e t  in (UnivArgs (us, r)) ::
-                          uu____9298
+                        let uu____9274 = push e t  in (UnivArgs (us, r)) ::
+                          uu____9274
                     | h::t -> e :: h :: t  in
                   let ref =
-                    let uu____9310 =
-                      let uu____9317 =
-                        let uu____9318 =
-                          let uu____9319 = FStar_Syntax_Syntax.lid_of_fv fv
-                             in
-                          FStar_Const.Const_reflect uu____9319  in
-                        FStar_Syntax_Syntax.Tm_constant uu____9318  in
-                      FStar_Syntax_Syntax.mk uu____9317  in
-                    uu____9310 FStar_Pervasives_Native.None
-                      FStar_Range.dummyRange
+                    let uu____9286 =
+                      let uu____9287 =
+                        let uu____9288 = FStar_Syntax_Syntax.lid_of_fv fv  in
+                        FStar_Const.Const_reflect uu____9288  in
+                      FStar_Syntax_Syntax.Tm_constant uu____9287  in
+                    FStar_Syntax_Syntax.mk uu____9286 FStar_Range.dummyRange
                      in
                   let stack2 =
                     push
@@ -2514,31 +2513,31 @@ let (is_fext_on_domain :
       FStar_All.pipe_right on_domain_lids
         (FStar_List.existsb (fun l  -> FStar_Syntax_Syntax.fv_eq_lid fv l))
        in
-    let uu____9385 =
-      let uu____9386 = FStar_Syntax_Subst.compress t  in
-      uu____9386.FStar_Syntax_Syntax.n  in
-    match uu____9385 with
+    let uu____9354 =
+      let uu____9355 = FStar_Syntax_Subst.compress t  in
+      uu____9355.FStar_Syntax_Syntax.n  in
+    match uu____9354 with
     | FStar_Syntax_Syntax.Tm_app (hd,args) ->
-        let uu____9417 =
-          let uu____9418 = FStar_Syntax_Util.un_uinst hd  in
-          uu____9418.FStar_Syntax_Syntax.n  in
-        (match uu____9417 with
+        let uu____9386 =
+          let uu____9387 = FStar_Syntax_Util.un_uinst hd  in
+          uu____9387.FStar_Syntax_Syntax.n  in
+        (match uu____9386 with
          | FStar_Syntax_Syntax.Tm_fvar fv when
              (is_on_dom fv) &&
                ((FStar_List.length args) = (Prims.of_int (3)))
              ->
              let f =
-               let uu____9435 =
-                 let uu____9442 =
-                   let uu____9453 = FStar_All.pipe_right args FStar_List.tl
+               let uu____9404 =
+                 let uu____9411 =
+                   let uu____9422 = FStar_All.pipe_right args FStar_List.tl
                       in
-                   FStar_All.pipe_right uu____9453 FStar_List.tl  in
-                 FStar_All.pipe_right uu____9442 FStar_List.hd  in
-               FStar_All.pipe_right uu____9435 FStar_Pervasives_Native.fst
+                   FStar_All.pipe_right uu____9422 FStar_List.tl  in
+                 FStar_All.pipe_right uu____9411 FStar_List.hd  in
+               FStar_All.pipe_right uu____9404 FStar_Pervasives_Native.fst
                 in
              FStar_Pervasives_Native.Some f
-         | uu____9552 -> FStar_Pervasives_Native.None)
-    | uu____9553 -> FStar_Pervasives_Native.None
+         | uu____9521 -> FStar_Pervasives_Native.None)
+    | uu____9522 -> FStar_Pervasives_Native.None
   
 let rec (norm :
   FStar_TypeChecker_Cfg.cfg ->
@@ -2553,93 +2552,93 @@ let rec (norm :
               (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.norm_delayed
             then
               (match t.FStar_Syntax_Syntax.n with
-               | FStar_Syntax_Syntax.Tm_delayed uu____9832 ->
-                   let uu____9847 = FStar_Syntax_Print.term_to_string t  in
-                   FStar_Util.print1 "NORM delayed: %s\n" uu____9847
-               | uu____9850 -> ())
+               | FStar_Syntax_Syntax.Tm_delayed uu____9801 ->
+                   let uu____9816 = FStar_Syntax_Print.term_to_string t  in
+                   FStar_Util.print1 "NORM delayed: %s\n" uu____9816
+               | uu____9819 -> ())
             else ();
             FStar_Syntax_Subst.compress t  in
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____9860  ->
-               let uu____9861 = FStar_Syntax_Print.tag_of_term t1  in
-               let uu____9863 =
+            (fun uu____9829  ->
+               let uu____9830 = FStar_Syntax_Print.tag_of_term t1  in
+               let uu____9832 =
                  FStar_Util.string_of_bool
                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.no_full_norm
                   in
-               let uu____9865 = FStar_Syntax_Print.term_to_string t1  in
-               let uu____9867 =
+               let uu____9834 = FStar_Syntax_Print.term_to_string t1  in
+               let uu____9836 =
                  FStar_Util.string_of_int (FStar_List.length env1)  in
-               let uu____9875 =
-                 let uu____9877 =
-                   let uu____9880 = firstn (Prims.of_int (4)) stack1  in
-                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu____9880
+               let uu____9844 =
+                 let uu____9846 =
+                   let uu____9849 = firstn (Prims.of_int (4)) stack1  in
+                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu____9849
                     in
-                 stack_to_string uu____9877  in
+                 stack_to_string uu____9846  in
                FStar_Util.print5
                  ">>> %s (no_full_norm=%s)\nNorm %s  with with %s env elements top of the stack %s \n"
-                 uu____9861 uu____9863 uu____9865 uu____9867 uu____9875);
+                 uu____9830 uu____9832 uu____9834 uu____9836 uu____9844);
           FStar_TypeChecker_Cfg.log_cfg cfg
-            (fun uu____9908  ->
-               let uu____9909 = FStar_TypeChecker_Cfg.cfg_to_string cfg  in
-               FStar_Util.print1 ">>> cfg = %s\n" uu____9909);
+            (fun uu____9877  ->
+               let uu____9878 = FStar_TypeChecker_Cfg.cfg_to_string cfg  in
+               FStar_Util.print1 ">>> cfg = %s\n" uu____9878);
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown  ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9915  ->
-                     let uu____9916 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9884  ->
+                     let uu____9885 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9916);
+                       uu____9885);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_constant uu____9919 ->
+           | FStar_Syntax_Syntax.Tm_constant uu____9888 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9923  ->
-                     let uu____9924 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9892  ->
+                     let uu____9893 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9924);
+                       uu____9893);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_name uu____9927 ->
+           | FStar_Syntax_Syntax.Tm_name uu____9896 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9931  ->
-                     let uu____9932 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9900  ->
+                     let uu____9901 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9932);
+                       uu____9901);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_lazy uu____9935 ->
+           | FStar_Syntax_Syntax.Tm_lazy uu____9904 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9939  ->
-                     let uu____9940 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9908  ->
+                     let uu____9909 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9940);
+                       uu____9909);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____9943;
-                 FStar_Syntax_Syntax.fv_delta = uu____9944;
+               { FStar_Syntax_Syntax.fv_name = uu____9912;
+                 FStar_Syntax_Syntax.fv_delta = uu____9913;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.Data_ctor );_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9948  ->
-                     let uu____9949 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9917  ->
+                     let uu____9918 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9949);
+                       uu____9918);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____9952;
-                 FStar_Syntax_Syntax.fv_delta = uu____9953;
+               { FStar_Syntax_Syntax.fv_name = uu____9921;
+                 FStar_Syntax_Syntax.fv_delta = uu____9922;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-                   (FStar_Syntax_Syntax.Record_ctor uu____9954);_}
+                   (FStar_Syntax_Syntax.Record_ctor uu____9923);_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9964  ->
-                     let uu____9965 = FStar_Syntax_Print.term_to_string t1
+                  (fun uu____9933  ->
+                     let uu____9934 = FStar_Syntax_Print.term_to_string t1
                         in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9965);
+                       uu____9934);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                let lid = FStar_Syntax_Syntax.lid_of_fv fv  in
@@ -2647,25 +2646,25 @@ let rec (norm :
                  FStar_TypeChecker_Env.lookup_qname
                    cfg.FStar_TypeChecker_Cfg.tcenv lid
                   in
-               let uu____9971 =
+               let uu____9940 =
                  FStar_TypeChecker_Env.delta_depth_of_qninfo fv qninfo  in
-               (match uu____9971 with
+               (match uu____9940 with
                 | FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Delta_constant_at_level uu____9974)
-                    when uu____9974 = Prims.int_zero ->
+                    (FStar_Syntax_Syntax.Delta_constant_at_level uu____9943)
+                    when uu____9943 = Prims.int_zero ->
                     (FStar_TypeChecker_Cfg.log_unfolding cfg
-                       (fun uu____9978  ->
-                          let uu____9979 =
+                       (fun uu____9947  ->
+                          let uu____9948 =
                             FStar_Syntax_Print.term_to_string t1  in
                           FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                            uu____9979);
+                            uu____9948);
                      rebuild cfg env1 stack1 t1)
-                | uu____9982 ->
-                    let uu____9985 =
+                | uu____9951 ->
+                    let uu____9954 =
                       decide_unfolding cfg env1 stack1
                         t1.FStar_Syntax_Syntax.pos fv qninfo
                        in
-                    (match uu____9985 with
+                    (match uu____9954 with
                      | FStar_Pervasives_Native.Some (cfg1,stack2) ->
                          do_unfold_fv cfg1 env1 stack2 t1 qninfo fv
                      | FStar_Pervasives_Native.None  ->
@@ -2674,114 +2673,115 @@ let rec (norm :
                let qi1 =
                  FStar_Syntax_Syntax.on_antiquoted (norm cfg env1 []) qi  in
                let t2 =
-                 mk (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
+                 FStar_Syntax_Syntax.mk
+                   (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
                    t1.FStar_Syntax_Syntax.pos
                   in
-               let uu____10024 = closure_as_term cfg env1 t2  in
-               rebuild cfg env1 stack1 uu____10024
+               let uu____9993 = closure_as_term cfg env1 t2  in
+               rebuild cfg env1 stack1 uu____9993
            | FStar_Syntax_Syntax.Tm_app (hd,args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____10052 = is_norm_request hd args  in
-                  uu____10052 = Norm_request_requires_rejig)
+                 (let uu____10021 = is_norm_request hd args  in
+                  uu____10021 = Norm_request_requires_rejig)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Rejigging norm request ... \n"
                 else ();
-                (let uu____10058 = rejig_norm_request hd args  in
-                 norm cfg env1 stack1 uu____10058))
+                (let uu____10027 = rejig_norm_request hd args  in
+                 norm cfg env1 stack1 uu____10027))
            | FStar_Syntax_Syntax.Tm_app (hd,args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____10086 = is_norm_request hd args  in
-                  uu____10086 = Norm_request_ready)
+                 (let uu____10055 = is_norm_request hd args  in
+                  uu____10055 = Norm_request_ready)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Potential norm request ... \n"
                 else ();
                 (let cfg' =
-                   let uu___1278_10093 = cfg  in
+                   let uu___1276_10062 = cfg  in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1280_10096 = cfg.FStar_TypeChecker_Cfg.steps
+                       (let uu___1278_10065 = cfg.FStar_TypeChecker_Cfg.steps
                            in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.beta);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.iota);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.zeta);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.zeta_full =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.zeta_full);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.zeta_full);
                           FStar_TypeChecker_Cfg.weak =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.weak);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.weak);
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.hnf);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.primops);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
                             false;
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_fully =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.simplify);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.reify_);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1280_10096.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___1278_10065.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1278_10093.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___1276_10062.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1278_10093.FStar_TypeChecker_Cfg.debug);
+                       (uu___1276_10062.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
                        [FStar_TypeChecker_Env.Unfold
                           FStar_Syntax_Syntax.delta_constant];
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1278_10093.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___1276_10062.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1278_10093.FStar_TypeChecker_Cfg.strong);
+                       (uu___1276_10062.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1278_10093.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___1276_10062.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1278_10093.FStar_TypeChecker_Cfg.reifying)
+                       (uu___1276_10062.FStar_TypeChecker_Cfg.reifying)
                    }  in
-                 let uu____10103 =
+                 let uu____10072 =
                    get_norm_request cfg (norm cfg' env1 []) args  in
-                 match uu____10103 with
+                 match uu____10072 with
                  | FStar_Pervasives_Native.None  ->
                      (if
                         (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
@@ -2790,35 +2790,35 @@ let rec (norm :
                       (let stack2 =
                          FStar_All.pipe_right stack1
                            (FStar_List.fold_right
-                              (fun uu____10139  ->
+                              (fun uu____10108  ->
                                  fun stack2  ->
-                                   match uu____10139 with
+                                   match uu____10108 with
                                    | (a,aq) ->
-                                       let uu____10151 =
-                                         let uu____10152 =
-                                           let uu____10159 =
-                                             let uu____10160 =
-                                               let uu____10192 =
+                                       let uu____10120 =
+                                         let uu____10121 =
+                                           let uu____10128 =
+                                             let uu____10129 =
+                                               let uu____10161 =
                                                  FStar_Util.mk_ref
                                                    FStar_Pervasives_Native.None
                                                   in
-                                               (env1, a, uu____10192, false)
+                                               (env1, a, uu____10161, false)
                                                 in
-                                             Clos uu____10160  in
-                                           (uu____10159, aq,
+                                             Clos uu____10129  in
+                                           (uu____10128, aq,
                                              (t1.FStar_Syntax_Syntax.pos))
                                             in
-                                         Arg uu____10152  in
-                                       uu____10151 :: stack2) args)
+                                         Arg uu____10121  in
+                                       uu____10120 :: stack2) args)
                           in
                        FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____10260  ->
-                            let uu____10261 =
+                         (fun uu____10229  ->
+                            let uu____10230 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args)
                                in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____10261);
+                              uu____10230);
                        norm cfg env1 stack2 hd))
                  | FStar_Pervasives_Native.Some (s,tm) when is_nbe_request s
                      ->
@@ -2833,157 +2833,157 @@ let rec (norm :
                            FStar_TypeChecker_Cfg.config' [] s
                              cfg.FStar_TypeChecker_Cfg.tcenv
                             in
-                         let uu____10293 =
-                           let uu____10295 =
-                             let uu____10297 = FStar_Util.time_diff start fin
+                         let uu____10262 =
+                           let uu____10264 =
+                             let uu____10266 = FStar_Util.time_diff start fin
                                 in
-                             FStar_Pervasives_Native.snd uu____10297  in
-                           FStar_Util.string_of_int uu____10295  in
-                         let uu____10304 =
+                             FStar_Pervasives_Native.snd uu____10266  in
+                           FStar_Util.string_of_int uu____10264  in
+                         let uu____10273 =
                            FStar_Syntax_Print.term_to_string tm'  in
-                         let uu____10306 =
+                         let uu____10275 =
                            FStar_TypeChecker_Cfg.cfg_to_string cfg'1  in
-                         let uu____10308 =
+                         let uu____10277 =
                            FStar_Syntax_Print.term_to_string tm_norm  in
                          FStar_Util.print4
                            "NBE result timing (%s ms){\nOn term {\n%s\n}\nwith steps {%s}\nresult is{\n\n%s\n}\n}\n"
-                           uu____10293 uu____10304 uu____10306 uu____10308)
+                           uu____10262 uu____10273 uu____10275 uu____10277)
                       else ();
                       rebuild cfg env1 stack1 tm_norm)
                  | FStar_Pervasives_Native.Some (s,tm) ->
                      let delta_level =
-                       let uu____10328 =
+                       let uu____10297 =
                          FStar_All.pipe_right s
                            (FStar_Util.for_some
-                              (fun uu___13_10335  ->
-                                 match uu___13_10335 with
+                              (fun uu___13_10304  ->
+                                 match uu___13_10304 with
                                  | FStar_TypeChecker_Env.UnfoldUntil
-                                     uu____10337 -> true
+                                     uu____10306 -> true
                                  | FStar_TypeChecker_Env.UnfoldOnly
-                                     uu____10339 -> true
+                                     uu____10308 -> true
                                  | FStar_TypeChecker_Env.UnfoldFully
-                                     uu____10343 -> true
-                                 | uu____10347 -> false))
+                                     uu____10312 -> true
+                                 | uu____10316 -> false))
                           in
-                       if uu____10328
+                       if uu____10297
                        then
                          [FStar_TypeChecker_Env.Unfold
                             FStar_Syntax_Syntax.delta_constant]
                        else [FStar_TypeChecker_Env.NoDelta]  in
                      let cfg'1 =
-                       let uu___1318_10355 = cfg  in
-                       let uu____10356 =
-                         let uu___1320_10357 =
+                       let uu___1316_10324 = cfg  in
+                       let uu____10325 =
+                         let uu___1318_10326 =
                            FStar_TypeChecker_Cfg.to_fsteps s  in
                          {
                            FStar_TypeChecker_Cfg.beta =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.beta);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.beta);
                            FStar_TypeChecker_Cfg.iota =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.iota);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.iota);
                            FStar_TypeChecker_Cfg.zeta =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.zeta);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.zeta);
                            FStar_TypeChecker_Cfg.zeta_full =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.zeta_full);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.zeta_full);
                            FStar_TypeChecker_Cfg.weak =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.weak);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.weak);
                            FStar_TypeChecker_Cfg.hnf =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.hnf);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.hnf);
                            FStar_TypeChecker_Cfg.primops =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.primops);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.primops);
                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                            FStar_TypeChecker_Cfg.unfold_until =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.unfold_until);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.unfold_until);
                            FStar_TypeChecker_Cfg.unfold_only =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.unfold_only);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.unfold_only);
                            FStar_TypeChecker_Cfg.unfold_fully =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.unfold_fully);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.unfold_fully);
                            FStar_TypeChecker_Cfg.unfold_attr =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.unfold_attr);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.unfold_attr);
                            FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.unfold_tac);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.unfold_tac);
                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                              =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                            FStar_TypeChecker_Cfg.simplify =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.simplify);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.simplify);
                            FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.erase_universes);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.erase_universes);
                            FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.allow_unbound_universes);
                            FStar_TypeChecker_Cfg.reify_ =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.reify_);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.reify_);
                            FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.compress_uvars);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.compress_uvars);
                            FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.no_full_norm);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.no_full_norm);
                            FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.check_no_uvars);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.check_no_uvars);
                            FStar_TypeChecker_Cfg.unmeta =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.unmeta);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.unmeta);
                            FStar_TypeChecker_Cfg.unascribe =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.unascribe);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.unascribe);
                            FStar_TypeChecker_Cfg.in_full_norm_request = true;
                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                            FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.nbe_step);
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___1320_10357.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___1318_10326.FStar_TypeChecker_Cfg.for_extraction)
                          }  in
                        {
-                         FStar_TypeChecker_Cfg.steps = uu____10356;
+                         FStar_TypeChecker_Cfg.steps = uu____10325;
                          FStar_TypeChecker_Cfg.tcenv =
-                           (uu___1318_10355.FStar_TypeChecker_Cfg.tcenv);
+                           (uu___1316_10324.FStar_TypeChecker_Cfg.tcenv);
                          FStar_TypeChecker_Cfg.debug =
-                           (uu___1318_10355.FStar_TypeChecker_Cfg.debug);
+                           (uu___1316_10324.FStar_TypeChecker_Cfg.debug);
                          FStar_TypeChecker_Cfg.delta_level = delta_level;
                          FStar_TypeChecker_Cfg.primitive_steps =
-                           (uu___1318_10355.FStar_TypeChecker_Cfg.primitive_steps);
+                           (uu___1316_10324.FStar_TypeChecker_Cfg.primitive_steps);
                          FStar_TypeChecker_Cfg.strong =
-                           (uu___1318_10355.FStar_TypeChecker_Cfg.strong);
+                           (uu___1316_10324.FStar_TypeChecker_Cfg.strong);
                          FStar_TypeChecker_Cfg.memoize_lazy =
-                           (uu___1318_10355.FStar_TypeChecker_Cfg.memoize_lazy);
+                           (uu___1316_10324.FStar_TypeChecker_Cfg.memoize_lazy);
                          FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                          FStar_TypeChecker_Cfg.reifying =
-                           (uu___1318_10355.FStar_TypeChecker_Cfg.reifying)
+                           (uu___1316_10324.FStar_TypeChecker_Cfg.reifying)
                        }  in
                      let stack' =
                        let tail = (Cfg cfg) :: stack1  in
                        if
                          (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                        then
-                         let uu____10365 =
-                           let uu____10366 =
-                             let uu____10371 = FStar_Util.now ()  in
-                             (tm, uu____10371)  in
-                           Debug uu____10366  in
-                         uu____10365 :: tail
+                         let uu____10334 =
+                           let uu____10335 =
+                             let uu____10340 = FStar_Util.now ()  in
+                             (tm, uu____10340)  in
+                           Debug uu____10335  in
+                         uu____10334 :: tail
                        else tail  in
                      norm cfg'1 env1 stack' tm))
            | FStar_Syntax_Syntax.Tm_type u ->
                let u1 = norm_universe cfg env1 u  in
-               let uu____10376 =
-                 mk (FStar_Syntax_Syntax.Tm_type u1)
+               let uu____10345 =
+                 FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u1)
                    t1.FStar_Syntax_Syntax.pos
                   in
-               rebuild cfg env1 stack1 uu____10376
+               rebuild cfg env1 stack1 uu____10345
            | FStar_Syntax_Syntax.Tm_uinst (t',us) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                then norm cfg env1 stack1 t'
                else
                  (let us1 =
-                    let uu____10387 =
-                      let uu____10394 =
+                    let uu____10356 =
+                      let uu____10363 =
                         FStar_List.map (norm_universe cfg env1) us  in
-                      (uu____10394, (t1.FStar_Syntax_Syntax.pos))  in
-                    UnivArgs uu____10387  in
+                      (uu____10363, (t1.FStar_Syntax_Syntax.pos))  in
+                    UnivArgs uu____10356  in
                   let stack2 = us1 :: stack1  in norm cfg env1 stack2 t')
            | FStar_Syntax_Syntax.Tm_bvar x ->
-               let uu____10403 = lookup_bvar env1 x  in
-               (match uu____10403 with
-                | Univ uu____10404 ->
+               let uu____10372 = lookup_bvar env1 x  in
+               (match uu____10372 with
+                | Univ uu____10373 ->
                     failwith
                       "Impossible: term variable is bound to a universe"
                 | Dummy  -> failwith "Term variable not found"
@@ -2994,20 +2994,20 @@ let rec (norm :
                         ||
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full
                     then
-                      let uu____10458 = FStar_ST.op_Bang r  in
-                      (match uu____10458 with
+                      let uu____10427 = FStar_ST.op_Bang r  in
+                      (match uu____10427 with
                        | FStar_Pervasives_Native.Some (env3,t') ->
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10554  ->
-                                 let uu____10555 =
+                              (fun uu____10523  ->
+                                 let uu____10524 =
                                    FStar_Syntax_Print.term_to_string t1  in
-                                 let uu____10557 =
+                                 let uu____10526 =
                                    FStar_Syntax_Print.term_to_string t'  in
                                  FStar_Util.print2
-                                   "Lazy hit: %s cached to %s\n" uu____10555
-                                   uu____10557);
-                            (let uu____10560 = maybe_weakly_reduced t'  in
-                             if uu____10560
+                                   "Lazy hit: %s cached to %s\n" uu____10524
+                                   uu____10526);
+                            (let uu____10529 = maybe_weakly_reduced t'  in
+                             if uu____10529
                              then
                                match stack1 with
                                | [] when
@@ -3015,41 +3015,41 @@ let rec (norm :
                                      ||
                                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                                    -> rebuild cfg env3 stack1 t'
-                               | uu____10563 -> norm cfg env3 stack1 t'
+                               | uu____10532 -> norm cfg env3 stack1 t'
                              else rebuild cfg env3 stack1 t'))
                        | FStar_Pervasives_Native.None  ->
                            norm cfg env2 ((MemoLazy r) :: stack1) t0)
                     else norm cfg env2 stack1 t0)
            | FStar_Syntax_Syntax.Tm_abs (bs,body,lopt) ->
                (match stack1 with
-                | (UnivArgs uu____10607)::uu____10608 ->
+                | (UnivArgs uu____10576)::uu____10577 ->
                     failwith
                       "Ill-typed term: universes cannot be applied to term abstraction"
-                | (Arg (c,uu____10619,uu____10620))::stack_rest ->
+                | (Arg (c,uu____10588,uu____10589))::stack_rest ->
                     (match c with
-                     | Univ uu____10624 ->
+                     | Univ uu____10593 ->
                          norm cfg ((FStar_Pervasives_Native.None, c) :: env1)
                            stack_rest t1
-                     | uu____10633 ->
+                     | uu____10602 ->
                          (match bs with
                           | [] -> failwith "Impossible"
                           | b::[] ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____10663  ->
-                                    let uu____10664 = closure_to_string c  in
+                                 (fun uu____10632  ->
+                                    let uu____10633 = closure_to_string c  in
                                     FStar_Util.print1 "\tShifted %s\n"
-                                      uu____10664);
+                                      uu____10633);
                                norm cfg
                                  (((FStar_Pervasives_Native.Some b), c) ::
                                  env1) stack_rest body)
                           | b::tl ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____10700  ->
-                                    let uu____10701 = closure_to_string c  in
+                                 (fun uu____10669  ->
+                                    let uu____10670 = closure_to_string c  in
                                     FStar_Util.print1 "\tShifted %s\n"
-                                      uu____10701);
+                                      uu____10670);
                                (let body1 =
-                                  mk
+                                  FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_abs
                                        (tl, body, lopt))
                                     t1.FStar_Syntax_Syntax.pos
@@ -3061,27 +3061,27 @@ let rec (norm :
                 | (MemoLazy r)::stack2 ->
                     (set_memo cfg r (env1, t1);
                      FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____10749  ->
-                          let uu____10750 =
+                       (fun uu____10718  ->
+                          let uu____10719 =
                             FStar_Syntax_Print.term_to_string t1  in
-                          FStar_Util.print1 "\tSet memo %s\n" uu____10750);
+                          FStar_Util.print1 "\tSet memo %s\n" uu____10719);
                      norm cfg env1 stack2 t1)
-                | (Match uu____10753)::uu____10754 ->
+                | (Match uu____10722)::uu____10723 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10769 =
+                      (let uu____10738 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____10769 with
+                       match uu____10738 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____10805  -> dummy :: env2) env1)
+                                     fun uu____10774  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3093,78 +3093,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____10849 =
+                                          let uu____10818 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____10849)
+                                          norm cfg env' [] uu____10818)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_10857 = rc  in
+                                   (let uu___1440_10826 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_10857.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_10826.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_10857.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_10826.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10858 -> lopt  in
+                             | uu____10827 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10864  ->
-                                 let uu____10865 =
+                              (fun uu____10833  ->
+                                 let uu____10834 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10865);
+                                   uu____10834);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_10880 = cfg  in
+                               let uu___1447_10849 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_10880.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_10849.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Debug uu____10884)::uu____10885 ->
+                | (Debug uu____10853)::uu____10854 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10896 =
+                      (let uu____10865 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____10896 with
+                       match uu____10865 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____10932  -> dummy :: env2) env1)
+                                     fun uu____10901  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3176,78 +3176,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____10976 =
+                                          let uu____10945 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____10976)
+                                          norm cfg env' [] uu____10945)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_10984 = rc  in
+                                   (let uu___1440_10953 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_10984.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_10953.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_10984.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_10953.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10985 -> lopt  in
+                             | uu____10954 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10991  ->
-                                 let uu____10992 =
+                              (fun uu____10960  ->
+                                 let uu____10961 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10992);
+                                   uu____10961);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_11007 = cfg  in
+                               let uu___1447_10976 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_11007.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_10976.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Meta uu____11011)::uu____11012 ->
+                | (Meta uu____10980)::uu____10981 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____11025 =
+                      (let uu____10994 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11025 with
+                       match uu____10994 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____11061  -> dummy :: env2) env1)
+                                     fun uu____11030  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3259,78 +3259,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11105 =
+                                          let uu____11074 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11105)
+                                          norm cfg env' [] uu____11074)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_11113 = rc  in
+                                   (let uu___1440_11082 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_11113.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_11082.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_11113.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_11082.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11114 -> lopt  in
+                             | uu____11083 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11120  ->
-                                 let uu____11121 =
+                              (fun uu____11089  ->
+                                 let uu____11090 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11121);
+                                   uu____11090);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_11136 = cfg  in
+                               let uu___1447_11105 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_11136.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_11105.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Let uu____11140)::uu____11141 ->
+                | (Let uu____11109)::uu____11110 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____11156 =
+                      (let uu____11125 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11156 with
+                       match uu____11125 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____11192  -> dummy :: env2) env1)
+                                     fun uu____11161  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3342,78 +3342,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11236 =
+                                          let uu____11205 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11236)
+                                          norm cfg env' [] uu____11205)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_11244 = rc  in
+                                   (let uu___1440_11213 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_11244.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_11213.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_11244.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_11213.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11245 -> lopt  in
+                             | uu____11214 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11251  ->
-                                 let uu____11252 =
+                              (fun uu____11220  ->
+                                 let uu____11221 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11252);
+                                   uu____11221);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_11267 = cfg  in
+                               let uu___1447_11236 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_11267.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_11236.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (App uu____11271)::uu____11272 ->
+                | (App uu____11240)::uu____11241 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____11287 =
+                      (let uu____11256 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11287 with
+                       match uu____11256 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____11323  -> dummy :: env2) env1)
+                                     fun uu____11292  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3425,78 +3425,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11367 =
+                                          let uu____11336 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11367)
+                                          norm cfg env' [] uu____11336)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_11375 = rc  in
+                                   (let uu___1440_11344 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_11375.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_11344.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_11375.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_11344.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11376 -> lopt  in
+                             | uu____11345 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11382  ->
-                                 let uu____11383 =
+                              (fun uu____11351  ->
+                                 let uu____11352 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11383);
+                                   uu____11352);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_11398 = cfg  in
+                               let uu___1447_11367 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_11398.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_11367.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (CBVApp uu____11402)::uu____11403 ->
+                | (CBVApp uu____11371)::uu____11372 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____11418 =
+                      (let uu____11387 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11418 with
+                       match uu____11387 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____11454  -> dummy :: env2) env1)
+                                     fun uu____11423  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3508,78 +3508,78 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11498 =
+                                          let uu____11467 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11498)
+                                          norm cfg env' [] uu____11467)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_11506 = rc  in
+                                   (let uu___1440_11475 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_11506.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_11475.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_11506.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_11475.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11507 -> lopt  in
+                             | uu____11476 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11513  ->
-                                 let uu____11514 =
+                              (fun uu____11482  ->
+                                 let uu____11483 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11514);
+                                   uu____11483);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_11529 = cfg  in
+                               let uu___1447_11498 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_11529.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_11498.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Abs uu____11533)::uu____11534 ->
+                | (Abs uu____11502)::uu____11503 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____11553 =
+                      (let uu____11522 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11553 with
+                       match uu____11522 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____11589  -> dummy :: env2) env1)
+                                     fun uu____11558  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3591,56 +3591,56 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11633 =
+                                          let uu____11602 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11633)
+                                          norm cfg env' [] uu____11602)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_11641 = rc  in
+                                   (let uu___1440_11610 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_11641.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_11610.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_11641.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_11610.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11642 -> lopt  in
+                             | uu____11611 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11648  ->
-                                 let uu____11649 =
+                              (fun uu____11617  ->
+                                 let uu____11618 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11649);
+                                   uu____11618);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_11664 = cfg  in
+                               let uu___1447_11633 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_11664.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_11633.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
@@ -3654,15 +3654,15 @@ let rec (norm :
                       let t2 = closure_as_term cfg env1 t1  in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____11672 =
+                      (let uu____11641 =
                          FStar_Syntax_Subst.open_term' bs body  in
-                       match uu____11672 with
+                       match uu____11641 with
                        | (bs1,body1,opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2  ->
-                                     fun uu____11708  -> dummy :: env2) env1)
+                                     fun uu____11677  -> dummy :: env2) env1)
                               in
                            let lopt1 =
                              match lopt with
@@ -3674,56 +3674,56 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2  ->
-                                          let uu____11752 =
+                                          let uu____11721 =
                                             FStar_Syntax_Subst.subst opening
                                               t2
                                              in
-                                          norm cfg env' [] uu____11752)
+                                          norm cfg env' [] uu____11721)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening)
                                     in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1442_11760 = rc  in
+                                   (let uu___1440_11729 = rc  in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1442_11760.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1440_11729.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1442_11760.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1440_11729.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____11761 -> lopt  in
+                             | uu____11730 -> lopt  in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____11767  ->
-                                 let uu____11768 =
+                              (fun uu____11736  ->
+                                 let uu____11737 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1)
                                     in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____11768);
+                                   uu____11737);
                             (let stack2 = (Cfg cfg) :: stack1  in
                              let cfg1 =
-                               let uu___1449_11783 = cfg  in
+                               let uu___1447_11752 = cfg  in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1449_11783.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1447_11752.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              norm cfg1 env'
                                ((Abs
@@ -3732,141 +3732,140 @@ let rec (norm :
                                stack2) body1))))
            | FStar_Syntax_Syntax.Tm_app (head,args) ->
                let strict_args =
-                 let uu____11819 =
-                   let uu____11820 = FStar_Syntax_Util.un_uinst head  in
-                   uu____11820.FStar_Syntax_Syntax.n  in
-                 match uu____11819 with
+                 let uu____11788 =
+                   let uu____11789 = FStar_Syntax_Util.un_uinst head  in
+                   uu____11789.FStar_Syntax_Syntax.n  in
+                 match uu____11788 with
                  | FStar_Syntax_Syntax.Tm_fvar fv ->
                      FStar_TypeChecker_Env.fv_has_strict_args
                        cfg.FStar_TypeChecker_Cfg.tcenv fv
-                 | uu____11829 -> FStar_Pervasives_Native.None  in
+                 | uu____11798 -> FStar_Pervasives_Native.None  in
                (match strict_args with
                 | FStar_Pervasives_Native.None  ->
                     let stack2 =
                       FStar_All.pipe_right stack1
                         (FStar_List.fold_right
-                           (fun uu____11850  ->
+                           (fun uu____11819  ->
                               fun stack2  ->
-                                match uu____11850 with
+                                match uu____11819 with
                                 | (a,aq) ->
-                                    let uu____11862 =
-                                      let uu____11863 =
-                                        let uu____11870 =
-                                          let uu____11871 =
-                                            let uu____11903 =
+                                    let uu____11831 =
+                                      let uu____11832 =
+                                        let uu____11839 =
+                                          let uu____11840 =
+                                            let uu____11872 =
                                               FStar_Util.mk_ref
                                                 FStar_Pervasives_Native.None
                                                in
-                                            (env1, a, uu____11903, false)  in
-                                          Clos uu____11871  in
-                                        (uu____11870, aq,
+                                            (env1, a, uu____11872, false)  in
+                                          Clos uu____11840  in
+                                        (uu____11839, aq,
                                           (t1.FStar_Syntax_Syntax.pos))
                                          in
-                                      Arg uu____11863  in
-                                    uu____11862 :: stack2) args)
+                                      Arg uu____11832  in
+                                    uu____11831 :: stack2) args)
                        in
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11971  ->
-                          let uu____11972 =
+                       (fun uu____11940  ->
+                          let uu____11941 =
                             FStar_All.pipe_left FStar_Util.string_of_int
                               (FStar_List.length args)
                              in
                           FStar_Util.print1 "\tPushed %s arguments\n"
-                            uu____11972);
+                            uu____11941);
                      norm cfg env1 stack2 head)
                 | FStar_Pervasives_Native.Some strict_args1 ->
                     let norm_args =
                       FStar_All.pipe_right args
                         (FStar_List.map
-                           (fun uu____12023  ->
-                              match uu____12023 with
+                           (fun uu____11992  ->
+                              match uu____11992 with
                               | (a,i) ->
-                                  let uu____12034 = norm cfg env1 [] a  in
-                                  (uu____12034, i)))
+                                  let uu____12003 = norm cfg env1 [] a  in
+                                  (uu____12003, i)))
                        in
                     let norm_args_len = FStar_List.length norm_args  in
-                    let uu____12040 =
+                    let uu____12009 =
                       FStar_All.pipe_right strict_args1
                         (FStar_List.for_all
                            (fun i  ->
                               if i >= norm_args_len
                               then false
                               else
-                                (let uu____12055 = FStar_List.nth norm_args i
+                                (let uu____12024 = FStar_List.nth norm_args i
                                     in
-                                 match uu____12055 with
-                                 | (arg_i,uu____12066) ->
-                                     let uu____12067 =
+                                 match uu____12024 with
+                                 | (arg_i,uu____12035) ->
+                                     let uu____12036 =
                                        FStar_Syntax_Util.head_and_args arg_i
                                         in
-                                     (match uu____12067 with
-                                      | (head1,uu____12086) ->
-                                          let uu____12111 =
-                                            let uu____12112 =
+                                     (match uu____12036 with
+                                      | (head1,uu____12055) ->
+                                          let uu____12080 =
+                                            let uu____12081 =
                                               FStar_Syntax_Util.un_uinst
                                                 head1
                                                in
-                                            uu____12112.FStar_Syntax_Syntax.n
+                                            uu____12081.FStar_Syntax_Syntax.n
                                              in
-                                          (match uu____12111 with
+                                          (match uu____12080 with
                                            | FStar_Syntax_Syntax.Tm_constant
-                                               uu____12116 -> true
+                                               uu____12085 -> true
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
-                                               let uu____12119 =
+                                               let uu____12088 =
                                                  FStar_Syntax_Syntax.lid_of_fv
                                                    fv
                                                   in
                                                FStar_TypeChecker_Env.is_datacon
                                                  cfg.FStar_TypeChecker_Cfg.tcenv
-                                                 uu____12119
-                                           | uu____12120 -> false)))))
+                                                 uu____12088
+                                           | uu____12089 -> false)))))
                        in
-                    if uu____12040
+                    if uu____12009
                     then
                       let stack2 =
                         FStar_All.pipe_right stack1
                           (FStar_List.fold_right
-                             (fun uu____12137  ->
+                             (fun uu____12106  ->
                                 fun stack2  ->
-                                  match uu____12137 with
+                                  match uu____12106 with
                                   | (a,aq) ->
-                                      let uu____12149 =
-                                        let uu____12150 =
-                                          let uu____12157 =
-                                            let uu____12158 =
-                                              let uu____12190 =
+                                      let uu____12118 =
+                                        let uu____12119 =
+                                          let uu____12126 =
+                                            let uu____12127 =
+                                              let uu____12159 =
                                                 FStar_Util.mk_ref
                                                   (FStar_Pervasives_Native.Some
                                                      ([], a))
                                                  in
-                                              (env1, a, uu____12190, false)
+                                              (env1, a, uu____12159, false)
                                                in
-                                            Clos uu____12158  in
-                                          (uu____12157, aq,
+                                            Clos uu____12127  in
+                                          (uu____12126, aq,
                                             (t1.FStar_Syntax_Syntax.pos))
                                            in
-                                        Arg uu____12150  in
-                                      uu____12149 :: stack2) norm_args)
+                                        Arg uu____12119  in
+                                      uu____12118 :: stack2) norm_args)
                          in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____12272  ->
-                            let uu____12273 =
+                         (fun uu____12241  ->
+                            let uu____12242 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args)
                                in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____12273);
+                              uu____12242);
                        norm cfg env1 stack2 head)
                     else
                       (let head1 = closure_as_term cfg env1 head  in
                        let term =
                          FStar_Syntax_Syntax.mk_Tm_app head1 norm_args
-                           FStar_Pervasives_Native.None
                            t1.FStar_Syntax_Syntax.pos
                           in
                        rebuild cfg env1 stack1 term))
-           | FStar_Syntax_Syntax.Tm_refine (x,uu____12293) when
+           | FStar_Syntax_Syntax.Tm_refine (x,uu____12260) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                -> norm cfg env1 stack1 x.FStar_Syntax_Syntax.sort
            | FStar_Syntax_Syntax.Tm_refine (x,f) ->
@@ -3878,156 +3877,162 @@ let rec (norm :
                       let t_x = norm cfg env1 [] x.FStar_Syntax_Syntax.sort
                          in
                       let t2 =
-                        mk
+                        FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_refine
-                             ((let uu___1511_12338 = x  in
+                             ((let uu___1509_12305 = x  in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1511_12338.FStar_Syntax_Syntax.ppname);
+                                   (uu___1509_12305.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1511_12338.FStar_Syntax_Syntax.index);
+                                   (uu___1509_12305.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t_x
                                }), f)) t1.FStar_Syntax_Syntax.pos
                          in
                       rebuild cfg env1 stack1 t2
-                  | uu____12339 ->
-                      let uu____12354 = closure_as_term cfg env1 t1  in
-                      rebuild cfg env1 stack1 uu____12354)
+                  | uu____12306 ->
+                      let uu____12321 = closure_as_term cfg env1 t1  in
+                      rebuild cfg env1 stack1 uu____12321)
                else
                  (let t_x = norm cfg env1 [] x.FStar_Syntax_Syntax.sort  in
-                  let uu____12358 =
+                  let uu____12325 =
                     FStar_Syntax_Subst.open_term
                       [(x, FStar_Pervasives_Native.None)] f
                      in
-                  match uu____12358 with
+                  match uu____12325 with
                   | (closing,f1) ->
                       let f2 = norm cfg (dummy :: env1) [] f1  in
                       let t2 =
-                        let uu____12389 =
-                          let uu____12390 =
-                            let uu____12397 =
+                        let uu____12356 =
+                          let uu____12357 =
+                            let uu____12364 =
                               FStar_Syntax_Subst.close closing f2  in
-                            ((let uu___1520_12403 = x  in
+                            ((let uu___1518_12370 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1520_12403.FStar_Syntax_Syntax.ppname);
+                                  (uu___1518_12370.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___1520_12403.FStar_Syntax_Syntax.index);
+                                  (uu___1518_12370.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t_x
-                              }), uu____12397)
+                              }), uu____12364)
                              in
-                          FStar_Syntax_Syntax.Tm_refine uu____12390  in
-                        mk uu____12389 t1.FStar_Syntax_Syntax.pos  in
+                          FStar_Syntax_Syntax.Tm_refine uu____12357  in
+                        FStar_Syntax_Syntax.mk uu____12356
+                          t1.FStar_Syntax_Syntax.pos
+                         in
                       rebuild cfg env1 stack1 t2)
            | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                then
-                 let uu____12427 = closure_as_term cfg env1 t1  in
-                 rebuild cfg env1 stack1 uu____12427
+                 let uu____12394 = closure_as_term cfg env1 t1  in
+                 rebuild cfg env1 stack1 uu____12394
                else
-                 (let uu____12430 = FStar_Syntax_Subst.open_comp bs c  in
-                  match uu____12430 with
+                 (let uu____12397 = FStar_Syntax_Subst.open_comp bs c  in
+                  match uu____12397 with
                   | (bs1,c1) ->
                       let c2 =
-                        let uu____12438 =
+                        let uu____12405 =
                           FStar_All.pipe_right bs1
                             (FStar_List.fold_left
                                (fun env2  ->
-                                  fun uu____12464  -> dummy :: env2) env1)
+                                  fun uu____12431  -> dummy :: env2) env1)
                            in
-                        norm_comp cfg uu____12438 c1  in
+                        norm_comp cfg uu____12405 c1  in
                       let t2 =
-                        let uu____12488 = norm_binders cfg env1 bs1  in
-                        FStar_Syntax_Util.arrow uu____12488 c2  in
+                        let uu____12455 = norm_binders cfg env1 bs1  in
+                        FStar_Syntax_Util.arrow uu____12455 c2  in
                       rebuild cfg env1 stack1 t2)
            | FStar_Syntax_Syntax.Tm_ascribed (t11,(tc,tacopt),l) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unascribe
                -> norm cfg env1 stack1 t11
            | FStar_Syntax_Syntax.Tm_ascribed (t11,(tc,tacopt),l) ->
                (match stack1 with
-                | (Match uu____12601)::uu____12602 when
+                | (Match uu____12568)::uu____12569 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12615  ->
+                       (fun uu____12582  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | (Arg uu____12617)::uu____12618 when
+                | (Arg uu____12584)::uu____12585 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12629  ->
+                       (fun uu____12596  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
                 | (App
-                    (uu____12631,{
+                    (uu____12598,{
                                    FStar_Syntax_Syntax.n =
                                      FStar_Syntax_Syntax.Tm_constant
                                      (FStar_Const.Const_reify );
-                                   FStar_Syntax_Syntax.pos = uu____12632;
-                                   FStar_Syntax_Syntax.vars = uu____12633;_},uu____12634,uu____12635))::uu____12636
+                                   FStar_Syntax_Syntax.pos = uu____12599;
+                                   FStar_Syntax_Syntax.vars = uu____12600;_},uu____12601,uu____12602))::uu____12603
                     when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12643  ->
+                       (fun uu____12610  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | (MemoLazy uu____12645)::uu____12646 when
+                | (MemoLazy uu____12612)::uu____12613 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12657  ->
+                       (fun uu____12624  ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | uu____12659 ->
+                | uu____12626 ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12662  ->
+                       (fun uu____12629  ->
                           FStar_Util.print_string "+++ Keeping ascription \n");
                      (let t12 = norm cfg env1 [] t11  in
                       FStar_TypeChecker_Cfg.log cfg
-                        (fun uu____12667  ->
+                        (fun uu____12634  ->
                            FStar_Util.print_string
                              "+++ Normalizing ascription \n");
                       (let tc1 =
                          match tc with
                          | FStar_Util.Inl t2 ->
-                             let uu____12693 = norm cfg env1 [] t2  in
-                             FStar_Util.Inl uu____12693
+                             let uu____12660 = norm cfg env1 [] t2  in
+                             FStar_Util.Inl uu____12660
                          | FStar_Util.Inr c ->
-                             let uu____12707 = norm_comp cfg env1 c  in
-                             FStar_Util.Inr uu____12707
+                             let uu____12674 = norm_comp cfg env1 c  in
+                             FStar_Util.Inr uu____12674
                           in
                        let tacopt1 =
                          FStar_Util.map_opt tacopt (norm cfg env1 [])  in
                        match stack1 with
                        | (Cfg cfg1)::stack2 ->
                            let t2 =
-                             let uu____12730 =
-                               let uu____12731 =
-                                 let uu____12758 =
+                             let uu____12697 =
+                               let uu____12698 =
+                                 let uu____12725 =
                                    FStar_Syntax_Util.unascribe t12  in
-                                 (uu____12758, (tc1, tacopt1), l)  in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____12731
+                                 (uu____12725, (tc1, tacopt1), l)  in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____12698
                                 in
-                             mk uu____12730 t1.FStar_Syntax_Syntax.pos  in
+                             FStar_Syntax_Syntax.mk uu____12697
+                               t1.FStar_Syntax_Syntax.pos
+                              in
                            norm cfg1 env1 stack2 t2
-                       | uu____12793 ->
-                           let uu____12794 =
-                             let uu____12795 =
-                               let uu____12796 =
-                                 let uu____12823 =
+                       | uu____12760 ->
+                           let uu____12761 =
+                             let uu____12762 =
+                               let uu____12763 =
+                                 let uu____12790 =
                                    FStar_Syntax_Util.unascribe t12  in
-                                 (uu____12823, (tc1, tacopt1), l)  in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____12796
+                                 (uu____12790, (tc1, tacopt1), l)  in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____12763
                                 in
-                             mk uu____12795 t1.FStar_Syntax_Syntax.pos  in
-                           rebuild cfg env1 stack1 uu____12794))))
+                             FStar_Syntax_Syntax.mk uu____12762
+                               t1.FStar_Syntax_Syntax.pos
+                              in
+                           rebuild cfg env1 stack1 uu____12761))))
            | FStar_Syntax_Syntax.Tm_match (head,branches1) ->
                let stack2 =
                  (Match (env1, branches1, cfg, (t1.FStar_Syntax_Syntax.pos)))
@@ -4041,83 +4046,83 @@ let rec (norm :
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak)
                then
                  let cfg' =
-                   let uu___1599_12901 = cfg  in
+                   let uu___1597_12868 = cfg  in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1601_12904 = cfg.FStar_TypeChecker_Cfg.steps
+                       (let uu___1599_12871 = cfg.FStar_TypeChecker_Cfg.steps
                            in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.beta);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.iota);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.zeta);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.zeta_full =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.zeta_full);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.zeta_full);
                           FStar_TypeChecker_Cfg.weak = true;
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.hnf);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.primops);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.unfold_only);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.unfold_only);
                           FStar_TypeChecker_Cfg.unfold_fully =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.unfold_fully);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.unfold_fully);
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.simplify);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.reify_);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1601_12904.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___1599_12871.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.debug);
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.delta_level);
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.delta_level);
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.strong);
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.normalize_pure_lets);
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1599_12901.FStar_TypeChecker_Cfg.reifying)
+                       (uu___1597_12868.FStar_TypeChecker_Cfg.reifying)
                    }  in
                  norm cfg' env1 ((Cfg cfg) :: stack2) head
                else norm cfg env1 stack2 head
@@ -4129,137 +4134,136 @@ let rec (norm :
                  FStar_All.pipe_right lbs
                    (FStar_List.map
                       (fun lb  ->
-                         let uu____12945 =
+                         let uu____12912 =
                            FStar_Syntax_Subst.univ_var_opening
                              lb.FStar_Syntax_Syntax.lbunivs
                             in
-                         match uu____12945 with
+                         match uu____12912 with
                          | (openings,lbunivs) ->
                              let cfg1 =
-                               let uu___1614_12965 = cfg  in
-                               let uu____12966 =
+                               let uu___1612_12932 = cfg  in
+                               let uu____12933 =
                                  FStar_TypeChecker_Env.push_univ_vars
                                    cfg.FStar_TypeChecker_Cfg.tcenv lbunivs
                                   in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.steps);
-                                 FStar_TypeChecker_Cfg.tcenv = uu____12966;
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.steps);
+                                 FStar_TypeChecker_Cfg.tcenv = uu____12933;
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.strong);
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.strong);
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1614_12965.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1612_12932.FStar_TypeChecker_Cfg.reifying)
                                }  in
                              let norm1 t2 =
-                               let uu____12973 =
-                                 let uu____12974 =
+                               let uu____12940 =
+                                 let uu____12941 =
                                    FStar_Syntax_Subst.subst openings t2  in
-                                 norm cfg1 env1 [] uu____12974  in
+                                 norm cfg1 env1 [] uu____12941  in
                                FStar_Syntax_Subst.close_univ_vars lbunivs
-                                 uu____12973
+                                 uu____12940
                                 in
                              let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp
                                 in
                              let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef
                                 in
-                             let uu___1621_12977 = lb  in
+                             let uu___1619_12944 = lb  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1621_12977.FStar_Syntax_Syntax.lbname);
+                                 (uu___1619_12944.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs = lbunivs;
                                FStar_Syntax_Syntax.lbtyp = lbtyp;
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1621_12977.FStar_Syntax_Syntax.lbeff);
+                                 (uu___1619_12944.FStar_Syntax_Syntax.lbeff);
                                FStar_Syntax_Syntax.lbdef = lbdef;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1621_12977.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___1619_12944.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1621_12977.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1619_12944.FStar_Syntax_Syntax.lbpos)
                              }))
                   in
-               let uu____12978 =
-                 mk (FStar_Syntax_Syntax.Tm_let ((b, lbs1), lbody))
+               let uu____12945 =
+                 FStar_Syntax_Syntax.mk
+                   (FStar_Syntax_Syntax.Tm_let ((b, lbs1), lbody))
                    t1.FStar_Syntax_Syntax.pos
                   in
-               rebuild cfg env1 stack1 uu____12978
+               rebuild cfg env1 stack1 uu____12945
            | FStar_Syntax_Syntax.Tm_let
-               ((uu____12991,{
+               ((uu____12958,{
                                FStar_Syntax_Syntax.lbname = FStar_Util.Inr
-                                 uu____12992;
-                               FStar_Syntax_Syntax.lbunivs = uu____12993;
-                               FStar_Syntax_Syntax.lbtyp = uu____12994;
-                               FStar_Syntax_Syntax.lbeff = uu____12995;
-                               FStar_Syntax_Syntax.lbdef = uu____12996;
-                               FStar_Syntax_Syntax.lbattrs = uu____12997;
-                               FStar_Syntax_Syntax.lbpos = uu____12998;_}::uu____12999),uu____13000)
+                                 uu____12959;
+                               FStar_Syntax_Syntax.lbunivs = uu____12960;
+                               FStar_Syntax_Syntax.lbtyp = uu____12961;
+                               FStar_Syntax_Syntax.lbeff = uu____12962;
+                               FStar_Syntax_Syntax.lbdef = uu____12963;
+                               FStar_Syntax_Syntax.lbattrs = uu____12964;
+                               FStar_Syntax_Syntax.lbpos = uu____12965;_}::uu____12966),uu____12967)
                -> rebuild cfg env1 stack1 t1
            | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
-               let uu____13045 =
+               let uu____13012 =
                  FStar_TypeChecker_Cfg.should_reduce_local_let cfg lb  in
-               if uu____13045
+               if uu____13012
                then
                  let binder =
-                   let uu____13049 =
+                   let uu____13016 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
-                   FStar_Syntax_Syntax.mk_binder uu____13049  in
+                   FStar_Syntax_Syntax.mk_binder uu____13016  in
                  let def =
                    FStar_Syntax_Util.unmeta_lift lb.FStar_Syntax_Syntax.lbdef
                     in
                  let env2 =
-                   let uu____13060 =
-                     let uu____13067 =
-                       let uu____13068 =
-                         let uu____13100 =
+                   let uu____13027 =
+                     let uu____13034 =
+                       let uu____13035 =
+                         let uu____13067 =
                            FStar_Util.mk_ref FStar_Pervasives_Native.None  in
-                         (env1, def, uu____13100, false)  in
-                       Clos uu____13068  in
-                     ((FStar_Pervasives_Native.Some binder), uu____13067)  in
-                   uu____13060 :: env1  in
+                         (env1, def, uu____13067, false)  in
+                       Clos uu____13035  in
+                     ((FStar_Pervasives_Native.Some binder), uu____13034)  in
+                   uu____13027 :: env1  in
                  (FStar_TypeChecker_Cfg.log cfg
-                    (fun uu____13175  ->
+                    (fun uu____13142  ->
                        FStar_Util.print_string "+++ Reducing Tm_let\n");
                   norm cfg env2 stack1 body)
                else
-                 (let uu____13179 =
+                 (let uu____13146 =
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
                       &&
-                      (let uu____13182 =
+                      (let uu____13149 =
                          FStar_TypeChecker_Env.norm_eff_name
                            cfg.FStar_TypeChecker_Cfg.tcenv
                            lb.FStar_Syntax_Syntax.lbeff
                           in
-                       FStar_Syntax_Util.is_div_effect uu____13182)
+                       FStar_Syntax_Util.is_div_effect uu____13149)
                      in
-                  if uu____13179
+                  if uu____13146
                   then
                     let ffun =
-                      let uu____13187 =
-                        let uu____13194 =
-                          let uu____13195 =
-                            let uu____13214 =
-                              let uu____13223 =
-                                let uu____13230 =
-                                  FStar_All.pipe_right
-                                    lb.FStar_Syntax_Syntax.lbname
-                                    FStar_Util.left
-                                   in
-                                FStar_Syntax_Syntax.mk_binder uu____13230  in
-                              [uu____13223]  in
-                            (uu____13214, body, FStar_Pervasives_Native.None)
-                             in
-                          FStar_Syntax_Syntax.Tm_abs uu____13195  in
-                        FStar_Syntax_Syntax.mk uu____13194  in
-                      uu____13187 FStar_Pervasives_Native.None
+                      let uu____13154 =
+                        let uu____13155 =
+                          let uu____13174 =
+                            let uu____13183 =
+                              let uu____13190 =
+                                FStar_All.pipe_right
+                                  lb.FStar_Syntax_Syntax.lbname
+                                  FStar_Util.left
+                                 in
+                              FStar_Syntax_Syntax.mk_binder uu____13190  in
+                            [uu____13183]  in
+                          (uu____13174, body, FStar_Pervasives_Native.None)
+                           in
+                        FStar_Syntax_Syntax.Tm_abs uu____13155  in
+                      FStar_Syntax_Syntax.mk uu____13154
                         t1.FStar_Syntax_Syntax.pos
                        in
                     let stack2 =
@@ -4268,7 +4272,7 @@ let rec (norm :
                            (t1.FStar_Syntax_Syntax.pos)))
                       :: stack1  in
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____13264  ->
+                       (fun uu____13224  ->
                           FStar_Util.print_string
                             "+++ Evaluating DIV Tm_let\n");
                      norm cfg env1 stack2 lb.FStar_Syntax_Syntax.lbdef)
@@ -4277,29 +4281,29 @@ let rec (norm :
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____13271  ->
+                         (fun uu____13231  ->
                             FStar_Util.print_string
                               "+++ Not touching Tm_let\n");
-                       (let uu____13273 = closure_as_term cfg env1 t1  in
-                        rebuild cfg env1 stack1 uu____13273))
+                       (let uu____13233 = closure_as_term cfg env1 t1  in
+                        rebuild cfg env1 stack1 uu____13233))
                     else
-                      (let uu____13276 =
-                         let uu____13281 =
-                           let uu____13282 =
-                             let uu____13289 =
+                      (let uu____13236 =
+                         let uu____13241 =
+                           let uu____13242 =
+                             let uu____13249 =
                                FStar_All.pipe_right
                                  lb.FStar_Syntax_Syntax.lbname
                                  FStar_Util.left
                                 in
-                             FStar_All.pipe_right uu____13289
+                             FStar_All.pipe_right uu____13249
                                FStar_Syntax_Syntax.mk_binder
                               in
-                           [uu____13282]  in
-                         FStar_Syntax_Subst.open_term uu____13281 body  in
-                       match uu____13276 with
+                           [uu____13242]  in
+                         FStar_Syntax_Subst.open_term uu____13241 body  in
+                       match uu____13236 with
                        | (bs,body1) ->
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____13316  ->
+                              (fun uu____13276  ->
                                  FStar_Util.print_string
                                    "+++ Normalizing Tm_let -- type");
                             (let ty =
@@ -4307,75 +4311,75 @@ let rec (norm :
                                 in
                              let lbname =
                                let x =
-                                 let uu____13325 = FStar_List.hd bs  in
-                                 FStar_Pervasives_Native.fst uu____13325  in
+                                 let uu____13285 = FStar_List.hd bs  in
+                                 FStar_Pervasives_Native.fst uu____13285  in
                                FStar_Util.Inl
-                                 (let uu___1668_13341 = x  in
+                                 (let uu___1666_13301 = x  in
                                   {
                                     FStar_Syntax_Syntax.ppname =
-                                      (uu___1668_13341.FStar_Syntax_Syntax.ppname);
+                                      (uu___1666_13301.FStar_Syntax_Syntax.ppname);
                                     FStar_Syntax_Syntax.index =
-                                      (uu___1668_13341.FStar_Syntax_Syntax.index);
+                                      (uu___1666_13301.FStar_Syntax_Syntax.index);
                                     FStar_Syntax_Syntax.sort = ty
                                   })
                                 in
                              FStar_TypeChecker_Cfg.log cfg
-                               (fun uu____13344  ->
+                               (fun uu____13304  ->
                                   FStar_Util.print_string
                                     "+++ Normalizing Tm_let -- definiens\n");
                              (let lb1 =
-                                let uu___1673_13347 = lb  in
-                                let uu____13348 =
+                                let uu___1671_13307 = lb  in
+                                let uu____13308 =
                                   norm cfg env1 []
                                     lb.FStar_Syntax_Syntax.lbdef
                                    in
-                                let uu____13351 =
+                                let uu____13311 =
                                   FStar_List.map (norm cfg env1 [])
                                     lb.FStar_Syntax_Syntax.lbattrs
                                    in
                                 {
                                   FStar_Syntax_Syntax.lbname = lbname;
                                   FStar_Syntax_Syntax.lbunivs =
-                                    (uu___1673_13347.FStar_Syntax_Syntax.lbunivs);
+                                    (uu___1671_13307.FStar_Syntax_Syntax.lbunivs);
                                   FStar_Syntax_Syntax.lbtyp = ty;
                                   FStar_Syntax_Syntax.lbeff =
-                                    (uu___1673_13347.FStar_Syntax_Syntax.lbeff);
-                                  FStar_Syntax_Syntax.lbdef = uu____13348;
-                                  FStar_Syntax_Syntax.lbattrs = uu____13351;
+                                    (uu___1671_13307.FStar_Syntax_Syntax.lbeff);
+                                  FStar_Syntax_Syntax.lbdef = uu____13308;
+                                  FStar_Syntax_Syntax.lbattrs = uu____13311;
                                   FStar_Syntax_Syntax.lbpos =
-                                    (uu___1673_13347.FStar_Syntax_Syntax.lbpos)
+                                    (uu___1671_13307.FStar_Syntax_Syntax.lbpos)
                                 }  in
                               let env' =
                                 FStar_All.pipe_right bs
                                   (FStar_List.fold_left
                                      (fun env2  ->
-                                        fun uu____13386  -> dummy :: env2)
+                                        fun uu____13346  -> dummy :: env2)
                                      env1)
                                  in
                               let stack2 = (Cfg cfg) :: stack1  in
                               let cfg1 =
-                                let uu___1680_13411 = cfg  in
+                                let uu___1678_13371 = cfg  in
                                 {
                                   FStar_TypeChecker_Cfg.steps =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.steps);
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.steps);
                                   FStar_TypeChecker_Cfg.tcenv =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.tcenv);
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.tcenv);
                                   FStar_TypeChecker_Cfg.debug =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.debug);
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.debug);
                                   FStar_TypeChecker_Cfg.delta_level =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.delta_level);
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.delta_level);
                                   FStar_TypeChecker_Cfg.primitive_steps =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.primitive_steps);
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.primitive_steps);
                                   FStar_TypeChecker_Cfg.strong = true;
                                   FStar_TypeChecker_Cfg.memoize_lazy =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.memoize_lazy);
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.memoize_lazy);
                                   FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                   FStar_TypeChecker_Cfg.reifying =
-                                    (uu___1680_13411.FStar_TypeChecker_Cfg.reifying)
+                                    (uu___1678_13371.FStar_TypeChecker_Cfg.reifying)
                                 }  in
                               FStar_TypeChecker_Cfg.log cfg1
-                                (fun uu____13415  ->
+                                (fun uu____13375  ->
                                    FStar_Util.print_string
                                      "+++ Normalizing Tm_let -- body\n");
                               norm cfg1 env'
@@ -4394,8 +4398,8 @@ let rec (norm :
                     &&
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations)
                ->
-               let uu____13436 = FStar_Syntax_Subst.open_let_rec lbs body  in
-               (match uu____13436 with
+               let uu____13396 = FStar_Syntax_Subst.open_let_rec lbs body  in
+               (match uu____13396 with
                 | (lbs1,body1) ->
                     let lbs2 =
                       FStar_List.map
@@ -4404,46 +4408,46 @@ let rec (norm :
                              norm cfg env1 [] lb.FStar_Syntax_Syntax.lbtyp
                               in
                            let lbname =
-                             let uu____13472 =
-                               let uu___1696_13473 =
+                             let uu____13432 =
+                               let uu___1694_13433 =
                                  FStar_Util.left
                                    lb.FStar_Syntax_Syntax.lbname
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1696_13473.FStar_Syntax_Syntax.ppname);
+                                   (uu___1694_13433.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1696_13473.FStar_Syntax_Syntax.index);
+                                   (uu___1694_13433.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = ty
                                }  in
-                             FStar_Util.Inl uu____13472  in
-                           let uu____13474 =
+                             FStar_Util.Inl uu____13432  in
+                           let uu____13434 =
                              FStar_Syntax_Util.abs_formals
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           match uu____13474 with
+                           match uu____13434 with
                            | (xs,def_body,lopt) ->
                                let xs1 = norm_binders cfg env1 xs  in
                                let env2 =
-                                 let uu____13500 =
-                                   FStar_List.map (fun uu____13522  -> dummy)
+                                 let uu____13460 =
+                                   FStar_List.map (fun uu____13482  -> dummy)
                                      xs1
                                     in
-                                 let uu____13529 =
-                                   let uu____13538 =
+                                 let uu____13489 =
+                                   let uu____13498 =
                                      FStar_List.map
-                                       (fun uu____13554  -> dummy) lbs1
+                                       (fun uu____13514  -> dummy) lbs1
                                       in
-                                   FStar_List.append uu____13538 env1  in
-                                 FStar_List.append uu____13500 uu____13529
+                                   FStar_List.append uu____13498 env1  in
+                                 FStar_List.append uu____13460 uu____13489
                                   in
                                let def_body1 = norm cfg env2 [] def_body  in
                                let lopt1 =
                                  match lopt with
                                  | FStar_Pervasives_Native.Some rc ->
-                                     let uu____13574 =
-                                       let uu___1710_13575 = rc  in
-                                       let uu____13576 =
+                                     let uu____13534 =
+                                       let uu___1708_13535 = rc  in
+                                       let uu____13536 =
                                          FStar_Util.map_opt
                                            rc.FStar_Syntax_Syntax.residual_typ
                                            (norm cfg env2 [])
@@ -4451,51 +4455,51 @@ let rec (norm :
                                        {
                                          FStar_Syntax_Syntax.residual_effect
                                            =
-                                           (uu___1710_13575.FStar_Syntax_Syntax.residual_effect);
+                                           (uu___1708_13535.FStar_Syntax_Syntax.residual_effect);
                                          FStar_Syntax_Syntax.residual_typ =
-                                           uu____13576;
+                                           uu____13536;
                                          FStar_Syntax_Syntax.residual_flags =
-                                           (uu___1710_13575.FStar_Syntax_Syntax.residual_flags)
+                                           (uu___1708_13535.FStar_Syntax_Syntax.residual_flags)
                                        }  in
-                                     FStar_Pervasives_Native.Some uu____13574
-                                 | uu____13585 -> lopt  in
+                                     FStar_Pervasives_Native.Some uu____13534
+                                 | uu____13545 -> lopt  in
                                let def =
                                  FStar_Syntax_Util.abs xs1 def_body1 lopt1
                                   in
-                               let uu___1715_13591 = lb  in
+                               let uu___1713_13551 = lb  in
                                {
                                  FStar_Syntax_Syntax.lbname = lbname;
                                  FStar_Syntax_Syntax.lbunivs =
-                                   (uu___1715_13591.FStar_Syntax_Syntax.lbunivs);
+                                   (uu___1713_13551.FStar_Syntax_Syntax.lbunivs);
                                  FStar_Syntax_Syntax.lbtyp = ty;
                                  FStar_Syntax_Syntax.lbeff =
-                                   (uu___1715_13591.FStar_Syntax_Syntax.lbeff);
+                                   (uu___1713_13551.FStar_Syntax_Syntax.lbeff);
                                  FStar_Syntax_Syntax.lbdef = def;
                                  FStar_Syntax_Syntax.lbattrs =
-                                   (uu___1715_13591.FStar_Syntax_Syntax.lbattrs);
+                                   (uu___1713_13551.FStar_Syntax_Syntax.lbattrs);
                                  FStar_Syntax_Syntax.lbpos =
-                                   (uu___1715_13591.FStar_Syntax_Syntax.lbpos)
+                                   (uu___1713_13551.FStar_Syntax_Syntax.lbpos)
                                }) lbs1
                        in
                     let env' =
-                      let uu____13601 =
-                        FStar_List.map (fun uu____13617  -> dummy) lbs2  in
-                      FStar_List.append uu____13601 env1  in
+                      let uu____13561 =
+                        FStar_List.map (fun uu____13577  -> dummy) lbs2  in
+                      FStar_List.append uu____13561 env1  in
                     let body2 = norm cfg env' [] body1  in
-                    let uu____13625 =
+                    let uu____13585 =
                       FStar_Syntax_Subst.close_let_rec lbs2 body2  in
-                    (match uu____13625 with
+                    (match uu____13585 with
                      | (lbs3,body3) ->
                          let t2 =
-                           let uu___1724_13641 = t1  in
+                           let uu___1722_13601 = t1  in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_let
                                   ((true, lbs3), body3));
                              FStar_Syntax_Syntax.pos =
-                               (uu___1724_13641.FStar_Syntax_Syntax.pos);
+                               (uu___1722_13601.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
-                               (uu___1724_13641.FStar_Syntax_Syntax.vars)
+                               (uu___1722_13601.FStar_Syntax_Syntax.vars)
                            }  in
                          rebuild cfg env1 stack1 t2))
            | FStar_Syntax_Syntax.Tm_let (lbs,body) when
@@ -4505,29 +4509,30 @@ let rec (norm :
                  (Prims.op_Negation
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                ->
-               let uu____13675 = closure_as_term cfg env1 t1  in
-               rebuild cfg env1 stack1 uu____13675
+               let uu____13635 = closure_as_term cfg env1 t1  in
+               rebuild cfg env1 stack1 uu____13635
            | FStar_Syntax_Syntax.Tm_let (lbs,body) ->
-               let uu____13696 =
+               let uu____13656 =
                  FStar_List.fold_right
                    (fun lb  ->
-                      fun uu____13774  ->
-                        match uu____13774 with
+                      fun uu____13734  ->
+                        match uu____13734 with
                         | (rec_env,memos,i) ->
                             let bv =
-                              let uu___1740_13899 =
+                              let uu___1738_13859 =
                                 FStar_Util.left lb.FStar_Syntax_Syntax.lbname
                                  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1740_13899.FStar_Syntax_Syntax.ppname);
+                                  (uu___1738_13859.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index = i;
                                 FStar_Syntax_Syntax.sort =
-                                  (uu___1740_13899.FStar_Syntax_Syntax.sort)
+                                  (uu___1738_13859.FStar_Syntax_Syntax.sort)
                               }  in
                             let f_i = FStar_Syntax_Syntax.bv_to_tm bv  in
                             let fix_f_i =
-                              mk (FStar_Syntax_Syntax.Tm_let (lbs, f_i))
+                              FStar_Syntax_Syntax.mk
+                                (FStar_Syntax_Syntax.Tm_let (lbs, f_i))
                                 t1.FStar_Syntax_Syntax.pos
                                in
                             let memo =
@@ -4541,9 +4546,9 @@ let rec (norm :
                    (FStar_Pervasives_Native.snd lbs)
                    (env1, [], Prims.int_zero)
                   in
-               (match uu____13696 with
-                | (rec_env,memos,uu____14090) ->
-                    let uu____14145 =
+               (match uu____13656 with
+                | (rec_env,memos,uu____14050) ->
+                    let uu____14105 =
                       FStar_List.map2
                         (fun lb  ->
                            fun memo  ->
@@ -4556,29 +4561,29 @@ let rec (norm :
                       FStar_List.fold_right
                         (fun lb  ->
                            fun env2  ->
-                             let uu____14394 =
-                               let uu____14401 =
-                                 let uu____14402 =
-                                   let uu____14434 =
+                             let uu____14354 =
+                               let uu____14361 =
+                                 let uu____14362 =
+                                   let uu____14394 =
                                      FStar_Util.mk_ref
                                        FStar_Pervasives_Native.None
                                       in
                                    (rec_env, (lb.FStar_Syntax_Syntax.lbdef),
-                                     uu____14434, false)
+                                     uu____14394, false)
                                     in
-                                 Clos uu____14402  in
-                               (FStar_Pervasives_Native.None, uu____14401)
+                                 Clos uu____14362  in
+                               (FStar_Pervasives_Native.None, uu____14361)
                                 in
-                             uu____14394 :: env2)
+                             uu____14354 :: env2)
                         (FStar_Pervasives_Native.snd lbs) env1
                        in
                     norm cfg body_env stack1 body)
            | FStar_Syntax_Syntax.Tm_meta (head,m) ->
                (FStar_TypeChecker_Cfg.log cfg
-                  (fun uu____14519  ->
-                     let uu____14520 =
+                  (fun uu____14479  ->
+                     let uu____14480 =
                        FStar_Syntax_Print.metadata_to_string m  in
-                     FStar_Util.print1 ">> metadata = %s\n" uu____14520);
+                     FStar_Util.print1 ">> metadata = %s\n" uu____14480);
                 (match m with
                  | FStar_Syntax_Syntax.Meta_monadic (m1,t2) ->
                      reduce_impure_comp cfg env1 stack1 head
@@ -4586,16 +4591,16 @@ let rec (norm :
                  | FStar_Syntax_Syntax.Meta_monadic_lift (m1,m',t2) ->
                      reduce_impure_comp cfg env1 stack1 head
                        (FStar_Util.Inr (m1, m')) t2
-                 | uu____14544 ->
+                 | uu____14504 ->
                      if
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unmeta
                      then norm cfg env1 stack1 head
                      else
                        (match stack1 with
-                        | uu____14548::uu____14549 ->
+                        | uu____14508::uu____14509 ->
                             (match m with
                              | FStar_Syntax_Syntax.Meta_labeled
-                                 (l,r,uu____14554) ->
+                                 (l,r,uu____14514) ->
                                  norm cfg env1 ((Meta (env1, m, r)) ::
                                    stack1) head
                              | FStar_Syntax_Syntax.Meta_pattern (names,args)
@@ -4613,7 +4618,7 @@ let rec (norm :
                                             (names1, args1)),
                                          (t1.FStar_Syntax_Syntax.pos))) ::
                                    stack1) head
-                             | uu____14633 -> norm cfg env1 stack1 head)
+                             | uu____14593 -> norm cfg env1 stack1 head)
                         | [] ->
                             let head1 = norm cfg env1 [] head  in
                             let m1 =
@@ -4624,45 +4629,46 @@ let rec (norm :
                                     FStar_All.pipe_right names
                                       (FStar_List.map (norm cfg env1 []))
                                      in
-                                  let uu____14681 =
-                                    let uu____14702 =
+                                  let uu____14641 =
+                                    let uu____14662 =
                                       norm_pattern_args cfg env1 args  in
-                                    (names1, uu____14702)  in
+                                    (names1, uu____14662)  in
                                   FStar_Syntax_Syntax.Meta_pattern
-                                    uu____14681
-                              | uu____14731 -> m  in
+                                    uu____14641
+                              | uu____14691 -> m  in
                             let t2 =
-                              mk (FStar_Syntax_Syntax.Tm_meta (head1, m1))
+                              FStar_Syntax_Syntax.mk
+                                (FStar_Syntax_Syntax.Tm_meta (head1, m1))
                                 t1.FStar_Syntax_Syntax.pos
                                in
                             rebuild cfg env1 stack1 t2)))
-           | FStar_Syntax_Syntax.Tm_delayed uu____14737 ->
+           | FStar_Syntax_Syntax.Tm_delayed uu____14697 ->
                let t2 = FStar_Syntax_Subst.compress t1  in
                norm cfg env1 stack1 t2
-           | FStar_Syntax_Syntax.Tm_uvar uu____14753 ->
+           | FStar_Syntax_Syntax.Tm_uvar uu____14713 ->
                let t2 = FStar_Syntax_Subst.compress t1  in
                (match t2.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_uvar uu____14767 ->
+                | FStar_Syntax_Syntax.Tm_uvar uu____14727 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
                     then
-                      let uu____14781 =
-                        let uu____14783 =
+                      let uu____14741 =
+                        let uu____14743 =
                           FStar_Range.string_of_range
                             t2.FStar_Syntax_Syntax.pos
                            in
-                        let uu____14785 =
+                        let uu____14745 =
                           FStar_Syntax_Print.term_to_string t2  in
                         FStar_Util.format2
                           "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                          uu____14783 uu____14785
+                          uu____14743 uu____14745
                          in
-                      failwith uu____14781
+                      failwith uu____14741
                     else
-                      (let uu____14790 = inline_closure_env cfg env1 [] t2
+                      (let uu____14750 = inline_closure_env cfg env1 [] t2
                           in
-                       rebuild cfg env1 stack1 uu____14790)
-                | uu____14791 -> norm cfg env1 stack1 t2))
+                       rebuild cfg env1 stack1 uu____14750)
+                | uu____14751 -> norm cfg env1 stack1 t2))
 
 and (do_unfold_fv :
   FStar_TypeChecker_Cfg.cfg ->
@@ -4678,30 +4684,30 @@ and (do_unfold_fv :
         fun t0  ->
           fun qninfo  ->
             fun f  ->
-              let uu____14800 =
+              let uu____14760 =
                 FStar_TypeChecker_Env.lookup_definition_qninfo
                   cfg.FStar_TypeChecker_Cfg.delta_level
                   (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   qninfo
                  in
-              match uu____14800 with
+              match uu____14760 with
               | FStar_Pervasives_Native.None  ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____14814  ->
-                        let uu____14815 = FStar_Syntax_Print.fv_to_string f
+                     (fun uu____14774  ->
+                        let uu____14775 = FStar_Syntax_Print.fv_to_string f
                            in
                         FStar_Util.print1 " >> Tm_fvar case 2 for %s\n"
-                          uu____14815);
+                          uu____14775);
                    rebuild cfg env1 stack1 t0)
               | FStar_Pervasives_Native.Some (us,t) ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____14828  ->
-                        let uu____14829 =
+                     (fun uu____14788  ->
+                        let uu____14789 =
                           FStar_Syntax_Print.term_to_string t0  in
-                        let uu____14831 = FStar_Syntax_Print.term_to_string t
+                        let uu____14791 = FStar_Syntax_Print.term_to_string t
                            in
                         FStar_Util.print2 " >> Unfolded %s to %s\n"
-                          uu____14829 uu____14831);
+                          uu____14789 uu____14791);
                    (let t1 =
                       if
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_until
@@ -4717,21 +4723,21 @@ and (do_unfold_fv :
                     if n > Prims.int_zero
                     then
                       match stack1 with
-                      | (UnivArgs (us',uu____14844))::stack2 ->
-                          ((let uu____14853 =
+                      | (UnivArgs (us',uu____14804))::stack2 ->
+                          ((let uu____14813 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug
                                    cfg.FStar_TypeChecker_Cfg.tcenv)
                                 (FStar_Options.Other "univ_norm")
                                in
-                            if uu____14853
+                            if uu____14813
                             then
                               FStar_List.iter
                                 (fun x  ->
-                                   let uu____14861 =
+                                   let uu____14821 =
                                      FStar_Syntax_Print.univ_to_string x  in
                                    FStar_Util.print1 "Univ (normalizer) %s\n"
-                                     uu____14861) us'
+                                     uu____14821) us'
                             else ());
                            (let env2 =
                               FStar_All.pipe_right us'
@@ -4743,22 +4749,22 @@ and (do_unfold_fv :
                                         :: env2) env1)
                                in
                             norm cfg env2 stack2 t1))
-                      | uu____14897 when
+                      | uu____14857 when
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                             ||
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
                           -> norm cfg env1 stack1 t1
-                      | uu____14900 ->
-                          let uu____14903 =
-                            let uu____14905 =
+                      | uu____14860 ->
+                          let uu____14863 =
+                            let uu____14865 =
                               FStar_Syntax_Print.lid_to_string
                                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                in
                             FStar_Util.format1
                               "Impossible: missing universe instantiation on %s"
-                              uu____14905
+                              uu____14865
                              in
-                          failwith uu____14903
+                          failwith uu____14863
                     else norm cfg env1 stack1 t1))
 
 and (reduce_impure_comp :
@@ -4778,7 +4784,7 @@ and (reduce_impure_comp :
           fun m  ->
             fun t  ->
               let t1 = norm cfg env1 [] t  in
-              let uu____14925 =
+              let uu____14885 =
                 if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations
                 then
@@ -4790,35 +4796,35 @@ and (reduce_impure_comp :
                     FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
                     FStar_TypeChecker_Env.Inlining]  in
                   let cfg' =
-                    let uu___1851_14943 = cfg  in
-                    let uu____14944 =
+                    let uu___1849_14903 = cfg  in
+                    let uu____14904 =
                       FStar_List.fold_right
                         FStar_TypeChecker_Cfg.fstep_add_one new_steps
                         cfg.FStar_TypeChecker_Cfg.steps
                        in
                     {
-                      FStar_TypeChecker_Cfg.steps = uu____14944;
+                      FStar_TypeChecker_Cfg.steps = uu____14904;
                       FStar_TypeChecker_Cfg.tcenv =
-                        (uu___1851_14943.FStar_TypeChecker_Cfg.tcenv);
+                        (uu___1849_14903.FStar_TypeChecker_Cfg.tcenv);
                       FStar_TypeChecker_Cfg.debug =
-                        (uu___1851_14943.FStar_TypeChecker_Cfg.debug);
+                        (uu___1849_14903.FStar_TypeChecker_Cfg.debug);
                       FStar_TypeChecker_Cfg.delta_level =
                         [FStar_TypeChecker_Env.InliningDelta;
                         FStar_TypeChecker_Env.Eager_unfolding_only];
                       FStar_TypeChecker_Cfg.primitive_steps =
-                        (uu___1851_14943.FStar_TypeChecker_Cfg.primitive_steps);
+                        (uu___1849_14903.FStar_TypeChecker_Cfg.primitive_steps);
                       FStar_TypeChecker_Cfg.strong =
-                        (uu___1851_14943.FStar_TypeChecker_Cfg.strong);
+                        (uu___1849_14903.FStar_TypeChecker_Cfg.strong);
                       FStar_TypeChecker_Cfg.memoize_lazy =
-                        (uu___1851_14943.FStar_TypeChecker_Cfg.memoize_lazy);
+                        (uu___1849_14903.FStar_TypeChecker_Cfg.memoize_lazy);
                       FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (uu___1851_14943.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                        (uu___1849_14903.FStar_TypeChecker_Cfg.normalize_pure_lets);
                       FStar_TypeChecker_Cfg.reifying =
-                        (uu___1851_14943.FStar_TypeChecker_Cfg.reifying)
+                        (uu___1849_14903.FStar_TypeChecker_Cfg.reifying)
                     }  in
                   (cfg', ((Cfg cfg) :: stack1))
                 else (cfg, stack1)  in
-              match uu____14925 with
+              match uu____14885 with
               | (cfg1,stack2) ->
                   let metadata =
                     match m with
@@ -4849,36 +4855,36 @@ and (do_reify_monadic :
               fun t  ->
                 (match stack1 with
                  | (App
-                     (uu____14985,{
+                     (uu____14945,{
                                     FStar_Syntax_Syntax.n =
                                       FStar_Syntax_Syntax.Tm_constant
                                       (FStar_Const.Const_reify );
-                                    FStar_Syntax_Syntax.pos = uu____14986;
-                                    FStar_Syntax_Syntax.vars = uu____14987;_},uu____14988,uu____14989))::uu____14990
+                                    FStar_Syntax_Syntax.pos = uu____14946;
+                                    FStar_Syntax_Syntax.vars = uu____14947;_},uu____14948,uu____14949))::uu____14950
                      -> ()
-                 | uu____14995 ->
-                     let uu____14998 =
-                       let uu____15000 = stack_to_string stack1  in
+                 | uu____14955 ->
+                     let uu____14958 =
+                       let uu____14960 = stack_to_string stack1  in
                        FStar_Util.format1
                          "INTERNAL ERROR: do_reify_monadic: bad stack: %s"
-                         uu____15000
+                         uu____14960
                         in
-                     failwith uu____14998);
+                     failwith uu____14958);
                 (let top0 = top  in
                  let top1 = FStar_Syntax_Util.unascribe top  in
                  FStar_TypeChecker_Cfg.log cfg
-                   (fun uu____15009  ->
-                      let uu____15010 = FStar_Syntax_Print.tag_of_term top1
+                   (fun uu____14969  ->
+                      let uu____14970 = FStar_Syntax_Print.tag_of_term top1
                          in
-                      let uu____15012 =
+                      let uu____14972 =
                         FStar_Syntax_Print.term_to_string top1  in
-                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____15010
-                        uu____15012);
+                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____14970
+                        uu____14972);
                  (let top2 = FStar_Syntax_Util.unmeta_safe top1  in
-                  let uu____15016 =
-                    let uu____15017 = FStar_Syntax_Subst.compress top2  in
-                    uu____15017.FStar_Syntax_Syntax.n  in
-                  match uu____15016 with
+                  let uu____14976 =
+                    let uu____14977 = FStar_Syntax_Subst.compress top2  in
+                    uu____14977.FStar_Syntax_Syntax.n  in
+                  match uu____14976 with
                   | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),body) ->
                       let eff_name =
                         FStar_TypeChecker_Env.norm_eff_name
@@ -4888,129 +4894,124 @@ and (do_reify_monadic :
                         FStar_TypeChecker_Env.get_effect_decl
                           cfg.FStar_TypeChecker_Cfg.tcenv eff_name
                          in
-                      let uu____15039 =
-                        let uu____15048 =
+                      let uu____14999 =
+                        let uu____15008 =
                           FStar_All.pipe_right ed
                             FStar_Syntax_Util.get_eff_repr
                            in
-                        FStar_All.pipe_right uu____15048 FStar_Util.must  in
-                      (match uu____15039 with
-                       | (uu____15063,repr) ->
-                           let uu____15073 =
-                             let uu____15080 =
+                        FStar_All.pipe_right uu____15008 FStar_Util.must  in
+                      (match uu____14999 with
+                       | (uu____15023,repr) ->
+                           let uu____15033 =
+                             let uu____15040 =
                                FStar_All.pipe_right ed
                                  FStar_Syntax_Util.get_bind_repr
                                 in
-                             FStar_All.pipe_right uu____15080 FStar_Util.must
+                             FStar_All.pipe_right uu____15040 FStar_Util.must
                               in
-                           (match uu____15073 with
-                            | (uu____15117,bind_repr) ->
+                           (match uu____15033 with
+                            | (uu____15077,bind_repr) ->
                                 (match lb.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____15123 ->
+                                 | FStar_Util.Inr uu____15083 ->
                                      failwith
                                        "Cannot reify a top-level let binding"
                                  | FStar_Util.Inl x ->
                                      let is_return e =
-                                       let uu____15134 =
-                                         let uu____15135 =
+                                       let uu____15094 =
+                                         let uu____15095 =
                                            FStar_Syntax_Subst.compress e  in
-                                         uu____15135.FStar_Syntax_Syntax.n
+                                         uu____15095.FStar_Syntax_Syntax.n
                                           in
-                                       match uu____15134 with
+                                       match uu____15094 with
                                        | FStar_Syntax_Syntax.Tm_meta
                                            (e1,FStar_Syntax_Syntax.Meta_monadic
-                                            (uu____15141,uu____15142))
+                                            (uu____15101,uu____15102))
                                            ->
-                                           let uu____15151 =
-                                             let uu____15152 =
+                                           let uu____15111 =
+                                             let uu____15112 =
                                                FStar_Syntax_Subst.compress e1
                                                 in
-                                             uu____15152.FStar_Syntax_Syntax.n
+                                             uu____15112.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____15151 with
+                                           (match uu____15111 with
                                             | FStar_Syntax_Syntax.Tm_meta
                                                 (e2,FStar_Syntax_Syntax.Meta_monadic_lift
-                                                 (uu____15158,msrc,uu____15160))
+                                                 (uu____15118,msrc,uu____15120))
                                                 when
                                                 FStar_Syntax_Util.is_pure_effect
                                                   msrc
                                                 ->
-                                                let uu____15169 =
+                                                let uu____15129 =
                                                   FStar_Syntax_Subst.compress
                                                     e2
                                                    in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____15169
-                                            | uu____15170 ->
+                                                  uu____15129
+                                            | uu____15130 ->
                                                 FStar_Pervasives_Native.None)
-                                       | uu____15171 ->
+                                       | uu____15131 ->
                                            FStar_Pervasives_Native.None
                                         in
-                                     let uu____15172 =
+                                     let uu____15132 =
                                        is_return lb.FStar_Syntax_Syntax.lbdef
                                         in
-                                     (match uu____15172 with
+                                     (match uu____15132 with
                                       | FStar_Pervasives_Native.Some e ->
                                           let lb1 =
-                                            let uu___1930_15177 = lb  in
+                                            let uu___1928_15137 = lb  in
                                             {
                                               FStar_Syntax_Syntax.lbname =
-                                                (uu___1930_15177.FStar_Syntax_Syntax.lbname);
+                                                (uu___1928_15137.FStar_Syntax_Syntax.lbname);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___1930_15177.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___1928_15137.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___1930_15177.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___1928_15137.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
                                                 FStar_Parser_Const.effect_PURE_lid;
                                               FStar_Syntax_Syntax.lbdef = e;
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___1930_15177.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___1928_15137.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___1930_15177.FStar_Syntax_Syntax.lbpos)
+                                                (uu___1928_15137.FStar_Syntax_Syntax.lbpos)
                                             }  in
-                                          let uu____15178 =
+                                          let uu____15138 =
                                             FStar_List.tl stack1  in
-                                          let uu____15179 =
-                                            let uu____15180 =
-                                              let uu____15187 =
-                                                let uu____15188 =
-                                                  let uu____15202 =
-                                                    FStar_Syntax_Util.mk_reify
-                                                      body
-                                                     in
-                                                  ((false, [lb1]),
-                                                    uu____15202)
+                                          let uu____15139 =
+                                            let uu____15140 =
+                                              let uu____15141 =
+                                                let uu____15155 =
+                                                  FStar_Syntax_Util.mk_reify
+                                                    body
                                                    in
-                                                FStar_Syntax_Syntax.Tm_let
-                                                  uu____15188
+                                                ((false, [lb1]), uu____15155)
                                                  in
-                                              FStar_Syntax_Syntax.mk
-                                                uu____15187
+                                              FStar_Syntax_Syntax.Tm_let
+                                                uu____15141
                                                in
-                                            uu____15180
-                                              FStar_Pervasives_Native.None
+                                            FStar_Syntax_Syntax.mk
+                                              uu____15140
                                               top2.FStar_Syntax_Syntax.pos
                                              in
-                                          norm cfg env1 uu____15178
-                                            uu____15179
+                                          norm cfg env1 uu____15138
+                                            uu____15139
                                       | FStar_Pervasives_Native.None  ->
-                                          let uu____15218 =
-                                            let uu____15220 = is_return body
+                                          let uu____15171 =
+                                            let uu____15173 = is_return body
                                                in
-                                            match uu____15220 with
+                                            match uu____15173 with
                                             | FStar_Pervasives_Native.Some
                                                 {
                                                   FStar_Syntax_Syntax.n =
                                                     FStar_Syntax_Syntax.Tm_bvar
                                                     y;
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____15225;
+                                                    uu____15178;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____15226;_}
+                                                    uu____15179;_}
                                                 ->
                                                 FStar_Syntax_Syntax.bv_eq x y
-                                            | uu____15229 -> false  in
-                                          if uu____15218
+                                            | uu____15182 -> false  in
+                                          if uu____15171
                                           then
                                             norm cfg env1 stack1
                                               lb.FStar_Syntax_Syntax.lbdef
@@ -5023,30 +5024,30 @@ and (do_reify_monadic :
                                                  FStar_Syntax_Util.mk_reify
                                                  lb.FStar_Syntax_Syntax.lbdef
                                                 in
-                                             let uu____15244 =
+                                             let uu____15197 =
                                                let bv =
                                                  FStar_Syntax_Syntax.new_bv
                                                    FStar_Pervasives_Native.None
                                                    x.FStar_Syntax_Syntax.sort
                                                   in
                                                let lb1 =
-                                                 let uu____15253 =
-                                                   let uu____15256 =
-                                                     let uu____15267 =
+                                                 let uu____15206 =
+                                                   let uu____15209 =
+                                                     let uu____15220 =
                                                        FStar_Syntax_Syntax.as_arg
                                                          x.FStar_Syntax_Syntax.sort
                                                         in
-                                                     [uu____15267]  in
+                                                     [uu____15220]  in
                                                    FStar_Syntax_Util.mk_app
-                                                     repr uu____15256
+                                                     repr uu____15209
                                                     in
-                                                 let uu____15292 =
-                                                   let uu____15293 =
+                                                 let uu____15245 =
+                                                   let uu____15246 =
                                                      FStar_TypeChecker_Env.is_total_effect
                                                        cfg.FStar_TypeChecker_Cfg.tcenv
                                                        eff_name
                                                       in
-                                                   if uu____15293
+                                                   if uu____15246
                                                    then
                                                      FStar_Parser_Const.effect_Tot_lid
                                                    else
@@ -5058,9 +5059,9 @@ and (do_reify_monadic :
                                                    FStar_Syntax_Syntax.lbunivs
                                                      = [];
                                                    FStar_Syntax_Syntax.lbtyp
-                                                     = uu____15253;
+                                                     = uu____15206;
                                                    FStar_Syntax_Syntax.lbeff
-                                                     = uu____15292;
+                                                     = uu____15245;
                                                    FStar_Syntax_Syntax.lbdef
                                                      = head;
                                                    FStar_Syntax_Syntax.lbattrs
@@ -5069,12 +5070,12 @@ and (do_reify_monadic :
                                                      =
                                                      (head.FStar_Syntax_Syntax.pos)
                                                  }  in
-                                               let uu____15300 =
+                                               let uu____15253 =
                                                  FStar_Syntax_Syntax.bv_to_name
                                                    bv
                                                   in
-                                               (lb1, bv, uu____15300)  in
-                                             match uu____15244 with
+                                               (lb1, bv, uu____15253)  in
+                                             match uu____15197 with
                                              | (lb_head,head_bv,head1) ->
                                                  let body1 =
                                                    FStar_All.pipe_left
@@ -5093,169 +5094,159 @@ and (do_reify_monadic :
                                                        = []
                                                    }  in
                                                  let body2 =
-                                                   let uu____15317 =
-                                                     let uu____15324 =
-                                                       let uu____15325 =
-                                                         let uu____15344 =
-                                                           let uu____15353 =
-                                                             FStar_Syntax_Syntax.mk_binder
-                                                               x
-                                                              in
-                                                           [uu____15353]  in
-                                                         (uu____15344, body1,
-                                                           (FStar_Pervasives_Native.Some
-                                                              body_rc))
-                                                          in
-                                                       FStar_Syntax_Syntax.Tm_abs
-                                                         uu____15325
+                                                   let uu____15270 =
+                                                     let uu____15271 =
+                                                       let uu____15290 =
+                                                         let uu____15299 =
+                                                           FStar_Syntax_Syntax.mk_binder
+                                                             x
+                                                            in
+                                                         [uu____15299]  in
+                                                       (uu____15290, body1,
+                                                         (FStar_Pervasives_Native.Some
+                                                            body_rc))
                                                         in
-                                                     FStar_Syntax_Syntax.mk
-                                                       uu____15324
+                                                     FStar_Syntax_Syntax.Tm_abs
+                                                       uu____15271
                                                       in
-                                                   uu____15317
-                                                     FStar_Pervasives_Native.None
+                                                   FStar_Syntax_Syntax.mk
+                                                     uu____15270
                                                      body1.FStar_Syntax_Syntax.pos
                                                     in
                                                  let close =
                                                    closure_as_term cfg env1
                                                     in
                                                  let bind_inst =
-                                                   let uu____15392 =
-                                                     let uu____15393 =
+                                                   let uu____15338 =
+                                                     let uu____15339 =
                                                        FStar_Syntax_Subst.compress
                                                          bind_repr
                                                         in
-                                                     uu____15393.FStar_Syntax_Syntax.n
+                                                     uu____15339.FStar_Syntax_Syntax.n
                                                       in
-                                                   match uu____15392 with
+                                                   match uu____15338 with
                                                    | FStar_Syntax_Syntax.Tm_uinst
-                                                       (bind,uu____15399::uu____15400::[])
+                                                       (bind,uu____15345::uu____15346::[])
                                                        ->
-                                                       let uu____15405 =
-                                                         let uu____15412 =
-                                                           let uu____15413 =
-                                                             let uu____15420
+                                                       let uu____15351 =
+                                                         let uu____15352 =
+                                                           let uu____15359 =
+                                                             let uu____15360
                                                                =
-                                                               let uu____15421
+                                                               let uu____15361
                                                                  =
-                                                                 let uu____15422
-                                                                   =
-                                                                   close
-                                                                    lb.FStar_Syntax_Syntax.lbtyp
+                                                                 close
+                                                                   lb.FStar_Syntax_Syntax.lbtyp
+                                                                  in
+                                                               (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
+                                                                 cfg.FStar_TypeChecker_Cfg.tcenv
+                                                                 uu____15361
+                                                                in
+                                                             let uu____15362
+                                                               =
+                                                               let uu____15365
+                                                                 =
+                                                                 let uu____15366
+                                                                   = 
+                                                                   close t
                                                                     in
                                                                  (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                                    cfg.FStar_TypeChecker_Cfg.tcenv
-                                                                   uu____15422
+                                                                   uu____15366
                                                                   in
-                                                               let uu____15423
-                                                                 =
-                                                                 let uu____15426
-                                                                   =
-                                                                   let uu____15427
-                                                                    = 
-                                                                    close t
-                                                                     in
-                                                                   (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
-                                                                    cfg.FStar_TypeChecker_Cfg.tcenv
-                                                                    uu____15427
-                                                                    in
-                                                                 [uu____15426]
-                                                                  in
-                                                               uu____15421 ::
-                                                                 uu____15423
+                                                               [uu____15365]
                                                                 in
-                                                             (bind,
-                                                               uu____15420)
+                                                             uu____15360 ::
+                                                               uu____15362
                                                               in
-                                                           FStar_Syntax_Syntax.Tm_uinst
-                                                             uu____15413
+                                                           (bind,
+                                                             uu____15359)
                                                             in
-                                                         FStar_Syntax_Syntax.mk
-                                                           uu____15412
+                                                         FStar_Syntax_Syntax.Tm_uinst
+                                                           uu____15352
                                                           in
-                                                       uu____15405
-                                                         FStar_Pervasives_Native.None
-                                                         rng
-                                                   | uu____15430 ->
+                                                       FStar_Syntax_Syntax.mk
+                                                         uu____15351 rng
+                                                   | uu____15369 ->
                                                        failwith
                                                          "NIY : Reification of indexed effects"
                                                     in
                                                  let maybe_range_arg =
-                                                   let uu____15445 =
+                                                   let uu____15384 =
                                                      FStar_Util.for_some
                                                        (FStar_Syntax_Util.attr_eq
                                                           FStar_Syntax_Util.dm4f_bind_range_attr)
                                                        ed.FStar_Syntax_Syntax.eff_attrs
                                                       in
-                                                   if uu____15445
+                                                   if uu____15384
                                                    then
-                                                     let uu____15458 =
-                                                       let uu____15467 =
+                                                     let uu____15397 =
+                                                       let uu____15406 =
                                                          FStar_TypeChecker_Cfg.embed_simple
                                                            FStar_Syntax_Embeddings.e_range
                                                            lb.FStar_Syntax_Syntax.lbpos
                                                            lb.FStar_Syntax_Syntax.lbpos
                                                           in
                                                        FStar_Syntax_Syntax.as_arg
-                                                         uu____15467
+                                                         uu____15406
                                                         in
-                                                     let uu____15468 =
-                                                       let uu____15479 =
-                                                         let uu____15488 =
+                                                     let uu____15407 =
+                                                       let uu____15418 =
+                                                         let uu____15427 =
                                                            FStar_TypeChecker_Cfg.embed_simple
                                                              FStar_Syntax_Embeddings.e_range
                                                              body2.FStar_Syntax_Syntax.pos
                                                              body2.FStar_Syntax_Syntax.pos
                                                             in
                                                          FStar_Syntax_Syntax.as_arg
-                                                           uu____15488
+                                                           uu____15427
                                                           in
-                                                       [uu____15479]  in
-                                                     uu____15458 ::
-                                                       uu____15468
+                                                       [uu____15418]  in
+                                                     uu____15397 ::
+                                                       uu____15407
                                                    else []  in
                                                  let reified =
                                                    let args =
-                                                     let uu____15537 =
+                                                     let uu____15476 =
                                                        FStar_Syntax_Util.is_layered
                                                          ed
                                                         in
-                                                     if uu____15537
+                                                     if uu____15476
                                                      then
                                                        let unit_args =
-                                                         let uu____15561 =
-                                                           let uu____15562 =
-                                                             let uu____15565
+                                                         let uu____15500 =
+                                                           let uu____15501 =
+                                                             let uu____15504
                                                                =
-                                                               let uu____15566
+                                                               let uu____15505
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    ed
                                                                    FStar_Syntax_Util.get_bind_vc_combinator
                                                                   in
                                                                FStar_All.pipe_right
-                                                                 uu____15566
+                                                                 uu____15505
                                                                  FStar_Pervasives_Native.snd
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____15565
+                                                               uu____15504
                                                                FStar_Syntax_Subst.compress
                                                               in
-                                                           uu____15562.FStar_Syntax_Syntax.n
+                                                           uu____15501.FStar_Syntax_Syntax.n
                                                             in
-                                                         match uu____15561
+                                                         match uu____15500
                                                          with
                                                          | FStar_Syntax_Syntax.Tm_arrow
-                                                             (uu____15607::uu____15608::bs,uu____15610)
+                                                             (uu____15546::uu____15547::bs,uu____15549)
                                                              when
                                                              (FStar_List.length
                                                                 bs)
                                                                >=
                                                                (Prims.of_int (2))
                                                              ->
-                                                             let uu____15662
+                                                             let uu____15601
                                                                =
-                                                               let uu____15671
+                                                               let uu____15610
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    bs
@@ -5265,368 +5256,357 @@ and (do_reify_monadic :
                                                                     (Prims.of_int (2))))
                                                                   in
                                                                FStar_All.pipe_right
-                                                                 uu____15671
+                                                                 uu____15610
                                                                  FStar_Pervasives_Native.fst
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____15662
+                                                               uu____15601
                                                                (FStar_List.map
                                                                   (fun
-                                                                    uu____15802
+                                                                    uu____15741
                                                                      ->
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Syntax.unit_const))
-                                                         | uu____15809 ->
-                                                             let uu____15810
+                                                         | uu____15748 ->
+                                                             let uu____15749
                                                                =
-                                                               let uu____15816
+                                                               let uu____15755
                                                                  =
-                                                                 let uu____15818
+                                                                 let uu____15757
                                                                    =
                                                                    FStar_Ident.string_of_lid
                                                                     ed.FStar_Syntax_Syntax.mname
                                                                     in
-                                                                 let uu____15820
+                                                                 let uu____15759
                                                                    =
-                                                                   let uu____15822
+                                                                   let uu____15761
                                                                     =
-                                                                    let uu____15823
+                                                                    let uu____15762
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     ed
                                                                     FStar_Syntax_Util.get_bind_vc_combinator
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____15823
+                                                                    uu____15762
                                                                     FStar_Pervasives_Native.snd
                                                                      in
                                                                    FStar_All.pipe_right
-                                                                    uu____15822
+                                                                    uu____15761
                                                                     FStar_Syntax_Print.term_to_string
                                                                     in
                                                                  FStar_Util.format2
                                                                    "bind_wp for layered effect %s is not an arrow with >= 4 arguments (%s)"
-                                                                   uu____15818
-                                                                   uu____15820
+                                                                   uu____15757
+                                                                   uu____15759
                                                                   in
                                                                (FStar_Errors.Fatal_UnexpectedEffect,
-                                                                 uu____15816)
+                                                                 uu____15755)
                                                                 in
                                                              FStar_Errors.raise_error
-                                                               uu____15810
+                                                               uu____15749
                                                                rng
                                                           in
-                                                       let uu____15857 =
+                                                       let uu____15796 =
                                                          FStar_Syntax_Syntax.as_arg
                                                            lb.FStar_Syntax_Syntax.lbtyp
                                                           in
-                                                       let uu____15866 =
-                                                         let uu____15877 =
+                                                       let uu____15805 =
+                                                         let uu____15816 =
                                                            FStar_Syntax_Syntax.as_arg
                                                              t
                                                             in
-                                                         let uu____15886 =
-                                                           let uu____15897 =
-                                                             let uu____15908
+                                                         let uu____15825 =
+                                                           let uu____15836 =
+                                                             let uu____15847
                                                                =
                                                                FStar_Syntax_Syntax.as_arg
                                                                  head1
                                                                 in
-                                                             let uu____15917
+                                                             let uu____15856
                                                                =
-                                                               let uu____15928
+                                                               let uu____15867
                                                                  =
                                                                  FStar_Syntax_Syntax.as_arg
                                                                    body2
                                                                   in
-                                                               [uu____15928]
+                                                               [uu____15867]
                                                                 in
-                                                             uu____15908 ::
-                                                               uu____15917
+                                                             uu____15847 ::
+                                                               uu____15856
                                                               in
                                                            FStar_List.append
                                                              unit_args
-                                                             uu____15897
+                                                             uu____15836
                                                             in
-                                                         uu____15877 ::
-                                                           uu____15886
+                                                         uu____15816 ::
+                                                           uu____15825
                                                           in
-                                                       uu____15857 ::
-                                                         uu____15866
+                                                       uu____15796 ::
+                                                         uu____15805
                                                      else
-                                                       (let uu____15987 =
-                                                          let uu____15998 =
+                                                       (let uu____15926 =
+                                                          let uu____15937 =
                                                             FStar_Syntax_Syntax.as_arg
                                                               lb.FStar_Syntax_Syntax.lbtyp
                                                              in
-                                                          let uu____16007 =
-                                                            let uu____16018 =
+                                                          let uu____15946 =
+                                                            let uu____15957 =
                                                               FStar_Syntax_Syntax.as_arg
                                                                 t
                                                                in
-                                                            [uu____16018]  in
-                                                          uu____15998 ::
-                                                            uu____16007
+                                                            [uu____15957]  in
+                                                          uu____15937 ::
+                                                            uu____15946
                                                            in
-                                                        let uu____16051 =
-                                                          let uu____16062 =
-                                                            let uu____16073 =
+                                                        let uu____15990 =
+                                                          let uu____16001 =
+                                                            let uu____16012 =
                                                               FStar_Syntax_Syntax.as_arg
                                                                 FStar_Syntax_Syntax.tun
                                                                in
-                                                            let uu____16082 =
-                                                              let uu____16093
+                                                            let uu____16021 =
+                                                              let uu____16032
                                                                 =
                                                                 FStar_Syntax_Syntax.as_arg
                                                                   head1
                                                                  in
-                                                              let uu____16102
+                                                              let uu____16041
                                                                 =
-                                                                let uu____16113
+                                                                let uu____16052
                                                                   =
                                                                   FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Syntax.tun
                                                                    in
-                                                                let uu____16122
+                                                                let uu____16061
                                                                   =
-                                                                  let uu____16133
+                                                                  let uu____16072
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     body2  in
-                                                                  [uu____16133]
+                                                                  [uu____16072]
                                                                    in
-                                                                uu____16113
+                                                                uu____16052
                                                                   ::
-                                                                  uu____16122
+                                                                  uu____16061
                                                                  in
-                                                              uu____16093 ::
-                                                                uu____16102
+                                                              uu____16032 ::
+                                                                uu____16041
                                                                in
-                                                            uu____16073 ::
-                                                              uu____16082
+                                                            uu____16012 ::
+                                                              uu____16021
                                                              in
                                                           FStar_List.append
                                                             maybe_range_arg
-                                                            uu____16062
+                                                            uu____16001
                                                            in
                                                         FStar_List.append
-                                                          uu____15987
-                                                          uu____16051)
+                                                          uu____15926
+                                                          uu____15990)
                                                       in
-                                                   let uu____16198 =
-                                                     let uu____16205 =
-                                                       let uu____16206 =
-                                                         let uu____16220 =
-                                                           let uu____16223 =
-                                                             let uu____16230
+                                                   let uu____16137 =
+                                                     let uu____16138 =
+                                                       let uu____16152 =
+                                                         let uu____16155 =
+                                                           let uu____16162 =
+                                                             let uu____16163
                                                                =
-                                                               let uu____16231
-                                                                 =
-                                                                 FStar_Syntax_Syntax.mk_binder
-                                                                   head_bv
-                                                                  in
-                                                               [uu____16231]
+                                                               FStar_Syntax_Syntax.mk_binder
+                                                                 head_bv
                                                                 in
-                                                             FStar_Syntax_Subst.close
-                                                               uu____16230
+                                                             [uu____16163]
                                                               in
-                                                           let uu____16250 =
-                                                             FStar_Syntax_Syntax.mk
-                                                               (FStar_Syntax_Syntax.Tm_app
-                                                                  (bind_inst,
-                                                                    args))
-                                                               FStar_Pervasives_Native.None
-                                                               rng
-                                                              in
-                                                           FStar_All.pipe_left
-                                                             uu____16223
-                                                             uu____16250
+                                                           FStar_Syntax_Subst.close
+                                                             uu____16162
                                                             in
-                                                         ((false, [lb_head]),
-                                                           uu____16220)
+                                                         let uu____16182 =
+                                                           FStar_Syntax_Syntax.mk
+                                                             (FStar_Syntax_Syntax.Tm_app
+                                                                (bind_inst,
+                                                                  args)) rng
+                                                            in
+                                                         FStar_All.pipe_left
+                                                           uu____16155
+                                                           uu____16182
                                                           in
-                                                       FStar_Syntax_Syntax.Tm_let
-                                                         uu____16206
+                                                       ((false, [lb_head]),
+                                                         uu____16152)
                                                         in
-                                                     FStar_Syntax_Syntax.mk
-                                                       uu____16205
+                                                     FStar_Syntax_Syntax.Tm_let
+                                                       uu____16138
                                                       in
-                                                   uu____16198
-                                                     FStar_Pervasives_Native.None
-                                                     rng
+                                                   FStar_Syntax_Syntax.mk
+                                                     uu____16137 rng
                                                     in
                                                  (FStar_TypeChecker_Cfg.log
                                                     cfg
-                                                    (fun uu____16282  ->
-                                                       let uu____16283 =
+                                                    (fun uu____16214  ->
+                                                       let uu____16215 =
                                                          FStar_Syntax_Print.term_to_string
                                                            top0
                                                           in
-                                                       let uu____16285 =
+                                                       let uu____16217 =
                                                          FStar_Syntax_Print.term_to_string
                                                            reified
                                                           in
                                                        FStar_Util.print2
                                                          "Reified (1) <%s> to %s\n"
-                                                         uu____16283
-                                                         uu____16285);
-                                                  (let uu____16288 =
+                                                         uu____16215
+                                                         uu____16217);
+                                                  (let uu____16220 =
                                                      FStar_List.tl stack1  in
-                                                   norm cfg env1 uu____16288
+                                                   norm cfg env1 uu____16220
                                                      reified)))))))
                   | FStar_Syntax_Syntax.Tm_app (head,args) ->
-                      ((let uu____16316 = FStar_Options.defensive ()  in
-                        if uu____16316
+                      ((let uu____16248 = FStar_Options.defensive ()  in
+                        if uu____16248
                         then
-                          let is_arg_impure uu____16331 =
-                            match uu____16331 with
+                          let is_arg_impure uu____16263 =
+                            match uu____16263 with
                             | (e,q) ->
-                                let uu____16345 =
-                                  let uu____16346 =
+                                let uu____16277 =
+                                  let uu____16278 =
                                     FStar_Syntax_Subst.compress e  in
-                                  uu____16346.FStar_Syntax_Syntax.n  in
-                                (match uu____16345 with
+                                  uu____16278.FStar_Syntax_Syntax.n  in
+                                (match uu____16277 with
                                  | FStar_Syntax_Syntax.Tm_meta
                                      (e0,FStar_Syntax_Syntax.Meta_monadic_lift
                                       (m1,m2,t'))
                                      ->
-                                     let uu____16362 =
+                                     let uu____16294 =
                                        FStar_Syntax_Util.is_pure_effect m1
                                         in
-                                     Prims.op_Negation uu____16362
-                                 | uu____16364 -> false)
+                                     Prims.op_Negation uu____16294
+                                 | uu____16296 -> false)
                              in
-                          let uu____16366 =
-                            let uu____16368 =
-                              let uu____16379 =
+                          let uu____16298 =
+                            let uu____16300 =
+                              let uu____16311 =
                                 FStar_Syntax_Syntax.as_arg head  in
-                              uu____16379 :: args  in
-                            FStar_Util.for_some is_arg_impure uu____16368  in
-                          (if uu____16366
+                              uu____16311 :: args  in
+                            FStar_Util.for_some is_arg_impure uu____16300  in
+                          (if uu____16298
                            then
-                             let uu____16405 =
-                               let uu____16411 =
-                                 let uu____16413 =
+                             let uu____16337 =
+                               let uu____16343 =
+                                 let uu____16345 =
                                    FStar_Syntax_Print.term_to_string top2  in
                                  FStar_Util.format1
                                    "Incompatibility between typechecker and normalizer; this monadic application contains impure terms %s\n"
-                                   uu____16413
+                                   uu____16345
                                   in
-                               (FStar_Errors.Warning_Defensive, uu____16411)
+                               (FStar_Errors.Warning_Defensive, uu____16343)
                                 in
                              FStar_Errors.log_issue
-                               top2.FStar_Syntax_Syntax.pos uu____16405
+                               top2.FStar_Syntax_Syntax.pos uu____16337
                            else ())
                         else ());
-                       (let fallback1 uu____16426 =
+                       (let fallback1 uu____16358 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____16430  ->
-                               let uu____16431 =
+                            (fun uu____16362  ->
+                               let uu____16363 =
                                  FStar_Syntax_Print.term_to_string top0  in
                                FStar_Util.print2 "Reified (2) <%s> to %s\n"
-                                 uu____16431 "");
-                          (let uu____16435 = FStar_List.tl stack1  in
-                           let uu____16436 = FStar_Syntax_Util.mk_reify top2
+                                 uu____16363 "");
+                          (let uu____16367 = FStar_List.tl stack1  in
+                           let uu____16368 = FStar_Syntax_Util.mk_reify top2
                               in
-                           norm cfg env1 uu____16435 uu____16436)
+                           norm cfg env1 uu____16367 uu____16368)
                            in
-                        let fallback2 uu____16442 =
+                        let fallback2 uu____16374 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____16446  ->
-                               let uu____16447 =
+                            (fun uu____16378  ->
+                               let uu____16379 =
                                  FStar_Syntax_Print.term_to_string top0  in
                                FStar_Util.print2 "Reified (3) <%s> to %s\n"
-                                 uu____16447 "");
-                          (let uu____16451 = FStar_List.tl stack1  in
-                           let uu____16452 =
-                             mk
+                                 uu____16379 "");
+                          (let uu____16383 = FStar_List.tl stack1  in
+                           let uu____16384 =
+                             FStar_Syntax_Syntax.mk
                                (FStar_Syntax_Syntax.Tm_meta
                                   (top2,
                                     (FStar_Syntax_Syntax.Meta_monadic (m, t))))
                                top0.FStar_Syntax_Syntax.pos
                               in
-                           norm cfg env1 uu____16451 uu____16452)
+                           norm cfg env1 uu____16383 uu____16384)
                            in
-                        let uu____16457 =
-                          let uu____16458 = FStar_Syntax_Util.un_uinst head
+                        let uu____16389 =
+                          let uu____16390 = FStar_Syntax_Util.un_uinst head
                              in
-                          uu____16458.FStar_Syntax_Syntax.n  in
-                        match uu____16457 with
+                          uu____16390.FStar_Syntax_Syntax.n  in
+                        match uu____16389 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             let lid = FStar_Syntax_Syntax.lid_of_fv fv  in
                             let qninfo =
                               FStar_TypeChecker_Env.lookup_qname
                                 cfg.FStar_TypeChecker_Cfg.tcenv lid
                                in
-                            let uu____16464 =
-                              let uu____16466 =
+                            let uu____16396 =
+                              let uu____16398 =
                                 FStar_TypeChecker_Env.is_action
                                   cfg.FStar_TypeChecker_Cfg.tcenv lid
                                  in
-                              Prims.op_Negation uu____16466  in
-                            if uu____16464
+                              Prims.op_Negation uu____16398  in
+                            if uu____16396
                             then fallback1 ()
                             else
-                              (let uu____16471 =
-                                 let uu____16473 =
+                              (let uu____16403 =
+                                 let uu____16405 =
                                    FStar_TypeChecker_Env.lookup_definition_qninfo
                                      cfg.FStar_TypeChecker_Cfg.delta_level
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo
                                     in
-                                 FStar_Option.isNone uu____16473  in
-                               if uu____16471
+                                 FStar_Option.isNone uu____16405  in
+                               if uu____16403
                                then fallback2 ()
                                else
                                  (let t1 =
-                                    let uu____16490 =
-                                      let uu____16495 =
-                                        FStar_Syntax_Util.mk_reify head  in
-                                      FStar_Syntax_Syntax.mk_Tm_app
-                                        uu____16495 args
-                                       in
-                                    uu____16490 FStar_Pervasives_Native.None
-                                      t.FStar_Syntax_Syntax.pos
+                                    let uu____16420 =
+                                      FStar_Syntax_Util.mk_reify head  in
+                                    FStar_Syntax_Syntax.mk_Tm_app uu____16420
+                                      args t.FStar_Syntax_Syntax.pos
                                      in
-                                  let uu____16496 = FStar_List.tl stack1  in
-                                  norm cfg env1 uu____16496 t1))
-                        | uu____16497 -> fallback1 ()))
+                                  let uu____16421 = FStar_List.tl stack1  in
+                                  norm cfg env1 uu____16421 t1))
+                        | uu____16422 -> fallback1 ()))
                   | FStar_Syntax_Syntax.Tm_meta
-                      (e,FStar_Syntax_Syntax.Meta_monadic uu____16499) ->
+                      (e,FStar_Syntax_Syntax.Meta_monadic uu____16424) ->
                       do_reify_monadic fallback cfg env1 stack1 e m t
                   | FStar_Syntax_Syntax.Tm_meta
                       (e,FStar_Syntax_Syntax.Meta_monadic_lift
                        (msrc,mtgt,t'))
                       ->
                       let lifted =
-                        let uu____16523 = closure_as_term cfg env1 t'  in
-                        reify_lift cfg e msrc mtgt uu____16523  in
+                        let uu____16448 = closure_as_term cfg env1 t'  in
+                        reify_lift cfg e msrc mtgt uu____16448  in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____16527  ->
-                            let uu____16528 =
+                         (fun uu____16452  ->
+                            let uu____16453 =
                               FStar_Syntax_Print.term_to_string lifted  in
                             FStar_Util.print1 "Reified lift to (2): %s\n"
-                              uu____16528);
-                       (let uu____16531 = FStar_List.tl stack1  in
-                        norm cfg env1 uu____16531 lifted))
+                              uu____16453);
+                       (let uu____16456 = FStar_List.tl stack1  in
+                        norm cfg env1 uu____16456 lifted))
                   | FStar_Syntax_Syntax.Tm_match (e,branches1) ->
                       let branches2 =
                         FStar_All.pipe_right branches1
                           (FStar_List.map
-                             (fun uu____16652  ->
-                                match uu____16652 with
+                             (fun uu____16577  ->
+                                match uu____16577 with
                                 | (pat,wopt,tm) ->
-                                    let uu____16700 =
+                                    let uu____16625 =
                                       FStar_Syntax_Util.mk_reify tm  in
-                                    (pat, wopt, uu____16700)))
+                                    (pat, wopt, uu____16625)))
                          in
                       let tm =
-                        mk (FStar_Syntax_Syntax.Tm_match (e, branches2))
+                        FStar_Syntax_Syntax.mk
+                          (FStar_Syntax_Syntax.Tm_match (e, branches2))
                           top2.FStar_Syntax_Syntax.pos
                          in
-                      let uu____16732 = FStar_List.tl stack1  in
-                      norm cfg env1 uu____16732 tm
-                  | uu____16733 -> fallback ()))
+                      let uu____16657 = FStar_List.tl stack1  in
+                      norm cfg env1 uu____16657 tm
+                  | uu____16658 -> fallback ()))
 
 and (reify_lift :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5642,214 +5622,199 @@ and (reify_lift :
           fun t  ->
             let env1 = cfg.FStar_TypeChecker_Cfg.tcenv  in
             FStar_TypeChecker_Cfg.log cfg
-              (fun uu____16747  ->
-                 let uu____16748 = FStar_Ident.string_of_lid msrc  in
-                 let uu____16750 = FStar_Ident.string_of_lid mtgt  in
-                 let uu____16752 = FStar_Syntax_Print.term_to_string e  in
-                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____16748
-                   uu____16750 uu____16752);
-            (let uu____16755 =
+              (fun uu____16672  ->
+                 let uu____16673 = FStar_Ident.string_of_lid msrc  in
+                 let uu____16675 = FStar_Ident.string_of_lid mtgt  in
+                 let uu____16677 = FStar_Syntax_Print.term_to_string e  in
+                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____16673
+                   uu____16675 uu____16677);
+            (let uu____16680 =
                ((FStar_Syntax_Util.is_pure_effect msrc) ||
                   (FStar_Syntax_Util.is_div_effect msrc))
                  &&
-                 (let uu____16758 =
+                 (let uu____16683 =
                     FStar_All.pipe_right mtgt
                       (FStar_TypeChecker_Env.is_layered_effect env1)
                      in
-                  Prims.op_Negation uu____16758)
+                  Prims.op_Negation uu____16683)
                 in
-             if uu____16755
+             if uu____16680
              then
                let ed =
-                 let uu____16763 =
+                 let uu____16688 =
                    FStar_TypeChecker_Env.norm_eff_name
                      cfg.FStar_TypeChecker_Cfg.tcenv mtgt
                     in
-                 FStar_TypeChecker_Env.get_effect_decl env1 uu____16763  in
-               let uu____16764 =
-                 let uu____16773 =
+                 FStar_TypeChecker_Env.get_effect_decl env1 uu____16688  in
+               let uu____16689 =
+                 let uu____16698 =
                    FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr  in
-                 FStar_All.pipe_right uu____16773 FStar_Util.must  in
-               match uu____16764 with
-               | (uu____16820,repr) ->
-                   let uu____16830 =
-                     let uu____16839 =
+                 FStar_All.pipe_right uu____16698 FStar_Util.must  in
+               match uu____16689 with
+               | (uu____16745,repr) ->
+                   let uu____16755 =
+                     let uu____16764 =
                        FStar_All.pipe_right ed
                          FStar_Syntax_Util.get_return_repr
                         in
-                     FStar_All.pipe_right uu____16839 FStar_Util.must  in
-                   (match uu____16830 with
-                    | (uu____16886,return_repr) ->
+                     FStar_All.pipe_right uu____16764 FStar_Util.must  in
+                   (match uu____16755 with
+                    | (uu____16811,return_repr) ->
                         let return_inst =
-                          let uu____16899 =
-                            let uu____16900 =
+                          let uu____16824 =
+                            let uu____16825 =
                               FStar_Syntax_Subst.compress return_repr  in
-                            uu____16900.FStar_Syntax_Syntax.n  in
-                          match uu____16899 with
+                            uu____16825.FStar_Syntax_Syntax.n  in
+                          match uu____16824 with
                           | FStar_Syntax_Syntax.Tm_uinst
-                              (return_tm,uu____16906::[]) ->
-                              let uu____16911 =
-                                let uu____16918 =
-                                  let uu____16919 =
-                                    let uu____16926 =
-                                      let uu____16927 =
-                                        env1.FStar_TypeChecker_Env.universe_of
-                                          env1 t
-                                         in
-                                      [uu____16927]  in
-                                    (return_tm, uu____16926)  in
-                                  FStar_Syntax_Syntax.Tm_uinst uu____16919
-                                   in
-                                FStar_Syntax_Syntax.mk uu____16918  in
-                              uu____16911 FStar_Pervasives_Native.None
+                              (return_tm,uu____16831::[]) ->
+                              let uu____16836 =
+                                let uu____16837 =
+                                  let uu____16844 =
+                                    let uu____16845 =
+                                      env1.FStar_TypeChecker_Env.universe_of
+                                        env1 t
+                                       in
+                                    [uu____16845]  in
+                                  (return_tm, uu____16844)  in
+                                FStar_Syntax_Syntax.Tm_uinst uu____16837  in
+                              FStar_Syntax_Syntax.mk uu____16836
                                 e.FStar_Syntax_Syntax.pos
-                          | uu____16930 ->
+                          | uu____16848 ->
                               failwith "NIY : Reification of indexed effects"
                            in
-                        let uu____16934 =
+                        let uu____16852 =
                           let bv =
                             FStar_Syntax_Syntax.new_bv
                               FStar_Pervasives_Native.None t
                              in
                           let lb =
-                            let uu____16945 =
-                              let uu____16948 =
-                                let uu____16959 =
+                            let uu____16863 =
+                              let uu____16866 =
+                                let uu____16877 =
                                   FStar_Syntax_Syntax.as_arg t  in
-                                [uu____16959]  in
-                              FStar_Syntax_Util.mk_app repr uu____16948  in
+                                [uu____16877]  in
+                              FStar_Syntax_Util.mk_app repr uu____16866  in
                             {
                               FStar_Syntax_Syntax.lbname =
                                 (FStar_Util.Inl bv);
                               FStar_Syntax_Syntax.lbunivs = [];
-                              FStar_Syntax_Syntax.lbtyp = uu____16945;
+                              FStar_Syntax_Syntax.lbtyp = uu____16863;
                               FStar_Syntax_Syntax.lbeff = msrc;
                               FStar_Syntax_Syntax.lbdef = e;
                               FStar_Syntax_Syntax.lbattrs = [];
                               FStar_Syntax_Syntax.lbpos =
                                 (e.FStar_Syntax_Syntax.pos)
                             }  in
-                          let uu____16986 = FStar_Syntax_Syntax.bv_to_name bv
+                          let uu____16904 = FStar_Syntax_Syntax.bv_to_name bv
                              in
-                          (lb, bv, uu____16986)  in
-                        (match uu____16934 with
+                          (lb, bv, uu____16904)  in
+                        (match uu____16852 with
                          | (lb_e,e_bv,e1) ->
-                             let uu____16998 =
-                               let uu____17005 =
-                                 let uu____17006 =
-                                   let uu____17020 =
-                                     let uu____17023 =
-                                       let uu____17030 =
-                                         let uu____17031 =
-                                           FStar_Syntax_Syntax.mk_binder e_bv
-                                            in
-                                         [uu____17031]  in
-                                       FStar_Syntax_Subst.close uu____17030
-                                        in
-                                     let uu____17050 =
-                                       let uu____17051 =
-                                         let uu____17058 =
-                                           let uu____17059 =
-                                             let uu____17076 =
-                                               let uu____17087 =
-                                                 FStar_Syntax_Syntax.as_arg t
-                                                  in
-                                               let uu____17096 =
-                                                 let uu____17107 =
-                                                   FStar_Syntax_Syntax.as_arg
-                                                     e1
-                                                    in
-                                                 [uu____17107]  in
-                                               uu____17087 :: uu____17096  in
-                                             (return_inst, uu____17076)  in
-                                           FStar_Syntax_Syntax.Tm_app
-                                             uu____17059
-                                            in
-                                         FStar_Syntax_Syntax.mk uu____17058
+                             let uu____16916 =
+                               let uu____16917 =
+                                 let uu____16931 =
+                                   let uu____16934 =
+                                     let uu____16941 =
+                                       let uu____16942 =
+                                         FStar_Syntax_Syntax.mk_binder e_bv
                                           in
-                                       uu____17051
-                                         FStar_Pervasives_Native.None
-                                         e1.FStar_Syntax_Syntax.pos
+                                       [uu____16942]  in
+                                     FStar_Syntax_Subst.close uu____16941  in
+                                   let uu____16961 =
+                                     let uu____16962 =
+                                       let uu____16963 =
+                                         let uu____16980 =
+                                           let uu____16991 =
+                                             FStar_Syntax_Syntax.as_arg t  in
+                                           let uu____17000 =
+                                             let uu____17011 =
+                                               FStar_Syntax_Syntax.as_arg e1
+                                                in
+                                             [uu____17011]  in
+                                           uu____16991 :: uu____17000  in
+                                         (return_inst, uu____16980)  in
+                                       FStar_Syntax_Syntax.Tm_app uu____16963
                                         in
-                                     FStar_All.pipe_left uu____17023
-                                       uu____17050
+                                     FStar_Syntax_Syntax.mk uu____16962
+                                       e1.FStar_Syntax_Syntax.pos
                                       in
-                                   ((false, [lb_e]), uu____17020)  in
-                                 FStar_Syntax_Syntax.Tm_let uu____17006  in
-                               FStar_Syntax_Syntax.mk uu____17005  in
-                             uu____16998 FStar_Pervasives_Native.None
+                                   FStar_All.pipe_left uu____16934
+                                     uu____16961
+                                    in
+                                 ((false, [lb_e]), uu____16931)  in
+                               FStar_Syntax_Syntax.Tm_let uu____16917  in
+                             FStar_Syntax_Syntax.mk uu____16916
                                e1.FStar_Syntax_Syntax.pos))
              else
-               (let uu____17169 =
+               (let uu____17073 =
                   FStar_TypeChecker_Env.monad_leq env1 msrc mtgt  in
-                match uu____17169 with
+                match uu____17073 with
                 | FStar_Pervasives_Native.None  ->
-                    let uu____17172 =
-                      let uu____17174 = FStar_Ident.string_of_lid msrc  in
-                      let uu____17176 = FStar_Ident.string_of_lid mtgt  in
+                    let uu____17076 =
+                      let uu____17078 = FStar_Ident.string_of_lid msrc  in
+                      let uu____17080 = FStar_Ident.string_of_lid mtgt  in
                       FStar_Util.format2
                         "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                        uu____17174 uu____17176
+                        uu____17078 uu____17080
                        in
-                    failwith uu____17172
+                    failwith uu____17076
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____17179;
-                      FStar_TypeChecker_Env.mtarget = uu____17180;
+                    { FStar_TypeChecker_Env.msource = uu____17083;
+                      FStar_TypeChecker_Env.mtarget = uu____17084;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____17181;
+                        { FStar_TypeChecker_Env.mlift_wp = uu____17085;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.None ;_};_}
                     ->
-                    let uu____17201 =
-                      let uu____17203 = FStar_Ident.string_of_lid msrc  in
-                      let uu____17205 = FStar_Ident.string_of_lid mtgt  in
+                    let uu____17105 =
+                      let uu____17107 = FStar_Ident.string_of_lid msrc  in
+                      let uu____17109 = FStar_Ident.string_of_lid mtgt  in
                       FStar_Util.format2
                         "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                        uu____17203 uu____17205
+                        uu____17107 uu____17109
                        in
-                    failwith uu____17201
+                    failwith uu____17105
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____17208;
-                      FStar_TypeChecker_Env.mtarget = uu____17209;
+                    { FStar_TypeChecker_Env.msource = uu____17112;
+                      FStar_TypeChecker_Env.mtarget = uu____17113;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____17210;
+                        { FStar_TypeChecker_Env.mlift_wp = uu____17114;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.Some lift;_};_}
                     ->
                     let e1 =
-                      let uu____17241 =
+                      let uu____17145 =
                         FStar_TypeChecker_Env.is_reifiable_effect env1 msrc
                          in
-                      if uu____17241
+                      if uu____17145
                       then FStar_Syntax_Util.mk_reify e
                       else
-                        (let uu____17246 =
-                           let uu____17253 =
-                             let uu____17254 =
-                               let uu____17273 =
-                                 let uu____17282 =
-                                   FStar_Syntax_Syntax.null_binder
-                                     FStar_Syntax_Syntax.t_unit
-                                    in
-                                 [uu____17282]  in
-                               (uu____17273, e,
-                                 (FStar_Pervasives_Native.Some
-                                    {
-                                      FStar_Syntax_Syntax.residual_effect =
-                                        msrc;
-                                      FStar_Syntax_Syntax.residual_typ =
-                                        (FStar_Pervasives_Native.Some t);
-                                      FStar_Syntax_Syntax.residual_flags = []
-                                    }))
-                                in
-                             FStar_Syntax_Syntax.Tm_abs uu____17254  in
-                           FStar_Syntax_Syntax.mk uu____17253  in
-                         uu____17246 FStar_Pervasives_Native.None
+                        (let uu____17150 =
+                           let uu____17151 =
+                             let uu____17170 =
+                               let uu____17179 =
+                                 FStar_Syntax_Syntax.null_binder
+                                   FStar_Syntax_Syntax.t_unit
+                                  in
+                               [uu____17179]  in
+                             (uu____17170, e,
+                               (FStar_Pervasives_Native.Some
+                                  {
+                                    FStar_Syntax_Syntax.residual_effect =
+                                      msrc;
+                                    FStar_Syntax_Syntax.residual_typ =
+                                      (FStar_Pervasives_Native.Some t);
+                                    FStar_Syntax_Syntax.residual_flags = []
+                                  }))
+                              in
+                           FStar_Syntax_Syntax.Tm_abs uu____17151  in
+                         FStar_Syntax_Syntax.mk uu____17150
                            e.FStar_Syntax_Syntax.pos)
                        in
-                    let uu____17315 =
+                    let uu____17212 =
                       env1.FStar_TypeChecker_Env.universe_of env1 t  in
-                    lift uu____17315 t e1))
+                    lift uu____17212 t e1))
 
 and (norm_pattern_args :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5867,11 +5832,11 @@ and (norm_pattern_args :
         FStar_All.pipe_right args
           (FStar_List.map
              (FStar_List.map
-                (fun uu____17385  ->
-                   match uu____17385 with
+                (fun uu____17282  ->
+                   match uu____17282 with
                    | (a,imp) ->
-                       let uu____17404 = norm cfg env1 [] a  in
-                       (uu____17404, imp))))
+                       let uu____17301 = norm cfg env1 [] a  in
+                       (uu____17301, imp))))
 
 and (norm_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5881,75 +5846,75 @@ and (norm_comp :
     fun env1  ->
       fun comp  ->
         FStar_TypeChecker_Cfg.log cfg
-          (fun uu____17414  ->
-             let uu____17415 = FStar_Syntax_Print.comp_to_string comp  in
-             let uu____17417 =
+          (fun uu____17311  ->
+             let uu____17312 = FStar_Syntax_Print.comp_to_string comp  in
+             let uu____17314 =
                FStar_Util.string_of_int (FStar_List.length env1)  in
              FStar_Util.print2 ">>> %s\nNormComp with with %s env elements\n"
-               uu____17415 uu____17417);
+               uu____17312 uu____17314);
         (match comp.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Total (t,uopt) ->
              let t1 = norm cfg env1 [] t  in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____17443 = norm_universe cfg env1 u  in
+                   let uu____17340 = norm_universe cfg env1 u  in
                    FStar_All.pipe_left
-                     (fun uu____17446  ->
-                        FStar_Pervasives_Native.Some uu____17446) uu____17443
+                     (fun uu____17343  ->
+                        FStar_Pervasives_Native.Some uu____17343) uu____17340
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                 in
-             let uu___2111_17447 = comp  in
+             let uu___2109_17344 = comp  in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Total (t1, uopt1));
                FStar_Syntax_Syntax.pos =
-                 (uu___2111_17447.FStar_Syntax_Syntax.pos);
+                 (uu___2109_17344.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2111_17447.FStar_Syntax_Syntax.vars)
+                 (uu___2109_17344.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.GTotal (t,uopt) ->
              let t1 = norm cfg env1 [] t  in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____17469 = norm_universe cfg env1 u  in
+                   let uu____17366 = norm_universe cfg env1 u  in
                    FStar_All.pipe_left
-                     (fun uu____17472  ->
-                        FStar_Pervasives_Native.Some uu____17472) uu____17469
+                     (fun uu____17369  ->
+                        FStar_Pervasives_Native.Some uu____17369) uu____17366
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                 in
-             let uu___2122_17473 = comp  in
+             let uu___2120_17370 = comp  in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.GTotal (t1, uopt1));
                FStar_Syntax_Syntax.pos =
-                 (uu___2122_17473.FStar_Syntax_Syntax.pos);
+                 (uu___2120_17370.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2122_17473.FStar_Syntax_Syntax.vars)
+                 (uu___2120_17370.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.Comp ct ->
              let norm_args =
                FStar_List.mapi
                  (fun idx  ->
-                    fun uu____17518  ->
-                      match uu____17518 with
+                    fun uu____17415  ->
+                      match uu____17415 with
                       | (a,i) ->
-                          let uu____17538 = norm cfg env1 [] a  in
-                          (uu____17538, i))
+                          let uu____17435 = norm cfg env1 [] a  in
+                          (uu____17435, i))
                 in
              let effect_args = norm_args ct.FStar_Syntax_Syntax.effect_args
                 in
              let flags =
                FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                  (FStar_List.map
-                    (fun uu___14_17560  ->
-                       match uu___14_17560 with
+                    (fun uu___14_17457  ->
+                       match uu___14_17457 with
                        | FStar_Syntax_Syntax.DECREASES t ->
-                           let uu____17564 = norm cfg env1 [] t  in
-                           FStar_Syntax_Syntax.DECREASES uu____17564
+                           let uu____17461 = norm cfg env1 [] t  in
+                           FStar_Syntax_Syntax.DECREASES uu____17461
                        | f -> f))
                 in
              let comp_univs =
@@ -5958,23 +5923,23 @@ and (norm_comp :
                 in
              let result_typ =
                norm cfg env1 [] ct.FStar_Syntax_Syntax.result_typ  in
-             let uu___2139_17572 = comp  in
+             let uu___2137_17469 = comp  in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Comp
-                    (let uu___2141_17575 = ct  in
+                    (let uu___2139_17472 = ct  in
                      {
                        FStar_Syntax_Syntax.comp_univs = comp_univs;
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___2141_17575.FStar_Syntax_Syntax.effect_name);
+                         (uu___2139_17472.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ = result_typ;
                        FStar_Syntax_Syntax.effect_args = effect_args;
                        FStar_Syntax_Syntax.flags = flags
                      }));
                FStar_Syntax_Syntax.pos =
-                 (uu___2139_17572.FStar_Syntax_Syntax.pos);
+                 (uu___2137_17469.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2139_17572.FStar_Syntax_Syntax.vars)
+                 (uu___2137_17469.FStar_Syntax_Syntax.vars)
              })
 
 and (norm_binder :
@@ -5984,27 +5949,27 @@ and (norm_binder :
   fun cfg  ->
     fun env1  ->
       fun b  ->
-        let uu____17579 = b  in
-        match uu____17579 with
+        let uu____17476 = b  in
+        match uu____17476 with
         | (x,imp) ->
             let x1 =
-              let uu___2149_17587 = x  in
-              let uu____17588 = norm cfg env1 [] x.FStar_Syntax_Syntax.sort
+              let uu___2147_17484 = x  in
+              let uu____17485 = norm cfg env1 [] x.FStar_Syntax_Syntax.sort
                  in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___2149_17587.FStar_Syntax_Syntax.ppname);
+                  (uu___2147_17484.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___2149_17587.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____17588
+                  (uu___2147_17484.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____17485
               }  in
             let imp1 =
               match imp with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-                  let uu____17599 =
-                    let uu____17600 = closure_as_term cfg env1 t  in
-                    FStar_Syntax_Syntax.Meta uu____17600  in
-                  FStar_Pervasives_Native.Some uu____17599
+                  let uu____17496 =
+                    let uu____17497 = closure_as_term cfg env1 t  in
+                    FStar_Syntax_Syntax.Meta uu____17497  in
+                  FStar_Pervasives_Native.Some uu____17496
               | i -> i  in
             (x1, imp1)
 
@@ -6015,16 +5980,16 @@ and (norm_binders :
   fun cfg  ->
     fun env1  ->
       fun bs  ->
-        let uu____17611 =
+        let uu____17508 =
           FStar_List.fold_left
-            (fun uu____17645  ->
+            (fun uu____17542  ->
                fun b  ->
-                 match uu____17645 with
+                 match uu____17542 with
                  | (nbs',env2) ->
                      let b1 = norm_binder cfg env2 b  in
                      ((b1 :: nbs'), (dummy :: env2))) ([], env1) bs
            in
-        match uu____17611 with | (nbs,uu____17725) -> FStar_List.rev nbs
+        match uu____17508 with | (nbs,uu____17622) -> FStar_List.rev nbs
 
 and (norm_lcomp_opt :
   FStar_TypeChecker_Cfg.cfg ->
@@ -6040,9 +6005,9 @@ and (norm_lcomp_opt :
             let flags =
               filter_out_lcomp_cflags rc.FStar_Syntax_Syntax.residual_flags
                in
-            let uu____17757 =
-              let uu___2174_17758 = rc  in
-              let uu____17759 =
+            let uu____17654 =
+              let uu___2172_17655 = rc  in
+              let uu____17656 =
                 if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                 then FStar_Pervasives_Native.None
@@ -6052,13 +6017,13 @@ and (norm_lcomp_opt :
                  in
               {
                 FStar_Syntax_Syntax.residual_effect =
-                  (uu___2174_17758.FStar_Syntax_Syntax.residual_effect);
-                FStar_Syntax_Syntax.residual_typ = uu____17759;
+                  (uu___2172_17655.FStar_Syntax_Syntax.residual_effect);
+                FStar_Syntax_Syntax.residual_typ = uu____17656;
                 FStar_Syntax_Syntax.residual_flags =
-                  (uu___2174_17758.FStar_Syntax_Syntax.residual_flags)
+                  (uu___2172_17655.FStar_Syntax_Syntax.residual_flags)
               }  in
-            FStar_Pervasives_Native.Some uu____17757
-        | uu____17777 -> lopt
+            FStar_Pervasives_Native.Some uu____17654
+        | uu____17674 -> lopt
 
 and (maybe_simplify :
   FStar_TypeChecker_Cfg.cfg ->
@@ -6071,36 +6036,36 @@ and (maybe_simplify :
           let tm' = maybe_simplify_aux cfg env1 stack1 tm  in
           if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.b380
           then
-            (let uu____17787 = FStar_Syntax_Print.term_to_string tm  in
-             let uu____17789 = FStar_Syntax_Print.term_to_string tm'  in
+            (let uu____17684 = FStar_Syntax_Print.term_to_string tm  in
+             let uu____17686 = FStar_Syntax_Print.term_to_string tm'  in
              FStar_Util.print3 "%sSimplified\n\t%s to\n\t%s\n"
                (if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
                 then ""
-                else "NOT ") uu____17787 uu____17789)
+                else "NOT ") uu____17684 uu____17686)
           else ();
           tm'
 
 and (norm_cb : FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Embeddings.norm_cb)
   =
   fun cfg  ->
-    fun uu___15_17801  ->
-      match uu___15_17801 with
+    fun uu___15_17698  ->
+      match uu___15_17698 with
       | FStar_Util.Inr x -> norm cfg [] [] x
       | FStar_Util.Inl l ->
-          let uu____17814 =
+          let uu____17711 =
             FStar_Syntax_DsEnv.try_lookup_lid
               (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.dsenv l
              in
-          (match uu____17814 with
+          (match uu____17711 with
            | FStar_Pervasives_Native.Some t -> t
            | FStar_Pervasives_Native.None  ->
-               let uu____17818 =
+               let uu____17715 =
                  FStar_Syntax_Syntax.lid_as_fv l
                    FStar_Syntax_Syntax.delta_constant
                    FStar_Pervasives_Native.None
                   in
-               FStar_Syntax_Syntax.fv_to_tm uu____17818)
+               FStar_Syntax_Syntax.fv_to_tm uu____17715)
 
 and (maybe_simplify_aux :
   FStar_TypeChecker_Cfg.cfg ->
@@ -6111,29 +6076,29 @@ and (maybe_simplify_aux :
       fun stack1  ->
         fun tm  ->
           let tm1 =
-            let uu____17826 = norm_cb cfg  in
-            reduce_primops uu____17826 cfg env1 tm  in
-          let uu____17831 =
+            let uu____17723 = norm_cb cfg  in
+            reduce_primops uu____17723 cfg env1 tm  in
+          let uu____17728 =
             FStar_All.pipe_left Prims.op_Negation
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
              in
-          if uu____17831
+          if uu____17728
           then tm1
           else
             (let w t =
-               let uu___2203_17850 = t  in
+               let uu___2201_17747 = t  in
                {
                  FStar_Syntax_Syntax.n =
-                   (uu___2203_17850.FStar_Syntax_Syntax.n);
+                   (uu___2201_17747.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = (tm1.FStar_Syntax_Syntax.pos);
                  FStar_Syntax_Syntax.vars =
-                   (uu___2203_17850.FStar_Syntax_Syntax.vars)
+                   (uu___2201_17747.FStar_Syntax_Syntax.vars)
                }  in
              let simp_t t =
-               let uu____17862 =
-                 let uu____17863 = FStar_Syntax_Util.unmeta t  in
-                 uu____17863.FStar_Syntax_Syntax.n  in
-               match uu____17862 with
+               let uu____17759 =
+                 let uu____17760 = FStar_Syntax_Util.unmeta t  in
+                 uu____17760.FStar_Syntax_Syntax.n  in
+               match uu____17759 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
@@ -6142,145 +6107,145 @@ and (maybe_simplify_aux :
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.false_lid
                    -> FStar_Pervasives_Native.Some false
-               | uu____17875 -> FStar_Pervasives_Native.None  in
+               | uu____17772 -> FStar_Pervasives_Native.None  in
              let rec args_are_binders args bs =
                match (args, bs) with
-               | ((t,uu____17939)::args1,(bv,uu____17942)::bs1) ->
-                   let uu____17996 =
-                     let uu____17997 = FStar_Syntax_Subst.compress t  in
-                     uu____17997.FStar_Syntax_Syntax.n  in
-                   (match uu____17996 with
+               | ((t,uu____17836)::args1,(bv,uu____17839)::bs1) ->
+                   let uu____17893 =
+                     let uu____17894 = FStar_Syntax_Subst.compress t  in
+                     uu____17894.FStar_Syntax_Syntax.n  in
+                   (match uu____17893 with
                     | FStar_Syntax_Syntax.Tm_name bv' ->
                         (FStar_Syntax_Syntax.bv_eq bv bv') &&
                           (args_are_binders args1 bs1)
-                    | uu____18002 -> false)
+                    | uu____17899 -> false)
                | ([],[]) -> true
-               | (uu____18033,uu____18034) -> false  in
+               | (uu____17930,uu____17931) -> false  in
              let is_applied bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____18085 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____18087 = FStar_Syntax_Print.tag_of_term t  in
-                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____18085
-                    uu____18087)
+                 (let uu____17982 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____17984 = FStar_Syntax_Print.tag_of_term t  in
+                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____17982
+                    uu____17984)
                else ();
-               (let uu____18092 = FStar_Syntax_Util.head_and_args' t  in
-                match uu____18092 with
+               (let uu____17989 = FStar_Syntax_Util.head_and_args' t  in
+                match uu____17989 with
                 | (hd,args) ->
-                    let uu____18131 =
-                      let uu____18132 = FStar_Syntax_Subst.compress hd  in
-                      uu____18132.FStar_Syntax_Syntax.n  in
-                    (match uu____18131 with
+                    let uu____18028 =
+                      let uu____18029 = FStar_Syntax_Subst.compress hd  in
+                      uu____18029.FStar_Syntax_Syntax.n  in
+                    (match uu____18028 with
                      | FStar_Syntax_Syntax.Tm_name bv when
                          args_are_binders args bs ->
                          (if
                             (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                           then
-                            (let uu____18140 =
+                            (let uu____18037 =
                                FStar_Syntax_Print.term_to_string t  in
-                             let uu____18142 =
+                             let uu____18039 =
                                FStar_Syntax_Print.bv_to_string bv  in
-                             let uu____18144 =
+                             let uu____18041 =
                                FStar_Syntax_Print.term_to_string hd  in
                              FStar_Util.print3
                                "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                               uu____18140 uu____18142 uu____18144)
+                               uu____18037 uu____18039 uu____18041)
                           else ();
                           FStar_Pervasives_Native.Some bv)
-                     | uu____18149 -> FStar_Pervasives_Native.None))
+                     | uu____18046 -> FStar_Pervasives_Native.None))
                 in
              let is_applied_maybe_squashed bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____18167 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____18169 = FStar_Syntax_Print.tag_of_term t  in
+                 (let uu____18064 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____18066 = FStar_Syntax_Print.tag_of_term t  in
                   FStar_Util.print2
-                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu____18167
-                    uu____18169)
+                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu____18064
+                    uu____18066)
                else ();
-               (let uu____18174 = FStar_Syntax_Util.is_squash t  in
-                match uu____18174 with
-                | FStar_Pervasives_Native.Some (uu____18185,t') ->
+               (let uu____18071 = FStar_Syntax_Util.is_squash t  in
+                match uu____18071 with
+                | FStar_Pervasives_Native.Some (uu____18082,t') ->
                     is_applied bs t'
-                | uu____18197 ->
-                    let uu____18206 = FStar_Syntax_Util.is_auto_squash t  in
-                    (match uu____18206 with
-                     | FStar_Pervasives_Native.Some (uu____18217,t') ->
+                | uu____18094 ->
+                    let uu____18103 = FStar_Syntax_Util.is_auto_squash t  in
+                    (match uu____18103 with
+                     | FStar_Pervasives_Native.Some (uu____18114,t') ->
                          is_applied bs t'
-                     | uu____18229 -> is_applied bs t))
+                     | uu____18126 -> is_applied bs t))
                 in
              let is_quantified_const bv phi =
-               let uu____18253 =
+               let uu____18150 =
                  FStar_Syntax_Util.destruct_typ_as_formula phi  in
-               match uu____18253 with
+               match uu____18150 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
-                   (lid,(p,uu____18260)::(q,uu____18262)::[])) when
+                   (lid,(p,uu____18157)::(q,uu____18159)::[])) when
                    FStar_Ident.lid_equals lid FStar_Parser_Const.imp_lid ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____18305 = FStar_Syntax_Print.term_to_string p
+                      (let uu____18202 = FStar_Syntax_Print.term_to_string p
                           in
-                       let uu____18307 = FStar_Syntax_Print.term_to_string q
+                       let uu____18204 = FStar_Syntax_Print.term_to_string q
                           in
                        FStar_Util.print2 "WPE> p = (%s); q = (%s)\n"
-                         uu____18305 uu____18307)
+                         uu____18202 uu____18204)
                     else ();
-                    (let uu____18312 =
+                    (let uu____18209 =
                        FStar_Syntax_Util.destruct_typ_as_formula p  in
-                     match uu____18312 with
+                     match uu____18209 with
                      | FStar_Pervasives_Native.None  ->
-                         let uu____18317 =
-                           let uu____18318 = FStar_Syntax_Subst.compress p
+                         let uu____18214 =
+                           let uu____18215 = FStar_Syntax_Subst.compress p
                               in
-                           uu____18318.FStar_Syntax_Syntax.n  in
-                         (match uu____18317 with
+                           uu____18215.FStar_Syntax_Syntax.n  in
+                         (match uu____18214 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 1\n"
                                else ();
-                               (let uu____18329 =
+                               (let uu____18226 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_true)] q
                                    in
-                                FStar_Pervasives_Native.Some uu____18329))
-                          | uu____18332 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu____18226))
+                          | uu____18229 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some
                          (FStar_Syntax_Util.BaseConn
-                         (lid1,(p1,uu____18335)::[])) when
+                         (lid1,(p1,uu____18232)::[])) when
                          FStar_Ident.lid_equals lid1
                            FStar_Parser_Const.not_lid
                          ->
-                         let uu____18360 =
-                           let uu____18361 = FStar_Syntax_Subst.compress p1
+                         let uu____18257 =
+                           let uu____18258 = FStar_Syntax_Subst.compress p1
                               in
-                           uu____18361.FStar_Syntax_Syntax.n  in
-                         (match uu____18360 with
+                           uu____18258.FStar_Syntax_Syntax.n  in
+                         (match uu____18257 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 2\n"
                                else ();
-                               (let uu____18372 =
+                               (let uu____18269 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_false)] q
                                    in
-                                FStar_Pervasives_Native.Some uu____18372))
-                          | uu____18375 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu____18269))
+                          | uu____18272 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
                          (bs,pats,phi1)) ->
-                         let uu____18379 =
+                         let uu____18276 =
                            FStar_Syntax_Util.destruct_typ_as_formula phi1  in
-                         (match uu____18379 with
+                         (match uu____18276 with
                           | FStar_Pervasives_Native.None  ->
-                              let uu____18384 =
+                              let uu____18281 =
                                 is_applied_maybe_squashed bs phi1  in
-                              (match uu____18384 with
+                              (match uu____18281 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -6295,22 +6260,22 @@ and (maybe_simplify_aux :
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0))
                                         in
-                                     let uu____18398 =
+                                     let uu____18295 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ftrue)]
                                          q
                                         in
-                                     FStar_Pervasives_Native.Some uu____18398))
-                               | uu____18401 -> FStar_Pervasives_Native.None)
+                                     FStar_Pervasives_Native.Some uu____18295))
+                               | uu____18298 -> FStar_Pervasives_Native.None)
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.BaseConn
-                              (lid1,(p1,uu____18406)::[])) when
+                              (lid1,(p1,uu____18303)::[])) when
                               FStar_Ident.lid_equals lid1
                                 FStar_Parser_Const.not_lid
                               ->
-                              let uu____18431 =
+                              let uu____18328 =
                                 is_applied_maybe_squashed bs p1  in
-                              (match uu____18431 with
+                              (match uu____18328 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -6325,100 +6290,100 @@ and (maybe_simplify_aux :
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0))
                                         in
-                                     let uu____18445 =
+                                     let uu____18342 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ffalse)]
                                          q
                                         in
-                                     FStar_Pervasives_Native.Some uu____18445))
-                               | uu____18448 -> FStar_Pervasives_Native.None)
-                          | uu____18451 -> FStar_Pervasives_Native.None)
-                     | uu____18454 -> FStar_Pervasives_Native.None))
-               | uu____18457 -> FStar_Pervasives_Native.None  in
+                                     FStar_Pervasives_Native.Some uu____18342))
+                               | uu____18345 -> FStar_Pervasives_Native.None)
+                          | uu____18348 -> FStar_Pervasives_Native.None)
+                     | uu____18351 -> FStar_Pervasives_Native.None))
+               | uu____18354 -> FStar_Pervasives_Native.None  in
              let is_forall_const phi =
-               let uu____18470 =
+               let uu____18367 =
                  FStar_Syntax_Util.destruct_typ_as_formula phi  in
-               match uu____18470 with
+               match uu____18367 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
-                   ((bv,uu____18476)::[],uu____18477,phi')) ->
+                   ((bv,uu____18373)::[],uu____18374,phi')) ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____18497 = FStar_Syntax_Print.bv_to_string bv
+                      (let uu____18394 = FStar_Syntax_Print.bv_to_string bv
                           in
-                       let uu____18499 =
+                       let uu____18396 =
                          FStar_Syntax_Print.term_to_string phi'  in
-                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu____18497
-                         uu____18499)
+                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu____18394
+                         uu____18396)
                     else ();
                     is_quantified_const bv phi')
-               | uu____18504 -> FStar_Pervasives_Native.None  in
+               | uu____18401 -> FStar_Pervasives_Native.None  in
              let is_const_match phi =
-               let uu____18519 =
-                 let uu____18520 = FStar_Syntax_Subst.compress phi  in
-                 uu____18520.FStar_Syntax_Syntax.n  in
-               match uu____18519 with
-               | FStar_Syntax_Syntax.Tm_match (uu____18526,br::brs) ->
-                   let uu____18593 = br  in
-                   (match uu____18593 with
-                    | (uu____18611,uu____18612,e) ->
+               let uu____18416 =
+                 let uu____18417 = FStar_Syntax_Subst.compress phi  in
+                 uu____18417.FStar_Syntax_Syntax.n  in
+               match uu____18416 with
+               | FStar_Syntax_Syntax.Tm_match (uu____18423,br::brs) ->
+                   let uu____18490 = br  in
+                   (match uu____18490 with
+                    | (uu____18508,uu____18509,e) ->
                         let r =
-                          let uu____18634 = simp_t e  in
-                          match uu____18634 with
+                          let uu____18531 = simp_t e  in
+                          match uu____18531 with
                           | FStar_Pervasives_Native.None  ->
                               FStar_Pervasives_Native.None
                           | FStar_Pervasives_Native.Some b ->
-                              let uu____18646 =
+                              let uu____18543 =
                                 FStar_List.for_all
-                                  (fun uu____18665  ->
-                                     match uu____18665 with
-                                     | (uu____18679,uu____18680,e') ->
-                                         let uu____18694 = simp_t e'  in
-                                         uu____18694 =
+                                  (fun uu____18562  ->
+                                     match uu____18562 with
+                                     | (uu____18576,uu____18577,e') ->
+                                         let uu____18591 = simp_t e'  in
+                                         uu____18591 =
                                            (FStar_Pervasives_Native.Some b))
                                   brs
                                  in
-                              if uu____18646
+                              if uu____18543
                               then FStar_Pervasives_Native.Some b
                               else FStar_Pervasives_Native.None
                            in
                         r)
-               | uu____18710 -> FStar_Pervasives_Native.None  in
+               | uu____18607 -> FStar_Pervasives_Native.None  in
              let maybe_auto_squash t =
-               let uu____18720 = FStar_Syntax_Util.is_sub_singleton t  in
-               if uu____18720
+               let uu____18617 = FStar_Syntax_Util.is_sub_singleton t  in
+               if uu____18617
                then t
                else
                  FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero
                    t
                 in
              let squashed_head_un_auto_squash_args t =
-               let maybe_un_auto_squash_arg uu____18758 =
-                 match uu____18758 with
+               let maybe_un_auto_squash_arg uu____18653 =
+                 match uu____18653 with
                  | (t1,q) ->
-                     let uu____18779 = FStar_Syntax_Util.is_auto_squash t1
+                     let uu____18674 = FStar_Syntax_Util.is_auto_squash t1
                         in
-                     (match uu____18779 with
+                     (match uu____18674 with
                       | FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.U_zero ,t2) -> (t2, q)
-                      | uu____18811 -> (t1, q))
+                      | uu____18706 -> (t1, q))
                   in
-               let uu____18824 = FStar_Syntax_Util.head_and_args t  in
-               match uu____18824 with
+               let uu____18719 = FStar_Syntax_Util.head_and_args t  in
+               match uu____18719 with
                | (head,args) ->
                    let args1 = FStar_List.map maybe_un_auto_squash_arg args
                       in
                    FStar_Syntax_Syntax.mk_Tm_app head args1
-                     FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+                     t.FStar_Syntax_Syntax.pos
                 in
              let rec clearly_inhabited ty =
-               let uu____18904 =
-                 let uu____18905 = FStar_Syntax_Util.unmeta ty  in
-                 uu____18905.FStar_Syntax_Syntax.n  in
-               match uu____18904 with
-               | FStar_Syntax_Syntax.Tm_uinst (t,uu____18910) ->
+               let uu____18797 =
+                 let uu____18798 = FStar_Syntax_Util.unmeta ty  in
+                 uu____18798.FStar_Syntax_Syntax.n  in
+               match uu____18797 with
+               | FStar_Syntax_Syntax.Tm_uinst (t,uu____18803) ->
                    clearly_inhabited t
-               | FStar_Syntax_Syntax.Tm_arrow (uu____18915,c) ->
+               | FStar_Syntax_Syntax.Tm_arrow (uu____18808,c) ->
                    clearly_inhabited (FStar_Syntax_Util.comp_result c)
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    let l = FStar_Syntax_Syntax.lid_of_fv fv  in
@@ -6427,248 +6392,248 @@ and (maybe_simplify_aux :
                       ||
                       (FStar_Ident.lid_equals l FStar_Parser_Const.string_lid))
                      || (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-               | uu____18939 -> false  in
+               | uu____18832 -> false  in
              let simplify arg =
-               let uu____18972 = simp_t (FStar_Pervasives_Native.fst arg)  in
-               (uu____18972, arg)  in
-             let uu____18987 = is_forall_const tm1  in
-             match uu____18987 with
+               let uu____18865 = simp_t (FStar_Pervasives_Native.fst arg)  in
+               (uu____18865, arg)  in
+             let uu____18880 = is_forall_const tm1  in
+             match uu____18880 with
              | FStar_Pervasives_Native.Some tm' ->
                  (if
                     (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                   then
-                    (let uu____18993 = FStar_Syntax_Print.term_to_string tm1
+                    (let uu____18886 = FStar_Syntax_Print.term_to_string tm1
                         in
-                     let uu____18995 = FStar_Syntax_Print.term_to_string tm'
+                     let uu____18888 = FStar_Syntax_Print.term_to_string tm'
                         in
-                     FStar_Util.print2 "WPE> %s ~> %s\n" uu____18993
-                       uu____18995)
+                     FStar_Util.print2 "WPE> %s ~> %s\n" uu____18886
+                       uu____18888)
                   else ();
-                  (let uu____19000 = norm cfg env1 [] tm'  in
-                   maybe_simplify_aux cfg env1 stack1 uu____19000))
+                  (let uu____18893 = norm cfg env1 [] tm'  in
+                   maybe_simplify_aux cfg env1 stack1 uu____18893))
              | FStar_Pervasives_Native.None  ->
-                 let uu____19001 =
-                   let uu____19002 = FStar_Syntax_Subst.compress tm1  in
-                   uu____19002.FStar_Syntax_Syntax.n  in
-                 (match uu____19001 with
+                 let uu____18894 =
+                   let uu____18895 = FStar_Syntax_Subst.compress tm1  in
+                   uu____18895.FStar_Syntax_Syntax.n  in
+                 (match uu____18894 with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                            ({
                               FStar_Syntax_Syntax.n =
                                 FStar_Syntax_Syntax.Tm_fvar fv;
-                              FStar_Syntax_Syntax.pos = uu____19006;
-                              FStar_Syntax_Syntax.vars = uu____19007;_},uu____19008);
-                         FStar_Syntax_Syntax.pos = uu____19009;
-                         FStar_Syntax_Syntax.vars = uu____19010;_},args)
+                              FStar_Syntax_Syntax.pos = uu____18899;
+                              FStar_Syntax_Syntax.vars = uu____18900;_},uu____18901);
+                         FStar_Syntax_Syntax.pos = uu____18902;
+                         FStar_Syntax_Syntax.vars = uu____18903;_},args)
                       ->
-                      let uu____19040 =
+                      let uu____18933 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid
                          in
-                      if uu____19040
+                      if uu____18933
                       then
-                        let uu____19043 =
+                        let uu____18936 =
                           FStar_All.pipe_right args (FStar_List.map simplify)
                            in
-                        (match uu____19043 with
-                         | (FStar_Pervasives_Native.Some (true ),uu____19101)::
-                             (uu____19102,(arg,uu____19104))::[] ->
+                        (match uu____18936 with
+                         | (FStar_Pervasives_Native.Some (true ),uu____18994)::
+                             (uu____18995,(arg,uu____18997))::[] ->
                              maybe_auto_squash arg
-                         | (uu____19177,(arg,uu____19179))::(FStar_Pervasives_Native.Some
+                         | (uu____19070,(arg,uu____19072))::(FStar_Pervasives_Native.Some
                                                              (true
-                                                             ),uu____19180)::[]
+                                                             ),uu____19073)::[]
                              -> maybe_auto_squash arg
                          | (FStar_Pervasives_Native.Some (false
-                            ),uu____19253)::uu____19254::[] ->
+                            ),uu____19146)::uu____19147::[] ->
                              w FStar_Syntax_Util.t_false
-                         | uu____19324::(FStar_Pervasives_Native.Some (false
-                                         ),uu____19325)::[]
+                         | uu____19217::(FStar_Pervasives_Native.Some (false
+                                         ),uu____19218)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____19395 ->
+                         | uu____19288 ->
                              squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____19413 =
+                        (let uu____19306 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid
                             in
-                         if uu____19413
+                         if uu____19306
                          then
-                           let uu____19416 =
+                           let uu____19309 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify)
                               in
-                           match uu____19416 with
+                           match uu____19309 with
                            | (FStar_Pervasives_Native.Some (true
-                              ),uu____19474)::uu____19475::[] ->
+                              ),uu____19367)::uu____19368::[] ->
                                w FStar_Syntax_Util.t_true
-                           | uu____19545::(FStar_Pervasives_Native.Some (true
-                                           ),uu____19546)::[]
+                           | uu____19438::(FStar_Pervasives_Native.Some (true
+                                           ),uu____19439)::[]
                                -> w FStar_Syntax_Util.t_true
                            | (FStar_Pervasives_Native.Some (false
-                              ),uu____19616)::(uu____19617,(arg,uu____19619))::[]
+                              ),uu____19509)::(uu____19510,(arg,uu____19512))::[]
                                -> maybe_auto_squash arg
-                           | (uu____19692,(arg,uu____19694))::(FStar_Pervasives_Native.Some
+                           | (uu____19585,(arg,uu____19587))::(FStar_Pervasives_Native.Some
                                                                (false
-                                                               ),uu____19695)::[]
+                                                               ),uu____19588)::[]
                                -> maybe_auto_squash arg
-                           | uu____19768 ->
+                           | uu____19661 ->
                                squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____19786 =
+                           (let uu____19679 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid
                                in
-                            if uu____19786
+                            if uu____19679
                             then
-                              let uu____19789 =
+                              let uu____19682 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify)
                                  in
-                              match uu____19789 with
-                              | uu____19847::(FStar_Pervasives_Native.Some
-                                              (true ),uu____19848)::[]
+                              match uu____19682 with
+                              | uu____19740::(FStar_Pervasives_Native.Some
+                                              (true ),uu____19741)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false
-                                 ),uu____19918)::uu____19919::[] ->
+                                 ),uu____19811)::uu____19812::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true
-                                 ),uu____19989)::(uu____19990,(arg,uu____19992))::[]
+                                 ),uu____19882)::(uu____19883,(arg,uu____19885))::[]
                                   -> maybe_auto_squash arg
-                              | (uu____20065,(p,uu____20067))::(uu____20068,
-                                                                (q,uu____20070))::[]
+                              | (uu____19958,(p,uu____19960))::(uu____19961,
+                                                                (q,uu____19963))::[]
                                   ->
-                                  let uu____20142 =
+                                  let uu____20035 =
                                     FStar_Syntax_Util.term_eq p q  in
-                                  (if uu____20142
+                                  (if uu____20035
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____20147 ->
+                              | uu____20040 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____20165 =
+                              (let uu____20058 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid
                                   in
-                               if uu____20165
+                               if uu____20058
                                then
-                                 let uu____20168 =
+                                 let uu____20061 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify)
                                     in
-                                 match uu____20168 with
+                                 match uu____20061 with
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____20226)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____20227)::[]
+                                    ),uu____20119)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____20120)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____20301)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____20302)::[]
+                                    ),uu____20194)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____20195)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____20376)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____20377)::[]
+                                    ),uu____20269)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____20270)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____20451)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____20452)::[]
+                                    ),uu____20344)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____20345)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____20526,(arg,uu____20528))::(FStar_Pervasives_Native.Some
+                                 | (uu____20419,(arg,uu____20421))::(FStar_Pervasives_Native.Some
                                                                     (true
-                                                                    ),uu____20529)::[]
+                                                                    ),uu____20422)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____20602)::(uu____20603,(arg,uu____20605))::[]
+                                    ),uu____20495)::(uu____20496,(arg,uu____20498))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____20678,(arg,uu____20680))::(FStar_Pervasives_Native.Some
+                                 | (uu____20571,(arg,uu____20573))::(FStar_Pervasives_Native.Some
                                                                     (false
-                                                                    ),uu____20681)::[]
+                                                                    ),uu____20574)::[]
                                      ->
-                                     let uu____20754 =
+                                     let uu____20647 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____20754
+                                     maybe_auto_squash uu____20647
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____20755)::(uu____20756,(arg,uu____20758))::[]
+                                    ),uu____20648)::(uu____20649,(arg,uu____20651))::[]
                                      ->
-                                     let uu____20831 =
+                                     let uu____20724 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____20831
-                                 | (uu____20832,(p,uu____20834))::(uu____20835,
-                                                                   (q,uu____20837))::[]
+                                     maybe_auto_squash uu____20724
+                                 | (uu____20725,(p,uu____20727))::(uu____20728,
+                                                                   (q,uu____20730))::[]
                                      ->
-                                     let uu____20909 =
+                                     let uu____20802 =
                                        FStar_Syntax_Util.term_eq p q  in
-                                     (if uu____20909
+                                     (if uu____20802
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____20914 ->
+                                 | uu____20807 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____20932 =
+                                 (let uu____20825 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid
                                      in
-                                  if uu____20932
+                                  if uu____20825
                                   then
-                                    let uu____20935 =
+                                    let uu____20828 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify)
                                        in
-                                    match uu____20935 with
+                                    match uu____20828 with
                                     | (FStar_Pervasives_Native.Some (true
-                                       ),uu____20993)::[] ->
+                                       ),uu____20886)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false
-                                       ),uu____21037)::[] ->
+                                       ),uu____20930)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____21081 ->
+                                    | uu____20974 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____21099 =
+                                    (let uu____20992 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid
                                         in
-                                     if uu____21099
+                                     if uu____20992
                                      then
                                        match args with
-                                       | (t,uu____21103)::[] ->
-                                           let uu____21128 =
-                                             let uu____21129 =
+                                       | (t,uu____20996)::[] ->
+                                           let uu____21021 =
+                                             let uu____21022 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____21129.FStar_Syntax_Syntax.n
+                                             uu____21022.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____21128 with
+                                           (match uu____21021 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____21132::[],body,uu____21134)
+                                                (uu____21025::[],body,uu____21027)
                                                 ->
-                                                let uu____21169 = simp_t body
+                                                let uu____21062 = simp_t body
                                                    in
-                                                (match uu____21169 with
+                                                (match uu____21062 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____21175 -> tm1)
-                                            | uu____21179 -> tm1)
+                                                 | uu____21068 -> tm1)
+                                            | uu____21072 -> tm1)
                                        | (ty,FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____21181))::(t,uu____21183)::[]
+                                          uu____21074))::(t,uu____21076)::[]
                                            ->
-                                           let uu____21223 =
-                                             let uu____21224 =
+                                           let uu____21116 =
+                                             let uu____21117 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____21224.FStar_Syntax_Syntax.n
+                                             uu____21117.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____21223 with
+                                           (match uu____21116 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____21227::[],body,uu____21229)
+                                                (uu____21120::[],body,uu____21122)
                                                 ->
-                                                let uu____21264 = simp_t body
+                                                let uu____21157 = simp_t body
                                                    in
-                                                (match uu____21264 with
+                                                (match uu____21157 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
@@ -6678,56 +6643,56 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____21272 -> tm1)
-                                            | uu____21276 -> tm1)
-                                       | uu____21277 -> tm1
+                                                 | uu____21165 -> tm1)
+                                            | uu____21169 -> tm1)
+                                       | uu____21170 -> tm1
                                      else
-                                       (let uu____21290 =
+                                       (let uu____21183 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid
                                            in
-                                        if uu____21290
+                                        if uu____21183
                                         then
                                           match args with
-                                          | (t,uu____21294)::[] ->
-                                              let uu____21319 =
-                                                let uu____21320 =
+                                          | (t,uu____21187)::[] ->
+                                              let uu____21212 =
+                                                let uu____21213 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____21320.FStar_Syntax_Syntax.n
+                                                uu____21213.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____21319 with
+                                              (match uu____21212 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____21323::[],body,uu____21325)
+                                                   (uu____21216::[],body,uu____21218)
                                                    ->
-                                                   let uu____21360 =
+                                                   let uu____21253 =
                                                      simp_t body  in
-                                                   (match uu____21360 with
+                                                   (match uu____21253 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____21366 -> tm1)
-                                               | uu____21370 -> tm1)
+                                                    | uu____21259 -> tm1)
+                                               | uu____21263 -> tm1)
                                           | (ty,FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____21372))::(t,uu____21374)::[]
+                                             uu____21265))::(t,uu____21267)::[]
                                               ->
-                                              let uu____21414 =
-                                                let uu____21415 =
+                                              let uu____21307 =
+                                                let uu____21308 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____21415.FStar_Syntax_Syntax.n
+                                                uu____21308.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____21414 with
+                                              (match uu____21307 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____21418::[],body,uu____21420)
+                                                   (uu____21311::[],body,uu____21313)
                                                    ->
-                                                   let uu____21455 =
+                                                   let uu____21348 =
                                                      simp_t body  in
-                                                   (match uu____21455 with
+                                                   (match uu____21348 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
@@ -6738,15 +6703,15 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____21463 -> tm1)
-                                               | uu____21467 -> tm1)
-                                          | uu____21468 -> tm1
+                                                    | uu____21356 -> tm1)
+                                               | uu____21360 -> tm1)
+                                          | uu____21361 -> tm1
                                         else
-                                          (let uu____21481 =
+                                          (let uu____21374 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid
                                               in
-                                           if uu____21481
+                                           if uu____21374
                                            then
                                              match args with
                                              | ({
@@ -6755,9 +6720,9 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____21484;
+                                                    uu____21377;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____21485;_},uu____21486)::[]
+                                                    uu____21378;_},uu____21379)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
@@ -6766,19 +6731,19 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____21512;
+                                                    uu____21405;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____21513;_},uu____21514)::[]
+                                                    uu____21406;_},uu____21407)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____21540 -> tm1
+                                             | uu____21433 -> tm1
                                            else
-                                             (let uu____21553 =
+                                             (let uu____21446 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid
                                                  in
-                                              if uu____21553
+                                              if uu____21446
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6787,14 +6752,14 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid]
                                                      in
-                                                  let uu____21567 =
-                                                    let uu____21568 =
+                                                  let uu____21460 =
+                                                    let uu____21461 =
                                                       FStar_Syntax_Subst.compress
                                                         t
                                                        in
-                                                    uu____21568.FStar_Syntax_Syntax.n
+                                                    uu____21461.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____21567 with
+                                                  match uu____21460 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -6804,93 +6769,93 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____21579 -> false  in
+                                                  | uu____21472 -> false  in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____21593 =
+                                                     let uu____21486 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____21593
+                                                       uu____21486
                                                        FStar_Pervasives_Native.fst
                                                       in
-                                                   let uu____21632 =
+                                                   let uu____21525 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure
                                                       in
-                                                   (if uu____21632
+                                                   (if uu____21525
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____21638 =
-                                                         let uu____21639 =
+                                                      (let uu____21531 =
+                                                         let uu____21532 =
                                                            FStar_Syntax_Subst.compress
                                                              t
                                                             in
-                                                         uu____21639.FStar_Syntax_Syntax.n
+                                                         uu____21532.FStar_Syntax_Syntax.n
                                                           in
-                                                       match uu____21638 with
+                                                       match uu____21531 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____21642 ->
+                                                           uu____21535 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t
                                                               in
-                                                           let uu____21650 =
+                                                           let uu____21543 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure
                                                               in
-                                                           if uu____21650
+                                                           if uu____21543
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____21659
+                                                                let uu____21552
                                                                   =
-                                                                  let uu____21660
+                                                                  let uu____21553
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1  in
-                                                                  uu____21660.FStar_Syntax_Syntax.n
+                                                                  uu____21553.FStar_Syntax_Syntax.n
                                                                    in
-                                                                match uu____21659
+                                                                match uu____21552
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
-                                                                    (hd,uu____21666)
+                                                                    (hd,uu____21559)
                                                                     -> hd
-                                                                | uu____21691
+                                                                | uu____21584
                                                                     ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app"
                                                                  in
-                                                              let uu____21695
+                                                              let uu____21588
                                                                 =
-                                                                let uu____21706
+                                                                let uu____21599
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg
                                                                    in
-                                                                [uu____21706]
+                                                                [uu____21599]
                                                                  in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____21695)
-                                                       | uu____21739 -> tm1))
+                                                                uu____21588)
+                                                       | uu____21632 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____21744 =
+                                                (let uu____21637 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1
                                                     in
-                                                 match uu____21744 with
+                                                 match uu____21637 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero
                                                       ,t)
@@ -6898,226 +6863,226 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____21764 ->
-                                                     let uu____21773 =
+                                                 | uu____21657 ->
+                                                     let uu____21666 =
                                                        norm_cb cfg  in
                                                      reduce_equality
-                                                       uu____21773 cfg env1
+                                                       uu____21666 cfg env1
                                                        tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____21779;
-                         FStar_Syntax_Syntax.vars = uu____21780;_},args)
+                         FStar_Syntax_Syntax.pos = uu____21672;
+                         FStar_Syntax_Syntax.vars = uu____21673;_},args)
                       ->
-                      let uu____21806 =
+                      let uu____21699 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid
                          in
-                      if uu____21806
+                      if uu____21699
                       then
-                        let uu____21809 =
+                        let uu____21702 =
                           FStar_All.pipe_right args (FStar_List.map simplify)
                            in
-                        (match uu____21809 with
-                         | (FStar_Pervasives_Native.Some (true ),uu____21867)::
-                             (uu____21868,(arg,uu____21870))::[] ->
+                        (match uu____21702 with
+                         | (FStar_Pervasives_Native.Some (true ),uu____21760)::
+                             (uu____21761,(arg,uu____21763))::[] ->
                              maybe_auto_squash arg
-                         | (uu____21943,(arg,uu____21945))::(FStar_Pervasives_Native.Some
+                         | (uu____21836,(arg,uu____21838))::(FStar_Pervasives_Native.Some
                                                              (true
-                                                             ),uu____21946)::[]
+                                                             ),uu____21839)::[]
                              -> maybe_auto_squash arg
                          | (FStar_Pervasives_Native.Some (false
-                            ),uu____22019)::uu____22020::[] ->
+                            ),uu____21912)::uu____21913::[] ->
                              w FStar_Syntax_Util.t_false
-                         | uu____22090::(FStar_Pervasives_Native.Some (false
-                                         ),uu____22091)::[]
+                         | uu____21983::(FStar_Pervasives_Native.Some (false
+                                         ),uu____21984)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____22161 ->
+                         | uu____22054 ->
                              squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____22179 =
+                        (let uu____22072 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid
                             in
-                         if uu____22179
+                         if uu____22072
                          then
-                           let uu____22182 =
+                           let uu____22075 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify)
                               in
-                           match uu____22182 with
+                           match uu____22075 with
                            | (FStar_Pervasives_Native.Some (true
-                              ),uu____22240)::uu____22241::[] ->
+                              ),uu____22133)::uu____22134::[] ->
                                w FStar_Syntax_Util.t_true
-                           | uu____22311::(FStar_Pervasives_Native.Some (true
-                                           ),uu____22312)::[]
+                           | uu____22204::(FStar_Pervasives_Native.Some (true
+                                           ),uu____22205)::[]
                                -> w FStar_Syntax_Util.t_true
                            | (FStar_Pervasives_Native.Some (false
-                              ),uu____22382)::(uu____22383,(arg,uu____22385))::[]
+                              ),uu____22275)::(uu____22276,(arg,uu____22278))::[]
                                -> maybe_auto_squash arg
-                           | (uu____22458,(arg,uu____22460))::(FStar_Pervasives_Native.Some
+                           | (uu____22351,(arg,uu____22353))::(FStar_Pervasives_Native.Some
                                                                (false
-                                                               ),uu____22461)::[]
+                                                               ),uu____22354)::[]
                                -> maybe_auto_squash arg
-                           | uu____22534 ->
+                           | uu____22427 ->
                                squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____22552 =
+                           (let uu____22445 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid
                                in
-                            if uu____22552
+                            if uu____22445
                             then
-                              let uu____22555 =
+                              let uu____22448 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify)
                                  in
-                              match uu____22555 with
-                              | uu____22613::(FStar_Pervasives_Native.Some
-                                              (true ),uu____22614)::[]
+                              match uu____22448 with
+                              | uu____22506::(FStar_Pervasives_Native.Some
+                                              (true ),uu____22507)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false
-                                 ),uu____22684)::uu____22685::[] ->
+                                 ),uu____22577)::uu____22578::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true
-                                 ),uu____22755)::(uu____22756,(arg,uu____22758))::[]
+                                 ),uu____22648)::(uu____22649,(arg,uu____22651))::[]
                                   -> maybe_auto_squash arg
-                              | (uu____22831,(p,uu____22833))::(uu____22834,
-                                                                (q,uu____22836))::[]
+                              | (uu____22724,(p,uu____22726))::(uu____22727,
+                                                                (q,uu____22729))::[]
                                   ->
-                                  let uu____22908 =
+                                  let uu____22801 =
                                     FStar_Syntax_Util.term_eq p q  in
-                                  (if uu____22908
+                                  (if uu____22801
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____22913 ->
+                              | uu____22806 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____22931 =
+                              (let uu____22824 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid
                                   in
-                               if uu____22931
+                               if uu____22824
                                then
-                                 let uu____22934 =
+                                 let uu____22827 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify)
                                     in
-                                 match uu____22934 with
+                                 match uu____22827 with
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____22992)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____22993)::[]
+                                    ),uu____22885)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____22886)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____23067)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____23068)::[]
+                                    ),uu____22960)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____22961)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____23142)::(FStar_Pervasives_Native.Some
-                                                     (false ),uu____23143)::[]
+                                    ),uu____23035)::(FStar_Pervasives_Native.Some
+                                                     (false ),uu____23036)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____23217)::(FStar_Pervasives_Native.Some
-                                                     (true ),uu____23218)::[]
+                                    ),uu____23110)::(FStar_Pervasives_Native.Some
+                                                     (true ),uu____23111)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____23292,(arg,uu____23294))::(FStar_Pervasives_Native.Some
+                                 | (uu____23185,(arg,uu____23187))::(FStar_Pervasives_Native.Some
                                                                     (true
-                                                                    ),uu____23295)::[]
+                                                                    ),uu____23188)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true
-                                    ),uu____23368)::(uu____23369,(arg,uu____23371))::[]
+                                    ),uu____23261)::(uu____23262,(arg,uu____23264))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____23444,(arg,uu____23446))::(FStar_Pervasives_Native.Some
+                                 | (uu____23337,(arg,uu____23339))::(FStar_Pervasives_Native.Some
                                                                     (false
-                                                                    ),uu____23447)::[]
+                                                                    ),uu____23340)::[]
                                      ->
-                                     let uu____23520 =
+                                     let uu____23413 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____23520
+                                     maybe_auto_squash uu____23413
                                  | (FStar_Pervasives_Native.Some (false
-                                    ),uu____23521)::(uu____23522,(arg,uu____23524))::[]
+                                    ),uu____23414)::(uu____23415,(arg,uu____23417))::[]
                                      ->
-                                     let uu____23597 =
+                                     let uu____23490 =
                                        FStar_Syntax_Util.mk_neg arg  in
-                                     maybe_auto_squash uu____23597
-                                 | (uu____23598,(p,uu____23600))::(uu____23601,
-                                                                   (q,uu____23603))::[]
+                                     maybe_auto_squash uu____23490
+                                 | (uu____23491,(p,uu____23493))::(uu____23494,
+                                                                   (q,uu____23496))::[]
                                      ->
-                                     let uu____23675 =
+                                     let uu____23568 =
                                        FStar_Syntax_Util.term_eq p q  in
-                                     (if uu____23675
+                                     (if uu____23568
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____23680 ->
+                                 | uu____23573 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____23698 =
+                                 (let uu____23591 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid
                                      in
-                                  if uu____23698
+                                  if uu____23591
                                   then
-                                    let uu____23701 =
+                                    let uu____23594 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify)
                                        in
-                                    match uu____23701 with
+                                    match uu____23594 with
                                     | (FStar_Pervasives_Native.Some (true
-                                       ),uu____23759)::[] ->
+                                       ),uu____23652)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false
-                                       ),uu____23803)::[] ->
+                                       ),uu____23696)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____23847 ->
+                                    | uu____23740 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____23865 =
+                                    (let uu____23758 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid
                                         in
-                                     if uu____23865
+                                     if uu____23758
                                      then
                                        match args with
-                                       | (t,uu____23869)::[] ->
-                                           let uu____23894 =
-                                             let uu____23895 =
+                                       | (t,uu____23762)::[] ->
+                                           let uu____23787 =
+                                             let uu____23788 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____23895.FStar_Syntax_Syntax.n
+                                             uu____23788.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____23894 with
+                                           (match uu____23787 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____23898::[],body,uu____23900)
+                                                (uu____23791::[],body,uu____23793)
                                                 ->
-                                                let uu____23935 = simp_t body
+                                                let uu____23828 = simp_t body
                                                    in
-                                                (match uu____23935 with
+                                                (match uu____23828 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____23941 -> tm1)
-                                            | uu____23945 -> tm1)
+                                                 | uu____23834 -> tm1)
+                                            | uu____23838 -> tm1)
                                        | (ty,FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____23947))::(t,uu____23949)::[]
+                                          uu____23840))::(t,uu____23842)::[]
                                            ->
-                                           let uu____23989 =
-                                             let uu____23990 =
+                                           let uu____23882 =
+                                             let uu____23883 =
                                                FStar_Syntax_Subst.compress t
                                                 in
-                                             uu____23990.FStar_Syntax_Syntax.n
+                                             uu____23883.FStar_Syntax_Syntax.n
                                               in
-                                           (match uu____23989 with
+                                           (match uu____23882 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____23993::[],body,uu____23995)
+                                                (uu____23886::[],body,uu____23888)
                                                 ->
-                                                let uu____24030 = simp_t body
+                                                let uu____23923 = simp_t body
                                                    in
-                                                (match uu____24030 with
+                                                (match uu____23923 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true ) ->
                                                      w
@@ -7127,56 +7092,56 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____24038 -> tm1)
-                                            | uu____24042 -> tm1)
-                                       | uu____24043 -> tm1
+                                                 | uu____23931 -> tm1)
+                                            | uu____23935 -> tm1)
+                                       | uu____23936 -> tm1
                                      else
-                                       (let uu____24056 =
+                                       (let uu____23949 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid
                                            in
-                                        if uu____24056
+                                        if uu____23949
                                         then
                                           match args with
-                                          | (t,uu____24060)::[] ->
-                                              let uu____24085 =
-                                                let uu____24086 =
+                                          | (t,uu____23953)::[] ->
+                                              let uu____23978 =
+                                                let uu____23979 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____24086.FStar_Syntax_Syntax.n
+                                                uu____23979.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____24085 with
+                                              (match uu____23978 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____24089::[],body,uu____24091)
+                                                   (uu____23982::[],body,uu____23984)
                                                    ->
-                                                   let uu____24126 =
+                                                   let uu____24019 =
                                                      simp_t body  in
-                                                   (match uu____24126 with
+                                                   (match uu____24019 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____24132 -> tm1)
-                                               | uu____24136 -> tm1)
+                                                    | uu____24025 -> tm1)
+                                               | uu____24029 -> tm1)
                                           | (ty,FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____24138))::(t,uu____24140)::[]
+                                             uu____24031))::(t,uu____24033)::[]
                                               ->
-                                              let uu____24180 =
-                                                let uu____24181 =
+                                              let uu____24073 =
+                                                let uu____24074 =
                                                   FStar_Syntax_Subst.compress
                                                     t
                                                    in
-                                                uu____24181.FStar_Syntax_Syntax.n
+                                                uu____24074.FStar_Syntax_Syntax.n
                                                  in
-                                              (match uu____24180 with
+                                              (match uu____24073 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____24184::[],body,uu____24186)
+                                                   (uu____24077::[],body,uu____24079)
                                                    ->
-                                                   let uu____24221 =
+                                                   let uu____24114 =
                                                      simp_t body  in
-                                                   (match uu____24221 with
+                                                   (match uu____24114 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false ) ->
                                                         w
@@ -7187,15 +7152,15 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____24229 -> tm1)
-                                               | uu____24233 -> tm1)
-                                          | uu____24234 -> tm1
+                                                    | uu____24122 -> tm1)
+                                               | uu____24126 -> tm1)
+                                          | uu____24127 -> tm1
                                         else
-                                          (let uu____24247 =
+                                          (let uu____24140 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid
                                               in
-                                           if uu____24247
+                                           if uu____24140
                                            then
                                              match args with
                                              | ({
@@ -7204,9 +7169,9 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____24250;
+                                                    uu____24143;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____24251;_},uu____24252)::[]
+                                                    uu____24144;_},uu____24145)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
@@ -7215,19 +7180,19 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false ));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____24278;
+                                                    uu____24171;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____24279;_},uu____24280)::[]
+                                                    uu____24172;_},uu____24173)::[]
                                                  ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____24306 -> tm1
+                                             | uu____24199 -> tm1
                                            else
-                                             (let uu____24319 =
+                                             (let uu____24212 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid
                                                  in
-                                              if uu____24319
+                                              if uu____24212
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -7236,14 +7201,14 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid]
                                                      in
-                                                  let uu____24333 =
-                                                    let uu____24334 =
+                                                  let uu____24226 =
+                                                    let uu____24227 =
                                                       FStar_Syntax_Subst.compress
                                                         t
                                                        in
-                                                    uu____24334.FStar_Syntax_Syntax.n
+                                                    uu____24227.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____24333 with
+                                                  match uu____24226 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -7253,93 +7218,93 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____24345 -> false  in
+                                                  | uu____24238 -> false  in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____24359 =
+                                                     let uu____24252 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____24359
+                                                       uu____24252
                                                        FStar_Pervasives_Native.fst
                                                       in
-                                                   let uu____24394 =
+                                                   let uu____24287 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure
                                                       in
-                                                   (if uu____24394
+                                                   (if uu____24287
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____24400 =
-                                                         let uu____24401 =
+                                                      (let uu____24293 =
+                                                         let uu____24294 =
                                                            FStar_Syntax_Subst.compress
                                                              t
                                                             in
-                                                         uu____24401.FStar_Syntax_Syntax.n
+                                                         uu____24294.FStar_Syntax_Syntax.n
                                                           in
-                                                       match uu____24400 with
+                                                       match uu____24293 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____24404 ->
+                                                           uu____24297 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t
                                                               in
-                                                           let uu____24412 =
+                                                           let uu____24305 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure
                                                               in
-                                                           if uu____24412
+                                                           if uu____24305
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____24421
+                                                                let uu____24314
                                                                   =
-                                                                  let uu____24422
+                                                                  let uu____24315
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1  in
-                                                                  uu____24422.FStar_Syntax_Syntax.n
+                                                                  uu____24315.FStar_Syntax_Syntax.n
                                                                    in
-                                                                match uu____24421
+                                                                match uu____24314
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
-                                                                    (hd,uu____24428)
+                                                                    (hd,uu____24321)
                                                                     -> hd
-                                                                | uu____24453
+                                                                | uu____24346
                                                                     ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app"
                                                                  in
-                                                              let uu____24457
+                                                              let uu____24350
                                                                 =
-                                                                let uu____24468
+                                                                let uu____24361
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg
                                                                    in
-                                                                [uu____24468]
+                                                                [uu____24361]
                                                                  in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____24457)
-                                                       | uu____24501 -> tm1))
+                                                                uu____24350)
+                                                       | uu____24394 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____24506 =
+                                                (let uu____24399 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1
                                                     in
-                                                 match uu____24506 with
+                                                 match uu____24399 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero
                                                       ,t)
@@ -7347,28 +7312,28 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____24526 ->
-                                                     let uu____24535 =
+                                                 | uu____24419 ->
+                                                     let uu____24428 =
                                                        norm_cb cfg  in
                                                      reduce_equality
-                                                       uu____24535 cfg env1
+                                                       uu____24428 cfg env1
                                                        tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_refine (bv,t) ->
-                      let uu____24546 = simp_t t  in
-                      (match uu____24546 with
+                      let uu____24439 = simp_t t  in
+                      (match uu____24439 with
                        | FStar_Pervasives_Native.Some (true ) ->
                            bv.FStar_Syntax_Syntax.sort
                        | FStar_Pervasives_Native.Some (false ) -> tm1
                        | FStar_Pervasives_Native.None  -> tm1)
-                  | FStar_Syntax_Syntax.Tm_match uu____24555 ->
-                      let uu____24578 = is_const_match tm1  in
-                      (match uu____24578 with
+                  | FStar_Syntax_Syntax.Tm_match uu____24448 ->
+                      let uu____24471 = is_const_match tm1  in
+                      (match uu____24471 with
                        | FStar_Pervasives_Native.Some (true ) ->
                            w FStar_Syntax_Util.t_true
                        | FStar_Pervasives_Native.Some (false ) ->
                            w FStar_Syntax_Util.t_false
                        | FStar_Pervasives_Native.None  -> tm1)
-                  | uu____24587 -> tm1))
+                  | uu____24480 -> tm1))
 
 and (rebuild :
   FStar_TypeChecker_Cfg.cfg ->
@@ -7379,59 +7344,59 @@ and (rebuild :
       fun stack1  ->
         fun t  ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____24597  ->
-               (let uu____24599 = FStar_Syntax_Print.tag_of_term t  in
-                let uu____24601 = FStar_Syntax_Print.term_to_string t  in
-                let uu____24603 =
+            (fun uu____24490  ->
+               (let uu____24492 = FStar_Syntax_Print.tag_of_term t  in
+                let uu____24494 = FStar_Syntax_Print.term_to_string t  in
+                let uu____24496 =
                   FStar_Util.string_of_int (FStar_List.length env1)  in
-                let uu____24611 =
-                  let uu____24613 =
-                    let uu____24616 = firstn (Prims.of_int (4)) stack1  in
+                let uu____24504 =
+                  let uu____24506 =
+                    let uu____24509 = firstn (Prims.of_int (4)) stack1  in
                     FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____24616
+                      uu____24509
                      in
-                  stack_to_string uu____24613  in
+                  stack_to_string uu____24506  in
                 FStar_Util.print4
                   ">>> %s\nRebuild %s with %s env elements and top of the stack %s \n"
-                  uu____24599 uu____24601 uu____24603 uu____24611);
-               (let uu____24641 =
+                  uu____24492 uu____24494 uu____24496 uu____24504);
+               (let uu____24534 =
                   FStar_TypeChecker_Env.debug cfg.FStar_TypeChecker_Cfg.tcenv
                     (FStar_Options.Other "NormRebuild")
                    in
-                if uu____24641
+                if uu____24534
                 then
-                  let uu____24645 = FStar_Syntax_Util.unbound_variables t  in
-                  match uu____24645 with
+                  let uu____24538 = FStar_Syntax_Util.unbound_variables t  in
+                  match uu____24538 with
                   | [] -> ()
                   | bvs ->
-                      ((let uu____24652 = FStar_Syntax_Print.tag_of_term t
+                      ((let uu____24545 = FStar_Syntax_Print.tag_of_term t
                            in
-                        let uu____24654 = FStar_Syntax_Print.term_to_string t
+                        let uu____24547 = FStar_Syntax_Print.term_to_string t
                            in
-                        let uu____24656 =
-                          let uu____24658 =
+                        let uu____24549 =
+                          let uu____24551 =
                             FStar_All.pipe_right bvs
                               (FStar_List.map FStar_Syntax_Print.bv_to_string)
                              in
-                          FStar_All.pipe_right uu____24658
+                          FStar_All.pipe_right uu____24551
                             (FStar_String.concat ", ")
                            in
                         FStar_Util.print3
-                          "!!! Rebuild (%s) %s, free vars=%s\n" uu____24652
-                          uu____24654 uu____24656);
+                          "!!! Rebuild (%s) %s, free vars=%s\n" uu____24545
+                          uu____24547 uu____24549);
                        failwith "DIE!")
                 else ()));
           (let f_opt = is_fext_on_domain t  in
-           let uu____24680 =
+           let uu____24573 =
              (FStar_All.pipe_right f_opt FStar_Util.is_some) &&
                (match stack1 with
-                | (Arg uu____24688)::uu____24689 -> true
-                | uu____24699 -> false)
+                | (Arg uu____24581)::uu____24582 -> true
+                | uu____24592 -> false)
               in
-           if uu____24680
+           if uu____24573
            then
-             let uu____24702 = FStar_All.pipe_right f_opt FStar_Util.must  in
-             FStar_All.pipe_right uu____24702 (norm cfg env1 stack1)
+             let uu____24595 = FStar_All.pipe_right f_opt FStar_Util.must  in
+             FStar_All.pipe_right uu____24595 (norm cfg env1 stack1)
            else
              (let t1 = maybe_simplify cfg env1 stack1 t  in
               match stack1 with
@@ -7441,84 +7406,84 @@ and (rebuild :
                      (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                    then
                      (let time_now = FStar_Util.now ()  in
-                      let uu____24716 =
-                        let uu____24718 =
-                          let uu____24720 =
+                      let uu____24609 =
+                        let uu____24611 =
+                          let uu____24613 =
                             FStar_Util.time_diff time_then time_now  in
-                          FStar_Pervasives_Native.snd uu____24720  in
-                        FStar_Util.string_of_int uu____24718  in
-                      let uu____24727 = FStar_Syntax_Print.term_to_string tm
+                          FStar_Pervasives_Native.snd uu____24613  in
+                        FStar_Util.string_of_int uu____24611  in
+                      let uu____24620 = FStar_Syntax_Print.term_to_string tm
                          in
-                      let uu____24729 =
+                      let uu____24622 =
                         FStar_TypeChecker_Cfg.cfg_to_string cfg  in
-                      let uu____24731 = FStar_Syntax_Print.term_to_string t1
+                      let uu____24624 = FStar_Syntax_Print.term_to_string t1
                          in
                       FStar_Util.print4
                         "Normalizer result timing (%s ms){\nOn term {\n%s\n}\nwith steps {%s}\nresult is{\n\n%s\n}\n}\n"
-                        uu____24716 uu____24727 uu____24729 uu____24731)
+                        uu____24609 uu____24620 uu____24622 uu____24624)
                    else ();
                    rebuild cfg env1 stack2 t1)
               | (Cfg cfg1)::stack2 -> rebuild cfg1 env1 stack2 t1
-              | (Meta (uu____24740,m,r))::stack2 ->
-                  let t2 = mk (FStar_Syntax_Syntax.Tm_meta (t1, m)) r  in
+              | (Meta (uu____24633,m,r))::stack2 ->
+                  let t2 =
+                    FStar_Syntax_Syntax.mk
+                      (FStar_Syntax_Syntax.Tm_meta (t1, m)) r
+                     in
                   rebuild cfg env1 stack2 t2
               | (MemoLazy r)::stack2 ->
                   (set_memo cfg r (env1, t1);
                    FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____24769  ->
-                        let uu____24770 =
+                     (fun uu____24662  ->
+                        let uu____24663 =
                           FStar_Syntax_Print.term_to_string t1  in
-                        FStar_Util.print1 "\tSet memo %s\n" uu____24770);
+                        FStar_Util.print1 "\tSet memo %s\n" uu____24663);
                    rebuild cfg env1 stack2 t1)
               | (Let (env',bs,lb,r))::stack2 ->
                   let body = FStar_Syntax_Subst.close bs t1  in
                   let t2 =
                     FStar_Syntax_Syntax.mk
-                      (FStar_Syntax_Syntax.Tm_let ((false, [lb]), body))
-                      FStar_Pervasives_Native.None r
+                      (FStar_Syntax_Syntax.Tm_let ((false, [lb]), body)) r
                      in
                   rebuild cfg env' stack2 t2
               | (Abs (env',bs,env'',lopt,r))::stack2 ->
                   let bs1 = norm_binders cfg env' bs  in
                   let lopt1 = norm_lcomp_opt cfg env'' lopt  in
-                  let uu____24813 =
-                    let uu___2832_24814 = FStar_Syntax_Util.abs bs1 t1 lopt1
+                  let uu____24706 =
+                    let uu___2830_24707 = FStar_Syntax_Util.abs bs1 t1 lopt1
                        in
                     {
                       FStar_Syntax_Syntax.n =
-                        (uu___2832_24814.FStar_Syntax_Syntax.n);
+                        (uu___2830_24707.FStar_Syntax_Syntax.n);
                       FStar_Syntax_Syntax.pos = r;
                       FStar_Syntax_Syntax.vars =
-                        (uu___2832_24814.FStar_Syntax_Syntax.vars)
+                        (uu___2830_24707.FStar_Syntax_Syntax.vars)
                     }  in
-                  rebuild cfg env1 stack2 uu____24813
-              | (Arg (Univ uu____24817,uu____24818,uu____24819))::uu____24820
+                  rebuild cfg env1 stack2 uu____24706
+              | (Arg (Univ uu____24710,uu____24711,uu____24712))::uu____24713
                   -> failwith "Impossible"
-              | (Arg (Dummy ,uu____24824,uu____24825))::uu____24826 ->
+              | (Arg (Dummy ,uu____24717,uu____24718))::uu____24719 ->
                   failwith "Impossible"
               | (UnivArgs (us,r))::stack2 ->
                   let t2 = FStar_Syntax_Syntax.mk_Tm_uinst t1 us  in
                   rebuild cfg env1 stack2 t2
               | (Arg
-                  (Clos (env_arg,tm,uu____24842,uu____24843),aq,r))::stack2
+                  (Clos (env_arg,tm,uu____24735,uu____24736),aq,r))::stack2
                   when
-                  let uu____24895 = head_of t1  in
-                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu____24895 ->
+                  let uu____24788 = head_of t1  in
+                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu____24788 ->
                   let t2 =
-                    let uu____24899 =
-                      let uu____24904 =
-                        let uu____24905 = closure_as_term cfg env_arg tm  in
-                        (uu____24905, aq)  in
-                      FStar_Syntax_Syntax.extend_app t1 uu____24904  in
-                    uu____24899 FStar_Pervasives_Native.None r  in
+                    let uu____24790 =
+                      let uu____24791 = closure_as_term cfg env_arg tm  in
+                      (uu____24791, aq)  in
+                    FStar_Syntax_Syntax.extend_app t1 uu____24790 r  in
                   rebuild cfg env1 stack2 t2
-              | (Arg (Clos (env_arg,tm,m,uu____24915),aq,r))::stack2 ->
+              | (Arg (Clos (env_arg,tm,m,uu____24801),aq,r))::stack2 ->
                   (FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____24970  ->
-                        let uu____24971 =
+                     (fun uu____24856  ->
+                        let uu____24857 =
                           FStar_Syntax_Print.term_to_string tm  in
                         FStar_Util.print1 "Rebuilding with arg %s\n"
-                          uu____24971);
+                          uu____24857);
                    if
                      Prims.op_Negation
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
@@ -7528,56 +7493,49 @@ and (rebuild :
                       then
                         let arg = closure_as_term cfg env_arg tm  in
                         let t2 =
-                          FStar_Syntax_Syntax.extend_app t1 (arg, aq)
-                            FStar_Pervasives_Native.None r
-                           in
+                          FStar_Syntax_Syntax.extend_app t1 (arg, aq) r  in
                         rebuild cfg env_arg stack2 t2
                       else
                         (let stack3 = (App (env1, t1, aq, r)) :: stack2  in
                          norm cfg env_arg stack3 tm))
                    else
-                     (let uu____24991 = FStar_ST.op_Bang m  in
-                      match uu____24991 with
+                     (let uu____24875 = FStar_ST.op_Bang m  in
+                      match uu____24875 with
                       | FStar_Pervasives_Native.None  ->
                           if
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
                           then
                             let arg = closure_as_term cfg env_arg tm  in
                             let t2 =
-                              FStar_Syntax_Syntax.extend_app t1 (arg, aq)
-                                FStar_Pervasives_Native.None r
+                              FStar_Syntax_Syntax.extend_app t1 (arg, aq) r
                                in
                             rebuild cfg env_arg stack2 t2
                           else
                             (let stack3 = (MemoLazy m) ::
                                (App (env1, t1, aq, r)) :: stack2  in
                              norm cfg env_arg stack3 tm)
-                      | FStar_Pervasives_Native.Some (uu____25079,a) ->
+                      | FStar_Pervasives_Native.Some (uu____24961,a) ->
                           let t2 =
-                            FStar_Syntax_Syntax.extend_app t1 (a, aq)
-                              FStar_Pervasives_Native.None r
-                             in
+                            FStar_Syntax_Syntax.extend_app t1 (a, aq) r  in
                           rebuild cfg env_arg stack2 t2))
               | (App (env2,head,aq,r))::stack' when should_reify cfg stack1
                   ->
                   let t0 = t1  in
-                  let fallback msg uu____25135 =
+                  let fallback msg uu____25015 =
                     FStar_TypeChecker_Cfg.log cfg
-                      (fun uu____25140  ->
-                         let uu____25141 =
+                      (fun uu____25020  ->
+                         let uu____25021 =
                            FStar_Syntax_Print.term_to_string t1  in
                          FStar_Util.print2 "Not reifying%s: %s\n" msg
-                           uu____25141);
-                    (let t2 =
-                       FStar_Syntax_Syntax.extend_app head (t1, aq)
-                         FStar_Pervasives_Native.None r
+                           uu____25021);
+                    (let t2 = FStar_Syntax_Syntax.extend_app head (t1, aq) r
                         in
                      rebuild cfg env2 stack' t2)
                      in
-                  let uu____25151 =
-                    let uu____25152 = FStar_Syntax_Subst.compress t1  in
-                    uu____25152.FStar_Syntax_Syntax.n  in
-                  (match uu____25151 with
+                  let uu____25029 =
+                    let uu____25030 = FStar_Syntax_Subst.compress t1  in
+                    uu____25030.FStar_Syntax_Syntax.n  in
+                  (match uu____25029 with
                    | FStar_Syntax_Syntax.Tm_meta
                        (t2,FStar_Syntax_Syntax.Meta_monadic (m,ty)) ->
                        do_reify_monadic (fallback " (1)") cfg env2 stack1 t2
@@ -7587,117 +7545,114 @@ and (rebuild :
                         (msrc,mtgt,ty))
                        ->
                        let lifted =
-                         let uu____25180 = closure_as_term cfg env2 ty  in
-                         reify_lift cfg t2 msrc mtgt uu____25180  in
+                         let uu____25058 = closure_as_term cfg env2 ty  in
+                         reify_lift cfg t2 msrc mtgt uu____25058  in
                        (FStar_TypeChecker_Cfg.log cfg
-                          (fun uu____25184  ->
-                             let uu____25185 =
+                          (fun uu____25062  ->
+                             let uu____25063 =
                                FStar_Syntax_Print.term_to_string lifted  in
                              FStar_Util.print1 "Reified lift to (1): %s\n"
-                               uu____25185);
-                        (let uu____25188 = FStar_List.tl stack1  in
-                         norm cfg env2 uu____25188 lifted))
+                               uu____25063);
+                        (let uu____25066 = FStar_List.tl stack1  in
+                         norm cfg env2 uu____25066 lifted))
                    | FStar_Syntax_Syntax.Tm_app
                        ({
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_constant
-                            (FStar_Const.Const_reflect uu____25189);
-                          FStar_Syntax_Syntax.pos = uu____25190;
-                          FStar_Syntax_Syntax.vars = uu____25191;_},(e,uu____25193)::[])
+                            (FStar_Const.Const_reflect uu____25067);
+                          FStar_Syntax_Syntax.pos = uu____25068;
+                          FStar_Syntax_Syntax.vars = uu____25069;_},(e,uu____25071)::[])
                        -> norm cfg env2 stack' e
-                   | FStar_Syntax_Syntax.Tm_app uu____25232 when
+                   | FStar_Syntax_Syntax.Tm_app uu____25110 when
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.primops
                        ->
-                       let uu____25249 = FStar_Syntax_Util.head_and_args t1
+                       let uu____25127 = FStar_Syntax_Util.head_and_args t1
                           in
-                       (match uu____25249 with
+                       (match uu____25127 with
                         | (hd,args) ->
-                            let uu____25292 =
-                              let uu____25293 = FStar_Syntax_Util.un_uinst hd
+                            let uu____25170 =
+                              let uu____25171 = FStar_Syntax_Util.un_uinst hd
                                  in
-                              uu____25293.FStar_Syntax_Syntax.n  in
-                            (match uu____25292 with
+                              uu____25171.FStar_Syntax_Syntax.n  in
+                            (match uu____25170 with
                              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                 let uu____25297 =
+                                 let uu____25175 =
                                    FStar_TypeChecker_Cfg.find_prim_step cfg
                                      fv
                                     in
-                                 (match uu____25297 with
+                                 (match uu____25175 with
                                   | FStar_Pervasives_Native.Some
                                       {
                                         FStar_TypeChecker_Cfg.name =
-                                          uu____25300;
+                                          uu____25178;
                                         FStar_TypeChecker_Cfg.arity =
-                                          uu____25301;
+                                          uu____25179;
                                         FStar_TypeChecker_Cfg.univ_arity =
-                                          uu____25302;
+                                          uu____25180;
                                         FStar_TypeChecker_Cfg.auto_reflect =
                                           FStar_Pervasives_Native.Some n;
                                         FStar_TypeChecker_Cfg.strong_reduction_ok
-                                          = uu____25304;
+                                          = uu____25182;
                                         FStar_TypeChecker_Cfg.requires_binder_substitution
-                                          = uu____25305;
+                                          = uu____25183;
                                         FStar_TypeChecker_Cfg.interpretation
-                                          = uu____25306;
+                                          = uu____25184;
                                         FStar_TypeChecker_Cfg.interpretation_nbe
-                                          = uu____25307;_}
+                                          = uu____25185;_}
                                       when (FStar_List.length args) = n ->
                                       norm cfg env2 stack' t1
-                                  | uu____25343 -> fallback " (3)" ())
-                             | uu____25347 -> fallback " (4)" ()))
-                   | uu____25349 -> fallback " (2)" ())
+                                  | uu____25221 -> fallback " (3)" ())
+                             | uu____25225 -> fallback " (4)" ()))
+                   | uu____25227 -> fallback " (2)" ())
               | (App (env2,head,aq,r))::stack2 ->
-                  let t2 =
-                    FStar_Syntax_Syntax.extend_app head (t1, aq)
-                      FStar_Pervasives_Native.None r
-                     in
+                  let t2 = FStar_Syntax_Syntax.extend_app head (t1, aq) r  in
                   rebuild cfg env2 stack2 t2
               | (CBVApp (env',head,aq,r))::stack2 ->
-                  let uu____25372 =
-                    let uu____25373 =
-                      let uu____25374 =
-                        let uu____25381 =
-                          let uu____25382 =
-                            let uu____25414 =
+                  let uu____25248 =
+                    let uu____25249 =
+                      let uu____25250 =
+                        let uu____25257 =
+                          let uu____25258 =
+                            let uu____25290 =
                               FStar_Util.mk_ref FStar_Pervasives_Native.None
                                in
-                            (env1, t1, uu____25414, false)  in
-                          Clos uu____25382  in
-                        (uu____25381, aq, (t1.FStar_Syntax_Syntax.pos))  in
-                      Arg uu____25374  in
-                    uu____25373 :: stack2  in
-                  norm cfg env' uu____25372 head
+                            (env1, t1, uu____25290, false)  in
+                          Clos uu____25258  in
+                        (uu____25257, aq, (t1.FStar_Syntax_Syntax.pos))  in
+                      Arg uu____25250  in
+                    uu____25249 :: stack2  in
+                  norm cfg env' uu____25248 head
               | (Match (env',branches1,cfg1,r))::stack2 ->
                   (FStar_TypeChecker_Cfg.log cfg1
-                     (fun uu____25489  ->
-                        let uu____25490 =
+                     (fun uu____25365  ->
+                        let uu____25366 =
                           FStar_Syntax_Print.term_to_string t1  in
                         FStar_Util.print1
                           "Rebuilding with match, scrutinee is %s ...\n"
-                          uu____25490);
+                          uu____25366);
                    (let scrutinee_env = env1  in
                     let env2 = env'  in
                     let scrutinee = t1  in
-                    let norm_and_rebuild_match uu____25501 =
+                    let norm_and_rebuild_match uu____25377 =
                       FStar_TypeChecker_Cfg.log cfg1
-                        (fun uu____25506  ->
-                           let uu____25507 =
+                        (fun uu____25382  ->
+                           let uu____25383 =
                              FStar_Syntax_Print.term_to_string scrutinee  in
-                           let uu____25509 =
-                             let uu____25511 =
+                           let uu____25385 =
+                             let uu____25387 =
                                FStar_All.pipe_right branches1
                                  (FStar_List.map
-                                    (fun uu____25541  ->
-                                       match uu____25541 with
-                                       | (p,uu____25552,uu____25553) ->
+                                    (fun uu____25417  ->
+                                       match uu____25417 with
+                                       | (p,uu____25428,uu____25429) ->
                                            FStar_Syntax_Print.pat_to_string p))
                                 in
-                             FStar_All.pipe_right uu____25511
+                             FStar_All.pipe_right uu____25387
                                (FStar_String.concat "\n\t")
                               in
                            FStar_Util.print2
                              "match is irreducible: scrutinee=%s\nbranches=%s\n"
-                             uu____25507 uu____25509);
+                             uu____25383 uu____25385);
                       (let whnf =
                          (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                            ||
@@ -7712,92 +7667,92 @@ and (rebuild :
                               FStar_All.pipe_right
                                 cfg1.FStar_TypeChecker_Cfg.delta_level
                                 (FStar_List.filter
-                                   (fun uu___16_25578  ->
-                                      match uu___16_25578 with
+                                   (fun uu___16_25454  ->
+                                      match uu___16_25454 with
                                       | FStar_TypeChecker_Env.InliningDelta 
                                           -> true
                                       | FStar_TypeChecker_Env.Eager_unfolding_only
                                            -> true
-                                      | uu____25582 -> false))
+                                      | uu____25458 -> false))
                                in
                             let steps =
-                              let uu___3009_25585 =
+                              let uu___3007_25461 =
                                 cfg1.FStar_TypeChecker_Cfg.steps  in
                               {
                                 FStar_TypeChecker_Cfg.beta =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.beta);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.beta);
                                 FStar_TypeChecker_Cfg.iota =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.iota);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.iota);
                                 FStar_TypeChecker_Cfg.zeta = false;
                                 FStar_TypeChecker_Cfg.zeta_full =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.zeta_full);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.zeta_full);
                                 FStar_TypeChecker_Cfg.weak =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.weak);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.weak);
                                 FStar_TypeChecker_Cfg.hnf =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.hnf);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.hnf);
                                 FStar_TypeChecker_Cfg.primops =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.primops);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.primops);
                                 FStar_TypeChecker_Cfg.do_not_unfold_pure_lets
                                   =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                                 FStar_TypeChecker_Cfg.unfold_until =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_only =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_fully =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.unfold_fully);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.unfold_fully);
                                 FStar_TypeChecker_Cfg.unfold_attr =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_tac = false;
                                 FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                   =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                                 FStar_TypeChecker_Cfg.simplify =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.simplify);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.simplify);
                                 FStar_TypeChecker_Cfg.erase_universes =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.erase_universes);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.erase_universes);
                                 FStar_TypeChecker_Cfg.allow_unbound_universes
                                   =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.allow_unbound_universes);
                                 FStar_TypeChecker_Cfg.reify_ =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.reify_);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.reify_);
                                 FStar_TypeChecker_Cfg.compress_uvars =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.compress_uvars);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.compress_uvars);
                                 FStar_TypeChecker_Cfg.no_full_norm =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.no_full_norm);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.no_full_norm);
                                 FStar_TypeChecker_Cfg.check_no_uvars =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.check_no_uvars);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.check_no_uvars);
                                 FStar_TypeChecker_Cfg.unmeta =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.unmeta);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.unmeta);
                                 FStar_TypeChecker_Cfg.unascribe =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.unascribe);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.unascribe);
                                 FStar_TypeChecker_Cfg.in_full_norm_request =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.in_full_norm_request);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.in_full_norm_request);
                                 FStar_TypeChecker_Cfg.weakly_reduce_scrutinee
                                   =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                                 FStar_TypeChecker_Cfg.nbe_step =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.nbe_step);
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.nbe_step);
                                 FStar_TypeChecker_Cfg.for_extraction =
-                                  (uu___3009_25585.FStar_TypeChecker_Cfg.for_extraction)
+                                  (uu___3007_25461.FStar_TypeChecker_Cfg.for_extraction)
                               }  in
-                            let uu___3012_25592 = cfg1  in
+                            let uu___3010_25468 = cfg1  in
                             {
                               FStar_TypeChecker_Cfg.steps = steps;
                               FStar_TypeChecker_Cfg.tcenv =
-                                (uu___3012_25592.FStar_TypeChecker_Cfg.tcenv);
+                                (uu___3010_25468.FStar_TypeChecker_Cfg.tcenv);
                               FStar_TypeChecker_Cfg.debug =
-                                (uu___3012_25592.FStar_TypeChecker_Cfg.debug);
+                                (uu___3010_25468.FStar_TypeChecker_Cfg.debug);
                               FStar_TypeChecker_Cfg.delta_level = new_delta;
                               FStar_TypeChecker_Cfg.primitive_steps =
-                                (uu___3012_25592.FStar_TypeChecker_Cfg.primitive_steps);
+                                (uu___3010_25468.FStar_TypeChecker_Cfg.primitive_steps);
                               FStar_TypeChecker_Cfg.strong = true;
                               FStar_TypeChecker_Cfg.memoize_lazy =
-                                (uu___3012_25592.FStar_TypeChecker_Cfg.memoize_lazy);
+                                (uu___3010_25468.FStar_TypeChecker_Cfg.memoize_lazy);
                               FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                (uu___3012_25592.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                (uu___3010_25468.FStar_TypeChecker_Cfg.normalize_pure_lets);
                               FStar_TypeChecker_Cfg.reifying =
-                                (uu___3012_25592.FStar_TypeChecker_Cfg.reifying)
+                                (uu___3010_25468.FStar_TypeChecker_Cfg.reifying)
                             })
                           in
                        let norm_or_whnf env3 t2 =
@@ -7806,111 +7761,111 @@ and (rebuild :
                          else norm cfg_exclude_zeta env3 [] t2  in
                        let rec norm_pat env3 p =
                          match p.FStar_Syntax_Syntax.v with
-                         | FStar_Syntax_Syntax.Pat_constant uu____25667 ->
+                         | FStar_Syntax_Syntax.Pat_constant uu____25543 ->
                              (p, env3)
                          | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-                             let uu____25698 =
+                             let uu____25574 =
                                FStar_All.pipe_right pats
                                  (FStar_List.fold_left
-                                    (fun uu____25787  ->
-                                       fun uu____25788  ->
-                                         match (uu____25787, uu____25788)
+                                    (fun uu____25663  ->
+                                       fun uu____25664  ->
+                                         match (uu____25663, uu____25664)
                                          with
                                          | ((pats1,env4),(p1,b)) ->
-                                             let uu____25938 =
+                                             let uu____25814 =
                                                norm_pat env4 p1  in
-                                             (match uu____25938 with
+                                             (match uu____25814 with
                                               | (p2,env5) ->
                                                   (((p2, b) :: pats1), env5)))
                                     ([], env3))
                                 in
-                             (match uu____25698 with
+                             (match uu____25574 with
                               | (pats1,env4) ->
-                                  ((let uu___3040_26108 = p  in
+                                  ((let uu___3038_25984 = p  in
                                     {
                                       FStar_Syntax_Syntax.v =
                                         (FStar_Syntax_Syntax.Pat_cons
                                            (fv, (FStar_List.rev pats1)));
                                       FStar_Syntax_Syntax.p =
-                                        (uu___3040_26108.FStar_Syntax_Syntax.p)
+                                        (uu___3038_25984.FStar_Syntax_Syntax.p)
                                     }), env4))
                          | FStar_Syntax_Syntax.Pat_var x ->
                              let x1 =
-                               let uu___3044_26129 = x  in
-                               let uu____26130 =
+                               let uu___3042_26005 = x  in
+                               let uu____26006 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3044_26129.FStar_Syntax_Syntax.ppname);
+                                   (uu___3042_26005.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3044_26129.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____26130
+                                   (uu___3042_26005.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____26006
                                }  in
-                             ((let uu___3047_26144 = p  in
+                             ((let uu___3045_26020 = p  in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_var x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3047_26144.FStar_Syntax_Syntax.p)
+                                   (uu___3045_26020.FStar_Syntax_Syntax.p)
                                }), (dummy :: env3))
                          | FStar_Syntax_Syntax.Pat_wild x ->
                              let x1 =
-                               let uu___3051_26155 = x  in
-                               let uu____26156 =
+                               let uu___3049_26031 = x  in
+                               let uu____26032 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3051_26155.FStar_Syntax_Syntax.ppname);
+                                   (uu___3049_26031.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3051_26155.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____26156
+                                   (uu___3049_26031.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____26032
                                }  in
-                             ((let uu___3054_26170 = p  in
+                             ((let uu___3052_26046 = p  in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_wild x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3054_26170.FStar_Syntax_Syntax.p)
+                                   (uu___3052_26046.FStar_Syntax_Syntax.p)
                                }), (dummy :: env3))
                          | FStar_Syntax_Syntax.Pat_dot_term (x,t2) ->
                              let x1 =
-                               let uu___3060_26186 = x  in
-                               let uu____26187 =
+                               let uu___3058_26062 = x  in
+                               let uu____26063 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort
                                   in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3060_26186.FStar_Syntax_Syntax.ppname);
+                                   (uu___3058_26062.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3060_26186.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____26187
+                                   (uu___3058_26062.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____26063
                                }  in
                              let t3 = norm_or_whnf env3 t2  in
-                             ((let uu___3064_26202 = p  in
+                             ((let uu___3062_26078 = p  in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_dot_term (x1, t3));
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3064_26202.FStar_Syntax_Syntax.p)
+                                   (uu___3062_26078.FStar_Syntax_Syntax.p)
                                }), env3)
                           in
                        let branches2 =
                          match env2 with
                          | [] when whnf -> branches1
-                         | uu____26246 ->
+                         | uu____26122 ->
                              FStar_All.pipe_right branches1
                                (FStar_List.map
                                   (fun branch  ->
-                                     let uu____26276 =
+                                     let uu____26152 =
                                        FStar_Syntax_Subst.open_branch branch
                                         in
-                                     match uu____26276 with
+                                     match uu____26152 with
                                      | (p,wopt,e) ->
-                                         let uu____26296 = norm_pat env2 p
+                                         let uu____26172 = norm_pat env2 p
                                             in
-                                         (match uu____26296 with
+                                         (match uu____26172 with
                                           | (p1,env3) ->
                                               let wopt1 =
                                                 match wopt with
@@ -7919,10 +7874,10 @@ and (rebuild :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     w ->
-                                                    let uu____26351 =
+                                                    let uu____26227 =
                                                       norm_or_whnf env3 w  in
                                                     FStar_Pervasives_Native.Some
-                                                      uu____26351
+                                                      uu____26227
                                                  in
                                               let e1 = norm_or_whnf env3 e
                                                  in
@@ -7930,7 +7885,7 @@ and (rebuild :
                                                 (p1, wopt1, e1))))
                           in
                        let scrutinee1 =
-                         let uu____26368 =
+                         let uu____26244 =
                            ((((cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                                 &&
                                 (Prims.op_Negation
@@ -7942,130 +7897,130 @@ and (rebuild :
                               (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weakly_reduce_scrutinee)
                              && (maybe_weakly_reduced scrutinee)
                             in
-                         if uu____26368
+                         if uu____26244
                          then
                            norm
-                             (let uu___3083_26375 = cfg1  in
+                             (let uu___3081_26251 = cfg1  in
                               {
                                 FStar_TypeChecker_Cfg.steps =
-                                  (let uu___3085_26378 =
+                                  (let uu___3083_26254 =
                                      cfg1.FStar_TypeChecker_Cfg.steps  in
                                    {
                                      FStar_TypeChecker_Cfg.beta =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.beta);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.beta);
                                      FStar_TypeChecker_Cfg.iota =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.iota);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.iota);
                                      FStar_TypeChecker_Cfg.zeta =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.zeta);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.zeta);
                                      FStar_TypeChecker_Cfg.zeta_full =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.zeta_full);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.zeta_full);
                                      FStar_TypeChecker_Cfg.weak =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.weak);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.weak);
                                      FStar_TypeChecker_Cfg.hnf =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.hnf);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.hnf);
                                      FStar_TypeChecker_Cfg.primops =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.primops);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.primops);
                                      FStar_TypeChecker_Cfg.do_not_unfold_pure_lets
                                        =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                                      FStar_TypeChecker_Cfg.unfold_until =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.unfold_until);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.unfold_until);
                                      FStar_TypeChecker_Cfg.unfold_only =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.unfold_only);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.unfold_only);
                                      FStar_TypeChecker_Cfg.unfold_fully =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.unfold_fully);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.unfold_fully);
                                      FStar_TypeChecker_Cfg.unfold_attr =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.unfold_attr);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.unfold_attr);
                                      FStar_TypeChecker_Cfg.unfold_tac =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.unfold_tac);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.unfold_tac);
                                      FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                        =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                                      FStar_TypeChecker_Cfg.simplify =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.simplify);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.simplify);
                                      FStar_TypeChecker_Cfg.erase_universes =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.erase_universes);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.erase_universes);
                                      FStar_TypeChecker_Cfg.allow_unbound_universes
                                        =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.allow_unbound_universes);
                                      FStar_TypeChecker_Cfg.reify_ =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.reify_);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.reify_);
                                      FStar_TypeChecker_Cfg.compress_uvars =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.compress_uvars);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.compress_uvars);
                                      FStar_TypeChecker_Cfg.no_full_norm =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.no_full_norm);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.no_full_norm);
                                      FStar_TypeChecker_Cfg.check_no_uvars =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.check_no_uvars);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.check_no_uvars);
                                      FStar_TypeChecker_Cfg.unmeta =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.unmeta);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.unmeta);
                                      FStar_TypeChecker_Cfg.unascribe =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.unascribe);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.unascribe);
                                      FStar_TypeChecker_Cfg.in_full_norm_request
                                        =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.in_full_norm_request);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.in_full_norm_request);
                                      FStar_TypeChecker_Cfg.weakly_reduce_scrutinee
                                        = false;
                                      FStar_TypeChecker_Cfg.nbe_step =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.nbe_step);
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.nbe_step);
                                      FStar_TypeChecker_Cfg.for_extraction =
-                                       (uu___3085_26378.FStar_TypeChecker_Cfg.for_extraction)
+                                       (uu___3083_26254.FStar_TypeChecker_Cfg.for_extraction)
                                    });
                                 FStar_TypeChecker_Cfg.tcenv =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.tcenv);
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.tcenv);
                                 FStar_TypeChecker_Cfg.debug =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.debug);
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.debug);
                                 FStar_TypeChecker_Cfg.delta_level =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.delta_level);
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.delta_level);
                                 FStar_TypeChecker_Cfg.primitive_steps =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.primitive_steps);
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.primitive_steps);
                                 FStar_TypeChecker_Cfg.strong =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.strong);
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.strong);
                                 FStar_TypeChecker_Cfg.memoize_lazy =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.memoize_lazy);
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.memoize_lazy);
                                 FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                 FStar_TypeChecker_Cfg.reifying =
-                                  (uu___3083_26375.FStar_TypeChecker_Cfg.reifying)
+                                  (uu___3081_26251.FStar_TypeChecker_Cfg.reifying)
                               }) scrutinee_env [] scrutinee
                          else scrutinee  in
-                       let uu____26382 =
-                         mk
+                       let uu____26258 =
+                         FStar_Syntax_Syntax.mk
                            (FStar_Syntax_Syntax.Tm_match
                               (scrutinee1, branches2)) r
                           in
-                       rebuild cfg1 env2 stack2 uu____26382)
+                       rebuild cfg1 env2 stack2 uu____26258)
                        in
                     let rec is_cons head =
-                      let uu____26408 =
-                        let uu____26409 = FStar_Syntax_Subst.compress head
+                      let uu____26284 =
+                        let uu____26285 = FStar_Syntax_Subst.compress head
                            in
-                        uu____26409.FStar_Syntax_Syntax.n  in
-                      match uu____26408 with
-                      | FStar_Syntax_Syntax.Tm_uinst (h,uu____26414) ->
+                        uu____26285.FStar_Syntax_Syntax.n  in
+                      match uu____26284 with
+                      | FStar_Syntax_Syntax.Tm_uinst (h,uu____26290) ->
                           is_cons h
-                      | FStar_Syntax_Syntax.Tm_constant uu____26419 -> true
+                      | FStar_Syntax_Syntax.Tm_constant uu____26295 -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____26421;
-                            FStar_Syntax_Syntax.fv_delta = uu____26422;
+                          { FStar_Syntax_Syntax.fv_name = uu____26297;
+                            FStar_Syntax_Syntax.fv_delta = uu____26298;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Data_ctor );_}
                           -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____26424;
-                            FStar_Syntax_Syntax.fv_delta = uu____26425;
+                          { FStar_Syntax_Syntax.fv_name = uu____26300;
+                            FStar_Syntax_Syntax.fv_delta = uu____26301;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Record_ctor uu____26426);_}
+                              (FStar_Syntax_Syntax.Record_ctor uu____26302);_}
                           -> true
-                      | uu____26434 -> false  in
+                      | uu____26310 -> false  in
                     let guard_when_clause wopt b rest =
                       match wopt with
                       | FStar_Pervasives_Native.None  -> b
                       | FStar_Pervasives_Native.Some w ->
                           let then_branch = b  in
                           let else_branch =
-                            mk
+                            FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_match (scrutinee, rest))
                               r
                              in
@@ -8077,120 +8032,120 @@ and (rebuild :
                         FStar_Syntax_Util.unmeta scrutinee_orig  in
                       let scrutinee2 = FStar_Syntax_Util.unlazy scrutinee1
                          in
-                      let uu____26603 =
+                      let uu____26479 =
                         FStar_Syntax_Util.head_and_args scrutinee2  in
-                      match uu____26603 with
+                      match uu____26479 with
                       | (head,args) ->
                           (match p.FStar_Syntax_Syntax.v with
                            | FStar_Syntax_Syntax.Pat_var bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
                            | FStar_Syntax_Syntax.Pat_wild bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
-                           | FStar_Syntax_Syntax.Pat_dot_term uu____26700 ->
+                           | FStar_Syntax_Syntax.Pat_dot_term uu____26576 ->
                                FStar_Util.Inl []
                            | FStar_Syntax_Syntax.Pat_constant s ->
                                (match scrutinee2.FStar_Syntax_Syntax.n with
                                 | FStar_Syntax_Syntax.Tm_constant s' when
                                     FStar_Const.eq_const s s' ->
                                     FStar_Util.Inl []
-                                | uu____26742 ->
-                                    let uu____26743 =
-                                      let uu____26745 = is_cons head  in
-                                      Prims.op_Negation uu____26745  in
-                                    FStar_Util.Inr uu____26743)
+                                | uu____26618 ->
+                                    let uu____26619 =
+                                      let uu____26621 = is_cons head  in
+                                      Prims.op_Negation uu____26621  in
+                                    FStar_Util.Inr uu____26619)
                            | FStar_Syntax_Syntax.Pat_cons (fv,arg_pats) ->
-                               let uu____26774 =
-                                 let uu____26775 =
+                               let uu____26650 =
+                                 let uu____26651 =
                                    FStar_Syntax_Util.un_uinst head  in
-                                 uu____26775.FStar_Syntax_Syntax.n  in
-                               (match uu____26774 with
+                                 uu____26651.FStar_Syntax_Syntax.n  in
+                               (match uu____26650 with
                                 | FStar_Syntax_Syntax.Tm_fvar fv' when
                                     FStar_Syntax_Syntax.fv_eq fv fv' ->
                                     matches_args [] args arg_pats
-                                | uu____26794 ->
-                                    let uu____26795 =
-                                      let uu____26797 = is_cons head  in
-                                      Prims.op_Negation uu____26797  in
-                                    FStar_Util.Inr uu____26795))
+                                | uu____26670 ->
+                                    let uu____26671 =
+                                      let uu____26673 = is_cons head  in
+                                      Prims.op_Negation uu____26673  in
+                                    FStar_Util.Inr uu____26671))
                     
                     and matches_args out a p =
                       match (a, p) with
                       | ([],[]) -> FStar_Util.Inl out
-                      | ((t2,uu____26888)::rest_a,(p1,uu____26891)::rest_p)
+                      | ((t2,uu____26764)::rest_a,(p1,uu____26767)::rest_p)
                           ->
-                          let uu____26950 = matches_pat t2 p1  in
-                          (match uu____26950 with
+                          let uu____26826 = matches_pat t2 p1  in
+                          (match uu____26826 with
                            | FStar_Util.Inl s ->
                                matches_args (FStar_List.append out s) rest_a
                                  rest_p
                            | m -> m)
-                      | uu____27003 -> FStar_Util.Inr false
+                      | uu____26879 -> FStar_Util.Inr false
                      in
                     let rec matches scrutinee1 p =
                       match p with
                       | [] -> norm_and_rebuild_match ()
                       | (p1,wopt,b)::rest ->
-                          let uu____27126 = matches_pat scrutinee1 p1  in
-                          (match uu____27126 with
+                          let uu____27002 = matches_pat scrutinee1 p1  in
+                          (match uu____27002 with
                            | FStar_Util.Inr (false ) ->
                                matches scrutinee1 rest
                            | FStar_Util.Inr (true ) ->
                                norm_and_rebuild_match ()
                            | FStar_Util.Inl s ->
                                (FStar_TypeChecker_Cfg.log cfg1
-                                  (fun uu____27172  ->
-                                     let uu____27173 =
+                                  (fun uu____27048  ->
+                                     let uu____27049 =
                                        FStar_Syntax_Print.pat_to_string p1
                                         in
-                                     let uu____27175 =
-                                       let uu____27177 =
+                                     let uu____27051 =
+                                       let uu____27053 =
                                          FStar_List.map
-                                           (fun uu____27189  ->
-                                              match uu____27189 with
-                                              | (uu____27195,t2) ->
+                                           (fun uu____27065  ->
+                                              match uu____27065 with
+                                              | (uu____27071,t2) ->
                                                   FStar_Syntax_Print.term_to_string
                                                     t2) s
                                           in
-                                       FStar_All.pipe_right uu____27177
+                                       FStar_All.pipe_right uu____27053
                                          (FStar_String.concat "; ")
                                         in
                                      FStar_Util.print2
                                        "Matches pattern %s with subst = %s\n"
-                                       uu____27173 uu____27175);
+                                       uu____27049 uu____27051);
                                 (let env0 = env2  in
                                  let env3 =
                                    FStar_List.fold_left
                                      (fun env3  ->
-                                        fun uu____27231  ->
-                                          match uu____27231 with
+                                        fun uu____27107  ->
+                                          match uu____27107 with
                                           | (bv,t2) ->
-                                              let uu____27254 =
-                                                let uu____27261 =
-                                                  let uu____27264 =
+                                              let uu____27130 =
+                                                let uu____27137 =
+                                                  let uu____27140 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       bv
                                                      in
                                                   FStar_Pervasives_Native.Some
-                                                    uu____27264
+                                                    uu____27140
                                                    in
-                                                let uu____27265 =
-                                                  let uu____27266 =
-                                                    let uu____27298 =
+                                                let uu____27141 =
+                                                  let uu____27142 =
+                                                    let uu____27174 =
                                                       FStar_Util.mk_ref
                                                         (FStar_Pervasives_Native.Some
                                                            ([], t2))
                                                        in
-                                                    ([], t2, uu____27298,
+                                                    ([], t2, uu____27174,
                                                       false)
                                                      in
-                                                  Clos uu____27266  in
-                                                (uu____27261, uu____27265)
+                                                  Clos uu____27142  in
+                                                (uu____27137, uu____27141)
                                                  in
-                                              uu____27254 :: env3) env2 s
+                                              uu____27130 :: env3) env2 s
                                     in
-                                 let uu____27391 =
+                                 let uu____27267 =
                                    guard_when_clause wopt b rest  in
-                                 norm cfg1 env3 stack2 uu____27391)))
+                                 norm cfg1 env3 stack2 uu____27267)))
                        in
                     if
                       (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
@@ -8209,59 +8164,59 @@ let (normalize_with_primitive_steps :
         fun t  ->
           let c = FStar_TypeChecker_Cfg.config' ps s e  in
           FStar_TypeChecker_Cfg.log_cfg c
-            (fun uu____27424  ->
-               let uu____27425 = FStar_TypeChecker_Cfg.cfg_to_string c  in
-               FStar_Util.print1 "Cfg = %s\n" uu____27425);
-          (let uu____27428 = is_nbe_request s  in
-           if uu____27428
+            (fun uu____27300  ->
+               let uu____27301 = FStar_TypeChecker_Cfg.cfg_to_string c  in
+               FStar_Util.print1 "Cfg = %s\n" uu____27301);
+          (let uu____27304 = is_nbe_request s  in
+           if uu____27304
            then
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____27434  ->
-                   let uu____27435 = FStar_Syntax_Print.term_to_string t  in
-                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu____27435);
+                (fun uu____27310  ->
+                   let uu____27311 = FStar_Syntax_Print.term_to_string t  in
+                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu____27311);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____27441  ->
-                   let uu____27442 = FStar_TypeChecker_Cfg.cfg_to_string c
+                (fun uu____27317  ->
+                   let uu____27318 = FStar_TypeChecker_Cfg.cfg_to_string c
                       in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____27442);
-              (let uu____27445 =
-                 FStar_Util.record_time (fun uu____27452  -> nbe_eval c s t)
+                   FStar_Util.print1 ">>> cfg = %s\n" uu____27318);
+              (let uu____27321 =
+                 FStar_Util.record_time (fun uu____27328  -> nbe_eval c s t)
                   in
-               match uu____27445 with
+               match uu____27321 with
                | (r,ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____27461  ->
-                         let uu____27462 =
+                      (fun uu____27337  ->
+                         let uu____27338 =
                            FStar_Syntax_Print.term_to_string r  in
-                         let uu____27464 = FStar_Util.string_of_int ms  in
+                         let uu____27340 = FStar_Util.string_of_int ms  in
                          FStar_Util.print2
                            "}\nNormalization result = (%s) in %s ms\n"
-                           uu____27462 uu____27464);
+                           uu____27338 uu____27340);
                     r)))
            else
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____27472  ->
-                   let uu____27473 = FStar_Syntax_Print.term_to_string t  in
+                (fun uu____27348  ->
+                   let uu____27349 = FStar_Syntax_Print.term_to_string t  in
                    FStar_Util.print1 "Starting normalizer for (%s) {\n"
-                     uu____27473);
+                     uu____27349);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____27479  ->
-                   let uu____27480 = FStar_TypeChecker_Cfg.cfg_to_string c
+                (fun uu____27355  ->
+                   let uu____27356 = FStar_TypeChecker_Cfg.cfg_to_string c
                       in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____27480);
-              (let uu____27483 =
-                 FStar_Util.record_time (fun uu____27490  -> norm c [] [] t)
+                   FStar_Util.print1 ">>> cfg = %s\n" uu____27356);
+              (let uu____27359 =
+                 FStar_Util.record_time (fun uu____27366  -> norm c [] [] t)
                   in
-               match uu____27483 with
+               match uu____27359 with
                | (r,ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____27505  ->
-                         let uu____27506 =
+                      (fun uu____27381  ->
+                         let uu____27382 =
                            FStar_Syntax_Print.term_to_string r  in
-                         let uu____27508 = FStar_Util.string_of_int ms  in
+                         let uu____27384 = FStar_Util.string_of_int ms  in
                          FStar_Util.print2
                            "}\nNormalization result = (%s) in %s ms\n"
-                           uu____27506 uu____27508);
+                           uu____27382 uu____27384);
                     r))))
   
 let (normalize :
@@ -8272,14 +8227,14 @@ let (normalize :
   fun s  ->
     fun e  ->
       fun t  ->
-        let uu____27527 =
-          let uu____27531 =
-            let uu____27533 = FStar_TypeChecker_Env.current_module e  in
-            FStar_Ident.string_of_lid uu____27533  in
-          FStar_Pervasives_Native.Some uu____27531  in
+        let uu____27403 =
+          let uu____27407 =
+            let uu____27409 = FStar_TypeChecker_Env.current_module e  in
+            FStar_Ident.string_of_lid uu____27409  in
+          FStar_Pervasives_Native.Some uu____27407  in
         FStar_Profiling.profile
-          (fun uu____27536  -> normalize_with_primitive_steps [] s e t)
-          uu____27527 "FStar.TypeChecker.Normalize"
+          (fun uu____27412  -> normalize_with_primitive_steps [] s e t)
+          uu____27403 "FStar.TypeChecker.Normalize"
   
 let (normalize_comp :
   FStar_TypeChecker_Env.steps ->
@@ -8291,26 +8246,26 @@ let (normalize_comp :
       fun c  ->
         let cfg = FStar_TypeChecker_Cfg.config s e  in
         FStar_TypeChecker_Cfg.log_top cfg
-          (fun uu____27558  ->
-             let uu____27559 = FStar_Syntax_Print.comp_to_string c  in
+          (fun uu____27434  ->
+             let uu____27435 = FStar_Syntax_Print.comp_to_string c  in
              FStar_Util.print1 "Starting normalizer for computation (%s) {\n"
-               uu____27559);
+               uu____27435);
         FStar_TypeChecker_Cfg.log_top cfg
-          (fun uu____27565  ->
-             let uu____27566 = FStar_TypeChecker_Cfg.cfg_to_string cfg  in
-             FStar_Util.print1 ">>> cfg = %s\n" uu____27566);
-        (let uu____27569 =
-           FStar_Util.record_time (fun uu____27576  -> norm_comp cfg [] c)
+          (fun uu____27441  ->
+             let uu____27442 = FStar_TypeChecker_Cfg.cfg_to_string cfg  in
+             FStar_Util.print1 ">>> cfg = %s\n" uu____27442);
+        (let uu____27445 =
+           FStar_Util.record_time (fun uu____27452  -> norm_comp cfg [] c)
             in
-         match uu____27569 with
+         match uu____27445 with
          | (c1,ms) ->
              (FStar_TypeChecker_Cfg.log_top cfg
-                (fun uu____27591  ->
-                   let uu____27592 = FStar_Syntax_Print.comp_to_string c1  in
-                   let uu____27594 = FStar_Util.string_of_int ms  in
+                (fun uu____27467  ->
+                   let uu____27468 = FStar_Syntax_Print.comp_to_string c1  in
+                   let uu____27470 = FStar_Util.string_of_int ms  in
                    FStar_Util.print2
-                     "}\nNormalization result = (%s) in %s ms\n" uu____27592
-                     uu____27594);
+                     "}\nNormalization result = (%s) in %s ms\n" uu____27468
+                     uu____27470);
               c1))
   
 let (normalize_universe :
@@ -8319,8 +8274,8 @@ let (normalize_universe :
   =
   fun env1  ->
     fun u  ->
-      let uu____27608 = FStar_TypeChecker_Cfg.config [] env1  in
-      norm_universe uu____27608 [] u
+      let uu____27484 = FStar_TypeChecker_Cfg.config [] env1  in
+      norm_universe uu____27484 [] u
   
 let (non_info_norm :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
@@ -8333,8 +8288,8 @@ let (non_info_norm :
         FStar_TypeChecker_Env.HNF;
         FStar_TypeChecker_Env.Unascribe;
         FStar_TypeChecker_Env.ForExtraction]  in
-      let uu____27630 = normalize steps env1 t  in
-      FStar_TypeChecker_Env.non_informative env1 uu____27630
+      let uu____27506 = normalize steps env1 t  in
+      FStar_TypeChecker_Env.non_informative env1 uu____27506
   
 let (ghost_to_pure :
   FStar_TypeChecker_Env.env ->
@@ -8343,81 +8298,81 @@ let (ghost_to_pure :
   fun env1  ->
     fun c  ->
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____27642 -> c
+      | FStar_Syntax_Syntax.Total uu____27518 -> c
       | FStar_Syntax_Syntax.GTotal (t,uopt) when non_info_norm env1 t ->
-          let uu___3253_27661 = c  in
+          let uu___3251_27537 = c  in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Total (t, uopt));
             FStar_Syntax_Syntax.pos =
-              (uu___3253_27661.FStar_Syntax_Syntax.pos);
+              (uu___3251_27537.FStar_Syntax_Syntax.pos);
             FStar_Syntax_Syntax.vars =
-              (uu___3253_27661.FStar_Syntax_Syntax.vars)
+              (uu___3251_27537.FStar_Syntax_Syntax.vars)
           }
       | FStar_Syntax_Syntax.Comp ct ->
           let l =
             FStar_TypeChecker_Env.norm_eff_name env1
               ct.FStar_Syntax_Syntax.effect_name
              in
-          let uu____27668 =
+          let uu____27544 =
             (FStar_Syntax_Util.is_ghost_effect l) &&
               (non_info_norm env1 ct.FStar_Syntax_Syntax.result_typ)
              in
-          if uu____27668
+          if uu____27544
           then
             let ct1 =
-              let uu____27672 =
+              let uu____27548 =
                 downgrade_ghost_effect_name
                   ct.FStar_Syntax_Syntax.effect_name
                  in
-              match uu____27672 with
+              match uu____27548 with
               | FStar_Pervasives_Native.Some pure_eff ->
                   let flags =
-                    let uu____27679 =
+                    let uu____27555 =
                       FStar_Ident.lid_equals pure_eff
                         FStar_Parser_Const.effect_Tot_lid
                        in
-                    if uu____27679
+                    if uu____27555
                     then FStar_Syntax_Syntax.TOTAL ::
                       (ct.FStar_Syntax_Syntax.flags)
                     else ct.FStar_Syntax_Syntax.flags  in
-                  let uu___3263_27686 = ct  in
+                  let uu___3261_27562 = ct  in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3263_27686.FStar_Syntax_Syntax.comp_univs);
+                      (uu___3261_27562.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name = pure_eff;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3263_27686.FStar_Syntax_Syntax.result_typ);
+                      (uu___3261_27562.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3263_27686.FStar_Syntax_Syntax.effect_args);
+                      (uu___3261_27562.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags = flags
                   }
               | FStar_Pervasives_Native.None  ->
                   let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env1 c
                      in
-                  let uu___3267_27688 = ct1  in
+                  let uu___3265_27564 = ct1  in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3267_27688.FStar_Syntax_Syntax.comp_univs);
+                      (uu___3265_27564.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name =
                       FStar_Parser_Const.effect_PURE_lid;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3267_27688.FStar_Syntax_Syntax.result_typ);
+                      (uu___3265_27564.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3267_27688.FStar_Syntax_Syntax.effect_args);
+                      (uu___3265_27564.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags =
-                      (uu___3267_27688.FStar_Syntax_Syntax.flags)
+                      (uu___3265_27564.FStar_Syntax_Syntax.flags)
                   }
                in
-            let uu___3270_27689 = c  in
+            let uu___3268_27565 = c  in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos =
-                (uu___3270_27689.FStar_Syntax_Syntax.pos);
+                (uu___3268_27565.FStar_Syntax_Syntax.pos);
               FStar_Syntax_Syntax.vars =
-                (uu___3270_27689.FStar_Syntax_Syntax.vars)
+                (uu___3268_27565.FStar_Syntax_Syntax.vars)
             }
           else c
-      | uu____27692 -> c
+      | uu____27568 -> c
   
 let (ghost_to_pure_lcomp :
   FStar_TypeChecker_Env.env ->
@@ -8425,30 +8380,30 @@ let (ghost_to_pure_lcomp :
   =
   fun env1  ->
     fun lc  ->
-      let uu____27704 =
+      let uu____27580 =
         (FStar_Syntax_Util.is_ghost_effect
            lc.FStar_TypeChecker_Common.eff_name)
           && (non_info_norm env1 lc.FStar_TypeChecker_Common.res_typ)
          in
-      if uu____27704
+      if uu____27580
       then
-        let uu____27707 =
+        let uu____27583 =
           downgrade_ghost_effect_name lc.FStar_TypeChecker_Common.eff_name
            in
-        match uu____27707 with
+        match uu____27583 with
         | FStar_Pervasives_Native.Some pure_eff ->
-            let uu___3278_27711 =
+            let uu___3276_27587 =
               FStar_TypeChecker_Common.apply_lcomp (ghost_to_pure env1)
                 (fun g  -> g) lc
                in
             {
               FStar_TypeChecker_Common.eff_name = pure_eff;
               FStar_TypeChecker_Common.res_typ =
-                (uu___3278_27711.FStar_TypeChecker_Common.res_typ);
+                (uu___3276_27587.FStar_TypeChecker_Common.res_typ);
               FStar_TypeChecker_Common.cflags =
-                (uu___3278_27711.FStar_TypeChecker_Common.cflags);
+                (uu___3276_27587.FStar_TypeChecker_Common.cflags);
               FStar_TypeChecker_Common.comp_thunk =
-                (uu___3278_27711.FStar_TypeChecker_Common.comp_thunk)
+                (uu___3276_27587.FStar_TypeChecker_Common.comp_thunk)
             }
         | FStar_Pervasives_Native.None  -> lc
       else lc
@@ -8459,22 +8414,22 @@ let (term_to_string :
     fun t  ->
       let t1 =
         try
-          (fun uu___3285_27730  ->
+          (fun uu___3283_27606  ->
              match () with
              | () ->
                  normalize [FStar_TypeChecker_Env.AllowUnboundUniverses] env1
                    t) ()
         with
-        | uu___3284_27733 ->
-            ((let uu____27735 =
-                let uu____27741 =
-                  let uu____27743 = FStar_Util.message_of_exn uu___3284_27733
+        | uu___3282_27609 ->
+            ((let uu____27611 =
+                let uu____27617 =
+                  let uu____27619 = FStar_Util.message_of_exn uu___3282_27609
                      in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____27743
+                    uu____27619
                    in
-                (FStar_Errors.Warning_NormalizationFailure, uu____27741)  in
-              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____27735);
+                (FStar_Errors.Warning_NormalizationFailure, uu____27617)  in
+              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____27611);
              t)
          in
       FStar_Syntax_Print.term_to_string' env1.FStar_TypeChecker_Env.dsenv t1
@@ -8485,25 +8440,25 @@ let (comp_to_string :
     fun c  ->
       let c1 =
         try
-          (fun uu___3295_27762  ->
+          (fun uu___3293_27638  ->
              match () with
              | () ->
-                 let uu____27763 =
+                 let uu____27639 =
                    FStar_TypeChecker_Cfg.config
                      [FStar_TypeChecker_Env.AllowUnboundUniverses] env1
                     in
-                 norm_comp uu____27763 [] c) ()
+                 norm_comp uu____27639 [] c) ()
         with
-        | uu___3294_27772 ->
-            ((let uu____27774 =
-                let uu____27780 =
-                  let uu____27782 = FStar_Util.message_of_exn uu___3294_27772
+        | uu___3292_27648 ->
+            ((let uu____27650 =
+                let uu____27656 =
+                  let uu____27658 = FStar_Util.message_of_exn uu___3292_27648
                      in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____27782
+                    uu____27658
                    in
-                (FStar_Errors.Warning_NormalizationFailure, uu____27780)  in
-              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____27774);
+                (FStar_Errors.Warning_NormalizationFailure, uu____27656)  in
+              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____27650);
              c)
          in
       FStar_Syntax_Print.comp_to_string' env1.FStar_TypeChecker_Env.dsenv c1
@@ -8527,15 +8482,16 @@ let (normalize_refinement :
               let t01 = aux x.FStar_Syntax_Syntax.sort  in
               (match t01.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_refine (y,phi1) ->
-                   let uu____27831 =
-                     let uu____27832 =
-                       let uu____27839 =
+                   let uu____27707 =
+                     let uu____27708 =
+                       let uu____27715 =
                          FStar_Syntax_Util.mk_conj_simp phi1 phi  in
-                       (y, uu____27839)  in
-                     FStar_Syntax_Syntax.Tm_refine uu____27832  in
-                   mk uu____27831 t01.FStar_Syntax_Syntax.pos
-               | uu____27844 -> t2)
-          | uu____27845 -> t2  in
+                       (y, uu____27715)  in
+                     FStar_Syntax_Syntax.Tm_refine uu____27708  in
+                   FStar_Syntax_Syntax.mk uu____27707
+                     t01.FStar_Syntax_Syntax.pos
+               | uu____27720 -> t2)
+          | uu____27721 -> t2  in
         aux t
   
 let (whnf_steps : FStar_TypeChecker_Env.step Prims.list) =
@@ -8591,32 +8547,31 @@ let (eta_expand_with_type :
   fun env1  ->
     fun e  ->
       fun t_e  ->
-        let uu____27939 = FStar_Syntax_Util.arrow_formals_comp t_e  in
-        match uu____27939 with
+        let uu____27815 = FStar_Syntax_Util.arrow_formals_comp t_e  in
+        match uu____27815 with
         | (formals,c) ->
             (match formals with
              | [] -> e
-             | uu____27952 ->
-                 let uu____27953 = FStar_Syntax_Util.abs_formals e  in
-                 (match uu____27953 with
-                  | (actuals,uu____27963,uu____27964) ->
+             | uu____27828 ->
+                 let uu____27829 = FStar_Syntax_Util.abs_formals e  in
+                 (match uu____27829 with
+                  | (actuals,uu____27839,uu____27840) ->
                       if
                         (FStar_List.length actuals) =
                           (FStar_List.length formals)
                       then e
                       else
-                        (let uu____27984 =
+                        (let uu____27860 =
                            FStar_All.pipe_right formals
                              FStar_Syntax_Util.args_of_binders
                             in
-                         match uu____27984 with
+                         match uu____27860 with
                          | (binders,args) ->
-                             let uu____27995 =
+                             let uu____27871 =
                                FStar_Syntax_Syntax.mk_Tm_app e args
-                                 FStar_Pervasives_Native.None
                                  e.FStar_Syntax_Syntax.pos
                                 in
-                             FStar_Syntax_Util.abs binders uu____27995
+                             FStar_Syntax_Util.abs binders uu____27871
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)))))
   
@@ -8629,454 +8584,451 @@ let (eta_expand :
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_name x ->
           eta_expand_with_type env1 t x.FStar_Syntax_Syntax.sort
-      | uu____28010 ->
-          let uu____28011 = FStar_Syntax_Util.head_and_args t  in
-          (match uu____28011 with
+      | uu____27886 ->
+          let uu____27887 = FStar_Syntax_Util.head_and_args t  in
+          (match uu____27887 with
            | (head,args) ->
-               let uu____28054 =
-                 let uu____28055 = FStar_Syntax_Subst.compress head  in
-                 uu____28055.FStar_Syntax_Syntax.n  in
-               (match uu____28054 with
+               let uu____27930 =
+                 let uu____27931 = FStar_Syntax_Subst.compress head  in
+                 uu____27931.FStar_Syntax_Syntax.n  in
+               (match uu____27930 with
                 | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-                    let uu____28076 =
-                      let uu____28083 =
+                    let uu____27952 =
+                      let uu____27959 =
                         FStar_Syntax_Subst.subst' s
                           u.FStar_Syntax_Syntax.ctx_uvar_typ
                          in
-                      FStar_Syntax_Util.arrow_formals uu____28083  in
-                    (match uu____28076 with
+                      FStar_Syntax_Util.arrow_formals uu____27959  in
+                    (match uu____27952 with
                      | (formals,_tres) ->
                          if
                            (FStar_List.length formals) =
                              (FStar_List.length args)
                          then t
                          else
-                           (let uu____28107 =
+                           (let uu____27983 =
                               env1.FStar_TypeChecker_Env.type_of
-                                (let uu___3365_28115 = env1  in
+                                (let uu___3363_27991 = env1  in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.solver);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.range);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.curmodule);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.gamma);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.modules);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
                                      FStar_Pervasives_Native.None;
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.sigtab);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.attrtab);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.effects);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.generalize);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.letrecs);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.top_level);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.use_eq);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.is_iface);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.admit);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.phase1);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.failhard);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.nosynth);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.tc_term);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.type_of);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.universe_of);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts = true;
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.splice);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.postprocess);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.dsenv);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.nbe);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___3363_27991.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___3365_28115.FStar_TypeChecker_Env.erasable_types_tab)
+                                     (uu___3363_27991.FStar_TypeChecker_Env.erasable_types_tab)
                                  }) t
                                in
-                            match uu____28107 with
-                            | (uu____28118,ty,uu____28120) ->
+                            match uu____27983 with
+                            | (uu____27994,ty,uu____27996) ->
                                 eta_expand_with_type env1 t ty))
-                | uu____28121 ->
-                    let uu____28122 =
+                | uu____27997 ->
+                    let uu____27998 =
                       env1.FStar_TypeChecker_Env.type_of
-                        (let uu___3372_28130 = env1  in
+                        (let uu___3370_28006 = env1  in
                          {
                            FStar_TypeChecker_Env.solver =
-                             (uu___3372_28130.FStar_TypeChecker_Env.solver);
+                             (uu___3370_28006.FStar_TypeChecker_Env.solver);
                            FStar_TypeChecker_Env.range =
-                             (uu___3372_28130.FStar_TypeChecker_Env.range);
+                             (uu___3370_28006.FStar_TypeChecker_Env.range);
                            FStar_TypeChecker_Env.curmodule =
-                             (uu___3372_28130.FStar_TypeChecker_Env.curmodule);
+                             (uu___3370_28006.FStar_TypeChecker_Env.curmodule);
                            FStar_TypeChecker_Env.gamma =
-                             (uu___3372_28130.FStar_TypeChecker_Env.gamma);
+                             (uu___3370_28006.FStar_TypeChecker_Env.gamma);
                            FStar_TypeChecker_Env.gamma_sig =
-                             (uu___3372_28130.FStar_TypeChecker_Env.gamma_sig);
+                             (uu___3370_28006.FStar_TypeChecker_Env.gamma_sig);
                            FStar_TypeChecker_Env.gamma_cache =
-                             (uu___3372_28130.FStar_TypeChecker_Env.gamma_cache);
+                             (uu___3370_28006.FStar_TypeChecker_Env.gamma_cache);
                            FStar_TypeChecker_Env.modules =
-                             (uu___3372_28130.FStar_TypeChecker_Env.modules);
+                             (uu___3370_28006.FStar_TypeChecker_Env.modules);
                            FStar_TypeChecker_Env.expected_typ =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Env.sigtab =
-                             (uu___3372_28130.FStar_TypeChecker_Env.sigtab);
+                             (uu___3370_28006.FStar_TypeChecker_Env.sigtab);
                            FStar_TypeChecker_Env.attrtab =
-                             (uu___3372_28130.FStar_TypeChecker_Env.attrtab);
+                             (uu___3370_28006.FStar_TypeChecker_Env.attrtab);
                            FStar_TypeChecker_Env.instantiate_imp =
-                             (uu___3372_28130.FStar_TypeChecker_Env.instantiate_imp);
+                             (uu___3370_28006.FStar_TypeChecker_Env.instantiate_imp);
                            FStar_TypeChecker_Env.effects =
-                             (uu___3372_28130.FStar_TypeChecker_Env.effects);
+                             (uu___3370_28006.FStar_TypeChecker_Env.effects);
                            FStar_TypeChecker_Env.generalize =
-                             (uu___3372_28130.FStar_TypeChecker_Env.generalize);
+                             (uu___3370_28006.FStar_TypeChecker_Env.generalize);
                            FStar_TypeChecker_Env.letrecs =
-                             (uu___3372_28130.FStar_TypeChecker_Env.letrecs);
+                             (uu___3370_28006.FStar_TypeChecker_Env.letrecs);
                            FStar_TypeChecker_Env.top_level =
-                             (uu___3372_28130.FStar_TypeChecker_Env.top_level);
+                             (uu___3370_28006.FStar_TypeChecker_Env.top_level);
                            FStar_TypeChecker_Env.check_uvars =
-                             (uu___3372_28130.FStar_TypeChecker_Env.check_uvars);
+                             (uu___3370_28006.FStar_TypeChecker_Env.check_uvars);
                            FStar_TypeChecker_Env.use_eq =
-                             (uu___3372_28130.FStar_TypeChecker_Env.use_eq);
+                             (uu___3370_28006.FStar_TypeChecker_Env.use_eq);
                            FStar_TypeChecker_Env.use_eq_strict =
-                             (uu___3372_28130.FStar_TypeChecker_Env.use_eq_strict);
+                             (uu___3370_28006.FStar_TypeChecker_Env.use_eq_strict);
                            FStar_TypeChecker_Env.is_iface =
-                             (uu___3372_28130.FStar_TypeChecker_Env.is_iface);
+                             (uu___3370_28006.FStar_TypeChecker_Env.is_iface);
                            FStar_TypeChecker_Env.admit =
-                             (uu___3372_28130.FStar_TypeChecker_Env.admit);
+                             (uu___3370_28006.FStar_TypeChecker_Env.admit);
                            FStar_TypeChecker_Env.lax = true;
                            FStar_TypeChecker_Env.lax_universes =
-                             (uu___3372_28130.FStar_TypeChecker_Env.lax_universes);
+                             (uu___3370_28006.FStar_TypeChecker_Env.lax_universes);
                            FStar_TypeChecker_Env.phase1 =
-                             (uu___3372_28130.FStar_TypeChecker_Env.phase1);
+                             (uu___3370_28006.FStar_TypeChecker_Env.phase1);
                            FStar_TypeChecker_Env.failhard =
-                             (uu___3372_28130.FStar_TypeChecker_Env.failhard);
+                             (uu___3370_28006.FStar_TypeChecker_Env.failhard);
                            FStar_TypeChecker_Env.nosynth =
-                             (uu___3372_28130.FStar_TypeChecker_Env.nosynth);
+                             (uu___3370_28006.FStar_TypeChecker_Env.nosynth);
                            FStar_TypeChecker_Env.uvar_subtyping =
-                             (uu___3372_28130.FStar_TypeChecker_Env.uvar_subtyping);
+                             (uu___3370_28006.FStar_TypeChecker_Env.uvar_subtyping);
                            FStar_TypeChecker_Env.tc_term =
-                             (uu___3372_28130.FStar_TypeChecker_Env.tc_term);
+                             (uu___3370_28006.FStar_TypeChecker_Env.tc_term);
                            FStar_TypeChecker_Env.type_of =
-                             (uu___3372_28130.FStar_TypeChecker_Env.type_of);
+                             (uu___3370_28006.FStar_TypeChecker_Env.type_of);
                            FStar_TypeChecker_Env.universe_of =
-                             (uu___3372_28130.FStar_TypeChecker_Env.universe_of);
+                             (uu___3370_28006.FStar_TypeChecker_Env.universe_of);
                            FStar_TypeChecker_Env.check_type_of =
-                             (uu___3372_28130.FStar_TypeChecker_Env.check_type_of);
+                             (uu___3370_28006.FStar_TypeChecker_Env.check_type_of);
                            FStar_TypeChecker_Env.use_bv_sorts = true;
                            FStar_TypeChecker_Env.qtbl_name_and_index =
-                             (uu___3372_28130.FStar_TypeChecker_Env.qtbl_name_and_index);
+                             (uu___3370_28006.FStar_TypeChecker_Env.qtbl_name_and_index);
                            FStar_TypeChecker_Env.normalized_eff_names =
-                             (uu___3372_28130.FStar_TypeChecker_Env.normalized_eff_names);
+                             (uu___3370_28006.FStar_TypeChecker_Env.normalized_eff_names);
                            FStar_TypeChecker_Env.fv_delta_depths =
-                             (uu___3372_28130.FStar_TypeChecker_Env.fv_delta_depths);
+                             (uu___3370_28006.FStar_TypeChecker_Env.fv_delta_depths);
                            FStar_TypeChecker_Env.proof_ns =
-                             (uu___3372_28130.FStar_TypeChecker_Env.proof_ns);
+                             (uu___3370_28006.FStar_TypeChecker_Env.proof_ns);
                            FStar_TypeChecker_Env.synth_hook =
-                             (uu___3372_28130.FStar_TypeChecker_Env.synth_hook);
+                             (uu___3370_28006.FStar_TypeChecker_Env.synth_hook);
                            FStar_TypeChecker_Env.try_solve_implicits_hook =
-                             (uu___3372_28130.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                             (uu___3370_28006.FStar_TypeChecker_Env.try_solve_implicits_hook);
                            FStar_TypeChecker_Env.splice =
-                             (uu___3372_28130.FStar_TypeChecker_Env.splice);
+                             (uu___3370_28006.FStar_TypeChecker_Env.splice);
                            FStar_TypeChecker_Env.mpreprocess =
-                             (uu___3372_28130.FStar_TypeChecker_Env.mpreprocess);
+                             (uu___3370_28006.FStar_TypeChecker_Env.mpreprocess);
                            FStar_TypeChecker_Env.postprocess =
-                             (uu___3372_28130.FStar_TypeChecker_Env.postprocess);
+                             (uu___3370_28006.FStar_TypeChecker_Env.postprocess);
                            FStar_TypeChecker_Env.identifier_info =
-                             (uu___3372_28130.FStar_TypeChecker_Env.identifier_info);
+                             (uu___3370_28006.FStar_TypeChecker_Env.identifier_info);
                            FStar_TypeChecker_Env.tc_hooks =
-                             (uu___3372_28130.FStar_TypeChecker_Env.tc_hooks);
+                             (uu___3370_28006.FStar_TypeChecker_Env.tc_hooks);
                            FStar_TypeChecker_Env.dsenv =
-                             (uu___3372_28130.FStar_TypeChecker_Env.dsenv);
+                             (uu___3370_28006.FStar_TypeChecker_Env.dsenv);
                            FStar_TypeChecker_Env.nbe =
-                             (uu___3372_28130.FStar_TypeChecker_Env.nbe);
+                             (uu___3370_28006.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___3372_28130.FStar_TypeChecker_Env.strict_args_tab);
+                             (uu___3370_28006.FStar_TypeChecker_Env.strict_args_tab);
                            FStar_TypeChecker_Env.erasable_types_tab =
-                             (uu___3372_28130.FStar_TypeChecker_Env.erasable_types_tab)
+                             (uu___3370_28006.FStar_TypeChecker_Env.erasable_types_tab)
                          }) t
                        in
-                    (match uu____28122 with
-                     | (uu____28133,ty,uu____28135) ->
+                    (match uu____27998 with
+                     | (uu____28009,ty,uu____28011) ->
                          eta_expand_with_type env1 t ty)))
   
 let rec (elim_delayed_subst_term :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let mk1 x =
-      FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-        t.FStar_Syntax_Syntax.pos
-       in
+    let mk x = FStar_Syntax_Syntax.mk x t.FStar_Syntax_Syntax.pos  in
     let t1 = FStar_Syntax_Subst.compress t  in
     let elim_bv x =
-      let uu___3384_28217 = x  in
-      let uu____28218 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort
+      let uu___3382_28093 = x  in
+      let uu____28094 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort
          in
       {
         FStar_Syntax_Syntax.ppname =
-          (uu___3384_28217.FStar_Syntax_Syntax.ppname);
+          (uu___3382_28093.FStar_Syntax_Syntax.ppname);
         FStar_Syntax_Syntax.index =
-          (uu___3384_28217.FStar_Syntax_Syntax.index);
-        FStar_Syntax_Syntax.sort = uu____28218
+          (uu___3382_28093.FStar_Syntax_Syntax.index);
+        FStar_Syntax_Syntax.sort = uu____28094
       }  in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____28221 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_bvar uu____28237 -> t1
-    | FStar_Syntax_Syntax.Tm_name uu____28238 -> t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____28239 -> t1
-    | FStar_Syntax_Syntax.Tm_uinst uu____28240 -> t1
-    | FStar_Syntax_Syntax.Tm_constant uu____28247 -> t1
-    | FStar_Syntax_Syntax.Tm_type uu____28248 -> t1
-    | FStar_Syntax_Syntax.Tm_lazy uu____28249 -> t1
+    | FStar_Syntax_Syntax.Tm_delayed uu____28097 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_bvar uu____28113 -> t1
+    | FStar_Syntax_Syntax.Tm_name uu____28114 -> t1
+    | FStar_Syntax_Syntax.Tm_fvar uu____28115 -> t1
+    | FStar_Syntax_Syntax.Tm_uinst uu____28116 -> t1
+    | FStar_Syntax_Syntax.Tm_constant uu____28123 -> t1
+    | FStar_Syntax_Syntax.Tm_type uu____28124 -> t1
+    | FStar_Syntax_Syntax.Tm_lazy uu____28125 -> t1
     | FStar_Syntax_Syntax.Tm_unknown  -> t1
     | FStar_Syntax_Syntax.Tm_abs (bs,t2,rc_opt) ->
         let elim_rc rc =
-          let uu___3410_28283 = rc  in
-          let uu____28284 =
+          let uu___3408_28159 = rc  in
+          let uu____28160 =
             FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
               elim_delayed_subst_term
              in
-          let uu____28293 =
+          let uu____28169 =
             elim_delayed_subst_cflags rc.FStar_Syntax_Syntax.residual_flags
              in
           {
             FStar_Syntax_Syntax.residual_effect =
-              (uu___3410_28283.FStar_Syntax_Syntax.residual_effect);
-            FStar_Syntax_Syntax.residual_typ = uu____28284;
-            FStar_Syntax_Syntax.residual_flags = uu____28293
+              (uu___3408_28159.FStar_Syntax_Syntax.residual_effect);
+            FStar_Syntax_Syntax.residual_typ = uu____28160;
+            FStar_Syntax_Syntax.residual_flags = uu____28169
           }  in
-        let uu____28296 =
-          let uu____28297 =
-            let uu____28316 = elim_delayed_subst_binders bs  in
-            let uu____28325 = elim_delayed_subst_term t2  in
-            let uu____28328 = FStar_Util.map_opt rc_opt elim_rc  in
-            (uu____28316, uu____28325, uu____28328)  in
-          FStar_Syntax_Syntax.Tm_abs uu____28297  in
-        mk1 uu____28296
+        let uu____28172 =
+          let uu____28173 =
+            let uu____28192 = elim_delayed_subst_binders bs  in
+            let uu____28201 = elim_delayed_subst_term t2  in
+            let uu____28204 = FStar_Util.map_opt rc_opt elim_rc  in
+            (uu____28192, uu____28201, uu____28204)  in
+          FStar_Syntax_Syntax.Tm_abs uu____28173  in
+        mk uu____28172
     | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-        let uu____28365 =
-          let uu____28366 =
-            let uu____28381 = elim_delayed_subst_binders bs  in
-            let uu____28390 = elim_delayed_subst_comp c  in
-            (uu____28381, uu____28390)  in
-          FStar_Syntax_Syntax.Tm_arrow uu____28366  in
-        mk1 uu____28365
+        let uu____28241 =
+          let uu____28242 =
+            let uu____28257 = elim_delayed_subst_binders bs  in
+            let uu____28266 = elim_delayed_subst_comp c  in
+            (uu____28257, uu____28266)  in
+          FStar_Syntax_Syntax.Tm_arrow uu____28242  in
+        mk uu____28241
     | FStar_Syntax_Syntax.Tm_refine (bv,phi) ->
-        let uu____28409 =
-          let uu____28410 =
-            let uu____28417 = elim_bv bv  in
-            let uu____28418 = elim_delayed_subst_term phi  in
-            (uu____28417, uu____28418)  in
-          FStar_Syntax_Syntax.Tm_refine uu____28410  in
-        mk1 uu____28409
+        let uu____28285 =
+          let uu____28286 =
+            let uu____28293 = elim_bv bv  in
+            let uu____28294 = elim_delayed_subst_term phi  in
+            (uu____28293, uu____28294)  in
+          FStar_Syntax_Syntax.Tm_refine uu____28286  in
+        mk uu____28285
     | FStar_Syntax_Syntax.Tm_app (t2,args) ->
-        let uu____28449 =
-          let uu____28450 =
-            let uu____28467 = elim_delayed_subst_term t2  in
-            let uu____28470 = elim_delayed_subst_args args  in
-            (uu____28467, uu____28470)  in
-          FStar_Syntax_Syntax.Tm_app uu____28450  in
-        mk1 uu____28449
+        let uu____28325 =
+          let uu____28326 =
+            let uu____28343 = elim_delayed_subst_term t2  in
+            let uu____28346 = elim_delayed_subst_args args  in
+            (uu____28343, uu____28346)  in
+          FStar_Syntax_Syntax.Tm_app uu____28326  in
+        mk uu____28325
     | FStar_Syntax_Syntax.Tm_match (t2,branches1) ->
         let rec elim_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_var x ->
-              let uu___3432_28542 = p  in
-              let uu____28543 =
-                let uu____28544 = elim_bv x  in
-                FStar_Syntax_Syntax.Pat_var uu____28544  in
+              let uu___3430_28418 = p  in
+              let uu____28419 =
+                let uu____28420 = elim_bv x  in
+                FStar_Syntax_Syntax.Pat_var uu____28420  in
               {
-                FStar_Syntax_Syntax.v = uu____28543;
+                FStar_Syntax_Syntax.v = uu____28419;
                 FStar_Syntax_Syntax.p =
-                  (uu___3432_28542.FStar_Syntax_Syntax.p)
+                  (uu___3430_28418.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_wild x ->
-              let uu___3436_28546 = p  in
-              let uu____28547 =
-                let uu____28548 = elim_bv x  in
-                FStar_Syntax_Syntax.Pat_wild uu____28548  in
+              let uu___3434_28422 = p  in
+              let uu____28423 =
+                let uu____28424 = elim_bv x  in
+                FStar_Syntax_Syntax.Pat_wild uu____28424  in
               {
-                FStar_Syntax_Syntax.v = uu____28547;
+                FStar_Syntax_Syntax.v = uu____28423;
                 FStar_Syntax_Syntax.p =
-                  (uu___3436_28546.FStar_Syntax_Syntax.p)
+                  (uu___3434_28422.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_dot_term (x,t0) ->
-              let uu___3442_28555 = p  in
-              let uu____28556 =
-                let uu____28557 =
-                  let uu____28564 = elim_bv x  in
-                  let uu____28565 = elim_delayed_subst_term t0  in
-                  (uu____28564, uu____28565)  in
-                FStar_Syntax_Syntax.Pat_dot_term uu____28557  in
+              let uu___3440_28431 = p  in
+              let uu____28432 =
+                let uu____28433 =
+                  let uu____28440 = elim_bv x  in
+                  let uu____28441 = elim_delayed_subst_term t0  in
+                  (uu____28440, uu____28441)  in
+                FStar_Syntax_Syntax.Pat_dot_term uu____28433  in
               {
-                FStar_Syntax_Syntax.v = uu____28556;
+                FStar_Syntax_Syntax.v = uu____28432;
                 FStar_Syntax_Syntax.p =
-                  (uu___3442_28555.FStar_Syntax_Syntax.p)
+                  (uu___3440_28431.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
-              let uu___3448_28590 = p  in
-              let uu____28591 =
-                let uu____28592 =
-                  let uu____28606 =
+              let uu___3446_28466 = p  in
+              let uu____28467 =
+                let uu____28468 =
+                  let uu____28482 =
                     FStar_List.map
-                      (fun uu____28632  ->
-                         match uu____28632 with
+                      (fun uu____28508  ->
+                         match uu____28508 with
                          | (x,b) ->
-                             let uu____28649 = elim_pat x  in
-                             (uu____28649, b)) pats
+                             let uu____28525 = elim_pat x  in
+                             (uu____28525, b)) pats
                      in
-                  (fv, uu____28606)  in
-                FStar_Syntax_Syntax.Pat_cons uu____28592  in
+                  (fv, uu____28482)  in
+                FStar_Syntax_Syntax.Pat_cons uu____28468  in
               {
-                FStar_Syntax_Syntax.v = uu____28591;
+                FStar_Syntax_Syntax.v = uu____28467;
                 FStar_Syntax_Syntax.p =
-                  (uu___3448_28590.FStar_Syntax_Syntax.p)
+                  (uu___3446_28466.FStar_Syntax_Syntax.p)
               }
-          | uu____28664 -> p  in
-        let elim_branch uu____28688 =
-          match uu____28688 with
+          | uu____28540 -> p  in
+        let elim_branch uu____28564 =
+          match uu____28564 with
           | (pat,wopt,t3) ->
-              let uu____28714 = elim_pat pat  in
-              let uu____28717 =
+              let uu____28590 = elim_pat pat  in
+              let uu____28593 =
                 FStar_Util.map_opt wopt elim_delayed_subst_term  in
-              let uu____28720 = elim_delayed_subst_term t3  in
-              (uu____28714, uu____28717, uu____28720)
+              let uu____28596 = elim_delayed_subst_term t3  in
+              (uu____28590, uu____28593, uu____28596)
            in
-        let uu____28725 =
-          let uu____28726 =
-            let uu____28749 = elim_delayed_subst_term t2  in
-            let uu____28752 = FStar_List.map elim_branch branches1  in
-            (uu____28749, uu____28752)  in
-          FStar_Syntax_Syntax.Tm_match uu____28726  in
-        mk1 uu____28725
+        let uu____28601 =
+          let uu____28602 =
+            let uu____28625 = elim_delayed_subst_term t2  in
+            let uu____28628 = FStar_List.map elim_branch branches1  in
+            (uu____28625, uu____28628)  in
+          FStar_Syntax_Syntax.Tm_match uu____28602  in
+        mk uu____28601
     | FStar_Syntax_Syntax.Tm_ascribed (t2,a,lopt) ->
-        let elim_ascription uu____28883 =
-          match uu____28883 with
+        let elim_ascription uu____28759 =
+          match uu____28759 with
           | (tc,topt) ->
-              let uu____28918 =
+              let uu____28794 =
                 match tc with
                 | FStar_Util.Inl t3 ->
-                    let uu____28928 = elim_delayed_subst_term t3  in
-                    FStar_Util.Inl uu____28928
+                    let uu____28804 = elim_delayed_subst_term t3  in
+                    FStar_Util.Inl uu____28804
                 | FStar_Util.Inr c ->
-                    let uu____28930 = elim_delayed_subst_comp c  in
-                    FStar_Util.Inr uu____28930
+                    let uu____28806 = elim_delayed_subst_comp c  in
+                    FStar_Util.Inr uu____28806
                  in
-              let uu____28931 =
+              let uu____28807 =
                 FStar_Util.map_opt topt elim_delayed_subst_term  in
-              (uu____28918, uu____28931)
+              (uu____28794, uu____28807)
            in
-        let uu____28940 =
-          let uu____28941 =
-            let uu____28968 = elim_delayed_subst_term t2  in
-            let uu____28971 = elim_ascription a  in
-            (uu____28968, uu____28971, lopt)  in
-          FStar_Syntax_Syntax.Tm_ascribed uu____28941  in
-        mk1 uu____28940
+        let uu____28816 =
+          let uu____28817 =
+            let uu____28844 = elim_delayed_subst_term t2  in
+            let uu____28847 = elim_ascription a  in
+            (uu____28844, uu____28847, lopt)  in
+          FStar_Syntax_Syntax.Tm_ascribed uu____28817  in
+        mk uu____28816
     | FStar_Syntax_Syntax.Tm_let (lbs,t2) ->
         let elim_lb lb =
-          let uu___3478_29034 = lb  in
-          let uu____29035 =
+          let uu___3476_28910 = lb  in
+          let uu____28911 =
             elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbtyp  in
-          let uu____29038 =
+          let uu____28914 =
             elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbdef  in
           {
             FStar_Syntax_Syntax.lbname =
-              (uu___3478_29034.FStar_Syntax_Syntax.lbname);
+              (uu___3476_28910.FStar_Syntax_Syntax.lbname);
             FStar_Syntax_Syntax.lbunivs =
-              (uu___3478_29034.FStar_Syntax_Syntax.lbunivs);
-            FStar_Syntax_Syntax.lbtyp = uu____29035;
+              (uu___3476_28910.FStar_Syntax_Syntax.lbunivs);
+            FStar_Syntax_Syntax.lbtyp = uu____28911;
             FStar_Syntax_Syntax.lbeff =
-              (uu___3478_29034.FStar_Syntax_Syntax.lbeff);
-            FStar_Syntax_Syntax.lbdef = uu____29038;
+              (uu___3476_28910.FStar_Syntax_Syntax.lbeff);
+            FStar_Syntax_Syntax.lbdef = uu____28914;
             FStar_Syntax_Syntax.lbattrs =
-              (uu___3478_29034.FStar_Syntax_Syntax.lbattrs);
+              (uu___3476_28910.FStar_Syntax_Syntax.lbattrs);
             FStar_Syntax_Syntax.lbpos =
-              (uu___3478_29034.FStar_Syntax_Syntax.lbpos)
+              (uu___3476_28910.FStar_Syntax_Syntax.lbpos)
           }  in
-        let uu____29041 =
-          let uu____29042 =
-            let uu____29056 =
-              let uu____29064 =
+        let uu____28917 =
+          let uu____28918 =
+            let uu____28932 =
+              let uu____28940 =
                 FStar_List.map elim_lb (FStar_Pervasives_Native.snd lbs)  in
-              ((FStar_Pervasives_Native.fst lbs), uu____29064)  in
-            let uu____29076 = elim_delayed_subst_term t2  in
-            (uu____29056, uu____29076)  in
-          FStar_Syntax_Syntax.Tm_let uu____29042  in
-        mk1 uu____29041
+              ((FStar_Pervasives_Native.fst lbs), uu____28940)  in
+            let uu____28952 = elim_delayed_subst_term t2  in
+            (uu____28932, uu____28952)  in
+          FStar_Syntax_Syntax.Tm_let uu____28918  in
+        mk uu____28917
     | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-        mk1 (FStar_Syntax_Syntax.Tm_uvar (u, s))
+        mk (FStar_Syntax_Syntax.Tm_uvar (u, s))
     | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
         let qi1 =
           FStar_Syntax_Syntax.on_antiquoted elim_delayed_subst_term qi  in
-        let uu____29121 =
-          let uu____29122 =
-            let uu____29129 = elim_delayed_subst_term tm  in
-            (uu____29129, qi1)  in
-          FStar_Syntax_Syntax.Tm_quoted uu____29122  in
-        mk1 uu____29121
+        let uu____28997 =
+          let uu____28998 =
+            let uu____29005 = elim_delayed_subst_term tm  in
+            (uu____29005, qi1)  in
+          FStar_Syntax_Syntax.Tm_quoted uu____28998  in
+        mk uu____28997
     | FStar_Syntax_Syntax.Tm_meta (t2,md) ->
-        let uu____29140 =
-          let uu____29141 =
-            let uu____29148 = elim_delayed_subst_term t2  in
-            let uu____29151 = elim_delayed_subst_meta md  in
-            (uu____29148, uu____29151)  in
-          FStar_Syntax_Syntax.Tm_meta uu____29141  in
-        mk1 uu____29140
+        let uu____29016 =
+          let uu____29017 =
+            let uu____29024 = elim_delayed_subst_term t2  in
+            let uu____29027 = elim_delayed_subst_meta md  in
+            (uu____29024, uu____29027)  in
+          FStar_Syntax_Syntax.Tm_meta uu____29017  in
+        mk uu____29016
 
 and (elim_delayed_subst_cflags :
   FStar_Syntax_Syntax.cflag Prims.list ->
@@ -9084,75 +9036,72 @@ and (elim_delayed_subst_cflags :
   =
   fun flags  ->
     FStar_List.map
-      (fun uu___17_29160  ->
-         match uu___17_29160 with
+      (fun uu___17_29036  ->
+         match uu___17_29036 with
          | FStar_Syntax_Syntax.DECREASES t ->
-             let uu____29164 = elim_delayed_subst_term t  in
-             FStar_Syntax_Syntax.DECREASES uu____29164
+             let uu____29040 = elim_delayed_subst_term t  in
+             FStar_Syntax_Syntax.DECREASES uu____29040
          | f -> f) flags
 
 and (elim_delayed_subst_comp :
   FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp) =
   fun c  ->
-    let mk1 x =
-      FStar_Syntax_Syntax.mk x FStar_Pervasives_Native.None
-        c.FStar_Syntax_Syntax.pos
-       in
+    let mk x = FStar_Syntax_Syntax.mk x c.FStar_Syntax_Syntax.pos  in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t,uopt) ->
-        let uu____29187 =
-          let uu____29188 =
-            let uu____29197 = elim_delayed_subst_term t  in
-            (uu____29197, uopt)  in
-          FStar_Syntax_Syntax.Total uu____29188  in
-        mk1 uu____29187
+        let uu____29063 =
+          let uu____29064 =
+            let uu____29073 = elim_delayed_subst_term t  in
+            (uu____29073, uopt)  in
+          FStar_Syntax_Syntax.Total uu____29064  in
+        mk uu____29063
     | FStar_Syntax_Syntax.GTotal (t,uopt) ->
-        let uu____29214 =
-          let uu____29215 =
-            let uu____29224 = elim_delayed_subst_term t  in
-            (uu____29224, uopt)  in
-          FStar_Syntax_Syntax.GTotal uu____29215  in
-        mk1 uu____29214
+        let uu____29090 =
+          let uu____29091 =
+            let uu____29100 = elim_delayed_subst_term t  in
+            (uu____29100, uopt)  in
+          FStar_Syntax_Syntax.GTotal uu____29091  in
+        mk uu____29090
     | FStar_Syntax_Syntax.Comp ct ->
         let ct1 =
-          let uu___3511_29233 = ct  in
-          let uu____29234 =
+          let uu___3509_29109 = ct  in
+          let uu____29110 =
             elim_delayed_subst_term ct.FStar_Syntax_Syntax.result_typ  in
-          let uu____29237 =
+          let uu____29113 =
             elim_delayed_subst_args ct.FStar_Syntax_Syntax.effect_args  in
-          let uu____29248 =
+          let uu____29124 =
             elim_delayed_subst_cflags ct.FStar_Syntax_Syntax.flags  in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___3511_29233.FStar_Syntax_Syntax.comp_univs);
+              (uu___3509_29109.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___3511_29233.FStar_Syntax_Syntax.effect_name);
-            FStar_Syntax_Syntax.result_typ = uu____29234;
-            FStar_Syntax_Syntax.effect_args = uu____29237;
-            FStar_Syntax_Syntax.flags = uu____29248
+              (uu___3509_29109.FStar_Syntax_Syntax.effect_name);
+            FStar_Syntax_Syntax.result_typ = uu____29110;
+            FStar_Syntax_Syntax.effect_args = uu____29113;
+            FStar_Syntax_Syntax.flags = uu____29124
           }  in
-        mk1 (FStar_Syntax_Syntax.Comp ct1)
+        mk (FStar_Syntax_Syntax.Comp ct1)
 
 and (elim_delayed_subst_meta :
   FStar_Syntax_Syntax.metadata -> FStar_Syntax_Syntax.metadata) =
-  fun uu___18_29251  ->
-    match uu___18_29251 with
+  fun uu___18_29127  ->
+    match uu___18_29127 with
     | FStar_Syntax_Syntax.Meta_pattern (names,args) ->
-        let uu____29286 =
-          let uu____29307 = FStar_List.map elim_delayed_subst_term names  in
-          let uu____29316 = FStar_List.map elim_delayed_subst_args args  in
-          (uu____29307, uu____29316)  in
-        FStar_Syntax_Syntax.Meta_pattern uu____29286
+        let uu____29162 =
+          let uu____29183 = FStar_List.map elim_delayed_subst_term names  in
+          let uu____29192 = FStar_List.map elim_delayed_subst_args args  in
+          (uu____29183, uu____29192)  in
+        FStar_Syntax_Syntax.Meta_pattern uu____29162
     | FStar_Syntax_Syntax.Meta_monadic (m,t) ->
-        let uu____29371 =
-          let uu____29378 = elim_delayed_subst_term t  in (m, uu____29378)
+        let uu____29247 =
+          let uu____29254 = elim_delayed_subst_term t  in (m, uu____29254)
            in
-        FStar_Syntax_Syntax.Meta_monadic uu____29371
+        FStar_Syntax_Syntax.Meta_monadic uu____29247
     | FStar_Syntax_Syntax.Meta_monadic_lift (m1,m2,t) ->
-        let uu____29390 =
-          let uu____29399 = elim_delayed_subst_term t  in
-          (m1, m2, uu____29399)  in
-        FStar_Syntax_Syntax.Meta_monadic_lift uu____29390
+        let uu____29266 =
+          let uu____29275 = elim_delayed_subst_term t  in
+          (m1, m2, uu____29275)  in
+        FStar_Syntax_Syntax.Meta_monadic_lift uu____29266
     | m -> m
 
 and (elim_delayed_subst_args :
@@ -9165,10 +9114,10 @@ and (elim_delayed_subst_args :
   =
   fun args  ->
     FStar_List.map
-      (fun uu____29432  ->
-         match uu____29432 with
+      (fun uu____29308  ->
+         match uu____29308 with
          | (t,q) ->
-             let uu____29451 = elim_delayed_subst_term t  in (uu____29451, q))
+             let uu____29327 = elim_delayed_subst_term t  in (uu____29327, q))
       args
 
 and (elim_delayed_subst_binders :
@@ -9179,21 +9128,21 @@ and (elim_delayed_subst_binders :
   =
   fun bs  ->
     FStar_List.map
-      (fun uu____29479  ->
-         match uu____29479 with
+      (fun uu____29355  ->
+         match uu____29355 with
          | (x,q) ->
-             let uu____29498 =
-               let uu___3537_29499 = x  in
-               let uu____29500 =
+             let uu____29374 =
+               let uu___3535_29375 = x  in
+               let uu____29376 =
                  elim_delayed_subst_term x.FStar_Syntax_Syntax.sort  in
                {
                  FStar_Syntax_Syntax.ppname =
-                   (uu___3537_29499.FStar_Syntax_Syntax.ppname);
+                   (uu___3535_29375.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
-                   (uu___3537_29499.FStar_Syntax_Syntax.index);
-                 FStar_Syntax_Syntax.sort = uu____29500
+                   (uu___3535_29375.FStar_Syntax_Syntax.index);
+                 FStar_Syntax_Syntax.sort = uu____29376
                }  in
-             (uu____29498, q)) bs
+             (uu____29374, q)) bs
 
 let (elim_uvars_aux_tc :
   FStar_TypeChecker_Env.env ->
@@ -9217,50 +9166,47 @@ let (elim_uvars_aux_tc :
             | ([],FStar_Util.Inl t) -> t
             | ([],FStar_Util.Inr c) ->
                 failwith "Impossible: empty bindes with a comp"
-            | (uu____29608,FStar_Util.Inr c) ->
+            | (uu____29484,FStar_Util.Inr c) ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (binders, c))
-                  FStar_Pervasives_Native.None c.FStar_Syntax_Syntax.pos
-            | (uu____29640,FStar_Util.Inl t) ->
-                let uu____29662 =
-                  let uu____29669 =
-                    let uu____29670 =
-                      let uu____29685 = FStar_Syntax_Syntax.mk_Total t  in
-                      (binders, uu____29685)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____29670  in
-                  FStar_Syntax_Syntax.mk uu____29669  in
-                uu____29662 FStar_Pervasives_Native.None
-                  t.FStar_Syntax_Syntax.pos
+                  c.FStar_Syntax_Syntax.pos
+            | (uu____29516,FStar_Util.Inl t) ->
+                let uu____29538 =
+                  let uu____29539 =
+                    let uu____29554 = FStar_Syntax_Syntax.mk_Total t  in
+                    (binders, uu____29554)  in
+                  FStar_Syntax_Syntax.Tm_arrow uu____29539  in
+                FStar_Syntax_Syntax.mk uu____29538 t.FStar_Syntax_Syntax.pos
              in
-          let uu____29698 = FStar_Syntax_Subst.open_univ_vars univ_names t
+          let uu____29567 = FStar_Syntax_Subst.open_univ_vars univ_names t
              in
-          match uu____29698 with
+          match uu____29567 with
           | (univ_names1,t1) ->
               let t2 = remove_uvar_solutions env1 t1  in
               let t3 = FStar_Syntax_Subst.close_univ_vars univ_names1 t2  in
               let t4 = elim_delayed_subst_term t3  in
-              let uu____29730 =
+              let uu____29599 =
                 match binders with
                 | [] -> ([], (FStar_Util.Inl t4))
-                | uu____29803 ->
-                    let uu____29804 =
-                      let uu____29813 =
-                        let uu____29814 = FStar_Syntax_Subst.compress t4  in
-                        uu____29814.FStar_Syntax_Syntax.n  in
-                      (uu____29813, tc)  in
-                    (match uu____29804 with
+                | uu____29672 ->
+                    let uu____29673 =
+                      let uu____29682 =
+                        let uu____29683 = FStar_Syntax_Subst.compress t4  in
+                        uu____29683.FStar_Syntax_Syntax.n  in
+                      (uu____29682, tc)  in
+                    (match uu____29673 with
                      | (FStar_Syntax_Syntax.Tm_arrow
-                        (binders1,c),FStar_Util.Inr uu____29843) ->
+                        (binders1,c),FStar_Util.Inr uu____29712) ->
                          (binders1, (FStar_Util.Inr c))
                      | (FStar_Syntax_Syntax.Tm_arrow
-                        (binders1,c),FStar_Util.Inl uu____29890) ->
+                        (binders1,c),FStar_Util.Inl uu____29759) ->
                          (binders1,
                            (FStar_Util.Inl (FStar_Syntax_Util.comp_result c)))
-                     | (uu____29935,FStar_Util.Inl uu____29936) ->
+                     | (uu____29804,FStar_Util.Inl uu____29805) ->
                          ([], (FStar_Util.Inl t4))
-                     | uu____29967 -> failwith "Impossible")
+                     | uu____29836 -> failwith "Impossible")
                  in
-              (match uu____29730 with
+              (match uu____29599 with
                | (binders1,tc1) -> (univ_names1, binders1, tc1))
   
 let (elim_uvars_aux_t :
@@ -9277,12 +9223,12 @@ let (elim_uvars_aux_t :
     fun univ_names  ->
       fun binders  ->
         fun t  ->
-          let uu____30106 =
+          let uu____29975 =
             elim_uvars_aux_tc env1 univ_names binders (FStar_Util.Inl t)  in
-          match uu____30106 with
+          match uu____29975 with
           | (univ_names1,binders1,tc) ->
-              let uu____30180 = FStar_Util.left tc  in
-              (univ_names1, binders1, uu____30180)
+              let uu____30049 = FStar_Util.left tc  in
+              (univ_names1, binders1, uu____30049)
   
 let (elim_uvars_aux_c :
   FStar_TypeChecker_Env.env ->
@@ -9298,12 +9244,12 @@ let (elim_uvars_aux_c :
     fun univ_names  ->
       fun binders  ->
         fun c  ->
-          let uu____30234 =
+          let uu____30103 =
             elim_uvars_aux_tc env1 univ_names binders (FStar_Util.Inr c)  in
-          match uu____30234 with
+          match uu____30103 with
           | (univ_names1,binders1,tc) ->
-              let uu____30308 = FStar_Util.right tc  in
-              (univ_names1, binders1, uu____30308)
+              let uu____30177 = FStar_Util.right tc  in
+              (univ_names1, binders1, uu____30177)
   
 let rec (elim_uvars :
   FStar_TypeChecker_Env.env ->
@@ -9314,262 +9260,262 @@ let rec (elim_uvars :
       match s.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_inductive_typ
           (lid,univ_names,binders,typ,lids,lids') ->
-          let uu____30350 = elim_uvars_aux_t env1 univ_names binders typ  in
-          (match uu____30350 with
+          let uu____30219 = elim_uvars_aux_t env1 univ_names binders typ  in
+          (match uu____30219 with
            | (univ_names1,binders1,typ1) ->
-               let uu___3620_30390 = s  in
+               let uu___3618_30259 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_inductive_typ
                       (lid, univ_names1, binders1, typ1, lids, lids'));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3620_30390.FStar_Syntax_Syntax.sigrng);
+                   (uu___3618_30259.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3620_30390.FStar_Syntax_Syntax.sigquals);
+                   (uu___3618_30259.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3620_30390.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3618_30259.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3620_30390.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3618_30259.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3620_30390.FStar_Syntax_Syntax.sigopts)
+                   (uu___3618_30259.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_bundle (sigs,lids) ->
-          let uu___3626_30405 = s  in
-          let uu____30406 =
-            let uu____30407 =
-              let uu____30416 = FStar_List.map (elim_uvars env1) sigs  in
-              (uu____30416, lids)  in
-            FStar_Syntax_Syntax.Sig_bundle uu____30407  in
+          let uu___3624_30274 = s  in
+          let uu____30275 =
+            let uu____30276 =
+              let uu____30285 = FStar_List.map (elim_uvars env1) sigs  in
+              (uu____30285, lids)  in
+            FStar_Syntax_Syntax.Sig_bundle uu____30276  in
           {
-            FStar_Syntax_Syntax.sigel = uu____30406;
+            FStar_Syntax_Syntax.sigel = uu____30275;
             FStar_Syntax_Syntax.sigrng =
-              (uu___3626_30405.FStar_Syntax_Syntax.sigrng);
+              (uu___3624_30274.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3626_30405.FStar_Syntax_Syntax.sigquals);
+              (uu___3624_30274.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3626_30405.FStar_Syntax_Syntax.sigmeta);
+              (uu___3624_30274.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3626_30405.FStar_Syntax_Syntax.sigattrs);
+              (uu___3624_30274.FStar_Syntax_Syntax.sigattrs);
             FStar_Syntax_Syntax.sigopts =
-              (uu___3626_30405.FStar_Syntax_Syntax.sigopts)
+              (uu___3624_30274.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_datacon (lid,univ_names,typ,lident,i,lids) ->
-          let uu____30435 = elim_uvars_aux_t env1 univ_names [] typ  in
-          (match uu____30435 with
-           | (univ_names1,uu____30459,typ1) ->
-               let uu___3640_30481 = s  in
+          let uu____30304 = elim_uvars_aux_t env1 univ_names [] typ  in
+          (match uu____30304 with
+           | (univ_names1,uu____30328,typ1) ->
+               let uu___3638_30350 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_datacon
                       (lid, univ_names1, typ1, lident, i, lids));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3640_30481.FStar_Syntax_Syntax.sigrng);
+                   (uu___3638_30350.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3640_30481.FStar_Syntax_Syntax.sigquals);
+                   (uu___3638_30350.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3640_30481.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3638_30350.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3640_30481.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3638_30350.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3640_30481.FStar_Syntax_Syntax.sigopts)
+                   (uu___3638_30350.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_declare_typ (lid,univ_names,typ) ->
-          let uu____30488 = elim_uvars_aux_t env1 univ_names [] typ  in
-          (match uu____30488 with
-           | (univ_names1,uu____30512,typ1) ->
-               let uu___3651_30534 = s  in
+          let uu____30357 = elim_uvars_aux_t env1 univ_names [] typ  in
+          (match uu____30357 with
+           | (univ_names1,uu____30381,typ1) ->
+               let uu___3649_30403 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_declare_typ
                       (lid, univ_names1, typ1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3651_30534.FStar_Syntax_Syntax.sigrng);
+                   (uu___3649_30403.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3651_30534.FStar_Syntax_Syntax.sigquals);
+                   (uu___3649_30403.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3651_30534.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3649_30403.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3651_30534.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3649_30403.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3651_30534.FStar_Syntax_Syntax.sigopts)
+                   (uu___3649_30403.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_let ((b,lbs),lids) ->
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb  ->
-                    let uu____30564 =
+                    let uu____30433 =
                       FStar_Syntax_Subst.univ_var_opening
                         lb.FStar_Syntax_Syntax.lbunivs
                        in
-                    match uu____30564 with
+                    match uu____30433 with
                     | (opening,lbunivs) ->
                         let elim t =
-                          let uu____30589 =
-                            let uu____30590 =
-                              let uu____30591 =
+                          let uu____30458 =
+                            let uu____30459 =
+                              let uu____30460 =
                                 FStar_Syntax_Subst.subst opening t  in
-                              remove_uvar_solutions env1 uu____30591  in
+                              remove_uvar_solutions env1 uu____30460  in
                             FStar_Syntax_Subst.close_univ_vars lbunivs
-                              uu____30590
+                              uu____30459
                              in
-                          elim_delayed_subst_term uu____30589  in
+                          elim_delayed_subst_term uu____30458  in
                         let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp  in
                         let lbdef = elim lb.FStar_Syntax_Syntax.lbdef  in
-                        let uu___3667_30594 = lb  in
+                        let uu___3665_30463 = lb  in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___3667_30594.FStar_Syntax_Syntax.lbname);
+                            (uu___3665_30463.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = lbunivs;
                           FStar_Syntax_Syntax.lbtyp = lbtyp;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___3667_30594.FStar_Syntax_Syntax.lbeff);
+                            (uu___3665_30463.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef = lbdef;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___3667_30594.FStar_Syntax_Syntax.lbattrs);
+                            (uu___3665_30463.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___3667_30594.FStar_Syntax_Syntax.lbpos)
+                            (uu___3665_30463.FStar_Syntax_Syntax.lbpos)
                         }))
              in
-          let uu___3670_30595 = s  in
+          let uu___3668_30464 = s  in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_let ((b, lbs1), lids));
             FStar_Syntax_Syntax.sigrng =
-              (uu___3670_30595.FStar_Syntax_Syntax.sigrng);
+              (uu___3668_30464.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3670_30595.FStar_Syntax_Syntax.sigquals);
+              (uu___3668_30464.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3670_30595.FStar_Syntax_Syntax.sigmeta);
+              (uu___3668_30464.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3670_30595.FStar_Syntax_Syntax.sigattrs);
+              (uu___3668_30464.FStar_Syntax_Syntax.sigattrs);
             FStar_Syntax_Syntax.sigopts =
-              (uu___3670_30595.FStar_Syntax_Syntax.sigopts)
+              (uu___3668_30464.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_assume (l,us,t) ->
-          let uu____30604 = elim_uvars_aux_t env1 us [] t  in
-          (match uu____30604 with
-           | (us1,uu____30628,t1) ->
-               let uu___3681_30650 = s  in
+          let uu____30473 = elim_uvars_aux_t env1 us [] t  in
+          (match uu____30473 with
+           | (us1,uu____30497,t1) ->
+               let uu___3679_30519 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_assume (l, us1, t1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3681_30650.FStar_Syntax_Syntax.sigrng);
+                   (uu___3679_30519.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3681_30650.FStar_Syntax_Syntax.sigquals);
+                   (uu___3679_30519.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3681_30650.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3679_30519.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3681_30650.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3679_30519.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3681_30650.FStar_Syntax_Syntax.sigopts)
+                   (uu___3679_30519.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____30652 =
+          let uu____30521 =
             elim_uvars_aux_t env1 ed.FStar_Syntax_Syntax.univs
               ed.FStar_Syntax_Syntax.binders FStar_Syntax_Syntax.t_unit
              in
-          (match uu____30652 with
-           | (univs,binders,uu____30671) ->
-               let uu____30692 =
-                 let uu____30697 = FStar_Syntax_Subst.univ_var_opening univs
+          (match uu____30521 with
+           | (univs,binders,uu____30540) ->
+               let uu____30561 =
+                 let uu____30566 = FStar_Syntax_Subst.univ_var_opening univs
                     in
-                 match uu____30697 with
+                 match uu____30566 with
                  | (univs_opening,univs1) ->
-                     let uu____30720 =
+                     let uu____30589 =
                        FStar_Syntax_Subst.univ_var_closing univs1  in
-                     (univs_opening, uu____30720)
+                     (univs_opening, uu____30589)
                   in
-               (match uu____30692 with
+               (match uu____30561 with
                 | (univs_opening,univs_closing) ->
-                    let uu____30723 =
+                    let uu____30592 =
                       let binders1 = FStar_Syntax_Subst.open_binders binders
                          in
-                      let uu____30729 =
+                      let uu____30598 =
                         FStar_Syntax_Subst.opening_of_binders binders1  in
-                      let uu____30730 =
+                      let uu____30599 =
                         FStar_Syntax_Subst.closing_of_binders binders1  in
-                      (uu____30729, uu____30730)  in
-                    (match uu____30723 with
+                      (uu____30598, uu____30599)  in
+                    (match uu____30592 with
                      | (b_opening,b_closing) ->
                          let n = FStar_List.length univs  in
                          let n_binders = FStar_List.length binders  in
-                         let elim_tscheme uu____30756 =
-                           match uu____30756 with
+                         let elim_tscheme uu____30625 =
+                           match uu____30625 with
                            | (us,t) ->
                                let n_us = FStar_List.length us  in
-                               let uu____30774 =
+                               let uu____30643 =
                                  FStar_Syntax_Subst.open_univ_vars us t  in
-                               (match uu____30774 with
+                               (match uu____30643 with
                                 | (us1,t1) ->
-                                    let uu____30785 =
-                                      let uu____30794 =
+                                    let uu____30654 =
+                                      let uu____30663 =
                                         FStar_All.pipe_right b_opening
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us)
                                          in
-                                      let uu____30799 =
+                                      let uu____30668 =
                                         FStar_All.pipe_right b_closing
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us)
                                          in
-                                      (uu____30794, uu____30799)  in
-                                    (match uu____30785 with
+                                      (uu____30663, uu____30668)  in
+                                    (match uu____30654 with
                                      | (b_opening1,b_closing1) ->
-                                         let uu____30822 =
-                                           let uu____30831 =
+                                         let uu____30691 =
+                                           let uu____30700 =
                                              FStar_All.pipe_right
                                                univs_opening
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders))
                                               in
-                                           let uu____30836 =
+                                           let uu____30705 =
                                              FStar_All.pipe_right
                                                univs_closing
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders))
                                               in
-                                           (uu____30831, uu____30836)  in
-                                         (match uu____30822 with
+                                           (uu____30700, uu____30705)  in
+                                         (match uu____30691 with
                                           | (univs_opening1,univs_closing1)
                                               ->
                                               let t2 =
-                                                let uu____30860 =
+                                                let uu____30729 =
                                                   FStar_Syntax_Subst.subst
                                                     b_opening1 t1
                                                    in
                                                 FStar_Syntax_Subst.subst
-                                                  univs_opening1 uu____30860
+                                                  univs_opening1 uu____30729
                                                  in
-                                              let uu____30861 =
+                                              let uu____30730 =
                                                 elim_uvars_aux_t env1 [] []
                                                   t2
                                                  in
-                                              (match uu____30861 with
-                                               | (uu____30888,uu____30889,t3)
+                                              (match uu____30730 with
+                                               | (uu____30757,uu____30758,t3)
                                                    ->
                                                    let t4 =
-                                                     let uu____30912 =
-                                                       let uu____30913 =
+                                                     let uu____30781 =
+                                                       let uu____30782 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            us1 t3
                                                           in
                                                        FStar_Syntax_Subst.subst
                                                          b_closing1
-                                                         uu____30913
+                                                         uu____30782
                                                         in
                                                      FStar_Syntax_Subst.subst
                                                        univs_closing1
-                                                       uu____30912
+                                                       uu____30781
                                                       in
                                                    (us1, t4)))))
                             in
                          let elim_term t =
-                           let uu____30922 =
+                           let uu____30791 =
                              elim_uvars_aux_t env1 univs binders t  in
-                           match uu____30922 with
-                           | (uu____30941,uu____30942,t1) -> t1  in
+                           match uu____30791 with
+                           | (uu____30810,uu____30811,t1) -> t1  in
                          let elim_action a =
                            let action_typ_templ =
                              let body =
@@ -9580,67 +9526,65 @@ let rec (elim_uvars :
                                           (a.FStar_Syntax_Syntax.action_typ)),
                                         FStar_Pervasives_Native.None),
                                       FStar_Pervasives_Native.None))
-                                 FStar_Pervasives_Native.None
                                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                 in
                              match a.FStar_Syntax_Syntax.action_params with
                              | [] -> body
-                             | uu____31018 ->
+                             | uu____30887 ->
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_abs
                                       ((a.FStar_Syntax_Syntax.action_params),
                                         body, FStar_Pervasives_Native.None))
-                                   FStar_Pervasives_Native.None
                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                               in
                            let destruct_action_body body =
-                             let uu____31045 =
-                               let uu____31046 =
+                             let uu____30914 =
+                               let uu____30915 =
                                  FStar_Syntax_Subst.compress body  in
-                               uu____31046.FStar_Syntax_Syntax.n  in
-                             match uu____31045 with
+                               uu____30915.FStar_Syntax_Syntax.n  in
+                             match uu____30914 with
                              | FStar_Syntax_Syntax.Tm_ascribed
                                  (defn,(FStar_Util.Inl
                                         typ,FStar_Pervasives_Native.None ),FStar_Pervasives_Native.None
                                   )
                                  -> (defn, typ)
-                             | uu____31105 -> failwith "Impossible"  in
+                             | uu____30974 -> failwith "Impossible"  in
                            let destruct_action_typ_templ t =
-                             let uu____31139 =
-                               let uu____31140 =
+                             let uu____31008 =
+                               let uu____31009 =
                                  FStar_Syntax_Subst.compress t  in
-                               uu____31140.FStar_Syntax_Syntax.n  in
-                             match uu____31139 with
+                               uu____31009.FStar_Syntax_Syntax.n  in
+                             match uu____31008 with
                              | FStar_Syntax_Syntax.Tm_abs
-                                 (pars,body,uu____31163) ->
-                                 let uu____31188 = destruct_action_body body
+                                 (pars,body,uu____31032) ->
+                                 let uu____31057 = destruct_action_body body
                                     in
-                                 (match uu____31188 with
+                                 (match uu____31057 with
                                   | (defn,typ) -> (pars, defn, typ))
-                             | uu____31237 ->
-                                 let uu____31238 = destruct_action_body t  in
-                                 (match uu____31238 with
+                             | uu____31106 ->
+                                 let uu____31107 = destruct_action_body t  in
+                                 (match uu____31107 with
                                   | (defn,typ) -> ([], defn, typ))
                               in
-                           let uu____31293 =
+                           let uu____31162 =
                              elim_tscheme
                                ((a.FStar_Syntax_Syntax.action_univs),
                                  action_typ_templ)
                               in
-                           match uu____31293 with
+                           match uu____31162 with
                            | (action_univs,t) ->
-                               let uu____31302 = destruct_action_typ_templ t
+                               let uu____31171 = destruct_action_typ_templ t
                                   in
-                               (match uu____31302 with
+                               (match uu____31171 with
                                 | (action_params,action_defn,action_typ) ->
                                     let a' =
-                                      let uu___3765_31349 = a  in
+                                      let uu___3763_31218 = a  in
                                       {
                                         FStar_Syntax_Syntax.action_name =
-                                          (uu___3765_31349.FStar_Syntax_Syntax.action_name);
+                                          (uu___3763_31218.FStar_Syntax_Syntax.action_name);
                                         FStar_Syntax_Syntax.action_unqualified_name
                                           =
-                                          (uu___3765_31349.FStar_Syntax_Syntax.action_unqualified_name);
+                                          (uu___3763_31218.FStar_Syntax_Syntax.action_unqualified_name);
                                         FStar_Syntax_Syntax.action_univs =
                                           action_univs;
                                         FStar_Syntax_Syntax.action_params =
@@ -9653,133 +9597,133 @@ let rec (elim_uvars :
                                     a')
                             in
                          let ed1 =
-                           let uu___3768_31351 = ed  in
-                           let uu____31352 =
+                           let uu___3766_31220 = ed  in
+                           let uu____31221 =
                              elim_tscheme ed.FStar_Syntax_Syntax.signature
                               in
-                           let uu____31353 =
+                           let uu____31222 =
                              FStar_Syntax_Util.apply_eff_combinators
                                elim_tscheme
                                ed.FStar_Syntax_Syntax.combinators
                               in
-                           let uu____31354 =
+                           let uu____31223 =
                              FStar_List.map elim_action
                                ed.FStar_Syntax_Syntax.actions
                               in
                            {
                              FStar_Syntax_Syntax.mname =
-                               (uu___3768_31351.FStar_Syntax_Syntax.mname);
+                               (uu___3766_31220.FStar_Syntax_Syntax.mname);
                              FStar_Syntax_Syntax.cattributes =
-                               (uu___3768_31351.FStar_Syntax_Syntax.cattributes);
+                               (uu___3766_31220.FStar_Syntax_Syntax.cattributes);
                              FStar_Syntax_Syntax.univs = univs;
                              FStar_Syntax_Syntax.binders = binders;
-                             FStar_Syntax_Syntax.signature = uu____31352;
-                             FStar_Syntax_Syntax.combinators = uu____31353;
-                             FStar_Syntax_Syntax.actions = uu____31354;
+                             FStar_Syntax_Syntax.signature = uu____31221;
+                             FStar_Syntax_Syntax.combinators = uu____31222;
+                             FStar_Syntax_Syntax.actions = uu____31223;
                              FStar_Syntax_Syntax.eff_attrs =
-                               (uu___3768_31351.FStar_Syntax_Syntax.eff_attrs)
+                               (uu___3766_31220.FStar_Syntax_Syntax.eff_attrs)
                            }  in
-                         let uu___3771_31357 = s  in
+                         let uu___3769_31226 = s  in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_new_effect ed1);
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___3771_31357.FStar_Syntax_Syntax.sigrng);
+                             (uu___3769_31226.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___3771_31357.FStar_Syntax_Syntax.sigquals);
+                             (uu___3769_31226.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___3771_31357.FStar_Syntax_Syntax.sigmeta);
+                             (uu___3769_31226.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___3771_31357.FStar_Syntax_Syntax.sigattrs);
+                             (uu___3769_31226.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___3771_31357.FStar_Syntax_Syntax.sigopts)
+                             (uu___3769_31226.FStar_Syntax_Syntax.sigopts)
                          })))
       | FStar_Syntax_Syntax.Sig_sub_effect sub_eff ->
-          let elim_tscheme_opt uu___19_31378 =
-            match uu___19_31378 with
+          let elim_tscheme_opt uu___19_31247 =
+            match uu___19_31247 with
             | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
             | FStar_Pervasives_Native.Some (us,t) ->
-                let uu____31409 = elim_uvars_aux_t env1 us [] t  in
-                (match uu____31409 with
-                 | (us1,uu____31441,t1) ->
+                let uu____31278 = elim_uvars_aux_t env1 us [] t  in
+                (match uu____31278 with
+                 | (us1,uu____31310,t1) ->
                      FStar_Pervasives_Native.Some (us1, t1))
              in
           let sub_eff1 =
-            let uu___3786_31472 = sub_eff  in
-            let uu____31473 =
+            let uu___3784_31341 = sub_eff  in
+            let uu____31342 =
               elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift_wp  in
-            let uu____31476 =
+            let uu____31345 =
               elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift  in
             {
               FStar_Syntax_Syntax.source =
-                (uu___3786_31472.FStar_Syntax_Syntax.source);
+                (uu___3784_31341.FStar_Syntax_Syntax.source);
               FStar_Syntax_Syntax.target =
-                (uu___3786_31472.FStar_Syntax_Syntax.target);
-              FStar_Syntax_Syntax.lift_wp = uu____31473;
-              FStar_Syntax_Syntax.lift = uu____31476
+                (uu___3784_31341.FStar_Syntax_Syntax.target);
+              FStar_Syntax_Syntax.lift_wp = uu____31342;
+              FStar_Syntax_Syntax.lift = uu____31345
             }  in
-          let uu___3789_31479 = s  in
+          let uu___3787_31348 = s  in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_sub_effect sub_eff1);
             FStar_Syntax_Syntax.sigrng =
-              (uu___3789_31479.FStar_Syntax_Syntax.sigrng);
+              (uu___3787_31348.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3789_31479.FStar_Syntax_Syntax.sigquals);
+              (uu___3787_31348.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3789_31479.FStar_Syntax_Syntax.sigmeta);
+              (uu___3787_31348.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3789_31479.FStar_Syntax_Syntax.sigattrs);
+              (uu___3787_31348.FStar_Syntax_Syntax.sigattrs);
             FStar_Syntax_Syntax.sigopts =
-              (uu___3789_31479.FStar_Syntax_Syntax.sigopts)
+              (uu___3787_31348.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_effect_abbrev
           (lid,univ_names,binders,comp,flags) ->
-          let uu____31489 = elim_uvars_aux_c env1 univ_names binders comp  in
-          (match uu____31489 with
+          let uu____31358 = elim_uvars_aux_c env1 univ_names binders comp  in
+          (match uu____31358 with
            | (univ_names1,binders1,comp1) ->
-               let uu___3802_31529 = s  in
+               let uu___3800_31398 = s  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_effect_abbrev
                       (lid, univ_names1, binders1, comp1, flags));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3802_31529.FStar_Syntax_Syntax.sigrng);
+                   (uu___3800_31398.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3802_31529.FStar_Syntax_Syntax.sigquals);
+                   (uu___3800_31398.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3802_31529.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3800_31398.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3802_31529.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3800_31398.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3802_31529.FStar_Syntax_Syntax.sigopts)
+                   (uu___3800_31398.FStar_Syntax_Syntax.sigopts)
                })
-      | FStar_Syntax_Syntax.Sig_pragma uu____31532 -> s
-      | FStar_Syntax_Syntax.Sig_fail uu____31533 -> s
-      | FStar_Syntax_Syntax.Sig_splice uu____31546 -> s
+      | FStar_Syntax_Syntax.Sig_pragma uu____31401 -> s
+      | FStar_Syntax_Syntax.Sig_fail uu____31402 -> s
+      | FStar_Syntax_Syntax.Sig_splice uu____31415 -> s
       | FStar_Syntax_Syntax.Sig_polymonadic_bind (m,n,p,(us_t,t),(us_ty,ty))
           ->
-          let uu____31576 = elim_uvars_aux_t env1 us_t [] t  in
-          (match uu____31576 with
-           | (us_t1,uu____31600,t1) ->
-               let uu____31622 = elim_uvars_aux_t env1 us_ty [] ty  in
-               (match uu____31622 with
-                | (us_ty1,uu____31646,ty1) ->
-                    let uu___3829_31668 = s  in
+          let uu____31445 = elim_uvars_aux_t env1 us_t [] t  in
+          (match uu____31445 with
+           | (us_t1,uu____31469,t1) ->
+               let uu____31491 = elim_uvars_aux_t env1 us_ty [] ty  in
+               (match uu____31491 with
+                | (us_ty1,uu____31515,ty1) ->
+                    let uu___3827_31537 = s  in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_polymonadic_bind
                            (m, n, p, (us_t1, t1), (us_ty1, ty1)));
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___3829_31668.FStar_Syntax_Syntax.sigrng);
+                        (uu___3827_31537.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___3829_31668.FStar_Syntax_Syntax.sigquals);
+                        (uu___3827_31537.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___3829_31668.FStar_Syntax_Syntax.sigmeta);
+                        (uu___3827_31537.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___3829_31668.FStar_Syntax_Syntax.sigattrs);
+                        (uu___3827_31537.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___3829_31668.FStar_Syntax_Syntax.sigopts)
+                        (uu___3827_31537.FStar_Syntax_Syntax.sigopts)
                     }))
   
 let (erase_universes :
@@ -9800,21 +9744,21 @@ let (unfold_head_once :
   fun env1  ->
     fun t  ->
       let aux f us args =
-        let uu____31719 =
+        let uu____31588 =
           FStar_TypeChecker_Env.lookup_nonrec_definition
             [FStar_TypeChecker_Env.Unfold FStar_Syntax_Syntax.delta_constant]
             env1 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
            in
-        match uu____31719 with
+        match uu____31588 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some head_def_ts ->
-            let uu____31741 =
+            let uu____31610 =
               FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us  in
-            (match uu____31741 with
-             | (uu____31748,head_def) ->
+            (match uu____31610 with
+             | (uu____31617,head_def) ->
                  let t' =
                    FStar_Syntax_Syntax.mk_Tm_app head_def args
-                     FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+                     t.FStar_Syntax_Syntax.pos
                     in
                  let t'1 =
                    normalize
@@ -9823,18 +9767,18 @@ let (unfold_head_once :
                     in
                  FStar_Pervasives_Native.Some t'1)
          in
-      let uu____31754 = FStar_Syntax_Util.head_and_args t  in
-      match uu____31754 with
+      let uu____31621 = FStar_Syntax_Util.head_and_args t  in
+      match uu____31621 with
       | (head,args) ->
-          let uu____31799 =
-            let uu____31800 = FStar_Syntax_Subst.compress head  in
-            uu____31800.FStar_Syntax_Syntax.n  in
-          (match uu____31799 with
+          let uu____31666 =
+            let uu____31667 = FStar_Syntax_Subst.compress head  in
+            uu____31667.FStar_Syntax_Syntax.n  in
+          (match uu____31666 with
            | FStar_Syntax_Syntax.Tm_fvar fv -> aux fv [] args
            | FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.pos = uu____31807;
-                  FStar_Syntax_Syntax.vars = uu____31808;_},us)
+                  FStar_Syntax_Syntax.pos = uu____31674;
+                  FStar_Syntax_Syntax.vars = uu____31675;_},us)
                -> aux fv us args
-           | uu____31814 -> FStar_Pervasives_Native.None)
+           | uu____31681 -> FStar_Pervasives_Native.None)
   

--- a/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
+++ b/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
@@ -236,7 +236,7 @@ let (pat_as_exp :
                 | uu____933 ->
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_constant c)
-                      FStar_Pervasives_Native.None p1.FStar_Syntax_Syntax.p
+                      p1.FStar_Syntax_Syntax.p
                  in
               ([], [], [], env1, e, FStar_TypeChecker_Common.trivial_guard,
                 p1)
@@ -289,7 +289,7 @@ let (pat_as_exp :
                | (x1,g,env2) ->
                    let e =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name x1)
-                       FStar_Pervasives_Native.None p1.FStar_Syntax_Syntax.p
+                       p1.FStar_Syntax_Syntax.p
                       in
                    ([x1], [], [x1], env2, e, g, p1))
           | FStar_Syntax_Syntax.Pat_var x ->
@@ -298,7 +298,7 @@ let (pat_as_exp :
                | (x1,g,env2) ->
                    let e =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name x1)
-                       FStar_Pervasives_Native.None p1.FStar_Syntax_Syntax.p
+                       p1.FStar_Syntax_Syntax.p
                       in
                    ([x1], [x1], [], env2, e, g, p1))
           | FStar_Syntax_Syntax.Pat_cons (fv,pats) ->
@@ -330,61 +330,58 @@ let (pat_as_exp :
               (match uu____1196 with
                | (b,a,w,env2,args,guard,pats1) ->
                    let e =
-                     let uu____1762 =
-                       let uu____1767 = FStar_Syntax_Syntax.fv_to_tm fv  in
-                       let uu____1768 =
-                         FStar_All.pipe_right args FStar_List.rev  in
-                       FStar_Syntax_Syntax.mk_Tm_app uu____1767 uu____1768
-                        in
-                     uu____1762 FStar_Pervasives_Native.None
+                     let uu____1760 = FStar_Syntax_Syntax.fv_to_tm fv  in
+                     let uu____1761 =
+                       FStar_All.pipe_right args FStar_List.rev  in
+                     FStar_Syntax_Syntax.mk_Tm_app uu____1760 uu____1761
                        p1.FStar_Syntax_Syntax.p
                       in
-                   let uu____1771 =
+                   let uu____1764 =
                      FStar_All.pipe_right (FStar_List.rev b)
                        FStar_List.flatten
                       in
-                   let uu____1782 =
+                   let uu____1775 =
                      FStar_All.pipe_right (FStar_List.rev a)
                        FStar_List.flatten
                       in
-                   let uu____1793 =
+                   let uu____1786 =
                      FStar_All.pipe_right (FStar_List.rev w)
                        FStar_List.flatten
                       in
-                   (uu____1771, uu____1782, uu____1793, env2, e, guard,
-                     (let uu___188_1811 = p1  in
+                   (uu____1764, uu____1775, uu____1786, env2, e, guard,
+                     (let uu___188_1804 = p1  in
                       {
                         FStar_Syntax_Syntax.v =
                           (FStar_Syntax_Syntax.Pat_cons
                              (fv, (FStar_List.rev pats1)));
                         FStar_Syntax_Syntax.p =
-                          (uu___188_1811.FStar_Syntax_Syntax.p)
+                          (uu___188_1804.FStar_Syntax_Syntax.p)
                       })))
            in
         let one_pat env1 p1 =
           let p2 = elaborate_pat env1 p1  in
-          let uu____1856 = pat_as_arg_with_env env1 p2  in
-          match uu____1856 with
+          let uu____1849 = pat_as_arg_with_env env1 p2  in
+          match uu____1849 with
           | (b,a,w,env2,arg,guard,p3) ->
-              let uu____1914 =
+              let uu____1907 =
                 FStar_All.pipe_right b
                   (FStar_Util.find_dup FStar_Syntax_Syntax.bv_eq)
                  in
-              (match uu____1914 with
+              (match uu____1907 with
                | FStar_Pervasives_Native.Some x ->
                    let m = FStar_Syntax_Print.bv_to_string x  in
                    let err =
-                     let uu____1948 =
+                     let uu____1941 =
                        FStar_Util.format1
                          "The pattern variable \"%s\" was used more than once"
                          m
                         in
-                     (FStar_Errors.Fatal_NonLinearPatternVars, uu____1948)
+                     (FStar_Errors.Fatal_NonLinearPatternVars, uu____1941)
                       in
                    FStar_Errors.raise_error err p3.FStar_Syntax_Syntax.p
-               | uu____1970 -> (b, a, w, arg, guard, p3))
+               | uu____1963 -> (b, a, w, arg, guard, p3))
            in
-        let uu____1979 = one_pat env p  in
-        match uu____1979 with
-        | (b,uu____2009,uu____2010,tm,guard,p1) -> (b, tm, guard, p1)
+        let uu____1972 = one_pat env p  in
+        match uu____1972 with
+        | (b,uu____2002,uu____2003,tm,guard,p1) -> (b, tm, guard, p1)
   

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -143,8 +143,7 @@ let (new_uvar :
                   (let t =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_uvar
-                          (ctx_uvar, ([], FStar_Syntax_Syntax.NoUseRange)))
-                       FStar_Pervasives_Native.None r
+                          (ctx_uvar, ([], FStar_Syntax_Syntax.NoUseRange))) r
                       in
                    let imp =
                      {
@@ -1136,21 +1135,19 @@ let new_problem :
                         | FStar_Pervasives_Native.None  -> lg
                         | FStar_Pervasives_Native.Some x ->
                             let uu____2662 =
-                              let uu____2667 =
-                                let uu____2668 =
-                                  let uu____2677 =
-                                    FStar_Syntax_Syntax.bv_to_name x  in
-                                  FStar_All.pipe_left
-                                    FStar_Syntax_Syntax.as_arg uu____2677
-                                   in
-                                [uu____2668]  in
-                              FStar_Syntax_Syntax.mk_Tm_app lg uu____2667  in
-                            uu____2662 FStar_Pervasives_Native.None loc
+                              let uu____2663 =
+                                let uu____2672 =
+                                  FStar_Syntax_Syntax.bv_to_name x  in
+                                FStar_All.pipe_left
+                                  FStar_Syntax_Syntax.as_arg uu____2672
+                                 in
+                              [uu____2663]  in
+                            FStar_Syntax_Syntax.mk_Tm_app lg uu____2662 loc
                          in
                       let prob =
-                        let uu____2705 = next_pid ()  in
+                        let uu____2700 = next_pid ()  in
                         {
-                          FStar_TypeChecker_Common.pid = uu____2705;
+                          FStar_TypeChecker_Common.pid = uu____2700;
                           FStar_TypeChecker_Common.lhs = lhs;
                           FStar_TypeChecker_Common.relation = rel;
                           FStar_TypeChecker_Common.rhs = rhs;
@@ -1181,9 +1178,9 @@ let (problem_using_guard :
           fun elt  ->
             fun reason  ->
               let p =
-                let uu____2753 = next_pid ()  in
+                let uu____2748 = next_pid ()  in
                 {
-                  FStar_TypeChecker_Common.pid = uu____2753;
+                  FStar_TypeChecker_Common.pid = uu____2748;
                   FStar_TypeChecker_Common.lhs = lhs;
                   FStar_TypeChecker_Common.relation = rel;
                   FStar_TypeChecker_Common.rhs = rhs;
@@ -1200,9 +1197,9 @@ let (problem_using_guard :
               def_check_prob reason (FStar_TypeChecker_Common.TProb p); p
   
 let guard_on_element :
-  'uuuuuu2768 .
+  'uuuuuu2763 .
     worklist ->
-      'uuuuuu2768 FStar_TypeChecker_Common.problem ->
+      'uuuuuu2763 FStar_TypeChecker_Common.problem ->
         FStar_Syntax_Syntax.bv ->
           FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
             FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
@@ -1219,14 +1216,14 @@ let guard_on_element :
                  in
               FStar_Syntax_Util.mk_forall u x phi
           | FStar_Pervasives_Native.Some e ->
-              let uu____2801 =
-                let uu____2804 =
-                  let uu____2805 =
-                    let uu____2812 = FStar_Syntax_Syntax.bv_to_name e  in
-                    (x, uu____2812)  in
-                  FStar_Syntax_Syntax.NT uu____2805  in
-                [uu____2804]  in
-              FStar_Syntax_Subst.subst uu____2801 phi
+              let uu____2796 =
+                let uu____2799 =
+                  let uu____2800 =
+                    let uu____2807 = FStar_Syntax_Syntax.bv_to_name e  in
+                    (x, uu____2807)  in
+                  FStar_Syntax_Syntax.NT uu____2800  in
+                [uu____2799]  in
+              FStar_Syntax_Subst.subst uu____2796 phi
   
 let (explain :
   FStar_TypeChecker_Env.env ->
@@ -1235,33 +1232,33 @@ let (explain :
   fun env  ->
     fun d  ->
       fun s  ->
-        let uu____2834 =
+        let uu____2829 =
           (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "ExplainRel"))
             ||
             (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel"))
            in
-        if uu____2834
+        if uu____2829
         then
-          let uu____2842 =
+          let uu____2837 =
             FStar_All.pipe_left FStar_Range.string_of_range (p_loc d)  in
-          let uu____2845 = prob_to_string env d  in
-          let uu____2847 =
+          let uu____2840 = prob_to_string env d  in
+          let uu____2842 =
             FStar_All.pipe_right (p_reason d) (FStar_String.concat "\n\t>")
              in
-          let uu____2854 = FStar_Thunk.force s  in
+          let uu____2849 = FStar_Thunk.force s  in
           FStar_Util.format4
             "(%s) Failed to solve the sub-problem\n%s\nWhich arose because:\n\t%s\nFailed because:%s\n"
-            uu____2842 uu____2845 uu____2847 uu____2854
+            uu____2837 uu____2840 uu____2842 uu____2849
         else
           (let d1 = maybe_invert_p d  in
            let rel =
              match p_rel d1 with
              | FStar_TypeChecker_Common.EQ  -> "equal to"
              | FStar_TypeChecker_Common.SUB  -> "a subtype of"
-             | uu____2866 -> failwith "impossible"  in
-           let uu____2869 =
+             | uu____2861 -> failwith "impossible"  in
+           let uu____2864 =
              match d1 with
              | FStar_TypeChecker_Common.TProb tp ->
                  FStar_TypeChecker_Err.print_discrepancy
@@ -1274,7 +1271,7 @@ let (explain :
                    cp.FStar_TypeChecker_Common.lhs
                    cp.FStar_TypeChecker_Common.rhs
               in
-           match uu____2869 with
+           match uu____2864 with
            | (lhs,rhs) ->
                FStar_Util.format3 "%s is not %s the expected type %s" lhs rel
                  rhs)
@@ -1283,20 +1280,20 @@ let (commit : uvi Prims.list -> unit) =
   fun uvis  ->
     FStar_All.pipe_right uvis
       (FStar_List.iter
-         (fun uu___15_2912  ->
-            match uu___15_2912 with
+         (fun uu___15_2907  ->
+            match uu___15_2907 with
             | UNIV (u,t) ->
                 (match t with
                  | FStar_Syntax_Syntax.U_unif u' ->
                      FStar_Syntax_Unionfind.univ_union u u'
-                 | uu____2926 -> FStar_Syntax_Unionfind.univ_change u t)
+                 | uu____2921 -> FStar_Syntax_Unionfind.univ_change u t)
             | TERM (u,t) ->
-                ((let uu____2930 =
+                ((let uu____2925 =
                     FStar_List.map FStar_Pervasives_Native.fst
                       u.FStar_Syntax_Syntax.ctx_uvar_binders
                      in
                   FStar_TypeChecker_Env.def_check_closed_in
-                    t.FStar_Syntax_Syntax.pos "commit" uu____2930 t);
+                    t.FStar_Syntax_Syntax.pos "commit" uu____2925 t);
                  FStar_Syntax_Util.set_uvar
                    u.FStar_Syntax_Syntax.ctx_uvar_head t)))
   
@@ -1307,15 +1304,15 @@ let (find_term_uvar :
   fun uv  ->
     fun s  ->
       FStar_Util.find_map s
-        (fun uu___16_2961  ->
-           match uu___16_2961 with
-           | UNIV uu____2964 -> FStar_Pervasives_Native.None
+        (fun uu___16_2956  ->
+           match uu___16_2956 with
+           | UNIV uu____2959 -> FStar_Pervasives_Native.None
            | TERM (u,t) ->
-               let uu____2971 =
+               let uu____2966 =
                  FStar_Syntax_Unionfind.equiv uv
                    u.FStar_Syntax_Syntax.ctx_uvar_head
                   in
-               if uu____2971
+               if uu____2966
                then FStar_Pervasives_Native.Some t
                else FStar_Pervasives_Native.None)
   
@@ -1327,14 +1324,14 @@ let (find_univ_uvar :
   fun u  ->
     fun s  ->
       FStar_Util.find_map s
-        (fun uu___17_2999  ->
-           match uu___17_2999 with
+        (fun uu___17_2994  ->
+           match uu___17_2994 with
            | UNIV (u',t) ->
-               let uu____3004 = FStar_Syntax_Unionfind.univ_equiv u u'  in
-               if uu____3004
+               let uu____2999 = FStar_Syntax_Unionfind.univ_equiv u u'  in
+               if uu____2999
                then FStar_Pervasives_Native.Some t
                else FStar_Pervasives_Native.None
-           | uu____3011 -> FStar_Pervasives_Native.None)
+           | uu____3006 -> FStar_Pervasives_Native.None)
   
 let (whnf' :
   FStar_TypeChecker_Env.env ->
@@ -1342,17 +1339,17 @@ let (whnf' :
   =
   fun env  ->
     fun t  ->
-      let uu____3023 =
-        let uu____3024 =
-          let uu____3025 = FStar_Syntax_Util.unmeta t  in
+      let uu____3018 =
+        let uu____3019 =
+          let uu____3020 = FStar_Syntax_Util.unmeta t  in
           FStar_TypeChecker_Normalize.normalize
             [FStar_TypeChecker_Env.Beta;
             FStar_TypeChecker_Env.Reify;
             FStar_TypeChecker_Env.Weak;
-            FStar_TypeChecker_Env.HNF] env uu____3025
+            FStar_TypeChecker_Env.HNF] env uu____3020
            in
-        FStar_Syntax_Subst.compress uu____3024  in
-      FStar_All.pipe_right uu____3023 FStar_Syntax_Util.unlazy_emb
+        FStar_Syntax_Subst.compress uu____3019  in
+      FStar_All.pipe_right uu____3018 FStar_Syntax_Util.unlazy_emb
   
 let (sn' :
   FStar_TypeChecker_Env.env ->
@@ -1360,13 +1357,13 @@ let (sn' :
   =
   fun env  ->
     fun t  ->
-      let uu____3037 =
-        let uu____3038 =
+      let uu____3032 =
+        let uu____3033 =
           FStar_TypeChecker_Normalize.normalize
             [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Reify] env t
            in
-        FStar_Syntax_Subst.compress uu____3038  in
-      FStar_All.pipe_right uu____3037 FStar_Syntax_Util.unlazy_emb
+        FStar_Syntax_Subst.compress uu____3033  in
+      FStar_All.pipe_right uu____3032 FStar_Syntax_Util.unlazy_emb
   
 let (sn :
   FStar_TypeChecker_Env.env ->
@@ -1374,12 +1371,12 @@ let (sn :
   =
   fun env  ->
     fun t  ->
-      let uu____3050 =
-        let uu____3054 =
-          let uu____3056 = FStar_TypeChecker_Env.current_module env  in
-          FStar_Ident.string_of_lid uu____3056  in
-        FStar_Pervasives_Native.Some uu____3054  in
-      FStar_Profiling.profile (fun uu____3059  -> sn' env t) uu____3050
+      let uu____3045 =
+        let uu____3049 =
+          let uu____3051 = FStar_TypeChecker_Env.current_module env  in
+          FStar_Ident.string_of_lid uu____3051  in
+        FStar_Pervasives_Native.Some uu____3049  in
+      FStar_Profiling.profile (fun uu____3054  -> sn' env t) uu____3045
         "FStar.TypeChecker.Rel.sn"
   
 let (norm_with_steps :
@@ -1392,27 +1389,27 @@ let (norm_with_steps :
     fun steps  ->
       fun env  ->
         fun t  ->
-          let uu____3084 =
-            let uu____3088 =
-              let uu____3090 = FStar_TypeChecker_Env.current_module env  in
-              FStar_Ident.string_of_lid uu____3090  in
-            FStar_Pervasives_Native.Some uu____3088  in
+          let uu____3079 =
+            let uu____3083 =
+              let uu____3085 = FStar_TypeChecker_Env.current_module env  in
+              FStar_Ident.string_of_lid uu____3085  in
+            FStar_Pervasives_Native.Some uu____3083  in
           FStar_Profiling.profile
-            (fun uu____3093  ->
-               FStar_TypeChecker_Normalize.normalize steps env t) uu____3084
+            (fun uu____3088  ->
+               FStar_TypeChecker_Normalize.normalize steps env t) uu____3079
             profiling_tag
   
 let (should_strongly_reduce : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____3101 = FStar_Syntax_Util.head_and_args t  in
-    match uu____3101 with
-    | (h,uu____3120) ->
-        let uu____3145 =
-          let uu____3146 = FStar_Syntax_Subst.compress h  in
-          uu____3146.FStar_Syntax_Syntax.n  in
-        (match uu____3145 with
+    let uu____3096 = FStar_Syntax_Util.head_and_args t  in
+    match uu____3096 with
+    | (h,uu____3115) ->
+        let uu____3140 =
+          let uu____3141 = FStar_Syntax_Subst.compress h  in
+          uu____3141.FStar_Syntax_Syntax.n  in
+        (match uu____3140 with
          | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) -> true
-         | uu____3151 -> false)
+         | uu____3146 -> false)
   
 let (whnf :
   FStar_TypeChecker_Env.env ->
@@ -1420,18 +1417,18 @@ let (whnf :
   =
   fun env  ->
     fun t  ->
-      let uu____3164 =
-        let uu____3168 =
-          let uu____3170 = FStar_TypeChecker_Env.current_module env  in
-          FStar_Ident.string_of_lid uu____3170  in
-        FStar_Pervasives_Native.Some uu____3168  in
+      let uu____3159 =
+        let uu____3163 =
+          let uu____3165 = FStar_TypeChecker_Env.current_module env  in
+          FStar_Ident.string_of_lid uu____3165  in
+        FStar_Pervasives_Native.Some uu____3163  in
       FStar_Profiling.profile
-        (fun uu____3175  ->
-           let uu____3176 = should_strongly_reduce t  in
-           if uu____3176
+        (fun uu____3170  ->
+           let uu____3171 = should_strongly_reduce t  in
+           if uu____3171
            then
-             let uu____3179 =
-               let uu____3180 =
+             let uu____3174 =
+               let uu____3175 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta;
                    FStar_TypeChecker_Env.Reify;
@@ -1439,20 +1436,20 @@ let (whnf :
                    FStar_TypeChecker_Env.UnfoldUntil
                      FStar_Syntax_Syntax.delta_constant] env t
                   in
-               FStar_Syntax_Subst.compress uu____3180  in
-             FStar_All.pipe_right uu____3179 FStar_Syntax_Util.unlazy_emb
-           else whnf' env t) uu____3164 "FStar.TypeChecker.Rel.whnf"
+               FStar_Syntax_Subst.compress uu____3175  in
+             FStar_All.pipe_right uu____3174 FStar_Syntax_Util.unlazy_emb
+           else whnf' env t) uu____3159 "FStar.TypeChecker.Rel.whnf"
   
 let norm_arg :
-  'uuuuuu3191 .
+  'uuuuuu3186 .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.term * 'uuuuuu3191) ->
-        (FStar_Syntax_Syntax.term * 'uuuuuu3191)
+      (FStar_Syntax_Syntax.term * 'uuuuuu3186) ->
+        (FStar_Syntax_Syntax.term * 'uuuuuu3186)
   =
   fun env  ->
     fun t  ->
-      let uu____3214 = sn env (FStar_Pervasives_Native.fst t)  in
-      (uu____3214, (FStar_Pervasives_Native.snd t))
+      let uu____3209 = sn env (FStar_Pervasives_Native.fst t)  in
+      (uu____3209, (FStar_Pervasives_Native.snd t))
   
 let (sn_binders :
   FStar_TypeChecker_Env.env ->
@@ -1464,20 +1461,20 @@ let (sn_binders :
     fun binders  ->
       FStar_All.pipe_right binders
         (FStar_List.map
-           (fun uu____3266  ->
-              match uu____3266 with
+           (fun uu____3261  ->
+              match uu____3261 with
               | (x,imp) ->
-                  let uu____3285 =
-                    let uu___465_3286 = x  in
-                    let uu____3287 = sn env x.FStar_Syntax_Syntax.sort  in
+                  let uu____3280 =
+                    let uu___465_3281 = x  in
+                    let uu____3282 = sn env x.FStar_Syntax_Syntax.sort  in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___465_3286.FStar_Syntax_Syntax.ppname);
+                        (uu___465_3281.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___465_3286.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = uu____3287
+                        (uu___465_3281.FStar_Syntax_Syntax.index);
+                      FStar_Syntax_Syntax.sort = uu____3282
                     }  in
-                  (uu____3285, imp)))
+                  (uu____3280, imp)))
   
 let (norm_univ :
   worklist -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) =
@@ -1487,13 +1484,13 @@ let (norm_univ :
         let u2 = FStar_Syntax_Subst.compress_univ u1  in
         match u2 with
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____3311 = aux u3  in FStar_Syntax_Syntax.U_succ uu____3311
+            let uu____3306 = aux u3  in FStar_Syntax_Syntax.U_succ uu____3306
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____3315 = FStar_List.map aux us  in
-            FStar_Syntax_Syntax.U_max uu____3315
-        | uu____3318 -> u2  in
-      let uu____3319 = aux u  in
-      FStar_TypeChecker_Normalize.normalize_universe wl.tcenv uu____3319
+            let uu____3310 = FStar_List.map aux us  in
+            FStar_Syntax_Syntax.U_max uu____3310
+        | uu____3313 -> u2  in
+      let uu____3314 = aux u  in
+      FStar_TypeChecker_Normalize.normalize_universe wl.tcenv uu____3314
   
 let (normalize_refinement :
   FStar_TypeChecker_Env.steps ->
@@ -1503,15 +1500,15 @@ let (normalize_refinement :
   fun steps  ->
     fun env  ->
       fun t0  ->
-        let uu____3336 =
-          let uu____3340 =
-            let uu____3342 = FStar_TypeChecker_Env.current_module env  in
-            FStar_Ident.string_of_lid uu____3342  in
-          FStar_Pervasives_Native.Some uu____3340  in
+        let uu____3331 =
+          let uu____3335 =
+            let uu____3337 = FStar_TypeChecker_Env.current_module env  in
+            FStar_Ident.string_of_lid uu____3337  in
+          FStar_Pervasives_Native.Some uu____3335  in
         FStar_Profiling.profile
-          (fun uu____3345  ->
+          (fun uu____3340  ->
              FStar_TypeChecker_Normalize.normalize_refinement steps env t0)
-          uu____3336 "FStar.TypeChecker.Rel.normalize_refinement"
+          uu____3331 "FStar.TypeChecker.Rel.normalize_refinement"
   
 let (base_and_refinement_maybe_delta :
   Prims.bool ->
@@ -1542,114 +1539,114 @@ let (base_and_refinement_maybe_delta :
                 ((x.FStar_Syntax_Syntax.sort),
                   (FStar_Pervasives_Native.Some (x, phi)))
               else
-                (let uu____3467 = norm_refinement env t12  in
-                 match uu____3467 with
+                (let uu____3462 = norm_refinement env t12  in
+                 match uu____3462 with
                  | {
                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine
                        (x1,phi1);
-                     FStar_Syntax_Syntax.pos = uu____3482;
-                     FStar_Syntax_Syntax.vars = uu____3483;_} ->
+                     FStar_Syntax_Syntax.pos = uu____3477;
+                     FStar_Syntax_Syntax.vars = uu____3478;_} ->
                      ((x1.FStar_Syntax_Syntax.sort),
                        (FStar_Pervasives_Native.Some (x1, phi1)))
                  | tt ->
-                     let uu____3507 =
-                       let uu____3509 = FStar_Syntax_Print.term_to_string tt
+                     let uu____3502 =
+                       let uu____3504 = FStar_Syntax_Print.term_to_string tt
                           in
-                       let uu____3511 = FStar_Syntax_Print.tag_of_term tt  in
+                       let uu____3506 = FStar_Syntax_Print.tag_of_term tt  in
                        FStar_Util.format2 "impossible: Got %s ... %s\n"
-                         uu____3509 uu____3511
+                         uu____3504 uu____3506
                         in
-                     failwith uu____3507)
+                     failwith uu____3502)
           | FStar_Syntax_Syntax.Tm_lazy i ->
-              let uu____3527 = FStar_Syntax_Util.unfold_lazy i  in
-              aux norm uu____3527
-          | FStar_Syntax_Syntax.Tm_uinst uu____3528 ->
+              let uu____3522 = FStar_Syntax_Util.unfold_lazy i  in
+              aux norm uu____3522
+          | FStar_Syntax_Syntax.Tm_uinst uu____3523 ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12  in
-                 let uu____3565 =
-                   let uu____3566 = FStar_Syntax_Subst.compress t1'  in
-                   uu____3566.FStar_Syntax_Syntax.n  in
-                 match uu____3565 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3581 -> aux true t1'
-                 | uu____3589 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_fvar uu____3604 ->
+                 let uu____3560 =
+                   let uu____3561 = FStar_Syntax_Subst.compress t1'  in
+                   uu____3561.FStar_Syntax_Syntax.n  in
+                 match uu____3560 with
+                 | FStar_Syntax_Syntax.Tm_refine uu____3576 -> aux true t1'
+                 | uu____3584 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_fvar uu____3599 ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12  in
-                 let uu____3635 =
-                   let uu____3636 = FStar_Syntax_Subst.compress t1'  in
-                   uu____3636.FStar_Syntax_Syntax.n  in
-                 match uu____3635 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3651 -> aux true t1'
-                 | uu____3659 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_app uu____3674 ->
+                 let uu____3630 =
+                   let uu____3631 = FStar_Syntax_Subst.compress t1'  in
+                   uu____3631.FStar_Syntax_Syntax.n  in
+                 match uu____3630 with
+                 | FStar_Syntax_Syntax.Tm_refine uu____3646 -> aux true t1'
+                 | uu____3654 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_app uu____3669 ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12  in
-                 let uu____3721 =
-                   let uu____3722 = FStar_Syntax_Subst.compress t1'  in
-                   uu____3722.FStar_Syntax_Syntax.n  in
-                 match uu____3721 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3737 -> aux true t1'
-                 | uu____3745 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_type uu____3760 ->
+                 let uu____3716 =
+                   let uu____3717 = FStar_Syntax_Subst.compress t1'  in
+                   uu____3717.FStar_Syntax_Syntax.n  in
+                 match uu____3716 with
+                 | FStar_Syntax_Syntax.Tm_refine uu____3732 -> aux true t1'
+                 | uu____3740 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_type uu____3755 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_constant uu____3775 ->
+          | FStar_Syntax_Syntax.Tm_constant uu____3770 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_name uu____3790 ->
+          | FStar_Syntax_Syntax.Tm_name uu____3785 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_bvar uu____3805 ->
+          | FStar_Syntax_Syntax.Tm_bvar uu____3800 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_arrow uu____3820 ->
+          | FStar_Syntax_Syntax.Tm_arrow uu____3815 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_abs uu____3849 ->
+          | FStar_Syntax_Syntax.Tm_abs uu____3844 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_quoted uu____3882 ->
+          | FStar_Syntax_Syntax.Tm_quoted uu____3877 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_uvar uu____3903 ->
+          | FStar_Syntax_Syntax.Tm_uvar uu____3898 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_let uu____3930 ->
+          | FStar_Syntax_Syntax.Tm_let uu____3925 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_match uu____3958 ->
+          | FStar_Syntax_Syntax.Tm_match uu____3953 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_meta uu____3995 ->
-              let uu____4002 =
-                let uu____4004 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____4006 = FStar_Syntax_Print.tag_of_term t12  in
+          | FStar_Syntax_Syntax.Tm_meta uu____3990 ->
+              let uu____3997 =
+                let uu____3999 = FStar_Syntax_Print.term_to_string t12  in
+                let uu____4001 = FStar_Syntax_Print.tag_of_term t12  in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____4004 uu____4006
+                  uu____3999 uu____4001
                  in
-              failwith uu____4002
-          | FStar_Syntax_Syntax.Tm_ascribed uu____4021 ->
-              let uu____4048 =
-                let uu____4050 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____4052 = FStar_Syntax_Print.tag_of_term t12  in
+              failwith uu____3997
+          | FStar_Syntax_Syntax.Tm_ascribed uu____4016 ->
+              let uu____4043 =
+                let uu____4045 = FStar_Syntax_Print.term_to_string t12  in
+                let uu____4047 = FStar_Syntax_Print.tag_of_term t12  in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____4050 uu____4052
+                  uu____4045 uu____4047
                  in
-              failwith uu____4048
-          | FStar_Syntax_Syntax.Tm_delayed uu____4067 ->
-              let uu____4082 =
-                let uu____4084 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____4086 = FStar_Syntax_Print.tag_of_term t12  in
+              failwith uu____4043
+          | FStar_Syntax_Syntax.Tm_delayed uu____4062 ->
+              let uu____4077 =
+                let uu____4079 = FStar_Syntax_Print.term_to_string t12  in
+                let uu____4081 = FStar_Syntax_Print.tag_of_term t12  in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____4084 uu____4086
+                  uu____4079 uu____4081
                  in
-              failwith uu____4082
+              failwith uu____4077
           | FStar_Syntax_Syntax.Tm_unknown  ->
-              let uu____4101 =
-                let uu____4103 = FStar_Syntax_Print.term_to_string t12  in
-                let uu____4105 = FStar_Syntax_Print.tag_of_term t12  in
+              let uu____4096 =
+                let uu____4098 = FStar_Syntax_Print.term_to_string t12  in
+                let uu____4100 = FStar_Syntax_Print.tag_of_term t12  in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____4103 uu____4105
+                  uu____4098 uu____4100
                  in
-              failwith uu____4101
+              failwith uu____4096
            in
-        let uu____4120 = whnf env t1  in aux false uu____4120
+        let uu____4115 = whnf env t1  in aux false uu____4115
   
 let (base_and_refinement :
   FStar_TypeChecker_Env.env ->
@@ -1663,16 +1660,16 @@ let (unrefine :
   =
   fun env  ->
     fun t  ->
-      let uu____4165 = base_and_refinement env t  in
-      FStar_All.pipe_right uu____4165 FStar_Pervasives_Native.fst
+      let uu____4160 = base_and_refinement env t  in
+      FStar_All.pipe_right uu____4160 FStar_Pervasives_Native.fst
   
 let (trivial_refinement :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term))
   =
   fun t  ->
-    let uu____4206 = FStar_Syntax_Syntax.null_bv t  in
-    (uu____4206, FStar_Syntax_Util.t_true)
+    let uu____4201 = FStar_Syntax_Syntax.null_bv t  in
+    (uu____4201, FStar_Syntax_Util.t_true)
   
 let (as_refinement :
   Prims.bool ->
@@ -1683,8 +1680,8 @@ let (as_refinement :
   fun delta  ->
     fun env  ->
       fun t  ->
-        let uu____4233 = base_and_refinement_maybe_delta delta env t  in
-        match uu____4233 with
+        let uu____4228 = base_and_refinement_maybe_delta delta env t  in
+        match uu____4228 with
         | (t_base,refinement) ->
             (match refinement with
              | FStar_Pervasives_Native.None  -> trivial_refinement t_base
@@ -1695,74 +1692,74 @@ let (force_refinement :
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)
     FStar_Pervasives_Native.option) -> FStar_Syntax_Syntax.term)
   =
-  fun uu____4293  ->
-    match uu____4293 with
+  fun uu____4288  ->
+    match uu____4288 with
     | (t_base,refopt) ->
-        let uu____4324 =
+        let uu____4319 =
           match refopt with
           | FStar_Pervasives_Native.Some (y,phi) -> (y, phi)
           | FStar_Pervasives_Native.None  -> trivial_refinement t_base  in
-        (match uu____4324 with
+        (match uu____4319 with
          | (y,phi) ->
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (y, phi))
-               FStar_Pervasives_Native.None t_base.FStar_Syntax_Syntax.pos)
+               t_base.FStar_Syntax_Syntax.pos)
   
 let (wl_prob_to_string :
   worklist -> FStar_TypeChecker_Common.prob -> Prims.string) =
   fun wl  -> fun prob  -> prob_to_string wl.tcenv prob 
 let (wl_to_string : worklist -> Prims.string) =
   fun wl  ->
-    let uu____4366 =
-      let uu____4370 =
-        let uu____4373 =
+    let uu____4361 =
+      let uu____4365 =
+        let uu____4368 =
           FStar_All.pipe_right wl.wl_deferred
             (FStar_List.map
-               (fun uu____4398  ->
-                  match uu____4398 with | (uu____4406,uu____4407,x) -> x))
+               (fun uu____4393  ->
+                  match uu____4393 with | (uu____4401,uu____4402,x) -> x))
            in
-        FStar_List.append wl.attempting uu____4373  in
-      FStar_List.map (wl_prob_to_string wl) uu____4370  in
-    FStar_All.pipe_right uu____4366 (FStar_String.concat "\n\t")
+        FStar_List.append wl.attempting uu____4368  in
+      FStar_List.map (wl_prob_to_string wl) uu____4365  in
+    FStar_All.pipe_right uu____4361 (FStar_String.concat "\n\t")
   
 type flex_t =
   (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar *
     FStar_Syntax_Syntax.args)
 let flex_t_to_string :
-  'uuuuuu4428 .
-    ('uuuuuu4428 * FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.args)
+  'uuuuuu4423 .
+    ('uuuuuu4423 * FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.args)
       -> Prims.string
   =
-  fun uu____4440  ->
-    match uu____4440 with
-    | (uu____4447,c,args) ->
-        let uu____4450 = print_ctx_uvar c  in
-        let uu____4452 = FStar_Syntax_Print.args_to_string args  in
-        FStar_Util.format2 "%s [%s]" uu____4450 uu____4452
+  fun uu____4435  ->
+    match uu____4435 with
+    | (uu____4442,c,args) ->
+        let uu____4445 = print_ctx_uvar c  in
+        let uu____4447 = FStar_Syntax_Print.args_to_string args  in
+        FStar_Util.format2 "%s [%s]" uu____4445 uu____4447
   
 let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____4462 = FStar_Syntax_Util.head_and_args t  in
-    match uu____4462 with
+    let uu____4457 = FStar_Syntax_Util.head_and_args t  in
+    match uu____4457 with
     | (head,_args) ->
-        let uu____4506 =
-          let uu____4507 = FStar_Syntax_Subst.compress head  in
-          uu____4507.FStar_Syntax_Syntax.n  in
-        (match uu____4506 with
-         | FStar_Syntax_Syntax.Tm_uvar uu____4511 -> true
-         | uu____4525 -> false)
+        let uu____4501 =
+          let uu____4502 = FStar_Syntax_Subst.compress head  in
+          uu____4502.FStar_Syntax_Syntax.n  in
+        (match uu____4501 with
+         | FStar_Syntax_Syntax.Tm_uvar uu____4506 -> true
+         | uu____4520 -> false)
   
 let (flex_uvar_head :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.ctx_uvar) =
   fun t  ->
-    let uu____4533 = FStar_Syntax_Util.head_and_args t  in
-    match uu____4533 with
+    let uu____4528 = FStar_Syntax_Util.head_and_args t  in
+    match uu____4528 with
     | (head,_args) ->
-        let uu____4576 =
-          let uu____4577 = FStar_Syntax_Subst.compress head  in
-          uu____4577.FStar_Syntax_Syntax.n  in
-        (match uu____4576 with
-         | FStar_Syntax_Syntax.Tm_uvar (u,uu____4581) -> u
-         | uu____4598 -> failwith "Not a flex-uvar")
+        let uu____4571 =
+          let uu____4572 = FStar_Syntax_Subst.compress head  in
+          uu____4572.FStar_Syntax_Syntax.n  in
+        (match uu____4571 with
+         | FStar_Syntax_Syntax.Tm_uvar (u,uu____4576) -> u
+         | uu____4593 -> failwith "Not a flex-uvar")
   
 let (ensure_no_uvar_subst :
   FStar_Syntax_Syntax.term ->
@@ -1773,121 +1770,119 @@ let (ensure_no_uvar_subst :
       let bv_not_affected_by s x =
         let t_x = FStar_Syntax_Syntax.bv_to_name x  in
         let t_x' = FStar_Syntax_Subst.subst' s t_x  in
-        let uu____4634 =
-          let uu____4635 = FStar_Syntax_Subst.compress t_x'  in
-          uu____4635.FStar_Syntax_Syntax.n  in
-        match uu____4634 with
+        let uu____4629 =
+          let uu____4630 = FStar_Syntax_Subst.compress t_x'  in
+          uu____4630.FStar_Syntax_Syntax.n  in
+        match uu____4629 with
         | FStar_Syntax_Syntax.Tm_name y -> FStar_Syntax_Syntax.bv_eq x y
-        | uu____4640 -> false  in
+        | uu____4635 -> false  in
       let binding_not_affected_by s b =
         match b with
         | FStar_Syntax_Syntax.Binding_var x -> bv_not_affected_by s x
-        | uu____4656 -> true  in
-      let uu____4658 = FStar_Syntax_Util.head_and_args t0  in
-      match uu____4658 with
+        | uu____4651 -> true  in
+      let uu____4653 = FStar_Syntax_Util.head_and_args t0  in
+      match uu____4653 with
       | (head,args) ->
-          let uu____4705 =
-            let uu____4706 = FStar_Syntax_Subst.compress head  in
-            uu____4706.FStar_Syntax_Syntax.n  in
-          (match uu____4705 with
-           | FStar_Syntax_Syntax.Tm_uvar (uv,([],uu____4714)) -> (t0, wl)
-           | FStar_Syntax_Syntax.Tm_uvar (uv,uu____4730) when
+          let uu____4700 =
+            let uu____4701 = FStar_Syntax_Subst.compress head  in
+            uu____4701.FStar_Syntax_Syntax.n  in
+          (match uu____4700 with
+           | FStar_Syntax_Syntax.Tm_uvar (uv,([],uu____4709)) -> (t0, wl)
+           | FStar_Syntax_Syntax.Tm_uvar (uv,uu____4725) when
                FStar_List.isEmpty uv.FStar_Syntax_Syntax.ctx_uvar_binders ->
                (t0, wl)
            | FStar_Syntax_Syntax.Tm_uvar (uv,s) ->
-               let uu____4771 =
+               let uu____4766 =
                  FStar_Common.max_suffix (binding_not_affected_by s)
                    uv.FStar_Syntax_Syntax.ctx_uvar_gamma
                   in
-               (match uu____4771 with
+               (match uu____4766 with
                 | (gamma_aff,new_gamma) ->
                     (match gamma_aff with
                      | [] -> (t0, wl)
-                     | uu____4798 ->
+                     | uu____4793 ->
                          let dom_binders =
                            FStar_TypeChecker_Env.binders_of_bindings
                              gamma_aff
                             in
-                         let uu____4802 =
-                           let uu____4809 =
+                         let uu____4797 =
+                           let uu____4804 =
                              FStar_TypeChecker_Env.binders_of_bindings
                                new_gamma
                               in
-                           let uu____4818 =
-                             let uu____4821 =
+                           let uu____4813 =
+                             let uu____4816 =
                                FStar_Syntax_Syntax.mk_Total
                                  uv.FStar_Syntax_Syntax.ctx_uvar_typ
                                 in
-                             FStar_Syntax_Util.arrow dom_binders uu____4821
+                             FStar_Syntax_Util.arrow dom_binders uu____4816
                               in
                            new_uvar
                              (Prims.op_Hat
                                 uv.FStar_Syntax_Syntax.ctx_uvar_reason
                                 "; force delayed") wl
-                             t0.FStar_Syntax_Syntax.pos new_gamma uu____4809
-                             uu____4818
+                             t0.FStar_Syntax_Syntax.pos new_gamma uu____4804
+                             uu____4813
                              uv.FStar_Syntax_Syntax.ctx_uvar_should_check
                              uv.FStar_Syntax_Syntax.ctx_uvar_meta
                             in
-                         (match uu____4802 with
+                         (match uu____4797 with
                           | (v,t_v,wl1) ->
                               let args_sol =
                                 FStar_List.map
-                                  (fun uu____4857  ->
-                                     match uu____4857 with
+                                  (fun uu____4852  ->
+                                     match uu____4852 with
                                      | (x,i) ->
-                                         let uu____4876 =
+                                         let uu____4871 =
                                            FStar_Syntax_Syntax.bv_to_name x
                                             in
-                                         (uu____4876, i)) dom_binders
+                                         (uu____4871, i)) dom_binders
                                  in
                               let sol =
                                 FStar_Syntax_Syntax.mk_Tm_app t_v args_sol
-                                  FStar_Pervasives_Native.None
                                   t0.FStar_Syntax_Syntax.pos
                                  in
                               (FStar_Syntax_Util.set_uvar
                                  uv.FStar_Syntax_Syntax.ctx_uvar_head sol;
                                (let args_sol_s =
                                   FStar_List.map
-                                    (fun uu____4908  ->
-                                       match uu____4908 with
+                                    (fun uu____4901  ->
+                                       match uu____4901 with
                                        | (a,i) ->
-                                           let uu____4927 =
+                                           let uu____4920 =
                                              FStar_Syntax_Subst.subst' s a
                                               in
-                                           (uu____4927, i)) args_sol
+                                           (uu____4920, i)) args_sol
                                    in
                                 let t =
                                   FStar_Syntax_Syntax.mk_Tm_app t_v
                                     (FStar_List.append args_sol_s args)
-                                    FStar_Pervasives_Native.None
                                     t0.FStar_Syntax_Syntax.pos
                                    in
                                 (t, wl1))))))
-           | uu____4939 ->
+           | uu____4930 ->
                failwith "ensure_no_uvar_subst: expected a uvar at the head")
   
 let (destruct_flex_t' : FStar_Syntax_Syntax.term -> flex_t) =
   fun t  ->
-    let uu____4951 = FStar_Syntax_Util.head_and_args t  in
-    match uu____4951 with
+    let uu____4942 = FStar_Syntax_Util.head_and_args t  in
+    match uu____4942 with
     | (head,args) ->
-        let uu____4994 =
-          let uu____4995 = FStar_Syntax_Subst.compress head  in
-          uu____4995.FStar_Syntax_Syntax.n  in
-        (match uu____4994 with
+        let uu____4985 =
+          let uu____4986 = FStar_Syntax_Subst.compress head  in
+          uu____4986.FStar_Syntax_Syntax.n  in
+        (match uu____4985 with
          | FStar_Syntax_Syntax.Tm_uvar (uv,s) -> (t, uv, args)
-         | uu____5016 -> failwith "Not a flex-uvar")
+         | uu____5007 -> failwith "Not a flex-uvar")
   
 let (destruct_flex_t :
   FStar_Syntax_Syntax.term -> worklist -> (flex_t * worklist)) =
   fun t  ->
     fun wl  ->
-      let uu____5037 = ensure_no_uvar_subst t wl  in
-      match uu____5037 with
+      let uu____5028 = ensure_no_uvar_subst t wl  in
+      match uu____5028 with
       | (t1,wl1) ->
-          let uu____5048 = destruct_flex_t' t1  in (uu____5048, wl1)
+          let uu____5039 = destruct_flex_t' t1  in (uu____5039, wl1)
   
 let (u_abs :
   FStar_Syntax_Syntax.typ ->
@@ -1897,30 +1892,30 @@ let (u_abs :
   fun k  ->
     fun ys  ->
       fun t  ->
-        let uu____5065 =
-          let uu____5088 =
-            let uu____5089 = FStar_Syntax_Subst.compress k  in
-            uu____5089.FStar_Syntax_Syntax.n  in
-          match uu____5088 with
+        let uu____5056 =
+          let uu____5079 =
+            let uu____5080 = FStar_Syntax_Subst.compress k  in
+            uu____5080.FStar_Syntax_Syntax.n  in
+          match uu____5079 with
           | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
               if (FStar_List.length bs) = (FStar_List.length ys)
               then
-                let uu____5171 = FStar_Syntax_Subst.open_comp bs c  in
-                ((ys, t), uu____5171)
+                let uu____5162 = FStar_Syntax_Subst.open_comp bs c  in
+                ((ys, t), uu____5162)
               else
-                (let uu____5206 = FStar_Syntax_Util.abs_formals t  in
-                 match uu____5206 with
-                 | (ys',t1,uu____5239) ->
-                     let uu____5244 = FStar_Syntax_Util.arrow_formals_comp k
+                (let uu____5197 = FStar_Syntax_Util.abs_formals t  in
+                 match uu____5197 with
+                 | (ys',t1,uu____5230) ->
+                     let uu____5235 = FStar_Syntax_Util.arrow_formals_comp k
                         in
-                     (((FStar_List.append ys ys'), t1), uu____5244))
-          | uu____5283 ->
-              let uu____5284 =
-                let uu____5289 = FStar_Syntax_Syntax.mk_Total k  in
-                ([], uu____5289)  in
-              ((ys, t), uu____5284)
+                     (((FStar_List.append ys ys'), t1), uu____5235))
+          | uu____5274 ->
+              let uu____5275 =
+                let uu____5280 = FStar_Syntax_Syntax.mk_Total k  in
+                ([], uu____5280)  in
+              ((ys, t), uu____5275)
            in
-        match uu____5065 with
+        match uu____5056 with
         | ((ys1,t1),(xs,c)) ->
             if (FStar_List.length xs) <> (FStar_List.length ys1)
             then
@@ -1931,8 +1926,8 @@ let (u_abs :
                       FStar_Pervasives_Native.None []))
             else
               (let c1 =
-                 let uu____5384 = FStar_Syntax_Util.rename_binders xs ys1  in
-                 FStar_Syntax_Subst.subst_comp uu____5384 c  in
+                 let uu____5375 = FStar_Syntax_Util.rename_binders xs ys1  in
+                 FStar_Syntax_Subst.subst_comp uu____5375 c  in
                FStar_Syntax_Util.abs ys1 t1
                  (FStar_Pervasives_Native.Some
                     (FStar_Syntax_Util.residual_comp_of_comp c1)))
@@ -1955,17 +1950,17 @@ let (solve_prob' :
                | FStar_Pervasives_Native.None  -> FStar_Syntax_Util.t_true
                | FStar_Pervasives_Native.Some phi -> phi  in
              let assign_solution xs uv phi1 =
-               (let uu____5462 =
+               (let uu____5453 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
                     (FStar_Options.Other "Rel")
                    in
-                if uu____5462
+                if uu____5453
                 then
-                  let uu____5467 = FStar_Util.string_of_int (p_pid prob)  in
-                  let uu____5469 = print_ctx_uvar uv  in
-                  let uu____5471 = FStar_Syntax_Print.term_to_string phi1  in
+                  let uu____5458 = FStar_Util.string_of_int (p_pid prob)  in
+                  let uu____5460 = print_ctx_uvar uv  in
+                  let uu____5462 = FStar_Syntax_Print.term_to_string phi1  in
                   FStar_Util.print3 "Solving %s (%s) with formula %s\n"
-                    uu____5467 uu____5469 uu____5471
+                    uu____5458 uu____5460 uu____5462
                 else ());
                (let phi2 =
                   FStar_Syntax_Util.abs xs phi1
@@ -1973,100 +1968,100 @@ let (solve_prob' :
                        (FStar_Syntax_Util.residual_tot
                           FStar_Syntax_Util.ktype0))
                    in
-                (let uu____5480 =
-                   let uu____5482 = FStar_Util.string_of_int (p_pid prob)  in
-                   Prims.op_Hat "solve_prob'.sol." uu____5482  in
-                 let uu____5485 =
-                   let uu____5488 = p_scope prob  in
+                (let uu____5471 =
+                   let uu____5473 = FStar_Util.string_of_int (p_pid prob)  in
+                   Prims.op_Hat "solve_prob'.sol." uu____5473  in
+                 let uu____5476 =
+                   let uu____5479 = p_scope prob  in
                    FStar_All.pipe_left
-                     (FStar_List.map FStar_Pervasives_Native.fst) uu____5488
+                     (FStar_List.map FStar_Pervasives_Native.fst) uu____5479
                     in
                  FStar_TypeChecker_Env.def_check_closed_in (p_loc prob)
-                   uu____5480 uu____5485 phi2);
+                   uu____5471 uu____5476 phi2);
                 FStar_Syntax_Util.set_uvar
                   uv.FStar_Syntax_Syntax.ctx_uvar_head phi2)
                 in
              let uv = p_guard_uvar prob  in
-             let fail uu____5521 =
-               let uu____5522 =
-                 let uu____5524 = FStar_Syntax_Print.ctx_uvar_to_string uv
+             let fail uu____5512 =
+               let uu____5513 =
+                 let uu____5515 = FStar_Syntax_Print.ctx_uvar_to_string uv
                     in
-                 let uu____5526 =
+                 let uu____5517 =
                    FStar_Syntax_Print.term_to_string (p_guard prob)  in
                  FStar_Util.format2
                    "Impossible: this instance %s has already been assigned a solution\n%s\n"
-                   uu____5524 uu____5526
+                   uu____5515 uu____5517
                   in
-               failwith uu____5522  in
+               failwith uu____5513  in
              let args_as_binders args =
                FStar_All.pipe_right args
                  (FStar_List.collect
-                    (fun uu____5592  ->
-                       match uu____5592 with
+                    (fun uu____5583  ->
+                       match uu____5583 with
                        | (a,i) ->
-                           let uu____5613 =
-                             let uu____5614 = FStar_Syntax_Subst.compress a
+                           let uu____5604 =
+                             let uu____5605 = FStar_Syntax_Subst.compress a
                                 in
-                             uu____5614.FStar_Syntax_Syntax.n  in
-                           (match uu____5613 with
+                             uu____5605.FStar_Syntax_Syntax.n  in
+                           (match uu____5604 with
                             | FStar_Syntax_Syntax.Tm_name x -> [(x, i)]
-                            | uu____5640 -> (fail (); []))))
+                            | uu____5631 -> (fail (); []))))
                 in
              let wl1 =
                let g = whnf wl.tcenv (p_guard prob)  in
-               let uu____5650 =
-                 let uu____5652 = is_flex g  in Prims.op_Negation uu____5652
+               let uu____5641 =
+                 let uu____5643 = is_flex g  in Prims.op_Negation uu____5643
                   in
-               if uu____5650
+               if uu____5641
                then (if resolve_ok then wl else (fail (); wl))
                else
-                 (let uu____5661 = destruct_flex_t g wl  in
-                  match uu____5661 with
-                  | ((uu____5666,uv1,args),wl1) ->
-                      ((let uu____5671 = args_as_binders args  in
-                        assign_solution uu____5671 uv1 phi);
+                 (let uu____5652 = destruct_flex_t g wl  in
+                  match uu____5652 with
+                  | ((uu____5657,uv1,args),wl1) ->
+                      ((let uu____5662 = args_as_binders args  in
+                        assign_solution uu____5662 uv1 phi);
                        wl1))
                 in
              commit uvis;
-             (let uu___734_5673 = wl1  in
+             (let uu___734_5664 = wl1  in
               {
-                attempting = (uu___734_5673.attempting);
-                wl_deferred = (uu___734_5673.wl_deferred);
+                attempting = (uu___734_5664.attempting);
+                wl_deferred = (uu___734_5664.wl_deferred);
                 ctr = (wl1.ctr + Prims.int_one);
-                defer_ok = (uu___734_5673.defer_ok);
-                smt_ok = (uu___734_5673.smt_ok);
-                umax_heuristic_ok = (uu___734_5673.umax_heuristic_ok);
-                tcenv = (uu___734_5673.tcenv);
-                wl_implicits = (uu___734_5673.wl_implicits);
-                repr_subcomp_allowed = (uu___734_5673.repr_subcomp_allowed)
+                defer_ok = (uu___734_5664.defer_ok);
+                smt_ok = (uu___734_5664.smt_ok);
+                umax_heuristic_ok = (uu___734_5664.umax_heuristic_ok);
+                tcenv = (uu___734_5664.tcenv);
+                wl_implicits = (uu___734_5664.wl_implicits);
+                repr_subcomp_allowed = (uu___734_5664.repr_subcomp_allowed)
               }))
   
 let (extend_solution : Prims.int -> uvi Prims.list -> worklist -> worklist) =
   fun pid  ->
     fun sol  ->
       fun wl  ->
-        (let uu____5698 =
+        (let uu____5689 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
              (FStar_Options.Other "Rel")
             in
-         if uu____5698
+         if uu____5689
          then
-           let uu____5703 = FStar_Util.string_of_int pid  in
-           let uu____5705 = uvis_to_string wl.tcenv sol  in
-           FStar_Util.print2 "Solving %s: with [%s]\n" uu____5703 uu____5705
+           let uu____5694 = FStar_Util.string_of_int pid  in
+           let uu____5696 = uvis_to_string wl.tcenv sol  in
+           FStar_Util.print2 "Solving %s: with [%s]\n" uu____5694 uu____5696
          else ());
         commit sol;
-        (let uu___742_5711 = wl  in
+        (let uu___742_5702 = wl  in
          {
-           attempting = (uu___742_5711.attempting);
-           wl_deferred = (uu___742_5711.wl_deferred);
+           attempting = (uu___742_5702.attempting);
+           wl_deferred = (uu___742_5702.wl_deferred);
            ctr = (wl.ctr + Prims.int_one);
-           defer_ok = (uu___742_5711.defer_ok);
-           smt_ok = (uu___742_5711.smt_ok);
-           umax_heuristic_ok = (uu___742_5711.umax_heuristic_ok);
-           tcenv = (uu___742_5711.tcenv);
-           wl_implicits = (uu___742_5711.wl_implicits);
-           repr_subcomp_allowed = (uu___742_5711.repr_subcomp_allowed)
+           defer_ok = (uu___742_5702.defer_ok);
+           smt_ok = (uu___742_5702.smt_ok);
+           umax_heuristic_ok = (uu___742_5702.umax_heuristic_ok);
+           tcenv = (uu___742_5702.tcenv);
+           wl_implicits = (uu___742_5702.wl_implicits);
+           repr_subcomp_allowed = (uu___742_5702.repr_subcomp_allowed)
          })
   
 let (solve_prob :
@@ -2081,16 +2076,16 @@ let (solve_prob :
           def_check_prob "solve_prob.prob" prob;
           FStar_Util.iter_opt logical_guard
             (def_check_scoped "solve_prob.guard" prob);
-          (let uu____5747 =
+          (let uu____5738 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
                (FStar_Options.Other "Rel")
               in
-           if uu____5747
+           if uu____5738
            then
-             let uu____5752 =
+             let uu____5743 =
                FStar_All.pipe_left FStar_Util.string_of_int (p_pid prob)  in
-             let uu____5756 = uvis_to_string wl.tcenv uvis  in
-             FStar_Util.print2 "Solving %s: with %s\n" uu____5752 uu____5756
+             let uu____5747 = uvis_to_string wl.tcenv uvis  in
+             FStar_Util.print2 "Solving %s: with %s\n" uu____5743 uu____5747
            else ());
           solve_prob' false prob logical_guard uvis wl
   
@@ -2102,8 +2097,8 @@ let (occurs :
   fun uk  ->
     fun t  ->
       let uvars =
-        let uu____5783 = FStar_Syntax_Free.uvars t  in
-        FStar_All.pipe_right uu____5783 FStar_Util.set_elements  in
+        let uu____5774 = FStar_Syntax_Free.uvars t  in
+        FStar_All.pipe_right uu____5774 FStar_Util.set_elements  in
       let occurs =
         FStar_All.pipe_right uvars
           (FStar_Util.for_some
@@ -2122,23 +2117,23 @@ let (occurs_check :
   =
   fun uk  ->
     fun t  ->
-      let uu____5823 = occurs uk t  in
-      match uu____5823 with
+      let uu____5814 = occurs uk t  in
+      match uu____5814 with
       | (uvars,occurs1) ->
           let msg =
             if Prims.op_Negation occurs1
             then FStar_Pervasives_Native.None
             else
-              (let uu____5862 =
-                 let uu____5864 =
+              (let uu____5853 =
+                 let uu____5855 =
                    FStar_Syntax_Print.uvar_to_string
                      uk.FStar_Syntax_Syntax.ctx_uvar_head
                     in
-                 let uu____5866 = FStar_Syntax_Print.term_to_string t  in
+                 let uu____5857 = FStar_Syntax_Print.term_to_string t  in
                  FStar_Util.format2 "occurs-check failed (%s occurs in %s)"
-                   uu____5864 uu____5866
+                   uu____5855 uu____5857
                   in
-               FStar_Pervasives_Native.Some uu____5862)
+               FStar_Pervasives_Native.Some uu____5853)
              in
           (uvars, (Prims.op_Negation occurs1), msg)
   
@@ -2152,13 +2147,13 @@ let rec (maximal_prefix :
     fun bs'  ->
       match (bs, bs') with
       | ((b,i)::bs_tail,(b',i')::bs'_tail) ->
-          let uu____5977 = FStar_Syntax_Syntax.bv_eq b b'  in
-          if uu____5977
+          let uu____5968 = FStar_Syntax_Syntax.bv_eq b b'  in
+          if uu____5968
           then
-            let uu____5988 = maximal_prefix bs_tail bs'_tail  in
-            (match uu____5988 with | (pfx,rest) -> (((b, i) :: pfx), rest))
+            let uu____5979 = maximal_prefix bs_tail bs'_tail  in
+            (match uu____5979 with | (pfx,rest) -> (((b, i) :: pfx), rest))
           else ([], (bs, bs'))
-      | uu____6039 -> ([], (bs, bs'))
+      | uu____6030 -> ([], (bs, bs'))
   
 let (extend_gamma :
   FStar_Syntax_Syntax.gamma ->
@@ -2168,9 +2163,9 @@ let (extend_gamma :
     fun bs  ->
       FStar_List.fold_left
         (fun g1  ->
-           fun uu____6096  ->
-             match uu____6096 with
-             | (x,uu____6108) -> (FStar_Syntax_Syntax.Binding_var x) :: g1) g
+           fun uu____6087  ->
+             match uu____6087 with
+             | (x,uu____6099) -> (FStar_Syntax_Syntax.Binding_var x) :: g1) g
         bs
   
 let (gamma_until :
@@ -2179,21 +2174,21 @@ let (gamma_until :
   =
   fun g  ->
     fun bs  ->
-      let uu____6126 = FStar_List.last bs  in
-      match uu____6126 with
+      let uu____6117 = FStar_List.last bs  in
+      match uu____6117 with
       | FStar_Pervasives_Native.None  -> []
-      | FStar_Pervasives_Native.Some (x,uu____6150) ->
-          let uu____6161 =
+      | FStar_Pervasives_Native.Some (x,uu____6141) ->
+          let uu____6152 =
             FStar_Util.prefix_until
-              (fun uu___18_6176  ->
-                 match uu___18_6176 with
+              (fun uu___18_6167  ->
+                 match uu___18_6167 with
                  | FStar_Syntax_Syntax.Binding_var x' ->
                      FStar_Syntax_Syntax.bv_eq x x'
-                 | uu____6179 -> false) g
+                 | uu____6170 -> false) g
              in
-          (match uu____6161 with
+          (match uu____6152 with
            | FStar_Pervasives_Native.None  -> []
-           | FStar_Pervasives_Native.Some (uu____6193,bx,rest) -> bx :: rest)
+           | FStar_Pervasives_Native.Some (uu____6184,bx,rest) -> bx :: rest)
   
 let (restrict_ctx :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -2202,15 +2197,15 @@ let (restrict_ctx :
   fun tgt  ->
     fun src  ->
       fun wl  ->
-        let uu____6230 =
+        let uu____6221 =
           maximal_prefix tgt.FStar_Syntax_Syntax.ctx_uvar_binders
             src.FStar_Syntax_Syntax.ctx_uvar_binders
            in
-        match uu____6230 with
-        | (pfx,uu____6240) ->
+        match uu____6221 with
+        | (pfx,uu____6231) ->
             let g = gamma_until src.FStar_Syntax_Syntax.ctx_uvar_gamma pfx
                in
-            let uu____6252 =
+            let uu____6243 =
               new_uvar
                 (Prims.op_Hat "restrict:"
                    src.FStar_Syntax_Syntax.ctx_uvar_reason) wl
@@ -2219,8 +2214,8 @@ let (restrict_ctx :
                 src.FStar_Syntax_Syntax.ctx_uvar_should_check
                 src.FStar_Syntax_Syntax.ctx_uvar_meta
                in
-            (match uu____6252 with
-             | (uu____6260,src',wl1) ->
+            (match uu____6243 with
+             | (uu____6251,src',wl1) ->
                  (FStar_Syntax_Util.set_uvar
                     src.FStar_Syntax_Syntax.ctx_uvar_head src';
                   wl1))
@@ -2257,68 +2252,68 @@ let (intersect_binders :
                  match b with
                  | FStar_Syntax_Syntax.Binding_var x ->
                      FStar_Util.set_add x out
-                 | uu____6374 -> out) FStar_Syntax_Syntax.no_names g
+                 | uu____6365 -> out) FStar_Syntax_Syntax.no_names g
            in
-        let uu____6375 =
+        let uu____6366 =
           FStar_All.pipe_right v2
             (FStar_List.fold_left
-               (fun uu____6439  ->
-                  fun uu____6440  ->
-                    match (uu____6439, uu____6440) with
+               (fun uu____6430  ->
+                  fun uu____6431  ->
+                    match (uu____6430, uu____6431) with
                     | ((isect,isect_set),(x,imp)) ->
-                        let uu____6543 =
-                          let uu____6545 = FStar_Util.set_mem x v1_set  in
-                          FStar_All.pipe_left Prims.op_Negation uu____6545
+                        let uu____6534 =
+                          let uu____6536 = FStar_Util.set_mem x v1_set  in
+                          FStar_All.pipe_left Prims.op_Negation uu____6536
                            in
-                        if uu____6543
+                        if uu____6534
                         then (isect, isect_set)
                         else
                           (let fvs =
                              FStar_Syntax_Free.names
                                x.FStar_Syntax_Syntax.sort
                               in
-                           let uu____6579 =
+                           let uu____6570 =
                              FStar_Util.set_is_subset_of fvs isect_set  in
-                           if uu____6579
+                           if uu____6570
                            then
-                             let uu____6596 = FStar_Util.set_add x isect_set
+                             let uu____6587 = FStar_Util.set_add x isect_set
                                 in
-                             (((x, imp) :: isect), uu____6596)
+                             (((x, imp) :: isect), uu____6587)
                            else (isect, isect_set))) ([], ctx_binders))
            in
-        match uu____6375 with | (isect,uu____6646) -> FStar_List.rev isect
+        match uu____6366 with | (isect,uu____6637) -> FStar_List.rev isect
   
 let binders_eq :
-  'uuuuuu6682 'uuuuuu6683 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu6682) Prims.list ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6683) Prims.list -> Prims.bool
+  'uuuuuu6673 'uuuuuu6674 .
+    (FStar_Syntax_Syntax.bv * 'uuuuuu6673) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6674) Prims.list -> Prims.bool
   =
   fun v1  ->
     fun v2  ->
       ((FStar_List.length v1) = (FStar_List.length v2)) &&
         (FStar_List.forall2
-           (fun uu____6741  ->
-              fun uu____6742  ->
-                match (uu____6741, uu____6742) with
-                | ((a,uu____6761),(b,uu____6763)) ->
+           (fun uu____6732  ->
+              fun uu____6733  ->
+                match (uu____6732, uu____6733) with
+                | ((a,uu____6752),(b,uu____6754)) ->
                     FStar_Syntax_Syntax.bv_eq a b) v1 v2)
   
 let name_exists_in_binders :
-  'uuuuuu6779 .
+  'uuuuuu6770 .
     FStar_Syntax_Syntax.bv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6779) Prims.list -> Prims.bool
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6770) Prims.list -> Prims.bool
   =
   fun x  ->
     fun bs  ->
       FStar_Util.for_some
-        (fun uu____6810  ->
-           match uu____6810 with
-           | (y,uu____6817) -> FStar_Syntax_Syntax.bv_eq x y) bs
+        (fun uu____6801  ->
+           match uu____6801 with
+           | (y,uu____6808) -> FStar_Syntax_Syntax.bv_eq x y) bs
   
 let pat_vars :
-  'uuuuuu6827 .
+  'uuuuuu6818 .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6827) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6818) Prims.list ->
         (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
           FStar_Pervasives_Native.option) Prims.list ->
           FStar_Syntax_Syntax.binders FStar_Pervasives_Native.option
@@ -2333,14 +2328,14 @@ let pat_vars :
               let hd = sn env arg  in
               (match hd.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_name a ->
-                   let uu____6989 =
+                   let uu____6980 =
                      (name_exists_in_binders a seen) ||
                        (name_exists_in_binders a ctx)
                       in
-                   if uu____6989
+                   if uu____6980
                    then FStar_Pervasives_Native.None
                    else aux ((a, i) :: seen) args2
-               | uu____7022 -> FStar_Pervasives_Native.None)
+               | uu____7013 -> FStar_Pervasives_Native.None)
            in
         aux [] args
   
@@ -2352,7 +2347,7 @@ type match_result =
   | FullMatch 
 let (uu___is_MisMatch : match_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | MisMatch _0 -> true | uu____7074 -> false
+    match projectee with | MisMatch _0 -> true | uu____7065 -> false
   
 let (__proj__MisMatch__item___0 :
   match_result ->
@@ -2361,44 +2356,44 @@ let (__proj__MisMatch__item___0 :
   = fun projectee  -> match projectee with | MisMatch _0 -> _0 
 let (uu___is_HeadMatch : match_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | HeadMatch _0 -> true | uu____7118 -> false
+    match projectee with | HeadMatch _0 -> true | uu____7109 -> false
   
 let (__proj__HeadMatch__item___0 : match_result -> Prims.bool) =
   fun projectee  -> match projectee with | HeadMatch _0 -> _0 
 let (uu___is_FullMatch : match_result -> Prims.bool) =
   fun projectee  ->
-    match projectee with | FullMatch  -> true | uu____7139 -> false
+    match projectee with | FullMatch  -> true | uu____7130 -> false
   
 let (string_of_match_result : match_result -> Prims.string) =
-  fun uu___19_7147  ->
-    match uu___19_7147 with
+  fun uu___19_7138  ->
+    match uu___19_7138 with
     | MisMatch (d1,d2) ->
-        let uu____7159 =
-          let uu____7161 =
+        let uu____7150 =
+          let uu____7152 =
             FStar_Common.string_of_option
               FStar_Syntax_Print.delta_depth_to_string d1
              in
-          let uu____7163 =
-            let uu____7165 =
-              let uu____7167 =
+          let uu____7154 =
+            let uu____7156 =
+              let uu____7158 =
                 FStar_Common.string_of_option
                   FStar_Syntax_Print.delta_depth_to_string d2
                  in
-              Prims.op_Hat uu____7167 ")"  in
-            Prims.op_Hat ") (" uu____7165  in
-          Prims.op_Hat uu____7161 uu____7163  in
-        Prims.op_Hat "MisMatch (" uu____7159
+              Prims.op_Hat uu____7158 ")"  in
+            Prims.op_Hat ") (" uu____7156  in
+          Prims.op_Hat uu____7152 uu____7154  in
+        Prims.op_Hat "MisMatch (" uu____7150
     | HeadMatch u ->
-        let uu____7174 = FStar_Util.string_of_bool u  in
-        Prims.op_Hat "HeadMatch " uu____7174
+        let uu____7165 = FStar_Util.string_of_bool u  in
+        Prims.op_Hat "HeadMatch " uu____7165
     | FullMatch  -> "FullMatch"
   
 let (head_match : match_result -> match_result) =
-  fun uu___20_7183  ->
-    match uu___20_7183 with
+  fun uu___20_7174  ->
+    match uu___20_7174 with
     | MisMatch (i,j) -> MisMatch (i, j)
     | HeadMatch (true ) -> HeadMatch true
-    | uu____7200 -> HeadMatch false
+    | uu____7191 -> HeadMatch false
   
 let (fv_delta_depth :
   FStar_TypeChecker_Env.env ->
@@ -2409,30 +2404,30 @@ let (fv_delta_depth :
       let d = FStar_TypeChecker_Env.delta_depth_of_fv env fv  in
       match d with
       | FStar_Syntax_Syntax.Delta_abstract d1 ->
-          let uu____7215 =
-            (let uu____7221 =
+          let uu____7206 =
+            (let uu____7212 =
                FStar_Ident.string_of_lid env.FStar_TypeChecker_Env.curmodule
                 in
-             let uu____7223 =
+             let uu____7214 =
                FStar_Ident.nsstr
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                 in
-             uu____7221 = uu____7223) &&
+             uu____7212 = uu____7214) &&
               (Prims.op_Negation env.FStar_TypeChecker_Env.is_iface)
              in
-          if uu____7215 then d1 else FStar_Syntax_Syntax.delta_constant
+          if uu____7206 then d1 else FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Delta_constant_at_level i when i > Prims.int_zero
           ->
-          let uu____7232 =
+          let uu____7223 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Unfold
                  FStar_Syntax_Syntax.delta_constant] env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____7232 with
+          (match uu____7223 with
            | FStar_Pervasives_Native.None  ->
                FStar_Syntax_Syntax.delta_constant
-           | uu____7243 -> d)
+           | uu____7234 -> d)
       | d1 -> d1
   
 let rec (delta_depth_of_term :
@@ -2444,45 +2439,45 @@ let rec (delta_depth_of_term :
     fun t  ->
       let t1 = FStar_Syntax_Util.unmeta t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta uu____7267 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____7277 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_meta uu____7258 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____7268 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____7296 = FStar_Syntax_Util.unfold_lazy i  in
-          delta_depth_of_term env uu____7296
+          let uu____7287 = FStar_Syntax_Util.unfold_lazy i  in
+          delta_depth_of_term env uu____7287
       | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_bvar uu____7297 ->
+      | FStar_Syntax_Syntax.Tm_bvar uu____7288 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_name uu____7298 ->
+      | FStar_Syntax_Syntax.Tm_name uu____7289 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uvar uu____7299 ->
+      | FStar_Syntax_Syntax.Tm_uvar uu____7290 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____7312 -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_match uu____7326 ->
+      | FStar_Syntax_Syntax.Tm_let uu____7303 -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_match uu____7317 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____7350) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t2,uu____7341) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____7356,uu____7357) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____7347,uu____7348) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_app (t2,uu____7399) ->
+      | FStar_Syntax_Syntax.Tm_app (t2,uu____7390) ->
           delta_depth_of_term env t2
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____7424;
-             FStar_Syntax_Syntax.index = uu____7425;
-             FStar_Syntax_Syntax.sort = t2;_},uu____7427)
+          ({ FStar_Syntax_Syntax.ppname = uu____7415;
+             FStar_Syntax_Syntax.index = uu____7416;
+             FStar_Syntax_Syntax.sort = t2;_},uu____7418)
           -> delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_constant uu____7435 ->
+      | FStar_Syntax_Syntax.Tm_constant uu____7426 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_type uu____7436 ->
+      | FStar_Syntax_Syntax.Tm_type uu____7427 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_arrow uu____7437 ->
+      | FStar_Syntax_Syntax.Tm_arrow uu____7428 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_quoted uu____7452 ->
+      | FStar_Syntax_Syntax.Tm_quoted uu____7443 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_abs uu____7459 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____7450 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____7479 = fv_delta_depth env fv  in
-          FStar_Pervasives_Native.Some uu____7479
+          let uu____7470 = fv_delta_depth env fv  in
+          FStar_Pervasives_Native.Some uu____7470
   
 let rec (head_matches :
   FStar_TypeChecker_Env.env ->
@@ -2495,119 +2490,119 @@ let rec (head_matches :
         let t21 = FStar_Syntax_Util.unmeta t2  in
         match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
         | (FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7498;
+           { FStar_Syntax_Syntax.blob = uu____7489;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7499;
-             FStar_Syntax_Syntax.ltyp = uu____7500;
-             FStar_Syntax_Syntax.rng = uu____7501;_},uu____7502)
+               uu____7490;
+             FStar_Syntax_Syntax.ltyp = uu____7491;
+             FStar_Syntax_Syntax.rng = uu____7492;_},uu____7493)
             ->
-            let uu____7513 = FStar_Syntax_Util.unlazy t11  in
-            head_matches env uu____7513 t21
-        | (uu____7514,FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7515;
+            let uu____7504 = FStar_Syntax_Util.unlazy t11  in
+            head_matches env uu____7504 t21
+        | (uu____7505,FStar_Syntax_Syntax.Tm_lazy
+           { FStar_Syntax_Syntax.blob = uu____7506;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7516;
-             FStar_Syntax_Syntax.ltyp = uu____7517;
-             FStar_Syntax_Syntax.rng = uu____7518;_})
+               uu____7507;
+             FStar_Syntax_Syntax.ltyp = uu____7508;
+             FStar_Syntax_Syntax.rng = uu____7509;_})
             ->
-            let uu____7529 = FStar_Syntax_Util.unlazy t21  in
-            head_matches env t11 uu____7529
+            let uu____7520 = FStar_Syntax_Util.unlazy t21  in
+            head_matches env t11 uu____7520
         | (FStar_Syntax_Syntax.Tm_name x,FStar_Syntax_Syntax.Tm_name y) ->
-            let uu____7532 = FStar_Syntax_Syntax.bv_eq x y  in
-            if uu____7532
+            let uu____7523 = FStar_Syntax_Syntax.bv_eq x y  in
+            if uu____7523
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_fvar f,FStar_Syntax_Syntax.Tm_fvar g) ->
-            let uu____7543 = FStar_Syntax_Syntax.fv_eq f g  in
-            if uu____7543
+            let uu____7534 = FStar_Syntax_Syntax.fv_eq f g  in
+            if uu____7534
             then FullMatch
             else
-              (let uu____7548 =
-                 let uu____7557 =
-                   let uu____7560 = fv_delta_depth env f  in
-                   FStar_Pervasives_Native.Some uu____7560  in
-                 let uu____7561 =
-                   let uu____7564 = fv_delta_depth env g  in
-                   FStar_Pervasives_Native.Some uu____7564  in
-                 (uu____7557, uu____7561)  in
-               MisMatch uu____7548)
+              (let uu____7539 =
+                 let uu____7548 =
+                   let uu____7551 = fv_delta_depth env f  in
+                   FStar_Pervasives_Native.Some uu____7551  in
+                 let uu____7552 =
+                   let uu____7555 = fv_delta_depth env g  in
+                   FStar_Pervasives_Native.Some uu____7555  in
+                 (uu____7548, uu____7552)  in
+               MisMatch uu____7539)
         | (FStar_Syntax_Syntax.Tm_uinst
-           (f,uu____7570),FStar_Syntax_Syntax.Tm_uinst (g,uu____7572)) ->
-            let uu____7581 = head_matches env f g  in
-            FStar_All.pipe_right uu____7581 head_match
+           (f,uu____7561),FStar_Syntax_Syntax.Tm_uinst (g,uu____7563)) ->
+            let uu____7572 = head_matches env f g  in
+            FStar_All.pipe_right uu____7572 head_match
         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
            ),FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify )) ->
             FullMatch
         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
-           ),uu____7582) -> HeadMatch true
-        | (uu____7584,FStar_Syntax_Syntax.Tm_constant
+           ),uu____7573) -> HeadMatch true
+        | (uu____7575,FStar_Syntax_Syntax.Tm_constant
            (FStar_Const.Const_reify )) -> HeadMatch true
         | (FStar_Syntax_Syntax.Tm_constant c,FStar_Syntax_Syntax.Tm_constant
            d) ->
-            let uu____7588 = FStar_Const.eq_const c d  in
-            if uu____7588
+            let uu____7579 = FStar_Const.eq_const c d  in
+            if uu____7579
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_uvar
-           (uv,uu____7598),FStar_Syntax_Syntax.Tm_uvar (uv',uu____7600)) ->
-            let uu____7633 =
+           (uv,uu____7589),FStar_Syntax_Syntax.Tm_uvar (uv',uu____7591)) ->
+            let uu____7624 =
               FStar_Syntax_Unionfind.equiv
                 uv.FStar_Syntax_Syntax.ctx_uvar_head
                 uv'.FStar_Syntax_Syntax.ctx_uvar_head
                in
-            if uu____7633
+            if uu____7624
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_refine
-           (x,uu____7643),FStar_Syntax_Syntax.Tm_refine (y,uu____7645)) ->
-            let uu____7654 =
+           (x,uu____7634),FStar_Syntax_Syntax.Tm_refine (y,uu____7636)) ->
+            let uu____7645 =
               head_matches env x.FStar_Syntax_Syntax.sort
                 y.FStar_Syntax_Syntax.sort
                in
-            FStar_All.pipe_right uu____7654 head_match
-        | (FStar_Syntax_Syntax.Tm_refine (x,uu____7656),uu____7657) ->
-            let uu____7662 = head_matches env x.FStar_Syntax_Syntax.sort t21
+            FStar_All.pipe_right uu____7645 head_match
+        | (FStar_Syntax_Syntax.Tm_refine (x,uu____7647),uu____7648) ->
+            let uu____7653 = head_matches env x.FStar_Syntax_Syntax.sort t21
                in
-            FStar_All.pipe_right uu____7662 head_match
-        | (uu____7663,FStar_Syntax_Syntax.Tm_refine (x,uu____7665)) ->
-            let uu____7670 = head_matches env t11 x.FStar_Syntax_Syntax.sort
+            FStar_All.pipe_right uu____7653 head_match
+        | (uu____7654,FStar_Syntax_Syntax.Tm_refine (x,uu____7656)) ->
+            let uu____7661 = head_matches env t11 x.FStar_Syntax_Syntax.sort
                in
-            FStar_All.pipe_right uu____7670 head_match
-        | (FStar_Syntax_Syntax.Tm_type uu____7671,FStar_Syntax_Syntax.Tm_type
-           uu____7672) -> HeadMatch false
+            FStar_All.pipe_right uu____7661 head_match
+        | (FStar_Syntax_Syntax.Tm_type uu____7662,FStar_Syntax_Syntax.Tm_type
+           uu____7663) -> HeadMatch false
         | (FStar_Syntax_Syntax.Tm_arrow
-           uu____7674,FStar_Syntax_Syntax.Tm_arrow uu____7675) ->
+           uu____7665,FStar_Syntax_Syntax.Tm_arrow uu____7666) ->
             HeadMatch false
         | (FStar_Syntax_Syntax.Tm_app
-           (head,uu____7706),FStar_Syntax_Syntax.Tm_app (head',uu____7708))
+           (head,uu____7697),FStar_Syntax_Syntax.Tm_app (head',uu____7699))
             ->
-            let uu____7757 = head_matches env head head'  in
-            FStar_All.pipe_right uu____7757 head_match
-        | (FStar_Syntax_Syntax.Tm_app (head,uu____7759),uu____7760) ->
-            let uu____7785 = head_matches env head t21  in
-            FStar_All.pipe_right uu____7785 head_match
-        | (uu____7786,FStar_Syntax_Syntax.Tm_app (head,uu____7788)) ->
-            let uu____7813 = head_matches env t11 head  in
-            FStar_All.pipe_right uu____7813 head_match
-        | (FStar_Syntax_Syntax.Tm_let uu____7814,FStar_Syntax_Syntax.Tm_let
-           uu____7815) -> HeadMatch true
+            let uu____7748 = head_matches env head head'  in
+            FStar_All.pipe_right uu____7748 head_match
+        | (FStar_Syntax_Syntax.Tm_app (head,uu____7750),uu____7751) ->
+            let uu____7776 = head_matches env head t21  in
+            FStar_All.pipe_right uu____7776 head_match
+        | (uu____7777,FStar_Syntax_Syntax.Tm_app (head,uu____7779)) ->
+            let uu____7804 = head_matches env t11 head  in
+            FStar_All.pipe_right uu____7804 head_match
+        | (FStar_Syntax_Syntax.Tm_let uu____7805,FStar_Syntax_Syntax.Tm_let
+           uu____7806) -> HeadMatch true
         | (FStar_Syntax_Syntax.Tm_match
-           uu____7843,FStar_Syntax_Syntax.Tm_match uu____7844) ->
+           uu____7834,FStar_Syntax_Syntax.Tm_match uu____7835) ->
             HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_abs uu____7890,FStar_Syntax_Syntax.Tm_abs
-           uu____7891) -> HeadMatch true
-        | uu____7929 ->
-            let uu____7934 =
-              let uu____7943 = delta_depth_of_term env t11  in
-              let uu____7946 = delta_depth_of_term env t21  in
-              (uu____7943, uu____7946)  in
-            MisMatch uu____7934
+        | (FStar_Syntax_Syntax.Tm_abs uu____7881,FStar_Syntax_Syntax.Tm_abs
+           uu____7882) -> HeadMatch true
+        | uu____7920 ->
+            let uu____7925 =
+              let uu____7934 = delta_depth_of_term env t11  in
+              let uu____7937 = delta_depth_of_term env t21  in
+              (uu____7934, uu____7937)  in
+            MisMatch uu____7925
   
 let (head_matches_delta :
   FStar_TypeChecker_Env.env ->
@@ -2623,46 +2618,46 @@ let (head_matches_delta :
         fun t2  ->
           let maybe_inline t =
             let head =
-              let uu____8015 = unrefine env t  in
-              FStar_Syntax_Util.head_of uu____8015  in
-            (let uu____8017 =
+              let uu____8006 = unrefine env t  in
+              FStar_Syntax_Util.head_of uu____8006  in
+            (let uu____8008 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta")
                 in
-             if uu____8017
+             if uu____8008
              then
-               let uu____8022 = FStar_Syntax_Print.term_to_string t  in
-               let uu____8024 = FStar_Syntax_Print.term_to_string head  in
-               FStar_Util.print2 "Head of %s is %s\n" uu____8022 uu____8024
+               let uu____8013 = FStar_Syntax_Print.term_to_string t  in
+               let uu____8015 = FStar_Syntax_Print.term_to_string head  in
+               FStar_Util.print2 "Head of %s is %s\n" uu____8013 uu____8015
              else ());
-            (let uu____8029 =
-               let uu____8030 = FStar_Syntax_Util.un_uinst head  in
-               uu____8030.FStar_Syntax_Syntax.n  in
-             match uu____8029 with
+            (let uu____8020 =
+               let uu____8021 = FStar_Syntax_Util.un_uinst head  in
+               uu____8021.FStar_Syntax_Syntax.n  in
+             match uu____8020 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____8036 =
+                 let uu____8027 =
                    FStar_TypeChecker_Env.lookup_definition
                      [FStar_TypeChecker_Env.Unfold
                         FStar_Syntax_Syntax.delta_constant;
                      FStar_TypeChecker_Env.Eager_unfolding_only] env
                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                     in
-                 (match uu____8036 with
+                 (match uu____8027 with
                   | FStar_Pervasives_Native.None  ->
-                      ((let uu____8050 =
+                      ((let uu____8041 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "RelDelta")
                            in
-                        if uu____8050
+                        if uu____8041
                         then
-                          let uu____8055 =
+                          let uu____8046 =
                             FStar_Syntax_Print.term_to_string head  in
                           FStar_Util.print1 "No definition found for %s\n"
-                            uu____8055
+                            uu____8046
                         else ());
                        FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some uu____8060 ->
+                  | FStar_Pervasives_Native.Some uu____8051 ->
                       let basic_steps =
                         [FStar_TypeChecker_Env.UnfoldUntil
                            FStar_Syntax_Syntax.delta_constant;
@@ -2685,28 +2680,28 @@ let (head_matches_delta :
                           "FStar.TypeChecker.Rel.norm_with_steps.1" steps env
                           t
                          in
-                      let uu____8078 =
-                        let uu____8080 = FStar_Syntax_Util.eq_tm t t'  in
-                        uu____8080 = FStar_Syntax_Util.Equal  in
-                      if uu____8078
+                      let uu____8069 =
+                        let uu____8071 = FStar_Syntax_Util.eq_tm t t'  in
+                        uu____8071 = FStar_Syntax_Util.Equal  in
+                      if uu____8069
                       then FStar_Pervasives_Native.None
                       else
-                        ((let uu____8087 =
+                        ((let uu____8078 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelDelta")
                              in
-                          if uu____8087
+                          if uu____8078
                           then
-                            let uu____8092 =
+                            let uu____8083 =
                               FStar_Syntax_Print.term_to_string t  in
-                            let uu____8094 =
+                            let uu____8085 =
                               FStar_Syntax_Print.term_to_string t'  in
-                            FStar_Util.print2 "Inlined %s to %s\n" uu____8092
-                              uu____8094
+                            FStar_Util.print2 "Inlined %s to %s\n" uu____8083
+                              uu____8085
                           else ());
                          FStar_Pervasives_Native.Some t'))
-             | uu____8099 -> FStar_Pervasives_Native.None)
+             | uu____8090 -> FStar_Pervasives_Native.None)
              in
           let success d r t11 t21 =
             (r,
@@ -2722,22 +2717,22 @@ let (head_matches_delta :
              in
           let rec aux retry n_delta t11 t21 =
             let r = head_matches env t11 t21  in
-            (let uu____8251 =
+            (let uu____8242 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta")
                 in
-             if uu____8251
+             if uu____8242
              then
-               let uu____8256 = FStar_Syntax_Print.term_to_string t11  in
-               let uu____8258 = FStar_Syntax_Print.term_to_string t21  in
-               let uu____8260 = string_of_match_result r  in
-               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu____8256
-                 uu____8258 uu____8260
+               let uu____8247 = FStar_Syntax_Print.term_to_string t11  in
+               let uu____8249 = FStar_Syntax_Print.term_to_string t21  in
+               let uu____8251 = string_of_match_result r  in
+               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu____8247
+                 uu____8249 uu____8251
              else ());
             (let reduce_one_and_try_again d1 d2 =
                let d1_greater_than_d2 =
                  FStar_TypeChecker_Common.delta_depth_greater_than d1 d2  in
-               let uu____8288 =
+               let uu____8279 =
                  if d1_greater_than_d2
                  then
                    let t1' =
@@ -2756,12 +2751,12 @@ let (head_matches_delta :
                        in
                     (t11, t2'))
                   in
-               match uu____8288 with
+               match uu____8279 with
                | (t12,t22) -> aux retry (n_delta + Prims.int_one) t12 t22  in
              let reduce_both_and_try_again d r1 =
-               let uu____8336 = FStar_TypeChecker_Common.decr_delta_depth d
+               let uu____8327 = FStar_TypeChecker_Common.decr_delta_depth d
                   in
-               match uu____8336 with
+               match uu____8327 with
                | FStar_Pervasives_Native.None  -> fail n_delta r1 t11 t21
                | FStar_Pervasives_Native.Some d1 ->
                    let t12 =
@@ -2793,16 +2788,16 @@ let (head_matches_delta :
              | MisMatch
                  (FStar_Pervasives_Native.Some
                   (FStar_Syntax_Syntax.Delta_equational_at_level
-                  uu____8374),uu____8375)
+                  uu____8365),uu____8366)
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8396 =
-                      let uu____8405 = maybe_inline t11  in
-                      let uu____8408 = maybe_inline t21  in
-                      (uu____8405, uu____8408)  in
-                    match uu____8396 with
+                   (let uu____8387 =
+                      let uu____8396 = maybe_inline t11  in
+                      let uu____8399 = maybe_inline t21  in
+                      (uu____8396, uu____8399)  in
+                    match uu____8387 with
                     | (FStar_Pervasives_Native.None
                        ,FStar_Pervasives_Native.None ) ->
                         fail n_delta r t11 t21
@@ -2816,17 +2811,17 @@ let (head_matches_delta :
                        t12,FStar_Pervasives_Native.Some t22) ->
                         aux false (n_delta + Prims.int_one) t12 t22)
              | MisMatch
-                 (uu____8451,FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____8452))
+                 (uu____8442,FStar_Pervasives_Native.Some
+                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____8443))
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8473 =
-                      let uu____8482 = maybe_inline t11  in
-                      let uu____8485 = maybe_inline t21  in
-                      (uu____8482, uu____8485)  in
-                    match uu____8473 with
+                   (let uu____8464 =
+                      let uu____8473 = maybe_inline t11  in
+                      let uu____8476 = maybe_inline t21  in
+                      (uu____8473, uu____8476)  in
+                    match uu____8464 with
                     | (FStar_Pervasives_Native.None
                        ,FStar_Pervasives_Native.None ) ->
                         fail n_delta r t11 t21
@@ -2847,42 +2842,42 @@ let (head_matches_delta :
                  (FStar_Pervasives_Native.Some
                   d1,FStar_Pervasives_Native.Some d2)
                  -> reduce_one_and_try_again d1 d2
-             | MisMatch uu____8540 -> fail n_delta r t11 t21
-             | uu____8549 -> success n_delta r t11 t21)
+             | MisMatch uu____8531 -> fail n_delta r t11 t21
+             | uu____8540 -> success n_delta r t11 t21)
              in
           let r = aux true Prims.int_zero t1 t2  in
-          (let uu____8564 =
+          (let uu____8555 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "RelDelta")
               in
-           if uu____8564
+           if uu____8555
            then
-             let uu____8569 = FStar_Syntax_Print.term_to_string t1  in
-             let uu____8571 = FStar_Syntax_Print.term_to_string t2  in
-             let uu____8573 =
+             let uu____8560 = FStar_Syntax_Print.term_to_string t1  in
+             let uu____8562 = FStar_Syntax_Print.term_to_string t2  in
+             let uu____8564 =
                string_of_match_result (FStar_Pervasives_Native.fst r)  in
-             let uu____8581 =
+             let uu____8572 =
                if FStar_Option.isNone (FStar_Pervasives_Native.snd r)
                then "None"
                else
-                 (let uu____8598 =
+                 (let uu____8589 =
                     FStar_All.pipe_right (FStar_Pervasives_Native.snd r)
                       FStar_Util.must
                      in
-                  FStar_All.pipe_right uu____8598
-                    (fun uu____8633  ->
-                       match uu____8633 with
+                  FStar_All.pipe_right uu____8589
+                    (fun uu____8624  ->
+                       match uu____8624 with
                        | (t11,t21) ->
-                           let uu____8641 =
+                           let uu____8632 =
                              FStar_Syntax_Print.term_to_string t11  in
-                           let uu____8643 =
-                             let uu____8645 =
+                           let uu____8634 =
+                             let uu____8636 =
                                FStar_Syntax_Print.term_to_string t21  in
-                             Prims.op_Hat "; " uu____8645  in
-                           Prims.op_Hat uu____8641 uu____8643))
+                             Prims.op_Hat "; " uu____8636  in
+                           Prims.op_Hat uu____8632 uu____8634))
                 in
              FStar_Util.print4 "head_matches_delta (%s, %s) = %s (%s)\n"
-               uu____8569 uu____8571 uu____8573 uu____8581
+               uu____8560 uu____8562 uu____8564 uu____8572
            else ());
           r
   
@@ -2891,12 +2886,12 @@ let (kind_type :
   =
   fun binders  ->
     fun r  ->
-      let uu____8662 = FStar_Syntax_Util.type_u ()  in
-      FStar_All.pipe_right uu____8662 FStar_Pervasives_Native.fst
+      let uu____8653 = FStar_Syntax_Util.type_u ()  in
+      FStar_All.pipe_right uu____8653 FStar_Pervasives_Native.fst
   
 let (rank_t_num : FStar_TypeChecker_Common.rank_t -> Prims.int) =
-  fun uu___21_8677  ->
-    match uu___21_8677 with
+  fun uu___21_8668  ->
+    match uu___21_8668 with
     | FStar_TypeChecker_Common.Rigid_rigid  -> Prims.int_zero
     | FStar_TypeChecker_Common.Flex_rigid_eq  -> Prims.int_one
     | FStar_TypeChecker_Common.Flex_flex_pattern_eq  -> (Prims.of_int (2))
@@ -2919,28 +2914,28 @@ let (compress_tprob :
   =
   fun tcenv  ->
     fun p  ->
-      let uu___1231_8726 = p  in
-      let uu____8729 = whnf tcenv p.FStar_TypeChecker_Common.lhs  in
-      let uu____8730 = whnf tcenv p.FStar_TypeChecker_Common.rhs  in
+      let uu___1231_8717 = p  in
+      let uu____8720 = whnf tcenv p.FStar_TypeChecker_Common.lhs  in
+      let uu____8721 = whnf tcenv p.FStar_TypeChecker_Common.rhs  in
       {
         FStar_TypeChecker_Common.pid =
-          (uu___1231_8726.FStar_TypeChecker_Common.pid);
-        FStar_TypeChecker_Common.lhs = uu____8729;
+          (uu___1231_8717.FStar_TypeChecker_Common.pid);
+        FStar_TypeChecker_Common.lhs = uu____8720;
         FStar_TypeChecker_Common.relation =
-          (uu___1231_8726.FStar_TypeChecker_Common.relation);
-        FStar_TypeChecker_Common.rhs = uu____8730;
+          (uu___1231_8717.FStar_TypeChecker_Common.relation);
+        FStar_TypeChecker_Common.rhs = uu____8721;
         FStar_TypeChecker_Common.element =
-          (uu___1231_8726.FStar_TypeChecker_Common.element);
+          (uu___1231_8717.FStar_TypeChecker_Common.element);
         FStar_TypeChecker_Common.logical_guard =
-          (uu___1231_8726.FStar_TypeChecker_Common.logical_guard);
+          (uu___1231_8717.FStar_TypeChecker_Common.logical_guard);
         FStar_TypeChecker_Common.logical_guard_uvar =
-          (uu___1231_8726.FStar_TypeChecker_Common.logical_guard_uvar);
+          (uu___1231_8717.FStar_TypeChecker_Common.logical_guard_uvar);
         FStar_TypeChecker_Common.reason =
-          (uu___1231_8726.FStar_TypeChecker_Common.reason);
+          (uu___1231_8717.FStar_TypeChecker_Common.reason);
         FStar_TypeChecker_Common.loc =
-          (uu___1231_8726.FStar_TypeChecker_Common.loc);
+          (uu___1231_8717.FStar_TypeChecker_Common.loc);
         FStar_TypeChecker_Common.rank =
-          (uu___1231_8726.FStar_TypeChecker_Common.rank)
+          (uu___1231_8717.FStar_TypeChecker_Common.rank)
       }
   
 let (compress_prob :
@@ -2951,10 +2946,10 @@ let (compress_prob :
     fun p  ->
       match p with
       | FStar_TypeChecker_Common.TProb p1 ->
-          let uu____8745 = compress_tprob tcenv p1  in
-          FStar_All.pipe_right uu____8745
-            (fun uu____8750  -> FStar_TypeChecker_Common.TProb uu____8750)
-      | FStar_TypeChecker_Common.CProb uu____8751 -> p
+          let uu____8736 = compress_tprob tcenv p1  in
+          FStar_All.pipe_right uu____8736
+            (fun uu____8741  -> FStar_TypeChecker_Common.TProb uu____8741)
+      | FStar_TypeChecker_Common.CProb uu____8742 -> p
   
 let (rank :
   FStar_TypeChecker_Env.env ->
@@ -2964,27 +2959,27 @@ let (rank :
   fun tcenv  ->
     fun pr  ->
       let prob =
-        let uu____8774 = compress_prob tcenv pr  in
-        FStar_All.pipe_right uu____8774 maybe_invert_p  in
+        let uu____8765 = compress_prob tcenv pr  in
+        FStar_All.pipe_right uu____8765 maybe_invert_p  in
       match prob with
       | FStar_TypeChecker_Common.TProb tp ->
-          let uu____8782 =
+          let uu____8773 =
             FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs
              in
-          (match uu____8782 with
+          (match uu____8773 with
            | (lh,lhs_args) ->
-               let uu____8829 =
+               let uu____8820 =
                  FStar_Syntax_Util.head_and_args
                    tp.FStar_TypeChecker_Common.rhs
                   in
-               (match uu____8829 with
+               (match uu____8820 with
                 | (rh,rhs_args) ->
-                    let uu____8876 =
+                    let uu____8867 =
                       match ((lh.FStar_Syntax_Syntax.n),
                               (rh.FStar_Syntax_Syntax.n))
                       with
                       | (FStar_Syntax_Syntax.Tm_uvar
-                         uu____8889,FStar_Syntax_Syntax.Tm_uvar uu____8890)
+                         uu____8880,FStar_Syntax_Syntax.Tm_uvar uu____8881)
                           ->
                           (match (lhs_args, rhs_args) with
                            | ([],[]) when
@@ -2993,169 +2988,169 @@ let (rank :
                                ->
                                (FStar_TypeChecker_Common.Flex_flex_pattern_eq,
                                  tp)
-                           | uu____8979 ->
+                           | uu____8970 ->
                                (FStar_TypeChecker_Common.Flex_flex, tp))
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____9006,uu____9007)
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____8997,uu____8998)
                           when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
-                      | (uu____9022,FStar_Syntax_Syntax.Tm_uvar uu____9023)
+                      | (uu____9013,FStar_Syntax_Syntax.Tm_uvar uu____9014)
                           when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
                       | (FStar_Syntax_Syntax.Tm_uvar
-                         uu____9038,FStar_Syntax_Syntax.Tm_arrow uu____9039)
+                         uu____9029,FStar_Syntax_Syntax.Tm_arrow uu____9030)
                           ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1282_9069 = tp  in
+                            (let uu___1282_9060 = tp  in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.pid);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.lhs);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.rhs);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.element);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.reason);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.loc);
+                                 (uu___1282_9060.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1282_9069.FStar_TypeChecker_Common.rank)
+                                 (uu___1282_9060.FStar_TypeChecker_Common.rank)
                              }))
                       | (FStar_Syntax_Syntax.Tm_uvar
-                         uu____9072,FStar_Syntax_Syntax.Tm_type uu____9073)
+                         uu____9063,FStar_Syntax_Syntax.Tm_type uu____9064)
                           ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1282_9089 = tp  in
+                            (let uu___1282_9080 = tp  in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.pid);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.lhs);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.rhs);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.element);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.reason);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.loc);
+                                 (uu___1282_9080.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1282_9089.FStar_TypeChecker_Common.rank)
+                                 (uu___1282_9080.FStar_TypeChecker_Common.rank)
                              }))
                       | (FStar_Syntax_Syntax.Tm_type
-                         uu____9092,FStar_Syntax_Syntax.Tm_uvar uu____9093)
+                         uu____9083,FStar_Syntax_Syntax.Tm_uvar uu____9084)
                           ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1282_9109 = tp  in
+                            (let uu___1282_9100 = tp  in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.pid);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.lhs);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.rhs);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.element);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.reason);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.loc);
+                                 (uu___1282_9100.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1282_9109.FStar_TypeChecker_Common.rank)
+                                 (uu___1282_9100.FStar_TypeChecker_Common.rank)
                              }))
-                      | (uu____9112,FStar_Syntax_Syntax.Tm_uvar uu____9113)
+                      | (uu____9103,FStar_Syntax_Syntax.Tm_uvar uu____9104)
                           -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____9128,uu____9129)
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____9119,uu____9120)
                           -> (FStar_TypeChecker_Common.Flex_rigid, tp)
-                      | (uu____9144,FStar_Syntax_Syntax.Tm_uvar uu____9145)
+                      | (uu____9135,FStar_Syntax_Syntax.Tm_uvar uu____9136)
                           -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (uu____9160,uu____9161) ->
+                      | (uu____9151,uu____9152) ->
                           (FStar_TypeChecker_Common.Rigid_rigid, tp)
                        in
-                    (match uu____8876 with
+                    (match uu____8867 with
                      | (rank,tp1) ->
-                         let uu____9174 =
+                         let uu____9165 =
                            FStar_All.pipe_right
-                             (let uu___1302_9178 = tp1  in
+                             (let uu___1302_9169 = tp1  in
                               {
                                 FStar_TypeChecker_Common.pid =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.pid);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.pid);
                                 FStar_TypeChecker_Common.lhs =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.lhs);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.lhs);
                                 FStar_TypeChecker_Common.relation =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.relation);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.relation);
                                 FStar_TypeChecker_Common.rhs =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.rhs);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.rhs);
                                 FStar_TypeChecker_Common.element =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.element);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.element);
                                 FStar_TypeChecker_Common.logical_guard =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.logical_guard);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.logical_guard);
                                 FStar_TypeChecker_Common.logical_guard_uvar =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.logical_guard_uvar);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.logical_guard_uvar);
                                 FStar_TypeChecker_Common.reason =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.reason);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.reason);
                                 FStar_TypeChecker_Common.loc =
-                                  (uu___1302_9178.FStar_TypeChecker_Common.loc);
+                                  (uu___1302_9169.FStar_TypeChecker_Common.loc);
                                 FStar_TypeChecker_Common.rank =
                                   (FStar_Pervasives_Native.Some rank)
                               })
-                             (fun uu____9181  ->
-                                FStar_TypeChecker_Common.TProb uu____9181)
+                             (fun uu____9172  ->
+                                FStar_TypeChecker_Common.TProb uu____9172)
                             in
-                         (rank, uu____9174))))
+                         (rank, uu____9165))))
       | FStar_TypeChecker_Common.CProb cp ->
-          let uu____9185 =
+          let uu____9176 =
             FStar_All.pipe_right
-              (let uu___1306_9189 = cp  in
+              (let uu___1306_9180 = cp  in
                {
                  FStar_TypeChecker_Common.pid =
-                   (uu___1306_9189.FStar_TypeChecker_Common.pid);
+                   (uu___1306_9180.FStar_TypeChecker_Common.pid);
                  FStar_TypeChecker_Common.lhs =
-                   (uu___1306_9189.FStar_TypeChecker_Common.lhs);
+                   (uu___1306_9180.FStar_TypeChecker_Common.lhs);
                  FStar_TypeChecker_Common.relation =
-                   (uu___1306_9189.FStar_TypeChecker_Common.relation);
+                   (uu___1306_9180.FStar_TypeChecker_Common.relation);
                  FStar_TypeChecker_Common.rhs =
-                   (uu___1306_9189.FStar_TypeChecker_Common.rhs);
+                   (uu___1306_9180.FStar_TypeChecker_Common.rhs);
                  FStar_TypeChecker_Common.element =
-                   (uu___1306_9189.FStar_TypeChecker_Common.element);
+                   (uu___1306_9180.FStar_TypeChecker_Common.element);
                  FStar_TypeChecker_Common.logical_guard =
-                   (uu___1306_9189.FStar_TypeChecker_Common.logical_guard);
+                   (uu___1306_9180.FStar_TypeChecker_Common.logical_guard);
                  FStar_TypeChecker_Common.logical_guard_uvar =
-                   (uu___1306_9189.FStar_TypeChecker_Common.logical_guard_uvar);
+                   (uu___1306_9180.FStar_TypeChecker_Common.logical_guard_uvar);
                  FStar_TypeChecker_Common.reason =
-                   (uu___1306_9189.FStar_TypeChecker_Common.reason);
+                   (uu___1306_9180.FStar_TypeChecker_Common.reason);
                  FStar_TypeChecker_Common.loc =
-                   (uu___1306_9189.FStar_TypeChecker_Common.loc);
+                   (uu___1306_9180.FStar_TypeChecker_Common.loc);
                  FStar_TypeChecker_Common.rank =
                    (FStar_Pervasives_Native.Some
                       FStar_TypeChecker_Common.Rigid_rigid)
                })
-              (fun uu____9192  -> FStar_TypeChecker_Common.CProb uu____9192)
+              (fun uu____9183  -> FStar_TypeChecker_Common.CProb uu____9183)
              in
-          (FStar_TypeChecker_Common.Rigid_rigid, uu____9185)
+          (FStar_TypeChecker_Common.Rigid_rigid, uu____9176)
   
 let (next_prob :
   worklist ->
@@ -3163,8 +3158,8 @@ let (next_prob :
       * FStar_TypeChecker_Common.rank_t) FStar_Pervasives_Native.option)
   =
   fun wl  ->
-    let rec aux uu____9252 probs =
-      match uu____9252 with
+    let rec aux uu____9243 probs =
+      match uu____9243 with
       | (min_rank,min,out) ->
           (match probs with
            | [] ->
@@ -3172,10 +3167,10 @@ let (next_prob :
                 | (FStar_Pervasives_Native.Some
                    p,FStar_Pervasives_Native.Some r) ->
                     FStar_Pervasives_Native.Some (p, out, r)
-                | uu____9333 -> FStar_Pervasives_Native.None)
+                | uu____9324 -> FStar_Pervasives_Native.None)
            | hd::tl ->
-               let uu____9354 = rank wl.tcenv hd  in
-               (match uu____9354 with
+               let uu____9345 = rank wl.tcenv hd  in
+               (match uu____9345 with
                 | (rank1,hd1) ->
                     if rank_leq rank1 FStar_TypeChecker_Common.Flex_rigid_eq
                     then
@@ -3187,12 +3182,12 @@ let (next_prob :
                            FStar_Pervasives_Native.Some
                              (hd1, (FStar_List.append out (m :: tl)), rank1))
                     else
-                      (let uu____9415 =
+                      (let uu____9406 =
                          (min_rank = FStar_Pervasives_Native.None) ||
-                           (let uu____9420 = FStar_Option.get min_rank  in
-                            rank_less_than rank1 uu____9420)
+                           (let uu____9411 = FStar_Option.get min_rank  in
+                            rank_less_than rank1 uu____9411)
                           in
-                       if uu____9415
+                       if uu____9406
                        then
                          match min with
                          | FStar_Pervasives_Native.None  ->
@@ -3218,33 +3213,33 @@ let (flex_prob_closing :
     fun bs  ->
       fun p  ->
         let flex_will_be_closed t =
-          let uu____9493 = FStar_Syntax_Util.head_and_args t  in
-          match uu____9493 with
-          | (hd,uu____9512) ->
-              let uu____9537 =
-                let uu____9538 = FStar_Syntax_Subst.compress hd  in
-                uu____9538.FStar_Syntax_Syntax.n  in
-              (match uu____9537 with
-               | FStar_Syntax_Syntax.Tm_uvar (u,uu____9543) ->
+          let uu____9484 = FStar_Syntax_Util.head_and_args t  in
+          match uu____9484 with
+          | (hd,uu____9503) ->
+              let uu____9528 =
+                let uu____9529 = FStar_Syntax_Subst.compress hd  in
+                uu____9529.FStar_Syntax_Syntax.n  in
+              (match uu____9528 with
+               | FStar_Syntax_Syntax.Tm_uvar (u,uu____9534) ->
                    FStar_All.pipe_right
                      u.FStar_Syntax_Syntax.ctx_uvar_binders
                      (FStar_Util.for_some
-                        (fun uu____9578  ->
-                           match uu____9578 with
-                           | (y,uu____9587) ->
+                        (fun uu____9569  ->
+                           match uu____9569 with
+                           | (y,uu____9578) ->
                                FStar_All.pipe_right bs
                                  (FStar_Util.for_some
-                                    (fun uu____9610  ->
-                                       match uu____9610 with
-                                       | (x,uu____9619) ->
+                                    (fun uu____9601  ->
+                                       match uu____9601 with
+                                       | (x,uu____9610) ->
                                            FStar_Syntax_Syntax.bv_eq x y))))
-               | uu____9624 -> false)
+               | uu____9615 -> false)
            in
-        let uu____9626 = rank tcenv p  in
-        match uu____9626 with
+        let uu____9617 = rank tcenv p  in
+        match uu____9617 with
         | (r,p1) ->
             (match p1 with
-             | FStar_TypeChecker_Common.CProb uu____9635 -> true
+             | FStar_TypeChecker_Common.CProb uu____9626 -> true
              | FStar_TypeChecker_Common.TProb p2 ->
                  (match r with
                   | FStar_TypeChecker_Common.Rigid_rigid  -> true
@@ -3269,26 +3264,26 @@ type univ_eq_sol =
   | UFailed of lstring 
 let (uu___is_UDeferred : univ_eq_sol -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UDeferred _0 -> true | uu____9716 -> false
+    match projectee with | UDeferred _0 -> true | uu____9707 -> false
   
 let (__proj__UDeferred__item___0 : univ_eq_sol -> worklist) =
   fun projectee  -> match projectee with | UDeferred _0 -> _0 
 let (uu___is_USolved : univ_eq_sol -> Prims.bool) =
   fun projectee  ->
-    match projectee with | USolved _0 -> true | uu____9735 -> false
+    match projectee with | USolved _0 -> true | uu____9726 -> false
   
 let (__proj__USolved__item___0 : univ_eq_sol -> worklist) =
   fun projectee  -> match projectee with | USolved _0 -> _0 
 let (uu___is_UFailed : univ_eq_sol -> Prims.bool) =
   fun projectee  ->
-    match projectee with | UFailed _0 -> true | uu____9754 -> false
+    match projectee with | UFailed _0 -> true | uu____9745 -> false
   
 let (__proj__UFailed__item___0 : univ_eq_sol -> lstring) =
   fun projectee  -> match projectee with | UFailed _0 -> _0 
 let (ufailed_simple : Prims.string -> univ_eq_sol) =
-  fun s  -> let uu____9771 = FStar_Thunk.mkv s  in UFailed uu____9771 
+  fun s  -> let uu____9762 = FStar_Thunk.mkv s  in UFailed uu____9762 
 let (ufailed_thunk : (unit -> Prims.string) -> univ_eq_sol) =
-  fun s  -> let uu____9786 = mklstr s  in UFailed uu____9786 
+  fun s  -> let uu____9777 = mklstr s  in UFailed uu____9777 
 let rec (really_solve_universe_eq :
   Prims.int ->
     worklist ->
@@ -3309,14 +3304,14 @@ let rec (really_solve_universe_eq :
                 FStar_All.pipe_right us
                   (FStar_Util.for_some
                      (fun u3  ->
-                        let uu____9837 = FStar_Syntax_Util.univ_kernel u3  in
-                        match uu____9837 with
-                        | (k,uu____9845) ->
+                        let uu____9828 = FStar_Syntax_Util.univ_kernel u3  in
+                        match uu____9828 with
+                        | (k,uu____9836) ->
                             (match k with
                              | FStar_Syntax_Syntax.U_unif v2 ->
                                  FStar_Syntax_Unionfind.univ_equiv v1 v2
-                             | uu____9860 -> false)))
-            | uu____9862 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u])
+                             | uu____9851 -> false)))
+            | uu____9853 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u])
              in
           let rec filter_out_common_univs u12 u22 =
             let common_elts =
@@ -3324,26 +3319,26 @@ let rec (really_solve_universe_eq :
                 (FStar_List.fold_left
                    (fun uvs  ->
                       fun uv1  ->
-                        let uu____9914 =
+                        let uu____9905 =
                           FStar_All.pipe_right u22
                             (FStar_List.existsML
                                (fun uv2  ->
                                   FStar_Syntax_Util.eq_univs uv1 uv2))
                            in
-                        if uu____9914 then uv1 :: uvs else uvs) [])
+                        if uu____9905 then uv1 :: uvs else uvs) [])
                in
             let filter =
               FStar_List.filter
                 (fun u  ->
-                   let uu____9938 =
+                   let uu____9929 =
                      FStar_All.pipe_right common_elts
                        (FStar_List.existsML
                           (fun u'  -> FStar_Syntax_Util.eq_univs u u'))
                       in
-                   Prims.op_Negation uu____9938)
+                   Prims.op_Negation uu____9929)
                in
-            let uu____9945 = filter u12  in
-            let uu____9948 = filter u22  in (uu____9945, uu____9948)  in
+            let uu____9936 = filter u12  in
+            let uu____9939 = filter u22  in (uu____9936, uu____9939)  in
           let try_umax_components u12 u22 msg =
             if Prims.op_Negation wl.umax_heuristic_ok
             then ufailed_simple "Unable to unify universe terms with umax"
@@ -3351,8 +3346,8 @@ let rec (really_solve_universe_eq :
               (match (u12, u22) with
                | (FStar_Syntax_Syntax.U_max us1,FStar_Syntax_Syntax.U_max
                   us2) ->
-                   let uu____9983 = filter_out_common_univs us1 us2  in
-                   (match uu____9983 with
+                   let uu____9974 = filter_out_common_univs us1 us2  in
+                   (match uu____9974 with
                     | (us11,us21) ->
                         if
                           (FStar_List.length us11) = (FStar_List.length us21)
@@ -3360,33 +3355,33 @@ let rec (really_solve_universe_eq :
                           let rec aux wl1 us12 us22 =
                             match (us12, us22) with
                             | (u13::us13,u23::us23) ->
-                                let uu____10043 =
+                                let uu____10034 =
                                   really_solve_universe_eq pid_orig wl1 u13
                                     u23
                                    in
-                                (match uu____10043 with
+                                (match uu____10034 with
                                  | USolved wl2 -> aux wl2 us13 us23
                                  | failed -> failed)
-                            | uu____10046 -> USolved wl1  in
+                            | uu____10037 -> USolved wl1  in
                           aux wl us11 us21
                         else
                           ufailed_thunk
-                            (fun uu____10063  ->
-                               let uu____10064 =
+                            (fun uu____10054  ->
+                               let uu____10055 =
                                  FStar_Syntax_Print.univ_to_string u12  in
-                               let uu____10066 =
+                               let uu____10057 =
                                  FStar_Syntax_Print.univ_to_string u22  in
                                FStar_Util.format2
                                  "Unable to unify universes: %s and %s"
-                                 uu____10064 uu____10066))
+                                 uu____10055 uu____10057))
                | (FStar_Syntax_Syntax.U_max us,u') ->
                    let rec aux wl1 us1 =
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____10092 =
+                         let uu____10083 =
                            really_solve_universe_eq pid_orig wl1 u u'  in
-                         (match uu____10092 with
+                         (match uu____10083 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed)
                       in
@@ -3396,67 +3391,67 @@ let rec (really_solve_universe_eq :
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____10118 =
+                         let uu____10109 =
                            really_solve_universe_eq pid_orig wl1 u u'  in
-                         (match uu____10118 with
+                         (match uu____10109 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed)
                       in
                    aux wl us
-               | uu____10121 ->
+               | uu____10112 ->
                    ufailed_thunk
-                     (fun uu____10132  ->
-                        let uu____10133 =
+                     (fun uu____10123  ->
+                        let uu____10124 =
                           FStar_Syntax_Print.univ_to_string u12  in
-                        let uu____10135 =
+                        let uu____10126 =
                           FStar_Syntax_Print.univ_to_string u22  in
                         FStar_Util.format3
                           "Unable to unify universes: %s and %s (%s)"
-                          uu____10133 uu____10135 msg))
+                          uu____10124 uu____10126 msg))
              in
           match (u11, u21) with
-          | (FStar_Syntax_Syntax.U_bvar uu____10138,uu____10139) ->
-              let uu____10141 =
-                let uu____10143 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10145 = FStar_Syntax_Print.univ_to_string u21  in
+          | (FStar_Syntax_Syntax.U_bvar uu____10129,uu____10130) ->
+              let uu____10132 =
+                let uu____10134 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10136 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10143 uu____10145
+                  uu____10134 uu____10136
                  in
-              failwith uu____10141
-          | (FStar_Syntax_Syntax.U_unknown ,uu____10148) ->
-              let uu____10149 =
-                let uu____10151 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10153 = FStar_Syntax_Print.univ_to_string u21  in
+              failwith uu____10132
+          | (FStar_Syntax_Syntax.U_unknown ,uu____10139) ->
+              let uu____10140 =
+                let uu____10142 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10144 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10151 uu____10153
+                  uu____10142 uu____10144
                  in
-              failwith uu____10149
-          | (uu____10156,FStar_Syntax_Syntax.U_bvar uu____10157) ->
-              let uu____10159 =
-                let uu____10161 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10163 = FStar_Syntax_Print.univ_to_string u21  in
+              failwith uu____10140
+          | (uu____10147,FStar_Syntax_Syntax.U_bvar uu____10148) ->
+              let uu____10150 =
+                let uu____10152 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10154 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10161 uu____10163
+                  uu____10152 uu____10154
                  in
-              failwith uu____10159
-          | (uu____10166,FStar_Syntax_Syntax.U_unknown ) ->
-              let uu____10167 =
-                let uu____10169 = FStar_Syntax_Print.univ_to_string u11  in
-                let uu____10171 = FStar_Syntax_Print.univ_to_string u21  in
+              failwith uu____10150
+          | (uu____10157,FStar_Syntax_Syntax.U_unknown ) ->
+              let uu____10158 =
+                let uu____10160 = FStar_Syntax_Print.univ_to_string u11  in
+                let uu____10162 = FStar_Syntax_Print.univ_to_string u21  in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____10169 uu____10171
+                  uu____10160 uu____10162
                  in
-              failwith uu____10167
+              failwith uu____10158
           | (FStar_Syntax_Syntax.U_name x,FStar_Syntax_Syntax.U_name y) ->
-              let uu____10176 =
-                let uu____10178 = FStar_Ident.text_of_id x  in
-                let uu____10180 = FStar_Ident.text_of_id y  in
-                uu____10178 = uu____10180  in
-              if uu____10176
+              let uu____10167 =
+                let uu____10169 = FStar_Ident.text_of_id x  in
+                let uu____10171 = FStar_Ident.text_of_id y  in
+                uu____10169 = uu____10171  in
+              if uu____10167
               then USolved wl
               else ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_zero ) ->
@@ -3464,85 +3459,85 @@ let rec (really_solve_universe_eq :
           | (FStar_Syntax_Syntax.U_succ u12,FStar_Syntax_Syntax.U_succ u22)
               -> really_solve_universe_eq pid_orig wl u12 u22
           | (FStar_Syntax_Syntax.U_unif v1,FStar_Syntax_Syntax.U_unif v2) ->
-              let uu____10211 = FStar_Syntax_Unionfind.univ_equiv v1 v2  in
-              if uu____10211
+              let uu____10202 = FStar_Syntax_Unionfind.univ_equiv v1 v2  in
+              if uu____10202
               then USolved wl
               else
                 (let wl1 = extend_solution pid_orig [UNIV (v1, u21)] wl  in
                  USolved wl1)
           | (FStar_Syntax_Syntax.U_unif v1,u) ->
               let u3 = norm_univ wl u  in
-              let uu____10230 = occurs_univ v1 u3  in
-              if uu____10230
+              let uu____10221 = occurs_univ v1 u3  in
+              if uu____10221
               then
-                let uu____10233 =
-                  let uu____10235 =
+                let uu____10224 =
+                  let uu____10226 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1)
                      in
-                  let uu____10237 = FStar_Syntax_Print.univ_to_string u3  in
+                  let uu____10228 = FStar_Syntax_Print.univ_to_string u3  in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____10235 uu____10237
+                    uu____10226 uu____10228
                    in
-                try_umax_components u11 u21 uu____10233
+                try_umax_components u11 u21 uu____10224
               else
-                (let uu____10242 =
+                (let uu____10233 =
                    extend_solution pid_orig [UNIV (v1, u3)] wl  in
-                 USolved uu____10242)
+                 USolved uu____10233)
           | (u,FStar_Syntax_Syntax.U_unif v1) ->
               let u3 = norm_univ wl u  in
-              let uu____10256 = occurs_univ v1 u3  in
-              if uu____10256
+              let uu____10247 = occurs_univ v1 u3  in
+              if uu____10247
               then
-                let uu____10259 =
-                  let uu____10261 =
+                let uu____10250 =
+                  let uu____10252 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1)
                      in
-                  let uu____10263 = FStar_Syntax_Print.univ_to_string u3  in
+                  let uu____10254 = FStar_Syntax_Print.univ_to_string u3  in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____10261 uu____10263
+                    uu____10252 uu____10254
                    in
-                try_umax_components u11 u21 uu____10259
+                try_umax_components u11 u21 uu____10250
               else
-                (let uu____10268 =
+                (let uu____10259 =
                    extend_solution pid_orig [UNIV (v1, u3)] wl  in
-                 USolved uu____10268)
-          | (FStar_Syntax_Syntax.U_max uu____10269,uu____10270) ->
+                 USolved uu____10259)
+          | (FStar_Syntax_Syntax.U_max uu____10260,uu____10261) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11  in
                  let u22 = norm_univ wl u21  in
-                 let uu____10278 = FStar_Syntax_Util.eq_univs u12 u22  in
-                 if uu____10278
+                 let uu____10269 = FStar_Syntax_Util.eq_univs u12 u22  in
+                 if uu____10269
                  then USolved wl
                  else try_umax_components u12 u22 "")
-          | (uu____10284,FStar_Syntax_Syntax.U_max uu____10285) ->
+          | (uu____10275,FStar_Syntax_Syntax.U_max uu____10276) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11  in
                  let u22 = norm_univ wl u21  in
-                 let uu____10293 = FStar_Syntax_Util.eq_univs u12 u22  in
-                 if uu____10293
+                 let uu____10284 = FStar_Syntax_Util.eq_univs u12 u22  in
+                 if uu____10284
                  then USolved wl
                  else try_umax_components u12 u22 "")
           | (FStar_Syntax_Syntax.U_succ
-             uu____10299,FStar_Syntax_Syntax.U_zero ) ->
+             uu____10290,FStar_Syntax_Syntax.U_zero ) ->
               ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_succ
-             uu____10301,FStar_Syntax_Syntax.U_name uu____10302) ->
+             uu____10292,FStar_Syntax_Syntax.U_name uu____10293) ->
               ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_succ
-             uu____10304) -> ufailed_simple "Incompatible universes"
+             uu____10295) -> ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero ,FStar_Syntax_Syntax.U_name
-             uu____10306) -> ufailed_simple "Incompatible universes"
+             uu____10297) -> ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_name
-             uu____10308,FStar_Syntax_Syntax.U_succ uu____10309) ->
+             uu____10299,FStar_Syntax_Syntax.U_succ uu____10300) ->
               ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_name
-             uu____10311,FStar_Syntax_Syntax.U_zero ) ->
+             uu____10302,FStar_Syntax_Syntax.U_zero ) ->
               ufailed_simple "Incompatible universes"
   
 let (solve_universe_eq :
@@ -3567,25 +3562,25 @@ let match_num_binders :
   =
   fun bc1  ->
     fun bc2  ->
-      let uu____10418 = bc1  in
-      match uu____10418 with
+      let uu____10409 = bc1  in
+      match uu____10409 with
       | (bs1,mk_cod1) ->
-          let uu____10462 = bc2  in
-          (match uu____10462 with
+          let uu____10453 = bc2  in
+          (match uu____10453 with
            | (bs2,mk_cod2) ->
                let rec aux bs11 bs21 =
                  match (bs11, bs21) with
                  | (x::xs,y::ys) ->
-                     let uu____10573 = aux xs ys  in
-                     (match uu____10573 with
+                     let uu____10564 = aux xs ys  in
+                     (match uu____10564 with
                       | ((xs1,xr),(ys1,yr)) ->
                           (((x :: xs1), xr), ((y :: ys1), yr)))
                  | (xs,ys) ->
-                     let uu____10656 =
-                       let uu____10663 = mk_cod1 xs  in ([], uu____10663)  in
-                     let uu____10666 =
-                       let uu____10673 = mk_cod2 ys  in ([], uu____10673)  in
-                     (uu____10656, uu____10666)
+                     let uu____10647 =
+                       let uu____10654 = mk_cod1 xs  in ([], uu____10654)  in
+                     let uu____10657 =
+                       let uu____10664 = mk_cod2 ys  in ([], uu____10664)  in
+                     (uu____10647, uu____10657)
                   in
                aux bs1 bs2)
   
@@ -3604,35 +3599,35 @@ let (guard_of_prob :
             let has_type_guard t11 t21 =
               match problem.FStar_TypeChecker_Common.element with
               | FStar_Pervasives_Native.Some t ->
-                  let uu____10742 = FStar_Syntax_Syntax.bv_to_name t  in
-                  FStar_Syntax_Util.mk_has_type t11 uu____10742 t21
+                  let uu____10733 = FStar_Syntax_Syntax.bv_to_name t  in
+                  FStar_Syntax_Util.mk_has_type t11 uu____10733 t21
               | FStar_Pervasives_Native.None  ->
                   let x =
                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                       t11
                      in
                   let u_x = env.FStar_TypeChecker_Env.universe_of env t11  in
-                  let uu____10745 =
-                    let uu____10746 = FStar_Syntax_Syntax.bv_to_name x  in
-                    FStar_Syntax_Util.mk_has_type t11 uu____10746 t21  in
-                  FStar_Syntax_Util.mk_forall u_x x uu____10745
+                  let uu____10736 =
+                    let uu____10737 = FStar_Syntax_Syntax.bv_to_name x  in
+                    FStar_Syntax_Util.mk_has_type t11 uu____10737 t21  in
+                  FStar_Syntax_Util.mk_forall u_x x uu____10736
                in
             match problem.FStar_TypeChecker_Common.relation with
             | FStar_TypeChecker_Common.EQ  ->
                 mk_eq2 wl env (FStar_TypeChecker_Common.TProb problem) t1 t2
             | FStar_TypeChecker_Common.SUB  ->
-                let uu____10751 = has_type_guard t1 t2  in (uu____10751, wl)
+                let uu____10742 = has_type_guard t1 t2  in (uu____10742, wl)
             | FStar_TypeChecker_Common.SUBINV  ->
-                let uu____10752 = has_type_guard t2 t1  in (uu____10752, wl)
+                let uu____10743 = has_type_guard t2 t1  in (uu____10743, wl)
   
 let is_flex_pat :
-  'uuuuuu10762 'uuuuuu10763 'uuuuuu10764 .
-    ('uuuuuu10762 * 'uuuuuu10763 * 'uuuuuu10764 Prims.list) -> Prims.bool
+  'uuuuuu10753 'uuuuuu10754 'uuuuuu10755 .
+    ('uuuuuu10753 * 'uuuuuu10754 * 'uuuuuu10755 Prims.list) -> Prims.bool
   =
-  fun uu___22_10778  ->
-    match uu___22_10778 with
-    | (uu____10787,uu____10788,[]) -> true
-    | uu____10792 -> false
+  fun uu___22_10769  ->
+    match uu___22_10769 with
+    | (uu____10778,uu____10779,[]) -> true
+    | uu____10783 -> false
   
 let (quasi_pattern :
   FStar_TypeChecker_Env.env ->
@@ -3642,162 +3637,162 @@ let (quasi_pattern :
   =
   fun env  ->
     fun f  ->
-      let uu____10825 = f  in
-      match uu____10825 with
-      | (uu____10832,{ FStar_Syntax_Syntax.ctx_uvar_head = uu____10833;
-                       FStar_Syntax_Syntax.ctx_uvar_gamma = uu____10834;
+      let uu____10816 = f  in
+      match uu____10816 with
+      | (uu____10823,{ FStar_Syntax_Syntax.ctx_uvar_head = uu____10824;
+                       FStar_Syntax_Syntax.ctx_uvar_gamma = uu____10825;
                        FStar_Syntax_Syntax.ctx_uvar_binders = ctx;
                        FStar_Syntax_Syntax.ctx_uvar_typ = t_hd;
-                       FStar_Syntax_Syntax.ctx_uvar_reason = uu____10837;
+                       FStar_Syntax_Syntax.ctx_uvar_reason = uu____10828;
                        FStar_Syntax_Syntax.ctx_uvar_should_check =
-                         uu____10838;
-                       FStar_Syntax_Syntax.ctx_uvar_range = uu____10839;
-                       FStar_Syntax_Syntax.ctx_uvar_meta = uu____10840;_},args)
+                         uu____10829;
+                       FStar_Syntax_Syntax.ctx_uvar_range = uu____10830;
+                       FStar_Syntax_Syntax.ctx_uvar_meta = uu____10831;_},args)
           ->
           let name_exists_in x bs =
             FStar_Util.for_some
-              (fun uu____10912  ->
-                 match uu____10912 with
-                 | (y,uu____10921) -> FStar_Syntax_Syntax.bv_eq x y) bs
+              (fun uu____10903  ->
+                 match uu____10903 with
+                 | (y,uu____10912) -> FStar_Syntax_Syntax.bv_eq x y) bs
              in
           let rec aux pat_binders formals t_res args1 =
             match (formals, args1) with
             | ([],[]) ->
-                let uu____11075 =
-                  let uu____11090 =
-                    let uu____11093 = FStar_Syntax_Syntax.mk_Total t_res  in
-                    FStar_Syntax_Util.arrow formals uu____11093  in
-                  ((FStar_List.rev pat_binders), uu____11090)  in
-                FStar_Pervasives_Native.Some uu____11075
-            | (uu____11126,[]) ->
-                let uu____11157 =
-                  let uu____11172 =
-                    let uu____11175 = FStar_Syntax_Syntax.mk_Total t_res  in
-                    FStar_Syntax_Util.arrow formals uu____11175  in
-                  ((FStar_List.rev pat_binders), uu____11172)  in
-                FStar_Pervasives_Native.Some uu____11157
+                let uu____11066 =
+                  let uu____11081 =
+                    let uu____11084 = FStar_Syntax_Syntax.mk_Total t_res  in
+                    FStar_Syntax_Util.arrow formals uu____11084  in
+                  ((FStar_List.rev pat_binders), uu____11081)  in
+                FStar_Pervasives_Native.Some uu____11066
+            | (uu____11117,[]) ->
+                let uu____11148 =
+                  let uu____11163 =
+                    let uu____11166 = FStar_Syntax_Syntax.mk_Total t_res  in
+                    FStar_Syntax_Util.arrow formals uu____11166  in
+                  ((FStar_List.rev pat_binders), uu____11163)  in
+                FStar_Pervasives_Native.Some uu____11148
             | ((formal,formal_imp)::formals1,(a,a_imp)::args2) ->
-                let uu____11266 =
-                  let uu____11267 = FStar_Syntax_Subst.compress a  in
-                  uu____11267.FStar_Syntax_Syntax.n  in
-                (match uu____11266 with
+                let uu____11257 =
+                  let uu____11258 = FStar_Syntax_Subst.compress a  in
+                  uu____11258.FStar_Syntax_Syntax.n  in
+                (match uu____11257 with
                  | FStar_Syntax_Syntax.Tm_name x ->
-                     let uu____11287 =
+                     let uu____11278 =
                        (name_exists_in x ctx) ||
                          (name_exists_in x pat_binders)
                         in
-                     if uu____11287
+                     if uu____11278
                      then
                        aux ((formal, formal_imp) :: pat_binders) formals1
                          t_res args2
                      else
                        (let x1 =
-                          let uu___1634_11317 = x  in
+                          let uu___1634_11308 = x  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___1634_11317.FStar_Syntax_Syntax.ppname);
+                              (uu___1634_11308.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___1634_11317.FStar_Syntax_Syntax.index);
+                              (uu___1634_11308.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort =
                               (formal.FStar_Syntax_Syntax.sort)
                           }  in
                         let subst =
-                          let uu____11321 =
-                            let uu____11322 =
-                              let uu____11329 =
+                          let uu____11312 =
+                            let uu____11313 =
+                              let uu____11320 =
                                 FStar_Syntax_Syntax.bv_to_name x1  in
-                              (formal, uu____11329)  in
-                            FStar_Syntax_Syntax.NT uu____11322  in
-                          [uu____11321]  in
+                              (formal, uu____11320)  in
+                            FStar_Syntax_Syntax.NT uu____11313  in
+                          [uu____11312]  in
                         let formals2 =
                           FStar_Syntax_Subst.subst_binders subst formals1  in
                         let t_res1 = FStar_Syntax_Subst.subst subst t_res  in
                         aux
-                          (((let uu___1640_11345 = x1  in
+                          (((let uu___1640_11336 = x1  in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___1640_11345.FStar_Syntax_Syntax.ppname);
+                                 (uu___1640_11336.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___1640_11345.FStar_Syntax_Syntax.index);
+                                 (uu___1640_11336.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort =
                                  (formal.FStar_Syntax_Syntax.sort)
                              }), a_imp) :: pat_binders) formals2 t_res1 args2)
-                 | uu____11346 ->
+                 | uu____11337 ->
                      aux ((formal, formal_imp) :: pat_binders) formals1 t_res
                        args2)
             | ([],args2) ->
-                let uu____11386 =
-                  let uu____11393 =
+                let uu____11377 =
+                  let uu____11384 =
                     FStar_TypeChecker_Normalize.unfold_whnf env t_res  in
-                  FStar_Syntax_Util.arrow_formals uu____11393  in
-                (match uu____11386 with
+                  FStar_Syntax_Util.arrow_formals uu____11384  in
+                (match uu____11377 with
                  | (more_formals,t_res1) ->
                      (match more_formals with
                       | [] -> FStar_Pervasives_Native.None
-                      | uu____11452 ->
+                      | uu____11443 ->
                           aux pat_binders more_formals t_res1 args2))
              in
           (match args with
            | [] -> FStar_Pervasives_Native.Some ([], t_hd)
-           | uu____11477 ->
-               let uu____11478 = FStar_Syntax_Util.arrow_formals t_hd  in
-               (match uu____11478 with
+           | uu____11468 ->
+               let uu____11469 = FStar_Syntax_Util.arrow_formals t_hd  in
+               (match uu____11469 with
                 | (formals,t_res) -> aux [] formals t_res args))
   
 let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
   fun env  ->
     fun probs  ->
-      (let uu____11774 =
+      (let uu____11765 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "Rel")
           in
-       if uu____11774
+       if uu____11765
        then
-         let uu____11779 = wl_to_string probs  in
-         FStar_Util.print1 "solve:\n\t%s\n" uu____11779
+         let uu____11770 = wl_to_string probs  in
+         FStar_Util.print1 "solve:\n\t%s\n" uu____11770
        else ());
-      (let uu____11785 =
+      (let uu____11776 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ImplicitTrace")
           in
-       if uu____11785
+       if uu____11776
        then
-         let uu____11790 =
+         let uu____11781 =
            FStar_TypeChecker_Common.implicits_to_string probs.wl_implicits
             in
-         FStar_Util.print1 "solve: wl_implicits = %s\n" uu____11790
+         FStar_Util.print1 "solve: wl_implicits = %s\n" uu____11781
        else ());
-      (let uu____11795 = next_prob probs  in
-       match uu____11795 with
+      (let uu____11786 = next_prob probs  in
+       match uu____11786 with
        | FStar_Pervasives_Native.Some (hd,tl,rank1) ->
            let probs1 =
-             let uu___1667_11822 = probs  in
+             let uu___1667_11813 = probs  in
              {
                attempting = tl;
-               wl_deferred = (uu___1667_11822.wl_deferred);
-               ctr = (uu___1667_11822.ctr);
-               defer_ok = (uu___1667_11822.defer_ok);
-               smt_ok = (uu___1667_11822.smt_ok);
-               umax_heuristic_ok = (uu___1667_11822.umax_heuristic_ok);
-               tcenv = (uu___1667_11822.tcenv);
-               wl_implicits = (uu___1667_11822.wl_implicits);
-               repr_subcomp_allowed = (uu___1667_11822.repr_subcomp_allowed)
+               wl_deferred = (uu___1667_11813.wl_deferred);
+               ctr = (uu___1667_11813.ctr);
+               defer_ok = (uu___1667_11813.defer_ok);
+               smt_ok = (uu___1667_11813.smt_ok);
+               umax_heuristic_ok = (uu___1667_11813.umax_heuristic_ok);
+               tcenv = (uu___1667_11813.tcenv);
+               wl_implicits = (uu___1667_11813.wl_implicits);
+               repr_subcomp_allowed = (uu___1667_11813.repr_subcomp_allowed)
              }  in
            (def_check_prob "solve,hd" hd;
             (match hd with
              | FStar_TypeChecker_Common.CProb cp ->
                  solve_c env (maybe_invert cp) probs1
              | FStar_TypeChecker_Common.TProb tp ->
-                 let uu____11831 =
+                 let uu____11822 =
                    FStar_Util.physical_equality
                      tp.FStar_TypeChecker_Common.lhs
                      tp.FStar_TypeChecker_Common.rhs
                     in
-                 if uu____11831
+                 if uu____11822
                  then
-                   let uu____11834 =
+                   let uu____11825 =
                      solve_prob hd FStar_Pervasives_Native.None [] probs1  in
-                   solve env uu____11834
+                   solve env uu____11825
                  else
                    if
                      (rank1 = FStar_TypeChecker_Common.Rigid_rigid) ||
@@ -3808,38 +3803,38 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                    else
                      if probs1.defer_ok
                      then
-                       (let uu____11841 =
+                       (let uu____11832 =
                           defer_lit
                             "deferring flex_rigid or flex_flex subtyping" hd
                             probs1
                            in
-                        solve env uu____11841)
+                        solve env uu____11832)
                      else
                        if rank1 = FStar_TypeChecker_Common.Flex_flex
                        then
                          solve_t env
-                           (let uu___1679_11847 = tp  in
+                           (let uu___1679_11838 = tp  in
                             {
                               FStar_TypeChecker_Common.pid =
-                                (uu___1679_11847.FStar_TypeChecker_Common.pid);
+                                (uu___1679_11838.FStar_TypeChecker_Common.pid);
                               FStar_TypeChecker_Common.lhs =
-                                (uu___1679_11847.FStar_TypeChecker_Common.lhs);
+                                (uu___1679_11838.FStar_TypeChecker_Common.lhs);
                               FStar_TypeChecker_Common.relation =
                                 FStar_TypeChecker_Common.EQ;
                               FStar_TypeChecker_Common.rhs =
-                                (uu___1679_11847.FStar_TypeChecker_Common.rhs);
+                                (uu___1679_11838.FStar_TypeChecker_Common.rhs);
                               FStar_TypeChecker_Common.element =
-                                (uu___1679_11847.FStar_TypeChecker_Common.element);
+                                (uu___1679_11838.FStar_TypeChecker_Common.element);
                               FStar_TypeChecker_Common.logical_guard =
-                                (uu___1679_11847.FStar_TypeChecker_Common.logical_guard);
+                                (uu___1679_11838.FStar_TypeChecker_Common.logical_guard);
                               FStar_TypeChecker_Common.logical_guard_uvar =
-                                (uu___1679_11847.FStar_TypeChecker_Common.logical_guard_uvar);
+                                (uu___1679_11838.FStar_TypeChecker_Common.logical_guard_uvar);
                               FStar_TypeChecker_Common.reason =
-                                (uu___1679_11847.FStar_TypeChecker_Common.reason);
+                                (uu___1679_11838.FStar_TypeChecker_Common.reason);
                               FStar_TypeChecker_Common.loc =
-                                (uu___1679_11847.FStar_TypeChecker_Common.loc);
+                                (uu___1679_11838.FStar_TypeChecker_Common.loc);
                               FStar_TypeChecker_Common.rank =
-                                (uu___1679_11847.FStar_TypeChecker_Common.rank)
+                                (uu___1679_11838.FStar_TypeChecker_Common.rank)
                             }) probs1
                        else
                          solve_rigid_flex_or_flex_rigid_subtyping rank1 env
@@ -3847,54 +3842,54 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
        | FStar_Pervasives_Native.None  ->
            (match probs.wl_deferred with
             | [] -> Success ([], (probs.wl_implicits))
-            | uu____11872 ->
-                let uu____11882 =
+            | uu____11863 ->
+                let uu____11873 =
                   FStar_All.pipe_right probs.wl_deferred
                     (FStar_List.partition
-                       (fun uu____11947  ->
-                          match uu____11947 with
-                          | (c,uu____11957,uu____11958) -> c < probs.ctr))
+                       (fun uu____11938  ->
+                          match uu____11938 with
+                          | (c,uu____11948,uu____11949) -> c < probs.ctr))
                    in
-                (match uu____11882 with
+                (match uu____11873 with
                  | (attempt1,rest) ->
                      (match attempt1 with
                       | [] ->
-                          let uu____12006 =
-                            let uu____12011 =
+                          let uu____11997 =
+                            let uu____12002 =
                               FStar_List.map
-                                (fun uu____12032  ->
-                                   match uu____12032 with
-                                   | (uu____12048,x,y) ->
-                                       let uu____12059 = FStar_Thunk.force x
+                                (fun uu____12023  ->
+                                   match uu____12023 with
+                                   | (uu____12039,x,y) ->
+                                       let uu____12050 = FStar_Thunk.force x
                                           in
-                                       (uu____12059, y)) probs.wl_deferred
+                                       (uu____12050, y)) probs.wl_deferred
                                in
-                            (uu____12011, (probs.wl_implicits))  in
-                          Success uu____12006
-                      | uu____12063 ->
-                          let uu____12073 =
-                            let uu___1697_12074 = probs  in
-                            let uu____12075 =
+                            (uu____12002, (probs.wl_implicits))  in
+                          Success uu____11997
+                      | uu____12054 ->
+                          let uu____12064 =
+                            let uu___1697_12065 = probs  in
+                            let uu____12066 =
                               FStar_All.pipe_right attempt1
                                 (FStar_List.map
-                                   (fun uu____12096  ->
-                                      match uu____12096 with
-                                      | (uu____12104,uu____12105,y) -> y))
+                                   (fun uu____12087  ->
+                                      match uu____12087 with
+                                      | (uu____12095,uu____12096,y) -> y))
                                in
                             {
-                              attempting = uu____12075;
+                              attempting = uu____12066;
                               wl_deferred = rest;
-                              ctr = (uu___1697_12074.ctr);
-                              defer_ok = (uu___1697_12074.defer_ok);
-                              smt_ok = (uu___1697_12074.smt_ok);
+                              ctr = (uu___1697_12065.ctr);
+                              defer_ok = (uu___1697_12065.defer_ok);
+                              smt_ok = (uu___1697_12065.smt_ok);
                               umax_heuristic_ok =
-                                (uu___1697_12074.umax_heuristic_ok);
-                              tcenv = (uu___1697_12074.tcenv);
-                              wl_implicits = (uu___1697_12074.wl_implicits);
+                                (uu___1697_12065.umax_heuristic_ok);
+                              tcenv = (uu___1697_12065.tcenv);
+                              wl_implicits = (uu___1697_12065.wl_implicits);
                               repr_subcomp_allowed =
-                                (uu___1697_12074.repr_subcomp_allowed)
+                                (uu___1697_12065.repr_subcomp_allowed)
                             }  in
-                          solve env uu____12073))))
+                          solve env uu____12064))))
 
 and (solve_one_universe_eq :
   FStar_TypeChecker_Env.env ->
@@ -3907,16 +3902,16 @@ and (solve_one_universe_eq :
       fun u1  ->
         fun u2  ->
           fun wl  ->
-            let uu____12114 = solve_universe_eq (p_pid orig) wl u1 u2  in
-            match uu____12114 with
+            let uu____12105 = solve_universe_eq (p_pid orig) wl u1 u2  in
+            match uu____12105 with
             | USolved wl1 ->
-                let uu____12116 =
+                let uu____12107 =
                   solve_prob orig FStar_Pervasives_Native.None [] wl1  in
-                solve env uu____12116
+                solve env uu____12107
             | UFailed msg -> giveup env msg orig
             | UDeferred wl1 ->
-                let uu____12119 = defer_lit "" orig wl1  in
-                solve env uu____12119
+                let uu____12110 = defer_lit "" orig wl1  in
+                solve env uu____12110
 
 and (solve_maybe_uinsts :
   FStar_TypeChecker_Env.env ->
@@ -3933,12 +3928,12 @@ and (solve_maybe_uinsts :
               match (us1, us2) with
               | ([],[]) -> USolved wl1
               | (u1::us11,u2::us21) ->
-                  let uu____12170 = solve_universe_eq (p_pid orig) wl1 u1 u2
+                  let uu____12161 = solve_universe_eq (p_pid orig) wl1 u1 u2
                      in
-                  (match uu____12170 with
+                  (match uu____12161 with
                    | USolved wl2 -> aux wl2 us11 us21
                    | failed_or_deferred -> failed_or_deferred)
-              | uu____12173 -> ufailed_simple "Unequal number of universes"
+              | uu____12164 -> ufailed_simple "Unequal number of universes"
                in
             let t11 = whnf env t1  in
             let t21 = whnf env t2  in
@@ -3946,17 +3941,17 @@ and (solve_maybe_uinsts :
             with
             | (FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                  FStar_Syntax_Syntax.pos = uu____12186;
-                  FStar_Syntax_Syntax.vars = uu____12187;_},us1),FStar_Syntax_Syntax.Tm_uinst
+                  FStar_Syntax_Syntax.pos = uu____12177;
+                  FStar_Syntax_Syntax.vars = uu____12178;_},us1),FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar g;
-                  FStar_Syntax_Syntax.pos = uu____12190;
-                  FStar_Syntax_Syntax.vars = uu____12191;_},us2))
+                  FStar_Syntax_Syntax.pos = uu____12181;
+                  FStar_Syntax_Syntax.vars = uu____12182;_},us2))
                 -> let b = FStar_Syntax_Syntax.fv_eq f g  in aux wl us1 us2
-            | (FStar_Syntax_Syntax.Tm_uinst uu____12204,uu____12205) ->
+            | (FStar_Syntax_Syntax.Tm_uinst uu____12195,uu____12196) ->
                 failwith "Impossible: expect head symbols to match"
-            | (uu____12213,FStar_Syntax_Syntax.Tm_uinst uu____12214) ->
+            | (uu____12204,FStar_Syntax_Syntax.Tm_uinst uu____12205) ->
                 failwith "Impossible: expect head symbols to match"
-            | uu____12222 -> USolved wl
+            | uu____12213 -> USolved wl
 
 and (giveup_or_defer :
   FStar_TypeChecker_Env.env ->
@@ -3968,16 +3963,16 @@ and (giveup_or_defer :
         fun msg  ->
           if wl.defer_ok
           then
-            ((let uu____12233 =
+            ((let uu____12224 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel")
                  in
-              if uu____12233
+              if uu____12224
               then
-                let uu____12238 = prob_to_string env orig  in
-                let uu____12240 = FStar_Thunk.force msg  in
+                let uu____12229 = prob_to_string env orig  in
+                let uu____12231 = FStar_Thunk.force msg  in
                 FStar_Util.print2 "\n\t\tDeferring %s\n\t\tBecause %s\n"
-                  uu____12238 uu____12240
+                  uu____12229 uu____12231
               else ());
              solve env (defer msg orig wl))
           else giveup env msg orig
@@ -3995,197 +3990,197 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
           (let flip = rank1 = FStar_TypeChecker_Common.Flex_rigid  in
            let meet_or_join op ts env1 wl1 =
              let eq_prob t1 t2 wl2 =
-               let uu____12333 =
+               let uu____12324 =
                  new_problem wl2 env1 t1 FStar_TypeChecker_Common.EQ t2
                    FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
                    "join/meet refinements"
                   in
-               match uu____12333 with
+               match uu____12324 with
                | (p,wl3) ->
                    (def_check_prob "meet_or_join"
                       (FStar_TypeChecker_Common.TProb p);
                     ((FStar_TypeChecker_Common.TProb p), wl3))
                 in
              let pairwise t1 t2 wl2 =
-               (let uu____12388 =
+               (let uu____12379 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                     (FStar_Options.Other "Rel")
                    in
-                if uu____12388
+                if uu____12379
                 then
-                  let uu____12393 = FStar_Syntax_Print.term_to_string t1  in
-                  let uu____12395 = FStar_Syntax_Print.term_to_string t2  in
+                  let uu____12384 = FStar_Syntax_Print.term_to_string t1  in
+                  let uu____12386 = FStar_Syntax_Print.term_to_string t2  in
                   FStar_Util.print2 "[meet/join]: pairwise: %s and %s\n"
-                    uu____12393 uu____12395
+                    uu____12384 uu____12386
                 else ());
-               (let uu____12400 = head_matches_delta env1 wl2 t1 t2  in
-                match uu____12400 with
+               (let uu____12391 = head_matches_delta env1 wl2 t1 t2  in
+                match uu____12391 with
                 | (mr,ts1) ->
                     (match mr with
                      | HeadMatch (true ) ->
-                         let uu____12446 = eq_prob t1 t2 wl2  in
-                         (match uu____12446 with | (p,wl3) -> (t1, [p], wl3))
-                     | MisMatch uu____12467 ->
-                         let uu____12476 = eq_prob t1 t2 wl2  in
-                         (match uu____12476 with | (p,wl3) -> (t1, [p], wl3))
+                         let uu____12437 = eq_prob t1 t2 wl2  in
+                         (match uu____12437 with | (p,wl3) -> (t1, [p], wl3))
+                     | MisMatch uu____12458 ->
+                         let uu____12467 = eq_prob t1 t2 wl2  in
+                         (match uu____12467 with | (p,wl3) -> (t1, [p], wl3))
                      | FullMatch  ->
                          (match ts1 with
                           | FStar_Pervasives_Native.None  -> (t1, [], wl2)
                           | FStar_Pervasives_Native.Some (t11,t21) ->
                               (t11, [], wl2))
                      | HeadMatch (false ) ->
-                         let uu____12526 =
+                         let uu____12517 =
                            match ts1 with
                            | FStar_Pervasives_Native.Some (t11,t21) ->
-                               let uu____12541 =
+                               let uu____12532 =
                                  FStar_Syntax_Subst.compress t11  in
-                               let uu____12542 =
+                               let uu____12533 =
                                  FStar_Syntax_Subst.compress t21  in
-                               (uu____12541, uu____12542)
+                               (uu____12532, uu____12533)
                            | FStar_Pervasives_Native.None  ->
-                               let uu____12547 =
+                               let uu____12538 =
                                  FStar_Syntax_Subst.compress t1  in
-                               let uu____12548 =
+                               let uu____12539 =
                                  FStar_Syntax_Subst.compress t2  in
-                               (uu____12547, uu____12548)
+                               (uu____12538, uu____12539)
                             in
-                         (match uu____12526 with
+                         (match uu____12517 with
                           | (t11,t21) ->
                               let try_eq t12 t22 wl3 =
-                                let uu____12579 =
+                                let uu____12570 =
                                   FStar_Syntax_Util.head_and_args t12  in
-                                match uu____12579 with
+                                match uu____12570 with
                                 | (t1_hd,t1_args) ->
-                                    let uu____12624 =
+                                    let uu____12615 =
                                       FStar_Syntax_Util.head_and_args t22  in
-                                    (match uu____12624 with
+                                    (match uu____12615 with
                                      | (t2_hd,t2_args) ->
                                          if
                                            (FStar_List.length t1_args) <>
                                              (FStar_List.length t2_args)
                                          then FStar_Pervasives_Native.None
                                          else
-                                           (let uu____12690 =
-                                              let uu____12697 =
-                                                let uu____12708 =
+                                           (let uu____12681 =
+                                              let uu____12688 =
+                                                let uu____12699 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t1_hd
                                                    in
-                                                uu____12708 :: t1_args  in
-                                              let uu____12725 =
-                                                let uu____12734 =
+                                                uu____12699 :: t1_args  in
+                                              let uu____12716 =
+                                                let uu____12725 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t2_hd
                                                    in
-                                                uu____12734 :: t2_args  in
+                                                uu____12725 :: t2_args  in
                                               FStar_List.fold_left2
-                                                (fun uu____12783  ->
-                                                   fun uu____12784  ->
-                                                     fun uu____12785  ->
-                                                       match (uu____12783,
-                                                               uu____12784,
-                                                               uu____12785)
+                                                (fun uu____12774  ->
+                                                   fun uu____12775  ->
+                                                     fun uu____12776  ->
+                                                       match (uu____12774,
+                                                               uu____12775,
+                                                               uu____12776)
                                                        with
                                                        | ((probs,wl4),
-                                                          (a1,uu____12835),
-                                                          (a2,uu____12837))
+                                                          (a1,uu____12826),
+                                                          (a2,uu____12828))
                                                            ->
-                                                           let uu____12874 =
+                                                           let uu____12865 =
                                                              eq_prob a1 a2
                                                                wl4
                                                               in
-                                                           (match uu____12874
+                                                           (match uu____12865
                                                             with
                                                             | (p,wl5) ->
                                                                 ((p ::
                                                                   probs),
                                                                   wl5)))
-                                                ([], wl3) uu____12697
-                                                uu____12725
+                                                ([], wl3) uu____12688
+                                                uu____12716
                                                in
-                                            match uu____12690 with
+                                            match uu____12681 with
                                             | (probs,wl4) ->
                                                 let wl' =
-                                                  let uu___1851_12900 = wl4
+                                                  let uu___1851_12891 = wl4
                                                      in
                                                   {
                                                     attempting = probs;
                                                     wl_deferred = [];
                                                     ctr =
-                                                      (uu___1851_12900.ctr);
+                                                      (uu___1851_12891.ctr);
                                                     defer_ok = false;
                                                     smt_ok = false;
                                                     umax_heuristic_ok =
-                                                      (uu___1851_12900.umax_heuristic_ok);
+                                                      (uu___1851_12891.umax_heuristic_ok);
                                                     tcenv =
-                                                      (uu___1851_12900.tcenv);
+                                                      (uu___1851_12891.tcenv);
                                                     wl_implicits = [];
                                                     repr_subcomp_allowed =
-                                                      (uu___1851_12900.repr_subcomp_allowed)
+                                                      (uu___1851_12891.repr_subcomp_allowed)
                                                   }  in
                                                 let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     ()
                                                    in
-                                                let uu____12911 =
+                                                let uu____12902 =
                                                   solve env1 wl'  in
-                                                (match uu____12911 with
-                                                 | Success (uu____12914,imps)
+                                                (match uu____12902 with
+                                                 | Success (uu____12905,imps)
                                                      ->
                                                      (FStar_Syntax_Unionfind.commit
                                                         tx;
                                                       FStar_Pervasives_Native.Some
-                                                        ((let uu___1860_12918
+                                                        ((let uu___1860_12909
                                                             = wl4  in
                                                           {
                                                             attempting =
-                                                              (uu___1860_12918.attempting);
+                                                              (uu___1860_12909.attempting);
                                                             wl_deferred =
-                                                              (uu___1860_12918.wl_deferred);
+                                                              (uu___1860_12909.wl_deferred);
                                                             ctr =
-                                                              (uu___1860_12918.ctr);
+                                                              (uu___1860_12909.ctr);
                                                             defer_ok =
-                                                              (uu___1860_12918.defer_ok);
+                                                              (uu___1860_12909.defer_ok);
                                                             smt_ok =
-                                                              (uu___1860_12918.smt_ok);
+                                                              (uu___1860_12909.smt_ok);
                                                             umax_heuristic_ok
                                                               =
-                                                              (uu___1860_12918.umax_heuristic_ok);
+                                                              (uu___1860_12909.umax_heuristic_ok);
                                                             tcenv =
-                                                              (uu___1860_12918.tcenv);
+                                                              (uu___1860_12909.tcenv);
                                                             wl_implicits =
                                                               (FStar_List.append
                                                                  wl4.wl_implicits
                                                                  imps);
                                                             repr_subcomp_allowed
                                                               =
-                                                              (uu___1860_12918.repr_subcomp_allowed)
+                                                              (uu___1860_12909.repr_subcomp_allowed)
                                                           })))
-                                                 | Failed uu____12919 ->
+                                                 | Failed uu____12910 ->
                                                      (FStar_Syntax_Unionfind.rollback
                                                         tx;
                                                       FStar_Pervasives_Native.None))))
                                  in
                               let combine t12 t22 wl3 =
-                                let uu____12951 =
+                                let uu____12942 =
                                   base_and_refinement_maybe_delta false env1
                                     t12
                                    in
-                                match uu____12951 with
+                                match uu____12942 with
                                 | (t1_base,p1_opt) ->
-                                    let uu____12987 =
+                                    let uu____12978 =
                                       base_and_refinement_maybe_delta false
                                         env1 t22
                                        in
-                                    (match uu____12987 with
+                                    (match uu____12978 with
                                      | (t2_base,p2_opt) ->
                                          let combine_refinements t_base
                                            p1_opt1 p2_opt1 =
                                            let refine x t =
-                                             let uu____13086 =
+                                             let uu____13077 =
                                                FStar_Syntax_Util.is_t_true t
                                                 in
-                                             if uu____13086
+                                             if uu____13077
                                              then x.FStar_Syntax_Syntax.sort
                                              else
                                                FStar_Syntax_Util.refine x t
@@ -4210,9 +4205,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                  FStar_Syntax_Subst.subst
                                                    subst phi2
                                                   in
-                                               let uu____13139 =
+                                               let uu____13130 =
                                                  op phi11 phi21  in
-                                               refine x1 uu____13139
+                                               refine x1 uu____13130
                                            | (FStar_Pervasives_Native.None
                                               ,FStar_Pervasives_Native.Some
                                               (x,phi)) ->
@@ -4228,11 +4223,11 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                  FStar_Syntax_Subst.subst
                                                    subst phi
                                                   in
-                                               let uu____13171 =
+                                               let uu____13162 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1
                                                   in
-                                               refine x1 uu____13171
+                                               refine x1 uu____13162
                                            | (FStar_Pervasives_Native.Some
                                               (x,phi),FStar_Pervasives_Native.None
                                               ) ->
@@ -4248,40 +4243,40 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                  FStar_Syntax_Subst.subst
                                                    subst phi
                                                   in
-                                               let uu____13203 =
+                                               let uu____13194 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1
                                                   in
-                                               refine x1 uu____13203
-                                           | uu____13206 -> t_base  in
-                                         let uu____13223 =
+                                               refine x1 uu____13194
+                                           | uu____13197 -> t_base  in
+                                         let uu____13214 =
                                            try_eq t1_base t2_base wl3  in
-                                         (match uu____13223 with
+                                         (match uu____13214 with
                                           | FStar_Pervasives_Native.Some wl4
                                               ->
-                                              let uu____13237 =
+                                              let uu____13228 =
                                                 combine_refinements t1_base
                                                   p1_opt p2_opt
                                                  in
-                                              (uu____13237, [], wl4)
+                                              (uu____13228, [], wl4)
                                           | FStar_Pervasives_Native.None  ->
-                                              let uu____13244 =
+                                              let uu____13235 =
                                                 base_and_refinement_maybe_delta
                                                   true env1 t12
                                                  in
-                                              (match uu____13244 with
+                                              (match uu____13235 with
                                                | (t1_base1,p1_opt1) ->
-                                                   let uu____13280 =
+                                                   let uu____13271 =
                                                      base_and_refinement_maybe_delta
                                                        true env1 t22
                                                       in
-                                                   (match uu____13280 with
+                                                   (match uu____13271 with
                                                     | (t2_base1,p2_opt1) ->
-                                                        let uu____13316 =
+                                                        let uu____13307 =
                                                           eq_prob t1_base1
                                                             t2_base1 wl3
                                                            in
-                                                        (match uu____13316
+                                                        (match uu____13307
                                                          with
                                                          | (p,wl4) ->
                                                              let t =
@@ -4292,45 +4287,45 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 in
                                                              (t, [p], wl4))))))
                                  in
-                              let uu____13340 = combine t11 t21 wl2  in
-                              (match uu____13340 with
+                              let uu____13331 = combine t11 t21 wl2  in
+                              (match uu____13331 with
                                | (t12,ps,wl3) ->
-                                   ((let uu____13373 =
+                                   ((let uu____13364 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "Rel")
                                         in
-                                     if uu____13373
+                                     if uu____13364
                                      then
-                                       let uu____13378 =
+                                       let uu____13369 =
                                          FStar_Syntax_Print.term_to_string
                                            t12
                                           in
                                        FStar_Util.print1
                                          "pairwise fallback2 succeeded: %s"
-                                         uu____13378
+                                         uu____13369
                                      else ());
                                     (t12, ps, wl3))))))
                 in
-             let rec aux uu____13420 ts1 =
-               match uu____13420 with
+             let rec aux uu____13411 ts1 =
+               match uu____13411 with
                | (out,probs,wl2) ->
                    (match ts1 with
                     | [] -> (out, probs, wl2)
                     | t::ts2 ->
-                        let uu____13483 = pairwise out t wl2  in
-                        (match uu____13483 with
+                        let uu____13474 = pairwise out t wl2  in
+                        (match uu____13474 with
                          | (out1,probs',wl3) ->
                              aux
                                (out1, (FStar_List.append probs probs'), wl3)
                                ts2))
                 in
-             let uu____13519 =
-               let uu____13530 = FStar_List.hd ts  in (uu____13530, [], wl1)
+             let uu____13510 =
+               let uu____13521 = FStar_List.hd ts  in (uu____13521, [], wl1)
                 in
-             let uu____13539 = FStar_List.tl ts  in
-             aux uu____13519 uu____13539  in
-           let uu____13546 =
+             let uu____13530 = FStar_List.tl ts  in
+             aux uu____13510 uu____13530  in
+           let uu____13537 =
              if flip
              then
                ((tp.FStar_TypeChecker_Common.lhs),
@@ -4339,42 +4334,42 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                ((tp.FStar_TypeChecker_Common.rhs),
                  (tp.FStar_TypeChecker_Common.lhs))
               in
-           match uu____13546 with
+           match uu____13537 with
            | (this_flex,this_rigid) ->
-               let uu____13572 =
-                 let uu____13573 = FStar_Syntax_Subst.compress this_rigid  in
-                 uu____13573.FStar_Syntax_Syntax.n  in
-               (match uu____13572 with
+               let uu____13563 =
+                 let uu____13564 = FStar_Syntax_Subst.compress this_rigid  in
+                 uu____13564.FStar_Syntax_Syntax.n  in
+               (match uu____13563 with
                 | FStar_Syntax_Syntax.Tm_arrow (_bs,comp) ->
-                    let uu____13598 =
+                    let uu____13589 =
                       FStar_Syntax_Util.is_tot_or_gtot_comp comp  in
-                    if uu____13598
+                    if uu____13589
                     then
-                      let uu____13601 = destruct_flex_t this_flex wl  in
-                      (match uu____13601 with
+                      let uu____13592 = destruct_flex_t this_flex wl  in
+                      (match uu____13592 with
                        | (flex,wl1) ->
-                           let uu____13608 = quasi_pattern env flex  in
-                           (match uu____13608 with
+                           let uu____13599 = quasi_pattern env flex  in
+                           (match uu____13599 with
                             | FStar_Pervasives_Native.None  ->
                                 giveup_lit env
                                   "flex-arrow subtyping, not a quasi pattern"
                                   (FStar_TypeChecker_Common.TProb tp)
                             | FStar_Pervasives_Native.Some (flex_bs,flex_t1)
                                 ->
-                                ((let uu____13627 =
+                                ((let uu____13618 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "Rel")
                                      in
-                                  if uu____13627
+                                  if uu____13618
                                   then
-                                    let uu____13632 =
+                                    let uu____13623 =
                                       FStar_Util.string_of_int
                                         tp.FStar_TypeChecker_Common.pid
                                        in
                                     FStar_Util.print1
                                       "Trying to solve by imitating arrow:%s\n"
-                                      uu____13632
+                                      uu____13623
                                   else ());
                                  imitate_arrow
                                    (FStar_TypeChecker_Common.TProb tp) env
@@ -4382,81 +4377,81 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                    tp.FStar_TypeChecker_Common.relation
                                    this_rigid)))
                     else
-                      (let uu____13639 =
+                      (let uu____13630 =
                          attempt
                            [FStar_TypeChecker_Common.TProb
-                              ((let uu___1962_13642 = tp  in
+                              ((let uu___1962_13633 = tp  in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.pid);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.lhs);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.lhs);
                                   FStar_TypeChecker_Common.relation =
                                     FStar_TypeChecker_Common.EQ;
                                   FStar_TypeChecker_Common.rhs =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.rhs);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.rhs);
                                   FStar_TypeChecker_Common.element =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.element);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.reason);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.loc);
+                                    (uu___1962_13633.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___1962_13642.FStar_TypeChecker_Common.rank)
+                                    (uu___1962_13633.FStar_TypeChecker_Common.rank)
                                 }))] wl
                           in
-                       solve env uu____13639)
-                | uu____13643 ->
-                    ((let uu____13645 =
+                       solve env uu____13630)
+                | uu____13634 ->
+                    ((let uu____13636 =
                         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "Rel")
                          in
-                      if uu____13645
+                      if uu____13636
                       then
-                        let uu____13650 =
+                        let uu____13641 =
                           FStar_Util.string_of_int
                             tp.FStar_TypeChecker_Common.pid
                            in
                         FStar_Util.print1
                           "Trying to solve by meeting refinements:%s\n"
-                          uu____13650
+                          uu____13641
                       else ());
-                     (let uu____13655 =
+                     (let uu____13646 =
                         FStar_Syntax_Util.head_and_args this_flex  in
-                      match uu____13655 with
+                      match uu____13646 with
                       | (u,_args) ->
-                          let uu____13698 =
-                            let uu____13699 = FStar_Syntax_Subst.compress u
+                          let uu____13689 =
+                            let uu____13690 = FStar_Syntax_Subst.compress u
                                in
-                            uu____13699.FStar_Syntax_Syntax.n  in
-                          (match uu____13698 with
+                            uu____13690.FStar_Syntax_Syntax.n  in
+                          (match uu____13689 with
                            | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar,_subst) ->
                                let equiv t =
-                                 let uu____13727 =
+                                 let uu____13718 =
                                    FStar_Syntax_Util.head_and_args t  in
-                                 match uu____13727 with
-                                 | (u',uu____13746) ->
-                                     let uu____13771 =
-                                       let uu____13772 = whnf env u'  in
-                                       uu____13772.FStar_Syntax_Syntax.n  in
-                                     (match uu____13771 with
+                                 match uu____13718 with
+                                 | (u',uu____13737) ->
+                                     let uu____13762 =
+                                       let uu____13763 = whnf env u'  in
+                                       uu____13763.FStar_Syntax_Syntax.n  in
+                                     (match uu____13762 with
                                       | FStar_Syntax_Syntax.Tm_uvar
                                           (ctx_uvar',_subst') ->
                                           FStar_Syntax_Unionfind.equiv
                                             ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head
                                             ctx_uvar'.FStar_Syntax_Syntax.ctx_uvar_head
-                                      | uu____13794 -> false)
+                                      | uu____13785 -> false)
                                   in
-                               let uu____13796 =
+                               let uu____13787 =
                                  FStar_All.pipe_right wl.attempting
                                    (FStar_List.partition
-                                      (fun uu___23_13819  ->
-                                         match uu___23_13819 with
+                                      (fun uu___23_13810  ->
+                                         match uu___23_13810 with
                                          | FStar_TypeChecker_Common.TProb tp1
                                              ->
                                              let tp2 = maybe_invert tp1  in
@@ -4471,21 +4466,21 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                   else
                                                     equiv
                                                       tp2.FStar_TypeChecker_Common.rhs
-                                              | uu____13833 -> false)
-                                         | uu____13837 -> false))
+                                              | uu____13824 -> false)
+                                         | uu____13828 -> false))
                                   in
-                               (match uu____13796 with
+                               (match uu____13787 with
                                 | (bounds_probs,rest) ->
                                     let bounds_typs =
-                                      let uu____13852 = whnf env this_rigid
+                                      let uu____13843 = whnf env this_rigid
                                          in
-                                      let uu____13853 =
+                                      let uu____13844 =
                                         FStar_List.collect
-                                          (fun uu___24_13859  ->
-                                             match uu___24_13859 with
+                                          (fun uu___24_13850  ->
+                                             match uu___24_13850 with
                                              | FStar_TypeChecker_Common.TProb
                                                  p ->
-                                                 let uu____13865 =
+                                                 let uu____13856 =
                                                    if flip
                                                    then
                                                      whnf env
@@ -4494,48 +4489,48 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                      whnf env
                                                        (maybe_invert p).FStar_TypeChecker_Common.lhs
                                                     in
-                                                 [uu____13865]
-                                             | uu____13869 -> [])
+                                                 [uu____13856]
+                                             | uu____13860 -> [])
                                           bounds_probs
                                          in
-                                      uu____13852 :: uu____13853  in
-                                    let uu____13870 =
+                                      uu____13843 :: uu____13844  in
+                                    let uu____13861 =
                                       meet_or_join
                                         (if flip
                                          then FStar_Syntax_Util.mk_conj_simp
                                          else FStar_Syntax_Util.mk_disj_simp)
                                         bounds_typs env wl
                                        in
-                                    (match uu____13870 with
+                                    (match uu____13861 with
                                      | (bound,sub_probs,wl1) ->
-                                         let uu____13903 =
+                                         let uu____13894 =
                                            let flex_u =
                                              flex_uvar_head this_flex  in
                                            let bound1 =
-                                             let uu____13918 =
-                                               let uu____13919 =
+                                             let uu____13909 =
+                                               let uu____13910 =
                                                  FStar_Syntax_Subst.compress
                                                    bound
                                                   in
-                                               uu____13919.FStar_Syntax_Syntax.n
+                                               uu____13910.FStar_Syntax_Syntax.n
                                                 in
-                                             match uu____13918 with
+                                             match uu____13909 with
                                              | FStar_Syntax_Syntax.Tm_refine
                                                  (x,phi) when
                                                  (tp.FStar_TypeChecker_Common.relation
                                                     =
                                                     FStar_TypeChecker_Common.SUB)
                                                    &&
-                                                   (let uu____13931 =
+                                                   (let uu____13922 =
                                                       occurs flex_u
                                                         x.FStar_Syntax_Syntax.sort
                                                        in
                                                     FStar_Pervasives_Native.snd
-                                                      uu____13931)
+                                                      uu____13922)
                                                  ->
                                                  x.FStar_Syntax_Syntax.sort
-                                             | uu____13942 -> bound  in
-                                           let uu____13943 =
+                                             | uu____13933 -> bound  in
+                                           let uu____13934 =
                                              new_problem wl1 env bound1
                                                FStar_TypeChecker_Common.EQ
                                                this_flex
@@ -4545,23 +4540,23 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                 then "joining refinements"
                                                 else "meeting refinements")
                                               in
-                                           (bound1, uu____13943)  in
-                                         (match uu____13903 with
+                                           (bound1, uu____13934)  in
+                                         (match uu____13894 with
                                           | (bound_typ,(eq_prob,wl')) ->
                                               (def_check_prob "meet_or_join2"
                                                  (FStar_TypeChecker_Common.TProb
                                                     eq_prob);
-                                               (let uu____13978 =
+                                               (let uu____13969 =
                                                   FStar_All.pipe_left
                                                     (FStar_TypeChecker_Env.debug
                                                        env)
                                                     (FStar_Options.Other
                                                        "Rel")
                                                    in
-                                                if uu____13978
+                                                if uu____13969
                                                 then
                                                   let wl'1 =
-                                                    let uu___2022_13984 = wl1
+                                                    let uu___2022_13975 = wl1
                                                        in
                                                     {
                                                       attempting =
@@ -4569,105 +4564,105 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                             eq_prob) ::
                                                         sub_probs);
                                                       wl_deferred =
-                                                        (uu___2022_13984.wl_deferred);
+                                                        (uu___2022_13975.wl_deferred);
                                                       ctr =
-                                                        (uu___2022_13984.ctr);
+                                                        (uu___2022_13975.ctr);
                                                       defer_ok =
-                                                        (uu___2022_13984.defer_ok);
+                                                        (uu___2022_13975.defer_ok);
                                                       smt_ok =
-                                                        (uu___2022_13984.smt_ok);
+                                                        (uu___2022_13975.smt_ok);
                                                       umax_heuristic_ok =
-                                                        (uu___2022_13984.umax_heuristic_ok);
+                                                        (uu___2022_13975.umax_heuristic_ok);
                                                       tcenv =
-                                                        (uu___2022_13984.tcenv);
+                                                        (uu___2022_13975.tcenv);
                                                       wl_implicits =
-                                                        (uu___2022_13984.wl_implicits);
+                                                        (uu___2022_13975.wl_implicits);
                                                       repr_subcomp_allowed =
-                                                        (uu___2022_13984.repr_subcomp_allowed)
+                                                        (uu___2022_13975.repr_subcomp_allowed)
                                                     }  in
-                                                  let uu____13985 =
+                                                  let uu____13976 =
                                                     wl_to_string wl'1  in
                                                   FStar_Util.print1
                                                     "After meet/join refinements: %s\n"
-                                                    uu____13985
+                                                    uu____13976
                                                 else ());
                                                (let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     ()
                                                    in
-                                                let uu____13991 =
+                                                let uu____13982 =
                                                   solve_t env eq_prob
-                                                    (let uu___2027_13993 =
+                                                    (let uu___2027_13984 =
                                                        wl'  in
                                                      {
                                                        attempting = sub_probs;
                                                        wl_deferred =
-                                                         (uu___2027_13993.wl_deferred);
+                                                         (uu___2027_13984.wl_deferred);
                                                        ctr =
-                                                         (uu___2027_13993.ctr);
+                                                         (uu___2027_13984.ctr);
                                                        defer_ok = false;
                                                        smt_ok =
-                                                         (uu___2027_13993.smt_ok);
+                                                         (uu___2027_13984.smt_ok);
                                                        umax_heuristic_ok =
-                                                         (uu___2027_13993.umax_heuristic_ok);
+                                                         (uu___2027_13984.umax_heuristic_ok);
                                                        tcenv =
-                                                         (uu___2027_13993.tcenv);
+                                                         (uu___2027_13984.tcenv);
                                                        wl_implicits = [];
                                                        repr_subcomp_allowed =
-                                                         (uu___2027_13993.repr_subcomp_allowed)
+                                                         (uu___2027_13984.repr_subcomp_allowed)
                                                      })
                                                    in
-                                                match uu____13991 with
-                                                | Success (uu____13995,imps)
+                                                match uu____13982 with
+                                                | Success (uu____13986,imps)
                                                     ->
                                                     let wl2 =
-                                                      let uu___2033_13998 =
+                                                      let uu___2033_13989 =
                                                         wl'  in
                                                       {
                                                         attempting = rest;
                                                         wl_deferred =
-                                                          (uu___2033_13998.wl_deferred);
+                                                          (uu___2033_13989.wl_deferred);
                                                         ctr =
-                                                          (uu___2033_13998.ctr);
+                                                          (uu___2033_13989.ctr);
                                                         defer_ok =
-                                                          (uu___2033_13998.defer_ok);
+                                                          (uu___2033_13989.defer_ok);
                                                         smt_ok =
-                                                          (uu___2033_13998.smt_ok);
+                                                          (uu___2033_13989.smt_ok);
                                                         umax_heuristic_ok =
-                                                          (uu___2033_13998.umax_heuristic_ok);
+                                                          (uu___2033_13989.umax_heuristic_ok);
                                                         tcenv =
-                                                          (uu___2033_13998.tcenv);
+                                                          (uu___2033_13989.tcenv);
                                                         wl_implicits =
-                                                          (uu___2033_13998.wl_implicits);
+                                                          (uu___2033_13989.wl_implicits);
                                                         repr_subcomp_allowed
                                                           =
-                                                          (uu___2033_13998.repr_subcomp_allowed)
+                                                          (uu___2033_13989.repr_subcomp_allowed)
                                                       }  in
                                                     let wl3 =
-                                                      let uu___2036_14000 =
+                                                      let uu___2036_13991 =
                                                         wl2  in
                                                       {
                                                         attempting =
-                                                          (uu___2036_14000.attempting);
+                                                          (uu___2036_13991.attempting);
                                                         wl_deferred =
-                                                          (uu___2036_14000.wl_deferred);
+                                                          (uu___2036_13991.wl_deferred);
                                                         ctr =
-                                                          (uu___2036_14000.ctr);
+                                                          (uu___2036_13991.ctr);
                                                         defer_ok =
-                                                          (uu___2036_14000.defer_ok);
+                                                          (uu___2036_13991.defer_ok);
                                                         smt_ok =
-                                                          (uu___2036_14000.smt_ok);
+                                                          (uu___2036_13991.smt_ok);
                                                         umax_heuristic_ok =
-                                                          (uu___2036_14000.umax_heuristic_ok);
+                                                          (uu___2036_13991.umax_heuristic_ok);
                                                         tcenv =
-                                                          (uu___2036_14000.tcenv);
+                                                          (uu___2036_13991.tcenv);
                                                         wl_implicits =
                                                           (FStar_List.append
                                                              wl'.wl_implicits
                                                              imps);
                                                         repr_subcomp_allowed
                                                           =
-                                                          (uu___2036_14000.repr_subcomp_allowed)
+                                                          (uu___2036_13991.repr_subcomp_allowed)
                                                       }  in
                                                     let g =
                                                       FStar_List.fold_left
@@ -4685,7 +4680,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                         (FStar_Pervasives_Native.Some
                                                            g) [] wl3
                                                        in
-                                                    let uu____14016 =
+                                                    let uu____14007 =
                                                       FStar_List.fold_left
                                                         (fun wl5  ->
                                                            fun p  ->
@@ -4699,17 +4694,17 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                        tx;
                                                      solve env wl4)
                                                 | Failed (p,msg) ->
-                                                    ((let uu____14028 =
+                                                    ((let uu____14019 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env)
                                                           (FStar_Options.Other
                                                              "Rel")
                                                          in
-                                                      if uu____14028
+                                                      if uu____14019
                                                       then
-                                                        let uu____14033 =
-                                                          let uu____14035 =
+                                                        let uu____14024 =
+                                                          let uu____14026 =
                                                             FStar_List.map
                                                               (prob_to_string
                                                                  env)
@@ -4718,29 +4713,29 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                               sub_probs)
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____14035
+                                                            uu____14026
                                                             (FStar_String.concat
                                                                "\n")
                                                            in
                                                         FStar_Util.print1
                                                           "meet/join attempted and failed to solve problems:\n%s\n"
-                                                          uu____14033
+                                                          uu____14024
                                                       else ());
-                                                     (let uu____14048 =
-                                                        let uu____14063 =
+                                                     (let uu____14039 =
+                                                        let uu____14054 =
                                                           base_and_refinement
                                                             env bound_typ
                                                            in
-                                                        (rank1, uu____14063)
+                                                        (rank1, uu____14054)
                                                          in
-                                                      match uu____14048 with
+                                                      match uu____14039 with
                                                       | (FStar_TypeChecker_Common.Rigid_flex
                                                          ,(t_base,FStar_Pervasives_Native.Some
-                                                           uu____14085))
+                                                           uu____14076))
                                                           ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____14111 =
+                                                           (let uu____14102 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4749,7 +4744,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping"
                                                                in
-                                                            match uu____14111
+                                                            match uu____14102
                                                             with
                                                             | (eq_prob1,wl2)
                                                                 ->
@@ -4768,7 +4763,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1)))
                                                                     [] wl2
                                                                      in
-                                                                  let uu____14131
+                                                                  let uu____14122
                                                                     =
                                                                     attempt
                                                                     [
@@ -4776,14 +4771,14 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3  in
                                                                   solve env
-                                                                    uu____14131))))
+                                                                    uu____14122))))
                                                       | (FStar_TypeChecker_Common.Flex_rigid
                                                          ,(t_base,FStar_Pervasives_Native.Some
                                                            (x,phi)))
                                                           ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____14156 =
+                                                           (let uu____14147 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4792,7 +4787,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping"
                                                                in
-                                                            match uu____14156
+                                                            match uu____14147
                                                             with
                                                             | (eq_prob1,wl2)
                                                                 ->
@@ -4805,9 +4800,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     wl2 tp x
                                                                     phi  in
                                                                   let wl3 =
-                                                                    let uu____14176
+                                                                    let uu____14167
                                                                     =
-                                                                    let uu____14181
+                                                                    let uu____14172
                                                                     =
                                                                     FStar_Syntax_Util.mk_conj
                                                                     phi1
@@ -4816,16 +4811,16 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1))
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____14181
+                                                                    uu____14172
                                                                      in
                                                                     solve_prob'
                                                                     false
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     tp)
-                                                                    uu____14176
+                                                                    uu____14167
                                                                     [] wl2
                                                                      in
-                                                                  let uu____14187
+                                                                  let uu____14178
                                                                     =
                                                                     attempt
                                                                     [
@@ -4833,9 +4828,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3  in
                                                                   solve env
-                                                                    uu____14187))))
-                                                      | uu____14188 ->
-                                                          let uu____14203 =
+                                                                    uu____14178))))
+                                                      | uu____14179 ->
+                                                          let uu____14194 =
                                                             FStar_Thunk.map
                                                               (fun s  ->
                                                                  Prims.op_Hat
@@ -4843,37 +4838,37 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                    s) msg
                                                              in
                                                           giveup env
-                                                            uu____14203 p)))))))
-                           | uu____14210 when flip ->
-                               let uu____14211 =
-                                 let uu____14213 =
+                                                            uu____14194 p)))))))
+                           | uu____14201 when flip ->
+                               let uu____14202 =
+                                 let uu____14204 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1)
                                     in
-                                 let uu____14215 =
+                                 let uu____14206 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp)
                                     in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a flex-rigid: %s"
-                                   uu____14213 uu____14215
+                                   uu____14204 uu____14206
                                   in
-                               failwith uu____14211
-                           | uu____14218 ->
-                               let uu____14219 =
-                                 let uu____14221 =
+                               failwith uu____14202
+                           | uu____14209 ->
+                               let uu____14210 =
+                                 let uu____14212 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1)
                                     in
-                                 let uu____14223 =
+                                 let uu____14214 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp)
                                     in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a rigid-flex: %s"
-                                   uu____14221 uu____14223
+                                   uu____14212 uu____14214
                                   in
-                               failwith uu____14219)))))
+                               failwith uu____14210)))))
 
 and (imitate_arrow :
   FStar_TypeChecker_Common.prob ->
@@ -4895,43 +4890,42 @@ and (imitate_arrow :
                 fun arrow  ->
                   let bs_lhs_args =
                     FStar_List.map
-                      (fun uu____14259  ->
-                         match uu____14259 with
+                      (fun uu____14250  ->
+                         match uu____14250 with
                          | (x,i) ->
-                             let uu____14278 =
+                             let uu____14269 =
                                FStar_Syntax_Syntax.bv_to_name x  in
-                             (uu____14278, i)) bs_lhs
+                             (uu____14269, i)) bs_lhs
                      in
-                  let uu____14281 = lhs  in
-                  match uu____14281 with
-                  | (uu____14282,u_lhs,uu____14284) ->
+                  let uu____14272 = lhs  in
+                  match uu____14272 with
+                  | (uu____14273,u_lhs,uu____14275) ->
                       let imitate_comp bs bs_terms c wl1 =
                         let imitate_tot_or_gtot t uopt f wl2 =
-                          let uu____14381 =
+                          let uu____14372 =
                             match uopt with
                             | FStar_Pervasives_Native.None  ->
                                 FStar_Syntax_Util.type_u ()
                             | FStar_Pervasives_Native.Some univ ->
-                                let uu____14391 =
+                                let uu____14382 =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_type univ)
-                                    FStar_Pervasives_Native.None
                                     t.FStar_Syntax_Syntax.pos
                                    in
-                                (uu____14391, univ)
+                                (uu____14382, univ)
                              in
-                          match uu____14381 with
+                          match uu____14372 with
                           | (k,univ) ->
-                              let uu____14398 =
+                              let uu____14389 =
                                 copy_uvar u_lhs (FStar_List.append bs_lhs bs)
                                   k wl2
                                  in
-                              (match uu____14398 with
-                               | (uu____14415,u,wl3) ->
-                                   let uu____14418 =
+                              (match uu____14389 with
+                               | (uu____14406,u,wl3) ->
+                                   let uu____14409 =
                                      f u (FStar_Pervasives_Native.Some univ)
                                       in
-                                   (uu____14418, wl3))
+                                   (uu____14409, wl3))
                            in
                         match c.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Total (t,uopt) ->
@@ -4941,168 +4935,168 @@ and (imitate_arrow :
                             imitate_tot_or_gtot t uopt
                               FStar_Syntax_Syntax.mk_GTotal' wl1
                         | FStar_Syntax_Syntax.Comp ct ->
-                            let uu____14444 =
-                              let uu____14457 =
-                                let uu____14468 =
+                            let uu____14435 =
+                              let uu____14448 =
+                                let uu____14459 =
                                   FStar_Syntax_Syntax.as_arg
                                     ct.FStar_Syntax_Syntax.result_typ
                                    in
-                                uu____14468 ::
+                                uu____14459 ::
                                   (ct.FStar_Syntax_Syntax.effect_args)
                                  in
                               FStar_List.fold_right
-                                (fun uu____14519  ->
-                                   fun uu____14520  ->
-                                     match (uu____14519, uu____14520) with
+                                (fun uu____14510  ->
+                                   fun uu____14511  ->
+                                     match (uu____14510, uu____14511) with
                                      | ((a,i),(out_args,wl2)) ->
-                                         let uu____14621 =
-                                           let uu____14628 =
-                                             let uu____14631 =
+                                         let uu____14612 =
+                                           let uu____14619 =
+                                             let uu____14622 =
                                                FStar_Syntax_Util.type_u ()
                                                 in
                                              FStar_All.pipe_left
                                                FStar_Pervasives_Native.fst
-                                               uu____14631
+                                               uu____14622
                                               in
-                                           copy_uvar u_lhs [] uu____14628 wl2
+                                           copy_uvar u_lhs [] uu____14619 wl2
                                             in
-                                         (match uu____14621 with
-                                          | (uu____14660,t_a,wl3) ->
-                                              let uu____14663 =
+                                         (match uu____14612 with
+                                          | (uu____14651,t_a,wl3) ->
+                                              let uu____14654 =
                                                 copy_uvar u_lhs bs t_a wl3
                                                  in
-                                              (match uu____14663 with
-                                               | (uu____14682,a',wl4) ->
+                                              (match uu____14654 with
+                                               | (uu____14673,a',wl4) ->
                                                    (((a', i) :: out_args),
-                                                     wl4)))) uu____14457
+                                                     wl4)))) uu____14448
                                 ([], wl1)
                                in
-                            (match uu____14444 with
+                            (match uu____14435 with
                              | (out_args,wl2) ->
                                  let ct' =
-                                   let uu___2147_14738 = ct  in
-                                   let uu____14739 =
-                                     let uu____14742 = FStar_List.hd out_args
+                                   let uu___2147_14729 = ct  in
+                                   let uu____14730 =
+                                     let uu____14733 = FStar_List.hd out_args
                                         in
-                                     FStar_Pervasives_Native.fst uu____14742
+                                     FStar_Pervasives_Native.fst uu____14733
                                       in
-                                   let uu____14757 = FStar_List.tl out_args
+                                   let uu____14748 = FStar_List.tl out_args
                                       in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
-                                       (uu___2147_14738.FStar_Syntax_Syntax.comp_univs);
+                                       (uu___2147_14729.FStar_Syntax_Syntax.comp_univs);
                                      FStar_Syntax_Syntax.effect_name =
-                                       (uu___2147_14738.FStar_Syntax_Syntax.effect_name);
+                                       (uu___2147_14729.FStar_Syntax_Syntax.effect_name);
                                      FStar_Syntax_Syntax.result_typ =
-                                       uu____14739;
+                                       uu____14730;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____14757;
+                                       uu____14748;
                                      FStar_Syntax_Syntax.flags =
-                                       (uu___2147_14738.FStar_Syntax_Syntax.flags)
+                                       (uu___2147_14729.FStar_Syntax_Syntax.flags)
                                    }  in
-                                 ((let uu___2150_14775 = c  in
+                                 ((let uu___2150_14766 = c  in
                                    {
                                      FStar_Syntax_Syntax.n =
                                        (FStar_Syntax_Syntax.Comp ct');
                                      FStar_Syntax_Syntax.pos =
-                                       (uu___2150_14775.FStar_Syntax_Syntax.pos);
+                                       (uu___2150_14766.FStar_Syntax_Syntax.pos);
                                      FStar_Syntax_Syntax.vars =
-                                       (uu___2150_14775.FStar_Syntax_Syntax.vars)
+                                       (uu___2150_14766.FStar_Syntax_Syntax.vars)
                                    }), wl2))
                          in
-                      let uu____14778 =
+                      let uu____14769 =
                         FStar_Syntax_Util.arrow_formals_comp arrow  in
-                      (match uu____14778 with
+                      (match uu____14769 with
                        | (formals,c) ->
                            let rec aux bs bs_terms formals1 wl1 =
                              match formals1 with
                              | [] ->
-                                 let uu____14816 =
+                                 let uu____14807 =
                                    imitate_comp bs bs_terms c wl1  in
-                                 (match uu____14816 with
+                                 (match uu____14807 with
                                   | (c',wl2) ->
                                       let lhs' =
                                         FStar_Syntax_Util.arrow bs c'  in
                                       let sol =
-                                        let uu____14827 =
-                                          let uu____14832 =
+                                        let uu____14818 =
+                                          let uu____14823 =
                                             FStar_Syntax_Util.abs bs_lhs lhs'
                                               (FStar_Pervasives_Native.Some
                                                  (FStar_Syntax_Util.residual_tot
                                                     t_res_lhs))
                                              in
-                                          (u_lhs, uu____14832)  in
-                                        TERM uu____14827  in
-                                      let uu____14833 =
+                                          (u_lhs, uu____14823)  in
+                                        TERM uu____14818  in
+                                      let uu____14824 =
                                         mk_t_problem wl2 [] orig lhs' rel
                                           arrow FStar_Pervasives_Native.None
                                           "arrow imitation"
                                          in
-                                      (match uu____14833 with
+                                      (match uu____14824 with
                                        | (sub_prob,wl3) ->
-                                           let uu____14847 =
-                                             let uu____14848 =
+                                           let uu____14838 =
+                                             let uu____14839 =
                                                solve_prob orig
                                                  FStar_Pervasives_Native.None
                                                  [sol] wl3
                                                 in
-                                             attempt [sub_prob] uu____14848
+                                             attempt [sub_prob] uu____14839
                                               in
-                                           solve env uu____14847))
+                                           solve env uu____14838))
                              | (x,imp)::formals2 ->
-                                 let uu____14870 =
-                                   let uu____14877 =
-                                     let uu____14880 =
+                                 let uu____14861 =
+                                   let uu____14868 =
+                                     let uu____14871 =
                                        FStar_Syntax_Util.type_u ()  in
-                                     FStar_All.pipe_right uu____14880
+                                     FStar_All.pipe_right uu____14871
                                        FStar_Pervasives_Native.fst
                                       in
                                    copy_uvar u_lhs
                                      (FStar_List.append bs_lhs bs)
-                                     uu____14877 wl1
+                                     uu____14868 wl1
                                     in
-                                 (match uu____14870 with
+                                 (match uu____14861 with
                                   | (_ctx_u_x,u_x,wl2) ->
                                       let y =
-                                        let uu____14901 =
-                                          let uu____14904 =
+                                        let uu____14892 =
+                                          let uu____14895 =
                                             FStar_Syntax_Syntax.range_of_bv x
                                              in
                                           FStar_Pervasives_Native.Some
-                                            uu____14904
+                                            uu____14895
                                            in
                                         FStar_Syntax_Syntax.new_bv
-                                          uu____14901 u_x
+                                          uu____14892 u_x
                                          in
-                                      let uu____14905 =
-                                        let uu____14908 =
-                                          let uu____14911 =
-                                            let uu____14912 =
+                                      let uu____14896 =
+                                        let uu____14899 =
+                                          let uu____14902 =
+                                            let uu____14903 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 y
                                                in
-                                            (uu____14912, imp)  in
-                                          [uu____14911]  in
+                                            (uu____14903, imp)  in
+                                          [uu____14902]  in
                                         FStar_List.append bs_terms
-                                          uu____14908
+                                          uu____14899
                                          in
                                       aux (FStar_List.append bs [(y, imp)])
-                                        uu____14905 formals2 wl2)
+                                        uu____14896 formals2 wl2)
                               in
-                           let uu____14939 = occurs_check u_lhs arrow  in
-                           (match uu____14939 with
-                            | (uu____14952,occurs_ok,msg) ->
+                           let uu____14930 = occurs_check u_lhs arrow  in
+                           (match uu____14930 with
+                            | (uu____14943,occurs_ok,msg) ->
                                 if Prims.op_Negation occurs_ok
                                 then
-                                  let uu____14968 =
+                                  let uu____14959 =
                                     mklstr
-                                      (fun uu____14973  ->
-                                         let uu____14974 =
+                                      (fun uu____14964  ->
+                                         let uu____14965 =
                                            FStar_Option.get msg  in
                                          Prims.op_Hat "occurs-check failed: "
-                                           uu____14974)
+                                           uu____14965)
                                      in
-                                  giveup_or_defer env orig wl uu____14968
+                                  giveup_or_defer env orig wl uu____14959
                                 else aux [] [] formals wl))
 
 and (solve_binders :
@@ -5124,139 +5118,139 @@ and (solve_binders :
         fun orig  ->
           fun wl  ->
             fun rhs  ->
-              (let uu____15007 =
+              (let uu____14998 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel")
                   in
-               if uu____15007
+               if uu____14998
                then
-                 let uu____15012 =
+                 let uu____15003 =
                    FStar_Syntax_Print.binders_to_string ", " bs1  in
-                 let uu____15015 =
+                 let uu____15006 =
                    FStar_Syntax_Print.binders_to_string ", " bs2  in
                  FStar_Util.print3 "solve_binders\n\t%s\n%s\n\t%s\n"
-                   uu____15012 (rel_to_string (p_rel orig)) uu____15015
+                   uu____15003 (rel_to_string (p_rel orig)) uu____15006
                else ());
               (let rec aux wl1 scope env1 subst xs ys =
                  match (xs, ys) with
                  | ([],[]) ->
-                     let uu____15146 = rhs wl1 scope env1 subst  in
-                     (match uu____15146 with
+                     let uu____15137 = rhs wl1 scope env1 subst  in
+                     (match uu____15137 with
                       | (rhs_prob,wl2) ->
-                          ((let uu____15169 =
+                          ((let uu____15160 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "Rel")
                                in
-                            if uu____15169
+                            if uu____15160
                             then
-                              let uu____15174 = prob_to_string env1 rhs_prob
+                              let uu____15165 = prob_to_string env1 rhs_prob
                                  in
-                              FStar_Util.print1 "rhs_prob = %s\n" uu____15174
+                              FStar_Util.print1 "rhs_prob = %s\n" uu____15165
                             else ());
                            (let formula = p_guard rhs_prob  in
                             (env1, (FStar_Util.Inl ([rhs_prob], formula)),
                               wl2))))
                  | ((hd1,imp)::xs1,(hd2,imp')::ys1) when
-                     let uu____15252 = FStar_Syntax_Util.eq_aqual imp imp'
+                     let uu____15243 = FStar_Syntax_Util.eq_aqual imp imp'
                         in
-                     uu____15252 = FStar_Syntax_Util.Equal ->
+                     uu____15243 = FStar_Syntax_Util.Equal ->
                      let hd11 =
-                       let uu___2220_15254 = hd1  in
-                       let uu____15255 =
+                       let uu___2220_15245 = hd1  in
+                       let uu____15246 =
                          FStar_Syntax_Subst.subst subst
                            hd1.FStar_Syntax_Syntax.sort
                           in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2220_15254.FStar_Syntax_Syntax.ppname);
+                           (uu___2220_15245.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2220_15254.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____15255
+                           (uu___2220_15245.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu____15246
                        }  in
                      let hd21 =
-                       let uu___2223_15259 = hd2  in
-                       let uu____15260 =
+                       let uu___2223_15250 = hd2  in
+                       let uu____15251 =
                          FStar_Syntax_Subst.subst subst
                            hd2.FStar_Syntax_Syntax.sort
                           in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2223_15259.FStar_Syntax_Syntax.ppname);
+                           (uu___2223_15250.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2223_15259.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____15260
+                           (uu___2223_15250.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu____15251
                        }  in
-                     let uu____15263 =
-                       let uu____15268 =
+                     let uu____15254 =
+                       let uu____15259 =
                          FStar_All.pipe_left invert_rel (p_rel orig)  in
                        mk_t_problem wl1 scope orig
-                         hd11.FStar_Syntax_Syntax.sort uu____15268
+                         hd11.FStar_Syntax_Syntax.sort uu____15259
                          hd21.FStar_Syntax_Syntax.sort
                          FStar_Pervasives_Native.None "Formal parameter"
                         in
-                     (match uu____15263 with
+                     (match uu____15254 with
                       | (prob,wl2) ->
                           let hd12 = FStar_Syntax_Syntax.freshen_bv hd11  in
                           let subst1 =
-                            let uu____15291 =
+                            let uu____15282 =
                               FStar_Syntax_Subst.shift_subst Prims.int_one
                                 subst
                                in
                             (FStar_Syntax_Syntax.DB (Prims.int_zero, hd12))
-                              :: uu____15291
+                              :: uu____15282
                              in
                           let env2 = FStar_TypeChecker_Env.push_bv env1 hd12
                              in
-                          let uu____15298 =
+                          let uu____15289 =
                             aux wl2 (FStar_List.append scope [(hd12, imp)])
                               env2 subst1 xs1 ys1
                              in
-                          (match uu____15298 with
+                          (match uu____15289 with
                            | (env3,FStar_Util.Inl (sub_probs,phi),wl3) ->
                                let phi1 =
-                                 let uu____15370 =
+                                 let uu____15361 =
                                    FStar_TypeChecker_Env.close_forall env3
                                      [(hd12, imp)] phi
                                     in
                                  FStar_Syntax_Util.mk_conj (p_guard prob)
-                                   uu____15370
+                                   uu____15361
                                   in
-                               ((let uu____15388 =
+                               ((let uu____15379 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env3)
                                      (FStar_Options.Other "Rel")
                                     in
-                                 if uu____15388
+                                 if uu____15379
                                  then
-                                   let uu____15393 =
+                                   let uu____15384 =
                                      FStar_Syntax_Print.term_to_string phi1
                                       in
-                                   let uu____15395 =
+                                   let uu____15386 =
                                      FStar_Syntax_Print.bv_to_string hd12  in
                                    FStar_Util.print2
-                                     "Formula is %s\n\thd1=%s\n" uu____15393
-                                     uu____15395
+                                     "Formula is %s\n\thd1=%s\n" uu____15384
+                                     uu____15386
                                  else ());
                                 (env3,
                                   (FStar_Util.Inl ((prob :: sub_probs), phi1)),
                                   wl3))
                            | fail -> fail))
-                 | uu____15430 ->
+                 | uu____15421 ->
                      (env1,
                        (FStar_Util.Inr "arity or argument-qualifier mismatch"),
                        wl1)
                   in
-               let uu____15466 = aux wl [] env [] bs1 bs2  in
-               match uu____15466 with
+               let uu____15457 = aux wl [] env [] bs1 bs2  in
+               match uu____15457 with
                | (env1,FStar_Util.Inr msg,wl1) -> giveup_lit env1 msg orig
                | (env1,FStar_Util.Inl (sub_probs,phi),wl1) ->
                    let wl2 =
                      solve_prob orig (FStar_Pervasives_Native.Some phi) []
                        wl1
                       in
-                   let uu____15525 = attempt sub_probs wl2  in
-                   solve env1 uu____15525)
+                   let uu____15516 = attempt sub_probs wl2  in
+                   solve env1 uu____15516)
 
 and (try_solve_without_smt_or_else :
   FStar_TypeChecker_Env.env ->
@@ -5271,36 +5265,36 @@ and (try_solve_without_smt_or_else :
       fun try_solve  ->
         fun else_solve  ->
           let wl' =
-            let uu___2261_15545 = wl  in
+            let uu___2261_15536 = wl  in
             {
               attempting = [];
               wl_deferred = [];
-              ctr = (uu___2261_15545.ctr);
+              ctr = (uu___2261_15536.ctr);
               defer_ok = false;
               smt_ok = false;
               umax_heuristic_ok = false;
-              tcenv = (uu___2261_15545.tcenv);
+              tcenv = (uu___2261_15536.tcenv);
               wl_implicits = [];
-              repr_subcomp_allowed = (uu___2261_15545.repr_subcomp_allowed)
+              repr_subcomp_allowed = (uu___2261_15536.repr_subcomp_allowed)
             }  in
           let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-          let uu____15557 = try_solve env wl'  in
-          match uu____15557 with
-          | Success (uu____15558,imps) ->
+          let uu____15548 = try_solve env wl'  in
+          match uu____15548 with
+          | Success (uu____15549,imps) ->
               (FStar_Syntax_Unionfind.commit tx;
                (let wl1 =
-                  let uu___2270_15562 = wl  in
+                  let uu___2270_15553 = wl  in
                   {
-                    attempting = (uu___2270_15562.attempting);
-                    wl_deferred = (uu___2270_15562.wl_deferred);
-                    ctr = (uu___2270_15562.ctr);
-                    defer_ok = (uu___2270_15562.defer_ok);
-                    smt_ok = (uu___2270_15562.smt_ok);
-                    umax_heuristic_ok = (uu___2270_15562.umax_heuristic_ok);
-                    tcenv = (uu___2270_15562.tcenv);
+                    attempting = (uu___2270_15553.attempting);
+                    wl_deferred = (uu___2270_15553.wl_deferred);
+                    ctr = (uu___2270_15553.ctr);
+                    defer_ok = (uu___2270_15553.defer_ok);
+                    smt_ok = (uu___2270_15553.smt_ok);
+                    umax_heuristic_ok = (uu___2270_15553.umax_heuristic_ok);
+                    tcenv = (uu___2270_15553.tcenv);
                     wl_implicits = (FStar_List.append wl.wl_implicits imps);
                     repr_subcomp_allowed =
-                      (uu___2270_15562.repr_subcomp_allowed)
+                      (uu___2270_15553.repr_subcomp_allowed)
                   }  in
                 solve env wl1))
           | Failed (p,s) ->
@@ -5311,8 +5305,8 @@ and (solve_t : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
     fun problem  ->
       fun wl  ->
         def_check_prob "solve_t" (FStar_TypeChecker_Common.TProb problem);
-        (let uu____15571 = compress_tprob wl.tcenv problem  in
-         solve_t' env uu____15571 wl)
+        (let uu____15562 = compress_tprob wl.tcenv problem  in
+         solve_t' env uu____15562 wl)
 
 and (solve_t_flex_rigid_eq :
   FStar_TypeChecker_Env.env ->
@@ -5325,46 +5319,46 @@ and (solve_t_flex_rigid_eq :
         fun lhs  ->
           fun rhs  ->
             let binders_as_bv_set bs =
-              let uu____15585 = FStar_List.map FStar_Pervasives_Native.fst bs
+              let uu____15576 = FStar_List.map FStar_Pervasives_Native.fst bs
                  in
-              FStar_Util.as_set uu____15585 FStar_Syntax_Syntax.order_bv  in
+              FStar_Util.as_set uu____15576 FStar_Syntax_Syntax.order_bv  in
             let mk_solution env1 lhs1 bs rhs1 =
-              let uu____15619 = lhs1  in
-              match uu____15619 with
-              | (uu____15622,ctx_u,uu____15624) ->
+              let uu____15610 = lhs1  in
+              match uu____15610 with
+              | (uu____15613,ctx_u,uu____15615) ->
                   let sol =
                     match bs with
                     | [] -> rhs1
-                    | uu____15632 ->
-                        let uu____15633 = sn_binders env1 bs  in
+                    | uu____15623 ->
+                        let uu____15624 = sn_binders env1 bs  in
                         u_abs ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
-                          uu____15633 rhs1
+                          uu____15624 rhs1
                      in
                   [TERM (ctx_u, sol)]
                in
             let try_quasi_pattern orig1 env1 wl1 lhs1 rhs1 =
-              let uu____15682 = quasi_pattern env1 lhs1  in
-              match uu____15682 with
+              let uu____15673 = quasi_pattern env1 lhs1  in
+              match uu____15673 with
               | FStar_Pervasives_Native.None  ->
                   ((FStar_Util.Inl "Not a quasi-pattern"), wl1)
-              | FStar_Pervasives_Native.Some (bs,uu____15716) ->
-                  let uu____15721 = lhs1  in
-                  (match uu____15721 with
+              | FStar_Pervasives_Native.Some (bs,uu____15707) ->
+                  let uu____15712 = lhs1  in
+                  (match uu____15712 with
                    | (t_lhs,ctx_u,args) ->
-                       let uu____15736 = occurs_check ctx_u rhs1  in
-                       (match uu____15736 with
+                       let uu____15727 = occurs_check ctx_u rhs1  in
+                       (match uu____15727 with
                         | (uvars,occurs_ok,msg) ->
                             if Prims.op_Negation occurs_ok
                             then
-                              let uu____15787 =
-                                let uu____15795 =
-                                  let uu____15797 = FStar_Option.get msg  in
+                              let uu____15778 =
+                                let uu____15786 =
+                                  let uu____15788 = FStar_Option.get msg  in
                                   Prims.op_Hat
                                     "quasi-pattern, occurs-check failed: "
-                                    uu____15797
+                                    uu____15788
                                    in
-                                FStar_Util.Inl uu____15795  in
-                              (uu____15787, wl1)
+                                FStar_Util.Inl uu____15786  in
+                              (uu____15778, wl1)
                             else
                               (let fvs_lhs =
                                  binders_as_bv_set
@@ -5373,114 +5367,109 @@ and (solve_t_flex_rigid_eq :
                                       bs)
                                   in
                                let fvs_rhs = FStar_Syntax_Free.names rhs1  in
-                               let uu____15825 =
-                                 let uu____15827 =
+                               let uu____15816 =
+                                 let uu____15818 =
                                    FStar_Util.set_is_subset_of fvs_rhs
                                      fvs_lhs
                                     in
-                                 Prims.op_Negation uu____15827  in
-                               if uu____15825
+                                 Prims.op_Negation uu____15818  in
+                               if uu____15816
                                then
                                  ((FStar_Util.Inl
                                      "quasi-pattern, free names on the RHS are not included in the LHS"),
                                    wl1)
                                else
-                                 (let uu____15854 =
-                                    let uu____15862 =
+                                 (let uu____15845 =
+                                    let uu____15853 =
                                       mk_solution env1 lhs1 bs rhs1  in
-                                    FStar_Util.Inr uu____15862  in
-                                  let uu____15868 =
+                                    FStar_Util.Inr uu____15853  in
+                                  let uu____15859 =
                                     restrict_all_uvars ctx_u uvars wl1  in
-                                  (uu____15854, uu____15868)))))
+                                  (uu____15845, uu____15859)))))
                in
             let imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs rhs1 =
-              let uu____15912 = FStar_Syntax_Util.head_and_args rhs1  in
-              match uu____15912 with
+              let uu____15903 = FStar_Syntax_Util.head_and_args rhs1  in
+              match uu____15903 with
               | (rhs_hd,args) ->
-                  let uu____15955 = FStar_Util.prefix args  in
-                  (match uu____15955 with
+                  let uu____15946 = FStar_Util.prefix args  in
+                  (match uu____15946 with
                    | (args_rhs,last_arg_rhs) ->
                        let rhs' =
                          FStar_Syntax_Syntax.mk_Tm_app rhs_hd args_rhs
-                           FStar_Pervasives_Native.None
                            rhs1.FStar_Syntax_Syntax.pos
                           in
-                       let uu____16027 = lhs1  in
-                       (match uu____16027 with
+                       let uu____16016 = lhs1  in
+                       (match uu____16016 with
                         | (t_lhs,u_lhs,_lhs_args) ->
-                            let uu____16031 =
-                              let uu____16042 =
-                                let uu____16049 =
-                                  let uu____16052 =
+                            let uu____16020 =
+                              let uu____16031 =
+                                let uu____16038 =
+                                  let uu____16041 =
                                     FStar_Syntax_Util.type_u ()  in
                                   FStar_All.pipe_left
-                                    FStar_Pervasives_Native.fst uu____16052
+                                    FStar_Pervasives_Native.fst uu____16041
                                    in
-                                copy_uvar u_lhs [] uu____16049 wl1  in
-                              match uu____16042 with
-                              | (uu____16079,t_last_arg,wl2) ->
-                                  let uu____16082 =
-                                    let uu____16089 =
-                                      let uu____16090 =
-                                        let uu____16099 =
+                                copy_uvar u_lhs [] uu____16038 wl1  in
+                              match uu____16031 with
+                              | (uu____16068,t_last_arg,wl2) ->
+                                  let uu____16071 =
+                                    let uu____16078 =
+                                      let uu____16079 =
+                                        let uu____16088 =
                                           FStar_Syntax_Syntax.null_binder
                                             t_last_arg
                                            in
-                                        [uu____16099]  in
-                                      FStar_List.append bs_lhs uu____16090
+                                        [uu____16088]  in
+                                      FStar_List.append bs_lhs uu____16079
                                        in
-                                    copy_uvar u_lhs uu____16089 t_res_lhs wl2
+                                    copy_uvar u_lhs uu____16078 t_res_lhs wl2
                                      in
-                                  (match uu____16082 with
-                                   | (uu____16134,lhs',wl3) ->
-                                       let uu____16137 =
+                                  (match uu____16071 with
+                                   | (uu____16123,lhs',wl3) ->
+                                       let uu____16126 =
                                          copy_uvar u_lhs bs_lhs t_last_arg
                                            wl3
                                           in
-                                       (match uu____16137 with
-                                        | (uu____16154,lhs'_last_arg,wl4) ->
+                                       (match uu____16126 with
+                                        | (uu____16143,lhs'_last_arg,wl4) ->
                                             (lhs', lhs'_last_arg, wl4)))
                                in
-                            (match uu____16031 with
+                            (match uu____16020 with
                              | (lhs',lhs'_last_arg,wl2) ->
                                  let sol =
-                                   let uu____16175 =
-                                     let uu____16176 =
-                                       let uu____16181 =
-                                         let uu____16182 =
-                                           let uu____16185 =
-                                             let uu____16190 =
-                                               let uu____16191 =
-                                                 FStar_Syntax_Syntax.as_arg
-                                                   lhs'_last_arg
-                                                  in
-                                               [uu____16191]  in
-                                             FStar_Syntax_Syntax.mk_Tm_app
-                                               lhs' uu____16190
-                                              in
-                                           uu____16185
-                                             FStar_Pervasives_Native.None
+                                   let uu____16164 =
+                                     let uu____16165 =
+                                       let uu____16170 =
+                                         let uu____16171 =
+                                           let uu____16174 =
+                                             let uu____16175 =
+                                               FStar_Syntax_Syntax.as_arg
+                                                 lhs'_last_arg
+                                                in
+                                             [uu____16175]  in
+                                           FStar_Syntax_Syntax.mk_Tm_app lhs'
+                                             uu____16174
                                              t_lhs.FStar_Syntax_Syntax.pos
                                             in
                                          FStar_Syntax_Util.abs bs_lhs
-                                           uu____16182
+                                           uu____16171
                                            (FStar_Pervasives_Native.Some
                                               (FStar_Syntax_Util.residual_tot
                                                  t_res_lhs))
                                           in
-                                       (u_lhs, uu____16181)  in
-                                     TERM uu____16176  in
-                                   [uu____16175]  in
-                                 let uu____16216 =
-                                   let uu____16223 =
+                                       (u_lhs, uu____16170)  in
+                                     TERM uu____16165  in
+                                   [uu____16164]  in
+                                 let uu____16200 =
+                                   let uu____16207 =
                                      mk_t_problem wl2 [] orig1 lhs'
                                        FStar_TypeChecker_Common.EQ rhs'
                                        FStar_Pervasives_Native.None
                                        "first-order lhs"
                                       in
-                                   match uu____16223 with
+                                   match uu____16207 with
                                    | (p1,wl3) ->
-                                       let uu____16243 =
+                                       let uu____16227 =
                                          mk_t_problem wl3 [] orig1
                                            lhs'_last_arg
                                            FStar_TypeChecker_Common.EQ
@@ -5489,65 +5478,65 @@ and (solve_t_flex_rigid_eq :
                                            FStar_Pervasives_Native.None
                                            "first-order rhs"
                                           in
-                                       (match uu____16243 with
+                                       (match uu____16227 with
                                         | (p2,wl4) -> ([p1; p2], wl4))
                                     in
-                                 (match uu____16216 with
+                                 (match uu____16200 with
                                   | (sub_probs,wl3) ->
-                                      let uu____16275 =
-                                        let uu____16276 =
+                                      let uu____16259 =
+                                        let uu____16260 =
                                           solve_prob orig1
                                             FStar_Pervasives_Native.None sol
                                             wl3
                                            in
-                                        attempt sub_probs uu____16276  in
-                                      solve env1 uu____16275))))
+                                        attempt sub_probs uu____16260  in
+                                      solve env1 uu____16259))))
                in
             let first_order orig1 env1 wl1 lhs1 rhs1 =
               let is_app rhs2 =
-                let uu____16310 = FStar_Syntax_Util.head_and_args rhs2  in
-                match uu____16310 with
-                | (uu____16328,args) ->
-                    (match args with | [] -> false | uu____16364 -> true)
+                let uu____16294 = FStar_Syntax_Util.head_and_args rhs2  in
+                match uu____16294 with
+                | (uu____16312,args) ->
+                    (match args with | [] -> false | uu____16348 -> true)
                  in
               let is_arrow rhs2 =
-                let uu____16383 =
-                  let uu____16384 = FStar_Syntax_Subst.compress rhs2  in
-                  uu____16384.FStar_Syntax_Syntax.n  in
-                match uu____16383 with
-                | FStar_Syntax_Syntax.Tm_arrow uu____16388 -> true
-                | uu____16404 -> false  in
-              let uu____16406 = quasi_pattern env1 lhs1  in
-              match uu____16406 with
+                let uu____16367 =
+                  let uu____16368 = FStar_Syntax_Subst.compress rhs2  in
+                  uu____16368.FStar_Syntax_Syntax.n  in
+                match uu____16367 with
+                | FStar_Syntax_Syntax.Tm_arrow uu____16372 -> true
+                | uu____16388 -> false  in
+              let uu____16390 = quasi_pattern env1 lhs1  in
+              match uu____16390 with
               | FStar_Pervasives_Native.None  ->
                   let msg =
                     mklstr
-                      (fun uu____16425  ->
-                         let uu____16426 = prob_to_string env1 orig1  in
+                      (fun uu____16409  ->
+                         let uu____16410 = prob_to_string env1 orig1  in
                          FStar_Util.format1
                            "first_order heuristic cannot solve %s; lhs not a quasi-pattern"
-                           uu____16426)
+                           uu____16410)
                      in
                   giveup_or_defer env1 orig1 wl1 msg
               | FStar_Pervasives_Native.Some (bs_lhs,t_res_lhs) ->
-                  let uu____16435 = is_app rhs1  in
-                  if uu____16435
+                  let uu____16419 = is_app rhs1  in
+                  if uu____16419
                   then imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs rhs1
                   else
-                    (let uu____16440 = is_arrow rhs1  in
-                     if uu____16440
+                    (let uu____16424 = is_arrow rhs1  in
+                     if uu____16424
                      then
                        imitate_arrow orig1 env1 wl1 lhs1 bs_lhs t_res_lhs
                          FStar_TypeChecker_Common.EQ rhs1
                      else
                        (let msg =
                           mklstr
-                            (fun uu____16453  ->
-                               let uu____16454 = prob_to_string env1 orig1
+                            (fun uu____16437  ->
+                               let uu____16438 = prob_to_string env1 orig1
                                   in
                                FStar_Util.format1
                                  "first_order heuristic cannot solve %s; rhs not an app or arrow"
-                                 uu____16454)
+                                 uu____16438)
                            in
                         giveup_or_defer env1 orig1 wl1 msg))
                in
@@ -5555,36 +5544,36 @@ and (solve_t_flex_rigid_eq :
             | FStar_TypeChecker_Common.SUB  ->
                 if wl.defer_ok
                 then
-                  let uu____16458 = FStar_Thunk.mkv "flex-rigid subtyping"
+                  let uu____16442 = FStar_Thunk.mkv "flex-rigid subtyping"
                      in
-                  giveup_or_defer env orig wl uu____16458
+                  giveup_or_defer env orig wl uu____16442
                 else solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.SUBINV  ->
                 if wl.defer_ok
                 then
-                  let uu____16464 = FStar_Thunk.mkv "flex-rigid subtyping"
+                  let uu____16448 = FStar_Thunk.mkv "flex-rigid subtyping"
                      in
-                  giveup_or_defer env orig wl uu____16464
+                  giveup_or_defer env orig wl uu____16448
                 else solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.EQ  ->
-                let uu____16469 = lhs  in
-                (match uu____16469 with
+                let uu____16453 = lhs  in
+                (match uu____16453 with
                  | (_t1,ctx_uv,args_lhs) ->
-                     let uu____16473 =
+                     let uu____16457 =
                        pat_vars env
                          ctx_uv.FStar_Syntax_Syntax.ctx_uvar_binders args_lhs
                         in
-                     (match uu____16473 with
+                     (match uu____16457 with
                       | FStar_Pervasives_Native.Some lhs_binders ->
                           let rhs1 = sn env rhs  in
                           let names_to_string1 fvs =
-                            let uu____16491 =
-                              let uu____16495 = FStar_Util.set_elements fvs
+                            let uu____16475 =
+                              let uu____16479 = FStar_Util.set_elements fvs
                                  in
                               FStar_List.map FStar_Syntax_Print.bv_to_string
-                                uu____16495
+                                uu____16479
                                in
-                            FStar_All.pipe_right uu____16491
+                            FStar_All.pipe_right uu____16475
                               (FStar_String.concat ", ")
                              in
                           let fvs1 =
@@ -5594,48 +5583,48 @@ and (solve_t_flex_rigid_eq :
                                  lhs_binders)
                              in
                           let fvs2 = FStar_Syntax_Free.names rhs1  in
-                          let uu____16516 = occurs_check ctx_uv rhs1  in
-                          (match uu____16516 with
+                          let uu____16500 = occurs_check ctx_uv rhs1  in
+                          (match uu____16500 with
                            | (uvars,occurs_ok,msg) ->
                                if Prims.op_Negation occurs_ok
                                then
-                                 let uu____16545 =
-                                   let uu____16546 =
-                                     let uu____16548 = FStar_Option.get msg
+                                 let uu____16529 =
+                                   let uu____16530 =
+                                     let uu____16532 = FStar_Option.get msg
                                         in
                                      Prims.op_Hat "occurs-check failed: "
-                                       uu____16548
+                                       uu____16532
                                       in
                                    FStar_All.pipe_left FStar_Thunk.mkv
-                                     uu____16546
+                                     uu____16530
                                     in
-                                 giveup_or_defer env orig wl uu____16545
+                                 giveup_or_defer env orig wl uu____16529
                                else
-                                 (let uu____16556 =
+                                 (let uu____16540 =
                                     FStar_Util.set_is_subset_of fvs2 fvs1  in
-                                  if uu____16556
+                                  if uu____16540
                                   then
                                     let sol =
                                       mk_solution env lhs lhs_binders rhs1
                                        in
                                     let wl1 =
                                       restrict_all_uvars ctx_uv uvars wl  in
-                                    let uu____16563 =
+                                    let uu____16547 =
                                       solve_prob orig
                                         FStar_Pervasives_Native.None sol wl1
                                        in
-                                    solve env uu____16563
+                                    solve env uu____16547
                                   else
                                     if wl.defer_ok
                                     then
                                       (let msg1 =
                                          mklstr
-                                           (fun uu____16579  ->
-                                              let uu____16580 =
+                                           (fun uu____16563  ->
+                                              let uu____16564 =
                                                 names_to_string1 fvs2  in
-                                              let uu____16582 =
+                                              let uu____16566 =
                                                 names_to_string1 fvs1  in
-                                              let uu____16584 =
+                                              let uu____16568 =
                                                 FStar_Syntax_Print.binders_to_string
                                                   ", "
                                                   (FStar_List.append
@@ -5644,28 +5633,28 @@ and (solve_t_flex_rigid_eq :
                                                  in
                                               FStar_Util.format3
                                                 "free names in the RHS {%s} are out of scope for the LHS: {%s}, {%s}"
-                                                uu____16580 uu____16582
-                                                uu____16584)
+                                                uu____16564 uu____16566
+                                                uu____16568)
                                           in
                                        giveup_or_defer env orig wl msg1)
                                     else first_order orig env wl lhs rhs1))
-                      | uu____16596 ->
+                      | uu____16580 ->
                           if wl.defer_ok
                           then
-                            let uu____16600 = FStar_Thunk.mkv "Not a pattern"
+                            let uu____16584 = FStar_Thunk.mkv "Not a pattern"
                                in
-                            giveup_or_defer env orig wl uu____16600
+                            giveup_or_defer env orig wl uu____16584
                           else
-                            (let uu____16605 =
+                            (let uu____16589 =
                                try_quasi_pattern orig env wl lhs rhs  in
-                             match uu____16605 with
+                             match uu____16589 with
                              | (FStar_Util.Inr sol,wl1) ->
-                                 let uu____16631 =
+                                 let uu____16615 =
                                    solve_prob orig
                                      FStar_Pervasives_Native.None sol wl1
                                     in
-                                 solve env uu____16631
-                             | (FStar_Util.Inl msg,uu____16633) ->
+                                 solve env uu____16615
+                             | (FStar_Util.Inl msg,uu____16617) ->
                                  first_order orig env wl lhs rhs)))
 
 and (solve_t_flex_flex :
@@ -5681,14 +5670,14 @@ and (solve_t_flex_flex :
             | FStar_TypeChecker_Common.SUB  ->
                 if wl.defer_ok
                 then
-                  let uu____16651 = FStar_Thunk.mkv "flex-flex subtyping"  in
-                  giveup_or_defer env orig wl uu____16651
+                  let uu____16635 = FStar_Thunk.mkv "flex-flex subtyping"  in
+                  giveup_or_defer env orig wl uu____16635
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.SUBINV  ->
                 if wl.defer_ok
                 then
-                  let uu____16657 = FStar_Thunk.mkv "flex-flex subtyping"  in
-                  giveup_or_defer env orig wl uu____16657
+                  let uu____16641 = FStar_Thunk.mkv "flex-flex subtyping"  in
+                  giveup_or_defer env orig wl uu____16641
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.EQ  ->
                 if
@@ -5696,47 +5685,47 @@ and (solve_t_flex_flex :
                     ((Prims.op_Negation (is_flex_pat lhs)) ||
                        (Prims.op_Negation (is_flex_pat rhs)))
                 then
-                  let uu____16679 = FStar_Thunk.mkv "flex-flex non-pattern"
+                  let uu____16663 = FStar_Thunk.mkv "flex-flex non-pattern"
                      in
-                  giveup_or_defer env orig wl uu____16679
+                  giveup_or_defer env orig wl uu____16663
                 else
-                  (let uu____16684 =
-                     let uu____16701 = quasi_pattern env lhs  in
-                     let uu____16708 = quasi_pattern env rhs  in
-                     (uu____16701, uu____16708)  in
-                   match uu____16684 with
+                  (let uu____16668 =
+                     let uu____16685 = quasi_pattern env lhs  in
+                     let uu____16692 = quasi_pattern env rhs  in
+                     (uu____16685, uu____16692)  in
+                   match uu____16668 with
                    | (FStar_Pervasives_Native.Some
                       (binders_lhs,t_res_lhs),FStar_Pervasives_Native.Some
                       (binders_rhs,t_res_rhs)) ->
-                       let uu____16751 = lhs  in
-                       (match uu____16751 with
-                        | ({ FStar_Syntax_Syntax.n = uu____16752;
+                       let uu____16735 = lhs  in
+                       (match uu____16735 with
+                        | ({ FStar_Syntax_Syntax.n = uu____16736;
                              FStar_Syntax_Syntax.pos = range;
-                             FStar_Syntax_Syntax.vars = uu____16754;_},u_lhs,uu____16756)
+                             FStar_Syntax_Syntax.vars = uu____16738;_},u_lhs,uu____16740)
                             ->
-                            let uu____16759 = rhs  in
-                            (match uu____16759 with
-                             | (uu____16760,u_rhs,uu____16762) ->
-                                 let uu____16763 =
+                            let uu____16743 = rhs  in
+                            (match uu____16743 with
+                             | (uu____16744,u_rhs,uu____16746) ->
+                                 let uu____16747 =
                                    (FStar_Syntax_Unionfind.equiv
                                       u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                       u_rhs.FStar_Syntax_Syntax.ctx_uvar_head)
                                      && (binders_eq binders_lhs binders_rhs)
                                     in
-                                 if uu____16763
+                                 if uu____16747
                                  then
-                                   let uu____16770 =
+                                   let uu____16754 =
                                      solve_prob orig
                                        FStar_Pervasives_Native.None [] wl
                                       in
-                                   solve env uu____16770
+                                   solve env uu____16754
                                  else
-                                   (let uu____16773 =
+                                   (let uu____16757 =
                                       maximal_prefix
                                         u_lhs.FStar_Syntax_Syntax.ctx_uvar_binders
                                         u_rhs.FStar_Syntax_Syntax.ctx_uvar_binders
                                        in
-                                    match uu____16773 with
+                                    match uu____16757 with
                                     | (ctx_w,(ctx_l,ctx_r)) ->
                                         let gamma_w =
                                           gamma_until
@@ -5750,14 +5739,14 @@ and (solve_t_flex_flex :
                                             (FStar_List.append ctx_r
                                                binders_rhs)
                                            in
-                                        let uu____16805 =
-                                          let uu____16812 =
-                                            let uu____16815 =
+                                        let uu____16789 =
+                                          let uu____16796 =
+                                            let uu____16799 =
                                               FStar_Syntax_Syntax.mk_Total
                                                 t_res_lhs
                                                in
                                             FStar_Syntax_Util.arrow zs
-                                              uu____16815
+                                              uu____16799
                                              in
                                           new_uvar
                                             (Prims.op_Hat "flex-flex quasi:"
@@ -5767,138 +5756,133 @@ and (solve_t_flex_flex :
                                                      (Prims.op_Hat "\trhs="
                                                         u_rhs.FStar_Syntax_Syntax.ctx_uvar_reason))))
                                             wl range gamma_w ctx_w
-                                            uu____16812
+                                            uu____16796
                                             FStar_Syntax_Syntax.Strict
                                             FStar_Pervasives_Native.None
                                            in
-                                        (match uu____16805 with
-                                         | (uu____16827,w,wl1) ->
+                                        (match uu____16789 with
+                                         | (uu____16811,w,wl1) ->
                                              let w_app =
-                                               let uu____16833 =
-                                                 let uu____16838 =
-                                                   FStar_List.map
-                                                     (fun uu____16849  ->
-                                                        match uu____16849
-                                                        with
-                                                        | (z,uu____16857) ->
-                                                            let uu____16862 =
-                                                              FStar_Syntax_Syntax.bv_to_name
-                                                                z
-                                                               in
-                                                            FStar_Syntax_Syntax.as_arg
-                                                              uu____16862) zs
-                                                    in
-                                                 FStar_Syntax_Syntax.mk_Tm_app
-                                                   w uu____16838
+                                               let uu____16815 =
+                                                 FStar_List.map
+                                                   (fun uu____16826  ->
+                                                      match uu____16826 with
+                                                      | (z,uu____16834) ->
+                                                          let uu____16839 =
+                                                            FStar_Syntax_Syntax.bv_to_name
+                                                              z
+                                                             in
+                                                          FStar_Syntax_Syntax.as_arg
+                                                            uu____16839) zs
                                                   in
-                                               uu____16833
-                                                 FStar_Pervasives_Native.None
+                                               FStar_Syntax_Syntax.mk_Tm_app
+                                                 w uu____16815
                                                  w.FStar_Syntax_Syntax.pos
                                                 in
-                                             ((let uu____16864 =
+                                             ((let uu____16841 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env)
                                                    (FStar_Options.Other "Rel")
                                                   in
-                                               if uu____16864
+                                               if uu____16841
                                                then
-                                                 let uu____16869 =
-                                                   let uu____16873 =
+                                                 let uu____16846 =
+                                                   let uu____16850 =
                                                      flex_t_to_string lhs  in
-                                                   let uu____16875 =
-                                                     let uu____16879 =
+                                                   let uu____16852 =
+                                                     let uu____16856 =
                                                        flex_t_to_string rhs
                                                         in
-                                                     let uu____16881 =
-                                                       let uu____16885 =
+                                                     let uu____16858 =
+                                                       let uu____16862 =
                                                          term_to_string w  in
-                                                       let uu____16887 =
-                                                         let uu____16891 =
+                                                       let uu____16864 =
+                                                         let uu____16868 =
                                                            FStar_Syntax_Print.binders_to_string
                                                              ", "
                                                              (FStar_List.append
                                                                 ctx_l
                                                                 binders_lhs)
                                                             in
-                                                         let uu____16900 =
-                                                           let uu____16904 =
+                                                         let uu____16877 =
+                                                           let uu____16881 =
                                                              FStar_Syntax_Print.binders_to_string
                                                                ", "
                                                                (FStar_List.append
                                                                   ctx_r
                                                                   binders_rhs)
                                                               in
-                                                           let uu____16913 =
-                                                             let uu____16917
+                                                           let uu____16890 =
+                                                             let uu____16894
                                                                =
                                                                FStar_Syntax_Print.binders_to_string
                                                                  ", " zs
                                                                 in
-                                                             [uu____16917]
+                                                             [uu____16894]
                                                               in
-                                                           uu____16904 ::
-                                                             uu____16913
+                                                           uu____16881 ::
+                                                             uu____16890
                                                             in
-                                                         uu____16891 ::
-                                                           uu____16900
+                                                         uu____16868 ::
+                                                           uu____16877
                                                           in
-                                                       uu____16885 ::
-                                                         uu____16887
+                                                       uu____16862 ::
+                                                         uu____16864
                                                         in
-                                                     uu____16879 ::
-                                                       uu____16881
+                                                     uu____16856 ::
+                                                       uu____16858
                                                       in
-                                                   uu____16873 :: uu____16875
+                                                   uu____16850 :: uu____16852
                                                     in
                                                  FStar_Util.print
                                                    "flex-flex quasi:\n\tlhs=%s\n\trhs=%s\n\tsol=%s\n\tctx_l@binders_lhs=%s\n\tctx_r@binders_rhs=%s\n\tzs=%s\n"
-                                                   uu____16869
+                                                   uu____16846
                                                else ());
                                               (let sol =
                                                  let s1 =
-                                                   let uu____16934 =
-                                                     let uu____16939 =
+                                                   let uu____16911 =
+                                                     let uu____16916 =
                                                        FStar_Syntax_Util.abs
                                                          binders_lhs w_app
                                                          (FStar_Pervasives_Native.Some
                                                             (FStar_Syntax_Util.residual_tot
                                                                t_res_lhs))
                                                         in
-                                                     (u_lhs, uu____16939)  in
-                                                   TERM uu____16934  in
-                                                 let uu____16940 =
+                                                     (u_lhs, uu____16916)  in
+                                                   TERM uu____16911  in
+                                                 let uu____16917 =
                                                    FStar_Syntax_Unionfind.equiv
                                                      u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                      u_rhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                     in
-                                                 if uu____16940
+                                                 if uu____16917
                                                  then [s1]
                                                  else
                                                    (let s2 =
-                                                      let uu____16948 =
-                                                        let uu____16953 =
+                                                      let uu____16925 =
+                                                        let uu____16930 =
                                                           FStar_Syntax_Util.abs
                                                             binders_rhs w_app
                                                             (FStar_Pervasives_Native.Some
                                                                (FStar_Syntax_Util.residual_tot
                                                                   t_res_lhs))
                                                            in
-                                                        (u_rhs, uu____16953)
+                                                        (u_rhs, uu____16930)
                                                          in
-                                                      TERM uu____16948  in
+                                                      TERM uu____16925  in
                                                     [s1; s2])
                                                   in
-                                               let uu____16954 =
+                                               let uu____16931 =
                                                  solve_prob orig
                                                    FStar_Pervasives_Native.None
                                                    sol wl1
                                                   in
-                                               solve env uu____16954))))))
-                   | uu____16955 ->
-                       let uu____16972 =
+                                               solve env uu____16931))))))
+                   | uu____16932 ->
+                       let uu____16949 =
                          FStar_Thunk.mkv "flex-flex: non-patterns"  in
-                       giveup_or_defer env orig wl uu____16972)
+                       giveup_or_defer env orig wl uu____16949)
 
 and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
   fun env  ->
@@ -5908,91 +5892,91 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
         (let giveup_or_defer1 orig msg = giveup_or_defer env orig wl msg  in
          let rigid_heads_match env1 need_unif torig wl1 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig  in
-           (let uu____17026 =
+           (let uu____17003 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "Rel")
                in
-            if uu____17026
+            if uu____17003
             then
-              let uu____17031 = FStar_Syntax_Print.term_to_string t1  in
-              let uu____17033 = FStar_Syntax_Print.tag_of_term t1  in
-              let uu____17035 = FStar_Syntax_Print.term_to_string t2  in
-              let uu____17037 = FStar_Syntax_Print.tag_of_term t2  in
+              let uu____17008 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____17010 = FStar_Syntax_Print.tag_of_term t1  in
+              let uu____17012 = FStar_Syntax_Print.term_to_string t2  in
+              let uu____17014 = FStar_Syntax_Print.tag_of_term t2  in
               FStar_Util.print5 "Heads %s: %s (%s) and %s (%s)\n"
                 (if need_unif then "need unification" else "match")
-                uu____17031 uu____17033 uu____17035 uu____17037
+                uu____17008 uu____17010 uu____17012 uu____17014
             else ());
-           (let uu____17048 = FStar_Syntax_Util.head_and_args t1  in
-            match uu____17048 with
+           (let uu____17025 = FStar_Syntax_Util.head_and_args t1  in
+            match uu____17025 with
             | (head1,args1) ->
-                let uu____17091 = FStar_Syntax_Util.head_and_args t2  in
-                (match uu____17091 with
+                let uu____17068 = FStar_Syntax_Util.head_and_args t2  in
+                (match uu____17068 with
                  | (head2,args2) ->
                      let solve_head_then wl2 k =
                        if need_unif
                        then k true wl2
                        else
-                         (let uu____17161 =
+                         (let uu____17138 =
                             solve_maybe_uinsts env1 orig head1 head2 wl2  in
-                          match uu____17161 with
+                          match uu____17138 with
                           | USolved wl3 -> k true wl3
                           | UFailed msg -> giveup env1 msg orig
                           | UDeferred wl3 ->
-                              let uu____17166 =
+                              let uu____17143 =
                                 defer_lit "universe constraints" orig wl3  in
-                              k false uu____17166)
+                              k false uu____17143)
                         in
                      let nargs = FStar_List.length args1  in
                      if nargs <> (FStar_List.length args2)
                      then
-                       let uu____17187 =
+                       let uu____17164 =
                          mklstr
-                           (fun uu____17198  ->
-                              let uu____17199 =
+                           (fun uu____17175  ->
+                              let uu____17176 =
                                 FStar_Syntax_Print.term_to_string head1  in
-                              let uu____17201 = args_to_string args1  in
-                              let uu____17205 =
+                              let uu____17178 = args_to_string args1  in
+                              let uu____17182 =
                                 FStar_Syntax_Print.term_to_string head2  in
-                              let uu____17207 = args_to_string args2  in
+                              let uu____17184 = args_to_string args2  in
                               FStar_Util.format4
                                 "unequal number of arguments: %s[%s] and %s[%s]"
-                                uu____17199 uu____17201 uu____17205
-                                uu____17207)
+                                uu____17176 uu____17178 uu____17182
+                                uu____17184)
                           in
-                       giveup env1 uu____17187 orig
+                       giveup env1 uu____17164 orig
                      else
-                       (let uu____17214 =
+                       (let uu____17191 =
                           (nargs = Prims.int_zero) ||
-                            (let uu____17219 =
+                            (let uu____17196 =
                                FStar_Syntax_Util.eq_args args1 args2  in
-                             uu____17219 = FStar_Syntax_Util.Equal)
+                             uu____17196 = FStar_Syntax_Util.Equal)
                            in
-                        if uu____17214
+                        if uu____17191
                         then
                           (if need_unif
                            then
                              solve_t env1
-                               (let uu___2526_17223 = problem  in
+                               (let uu___2526_17200 = problem  in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.pid);
+                                    (uu___2526_17200.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs = head1;
                                   FStar_TypeChecker_Common.relation =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.relation);
+                                    (uu___2526_17200.FStar_TypeChecker_Common.relation);
                                   FStar_TypeChecker_Common.rhs = head2;
                                   FStar_TypeChecker_Common.element =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.element);
+                                    (uu___2526_17200.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___2526_17200.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___2526_17200.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.reason);
+                                    (uu___2526_17200.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.loc);
+                                    (uu___2526_17200.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___2526_17223.FStar_TypeChecker_Common.rank)
+                                    (uu___2526_17200.FStar_TypeChecker_Common.rank)
                                 }) wl1
                            else
                              solve_head_then wl1
@@ -6000,19 +5984,19 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                   fun wl2  ->
                                     if ok
                                     then
-                                      let uu____17233 =
+                                      let uu____17210 =
                                         solve_prob orig
                                           FStar_Pervasives_Native.None [] wl2
                                          in
-                                      solve env1 uu____17233
+                                      solve env1 uu____17210
                                     else solve env1 wl2))
                         else
-                          (let uu____17238 = base_and_refinement env1 t1  in
-                           match uu____17238 with
+                          (let uu____17215 = base_and_refinement env1 t1  in
+                           match uu____17215 with
                            | (base1,refinement1) ->
-                               let uu____17263 = base_and_refinement env1 t2
+                               let uu____17240 = base_and_refinement env1 t2
                                   in
-                               (match uu____17263 with
+                               (match uu____17240 with
                                 | (base2,refinement2) ->
                                     (match (refinement1, refinement2) with
                                      | (FStar_Pervasives_Native.None
@@ -6030,17 +6014,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                  :: args2)
                                              else FStar_List.zip args1 args2
                                               in
-                                           let uu____17428 =
+                                           let uu____17405 =
                                              FStar_List.fold_right
-                                               (fun uu____17468  ->
-                                                  fun uu____17469  ->
-                                                    match (uu____17468,
-                                                            uu____17469)
+                                               (fun uu____17445  ->
+                                                  fun uu____17446  ->
+                                                    match (uu____17445,
+                                                            uu____17446)
                                                     with
-                                                    | (((a1,uu____17521),
-                                                        (a2,uu____17523)),
+                                                    | (((a1,uu____17498),
+                                                        (a2,uu____17500)),
                                                        (probs,wl3)) ->
-                                                        let uu____17572 =
+                                                        let uu____17549 =
                                                           mk_problem wl3 []
                                                             orig a1
                                                             FStar_TypeChecker_Common.EQ
@@ -6048,7 +6032,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                             FStar_Pervasives_Native.None
                                                             "index"
                                                            in
-                                                        (match uu____17572
+                                                        (match uu____17549
                                                          with
                                                          | (prob',wl4) ->
                                                              (((FStar_TypeChecker_Common.TProb
@@ -6056,30 +6040,30 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                probs), wl4)))
                                                argp ([], wl2)
                                               in
-                                           match uu____17428 with
+                                           match uu____17405 with
                                            | (subprobs,wl3) ->
-                                               ((let uu____17615 =
+                                               ((let uu____17592 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env1)
                                                      (FStar_Options.Other
                                                         "Rel")
                                                     in
-                                                 if uu____17615
+                                                 if uu____17592
                                                  then
-                                                   let uu____17620 =
+                                                   let uu____17597 =
                                                      FStar_Syntax_Print.list_to_string
                                                        (prob_to_string env1)
                                                        subprobs
                                                       in
                                                    FStar_Util.print1
                                                      "Adding subproblems for arguments: %s"
-                                                     uu____17620
+                                                     uu____17597
                                                  else ());
-                                                (let uu____17626 =
+                                                (let uu____17603 =
                                                    FStar_Options.defensive ()
                                                     in
-                                                 if uu____17626
+                                                 if uu____17603
                                                  then
                                                    FStar_List.iter
                                                      (def_check_prob
@@ -6095,19 +6079,19 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                   if Prims.op_Negation ok
                                                   then solve env2 wl3
                                                   else
-                                                    (let uu____17653 =
+                                                    (let uu____17630 =
                                                        mk_sub_probs wl3  in
-                                                     match uu____17653 with
+                                                     match uu____17630 with
                                                      | (subprobs,wl4) ->
                                                          let formula =
-                                                           let uu____17669 =
+                                                           let uu____17646 =
                                                              FStar_List.map
                                                                (fun p  ->
                                                                   p_guard p)
                                                                subprobs
                                                               in
                                                            FStar_Syntax_Util.mk_conj_l
-                                                             uu____17669
+                                                             uu____17646
                                                             in
                                                          let wl5 =
                                                            solve_prob orig
@@ -6115,120 +6099,120 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                 formula) []
                                                              wl4
                                                             in
-                                                         let uu____17677 =
+                                                         let uu____17654 =
                                                            attempt subprobs
                                                              wl5
                                                             in
                                                          solve env2
-                                                           uu____17677))
+                                                           uu____17654))
                                             in
                                          let solve_sub_probs_no_smt env2 wl2
                                            =
                                            solve_head_then wl2
                                              (fun ok  ->
                                                 fun wl3  ->
-                                                  let uu____17702 =
+                                                  let uu____17679 =
                                                     mk_sub_probs wl3  in
-                                                  match uu____17702 with
+                                                  match uu____17679 with
                                                   | (subprobs,wl4) ->
                                                       let formula =
-                                                        let uu____17718 =
+                                                        let uu____17695 =
                                                           FStar_List.map
                                                             (fun p  ->
                                                                p_guard p)
                                                             subprobs
                                                            in
                                                         FStar_Syntax_Util.mk_conj_l
-                                                          uu____17718
+                                                          uu____17695
                                                          in
                                                       let wl5 =
                                                         solve_prob orig
                                                           (FStar_Pervasives_Native.Some
                                                              formula) [] wl4
                                                          in
-                                                      let uu____17726 =
+                                                      let uu____17703 =
                                                         attempt subprobs wl5
                                                          in
-                                                      solve env2 uu____17726)
+                                                      solve env2 uu____17703)
                                             in
                                          let unfold_and_retry d env2 wl2
-                                           uu____17754 =
-                                           match uu____17754 with
+                                           uu____17731 =
+                                           match uu____17731 with
                                            | (prob,reason) ->
-                                               ((let uu____17771 =
+                                               ((let uu____17748 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env2)
                                                      (FStar_Options.Other
                                                         "Rel")
                                                     in
-                                                 if uu____17771
+                                                 if uu____17748
                                                  then
-                                                   let uu____17776 =
+                                                   let uu____17753 =
                                                      prob_to_string env2 orig
                                                       in
-                                                   let uu____17778 =
+                                                   let uu____17755 =
                                                      FStar_Thunk.force reason
                                                       in
                                                    FStar_Util.print2
                                                      "Failed to solve %s because a sub-problem is not solvable without SMT because %s"
-                                                     uu____17776 uu____17778
+                                                     uu____17753 uu____17755
                                                  else ());
-                                                (let uu____17784 =
-                                                   let uu____17793 =
+                                                (let uu____17761 =
+                                                   let uu____17770 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t1
                                                       in
-                                                   let uu____17796 =
+                                                   let uu____17773 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t2
                                                       in
-                                                   (uu____17793, uu____17796)
+                                                   (uu____17770, uu____17773)
                                                     in
-                                                 match uu____17784 with
+                                                 match uu____17761 with
                                                  | (FStar_Pervasives_Native.Some
                                                     t1',FStar_Pervasives_Native.Some
                                                     t2') ->
-                                                     let uu____17809 =
+                                                     let uu____17786 =
                                                        FStar_Syntax_Util.head_and_args
                                                          t1'
                                                         in
-                                                     (match uu____17809 with
-                                                      | (head1',uu____17827)
+                                                     (match uu____17786 with
+                                                      | (head1',uu____17804)
                                                           ->
-                                                          let uu____17852 =
+                                                          let uu____17829 =
                                                             FStar_Syntax_Util.head_and_args
                                                               t2'
                                                              in
-                                                          (match uu____17852
+                                                          (match uu____17829
                                                            with
-                                                           | (head2',uu____17870)
+                                                           | (head2',uu____17847)
                                                                ->
-                                                               let uu____17895
+                                                               let uu____17872
                                                                  =
-                                                                 let uu____17900
+                                                                 let uu____17877
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head1'
                                                                     head1
                                                                     in
-                                                                 let uu____17901
+                                                                 let uu____17878
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head2'
                                                                     head2
                                                                     in
-                                                                 (uu____17900,
-                                                                   uu____17901)
+                                                                 (uu____17877,
+                                                                   uu____17878)
                                                                   in
-                                                               (match uu____17895
+                                                               (match uu____17872
                                                                 with
                                                                 | (FStar_Syntax_Util.Equal
                                                                    ,FStar_Syntax_Util.Equal
                                                                    ) ->
                                                                     (
                                                                     (
-                                                                    let uu____17903
+                                                                    let uu____17880
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6237,72 +6221,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     "Rel")
                                                                      in
                                                                     if
-                                                                    uu____17903
+                                                                    uu____17880
                                                                     then
-                                                                    let uu____17908
+                                                                    let uu____17885
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1  in
-                                                                    let uu____17910
+                                                                    let uu____17887
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1'  in
-                                                                    let uu____17912
+                                                                    let uu____17889
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2  in
-                                                                    let uu____17914
+                                                                    let uu____17891
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2'  in
                                                                     FStar_Util.print4
                                                                     "Unfolding didn't make progress ... got %s ~> %s;\nand %s ~> %s\n"
-                                                                    uu____17908
-                                                                    uu____17910
-                                                                    uu____17912
-                                                                    uu____17914
+                                                                    uu____17885
+                                                                    uu____17887
+                                                                    uu____17889
+                                                                    uu____17891
                                                                     else ());
                                                                     solve_sub_probs
                                                                     env2 wl2)
-                                                                | uu____17919
+                                                                | uu____17896
                                                                     ->
                                                                     let torig'
                                                                     =
-                                                                    let uu___2614_17927
+                                                                    let uu___2614_17904
                                                                     = torig
                                                                      in
                                                                     {
                                                                     FStar_TypeChecker_Common.pid
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.pid);
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.pid);
                                                                     FStar_TypeChecker_Common.lhs
                                                                     = t1';
                                                                     FStar_TypeChecker_Common.relation
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.relation);
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.relation);
                                                                     FStar_TypeChecker_Common.rhs
                                                                     = t2';
                                                                     FStar_TypeChecker_Common.element
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.element);
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.element);
                                                                     FStar_TypeChecker_Common.logical_guard
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.logical_guard);
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.logical_guard);
                                                                     FStar_TypeChecker_Common.logical_guard_uvar
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.logical_guard_uvar);
                                                                     FStar_TypeChecker_Common.reason
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.reason);
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.reason);
                                                                     FStar_TypeChecker_Common.loc
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.loc);
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.loc);
                                                                     FStar_TypeChecker_Common.rank
                                                                     =
-                                                                    (uu___2614_17927.FStar_TypeChecker_Common.rank)
+                                                                    (uu___2614_17904.FStar_TypeChecker_Common.rank)
                                                                     }  in
                                                                     ((
-                                                                    let uu____17929
+                                                                    let uu____17906
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6311,9 +6295,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     "Rel")
                                                                      in
                                                                     if
-                                                                    uu____17929
+                                                                    uu____17906
                                                                     then
-                                                                    let uu____17934
+                                                                    let uu____17911
                                                                     =
                                                                     prob_to_string
                                                                     env2
@@ -6322,20 +6306,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                      in
                                                                     FStar_Util.print1
                                                                     "Unfolded and now trying %s\n"
-                                                                    uu____17934
+                                                                    uu____17911
                                                                     else ());
                                                                     solve_t
                                                                     env2
                                                                     torig'
                                                                     wl2))))
-                                                 | uu____17939 ->
+                                                 | uu____17916 ->
                                                      solve_sub_probs env2 wl2))
                                             in
                                          let d =
-                                           let uu____17951 =
+                                           let uu____17928 =
                                              delta_depth_of_term env1 head1
                                               in
-                                           match uu____17951 with
+                                           match uu____17928 with
                                            | FStar_Pervasives_Native.None  ->
                                                FStar_Pervasives_Native.None
                                            | FStar_Pervasives_Native.Some d
@@ -6344,20 +6328,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                  d
                                             in
                                          let treat_as_injective =
-                                           let uu____17959 =
-                                             let uu____17960 =
+                                           let uu____17936 =
+                                             let uu____17937 =
                                                FStar_Syntax_Util.un_uinst
                                                  head1
                                                 in
-                                             uu____17960.FStar_Syntax_Syntax.n
+                                             uu____17937.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____17959 with
+                                           match uu____17936 with
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
                                                FStar_TypeChecker_Env.fv_has_attr
                                                  env1 fv
                                                  FStar_Parser_Const.unifier_hint_injective_lid
-                                           | uu____17965 -> false  in
+                                           | uu____17942 -> false  in
                                          (match d with
                                           | FStar_Pervasives_Native.Some d1
                                               when
@@ -6369,9 +6353,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 env1 wl1
                                                 solve_sub_probs_no_smt
                                                 (unfold_and_retry d1)
-                                          | uu____17968 ->
+                                          | uu____17945 ->
                                               solve_sub_probs env1 wl1)
-                                     | uu____17971 ->
+                                     | uu____17948 ->
                                          let lhs =
                                            force_refinement
                                              (base1, refinement1)
@@ -6381,148 +6365,148 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                              (base2, refinement2)
                                             in
                                          solve_t env1
-                                           (let uu___2634_18007 = problem  in
+                                           (let uu___2634_17984 = problem  in
                                             {
                                               FStar_TypeChecker_Common.pid =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.pid);
+                                                (uu___2634_17984.FStar_TypeChecker_Common.pid);
                                               FStar_TypeChecker_Common.lhs =
                                                 lhs;
                                               FStar_TypeChecker_Common.relation
                                                 =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.relation);
+                                                (uu___2634_17984.FStar_TypeChecker_Common.relation);
                                               FStar_TypeChecker_Common.rhs =
                                                 rhs;
                                               FStar_TypeChecker_Common.element
                                                 =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.element);
+                                                (uu___2634_17984.FStar_TypeChecker_Common.element);
                                               FStar_TypeChecker_Common.logical_guard
                                                 =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.logical_guard);
+                                                (uu___2634_17984.FStar_TypeChecker_Common.logical_guard);
                                               FStar_TypeChecker_Common.logical_guard_uvar
                                                 =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                (uu___2634_17984.FStar_TypeChecker_Common.logical_guard_uvar);
                                               FStar_TypeChecker_Common.reason
                                                 =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.reason);
+                                                (uu___2634_17984.FStar_TypeChecker_Common.reason);
                                               FStar_TypeChecker_Common.loc =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.loc);
+                                                (uu___2634_17984.FStar_TypeChecker_Common.loc);
                                               FStar_TypeChecker_Common.rank =
-                                                (uu___2634_18007.FStar_TypeChecker_Common.rank)
+                                                (uu___2634_17984.FStar_TypeChecker_Common.rank)
                                             }) wl1))))))
             in
          let try_match_heuristic env1 orig wl1 s1 s2 t1t2_opt =
            let try_solve_branch scrutinee p =
-             let uu____18083 = destruct_flex_t scrutinee wl1  in
-             match uu____18083 with
+             let uu____18060 = destruct_flex_t scrutinee wl1  in
+             match uu____18060 with
              | ((_t,uv,_args),wl2) ->
-                 let uu____18094 =
+                 let uu____18071 =
                    FStar_TypeChecker_PatternUtils.pat_as_exp true env1 p  in
-                 (match uu____18094 with
-                  | (xs,pat_term,uu____18110,uu____18111) ->
-                      let uu____18116 =
+                 (match uu____18071 with
+                  | (xs,pat_term,uu____18087,uu____18088) ->
+                      let uu____18093 =
                         FStar_List.fold_left
-                          (fun uu____18139  ->
+                          (fun uu____18116  ->
                              fun x  ->
-                               match uu____18139 with
+                               match uu____18116 with
                                | (subst,wl3) ->
                                    let t_x =
                                      FStar_Syntax_Subst.subst subst
                                        x.FStar_Syntax_Syntax.sort
                                       in
-                                   let uu____18160 = copy_uvar uv [] t_x wl3
+                                   let uu____18137 = copy_uvar uv [] t_x wl3
                                       in
-                                   (match uu____18160 with
-                                    | (uu____18179,u,wl4) ->
+                                   (match uu____18137 with
+                                    | (uu____18156,u,wl4) ->
                                         let subst1 =
                                           (FStar_Syntax_Syntax.NT (x, u)) ::
                                           subst  in
                                         (subst1, wl4))) ([], wl2) xs
                          in
-                      (match uu____18116 with
+                      (match uu____18093 with
                        | (subst,wl3) ->
                            let pat_term1 =
                              FStar_Syntax_Subst.subst subst pat_term  in
-                           let uu____18200 =
+                           let uu____18177 =
                              new_problem wl3 env1 scrutinee
                                FStar_TypeChecker_Common.EQ pat_term1
                                FStar_Pervasives_Native.None
                                scrutinee.FStar_Syntax_Syntax.pos
                                "match heuristic"
                               in
-                           (match uu____18200 with
+                           (match uu____18177 with
                             | (prob,wl4) ->
                                 let wl' =
-                                  let uu___2674_18217 = wl4  in
+                                  let uu___2674_18194 = wl4  in
                                   {
                                     attempting =
                                       [FStar_TypeChecker_Common.TProb prob];
                                     wl_deferred = [];
-                                    ctr = (uu___2674_18217.ctr);
+                                    ctr = (uu___2674_18194.ctr);
                                     defer_ok = false;
                                     smt_ok = false;
                                     umax_heuristic_ok =
-                                      (uu___2674_18217.umax_heuristic_ok);
-                                    tcenv = (uu___2674_18217.tcenv);
+                                      (uu___2674_18194.umax_heuristic_ok);
+                                    tcenv = (uu___2674_18194.tcenv);
                                     wl_implicits = [];
                                     repr_subcomp_allowed =
-                                      (uu___2674_18217.repr_subcomp_allowed)
+                                      (uu___2674_18194.repr_subcomp_allowed)
                                   }  in
                                 let tx =
                                   FStar_Syntax_Unionfind.new_transaction ()
                                    in
-                                let uu____18228 = solve env1 wl'  in
-                                (match uu____18228 with
-                                 | Success (uu____18231,imps) ->
+                                let uu____18205 = solve env1 wl'  in
+                                (match uu____18205 with
+                                 | Success (uu____18208,imps) ->
                                      let wl'1 =
-                                       let uu___2682_18234 = wl'  in
+                                       let uu___2682_18211 = wl'  in
                                        {
                                          attempting = [orig];
                                          wl_deferred =
-                                           (uu___2682_18234.wl_deferred);
-                                         ctr = (uu___2682_18234.ctr);
+                                           (uu___2682_18211.wl_deferred);
+                                         ctr = (uu___2682_18211.ctr);
                                          defer_ok =
-                                           (uu___2682_18234.defer_ok);
-                                         smt_ok = (uu___2682_18234.smt_ok);
+                                           (uu___2682_18211.defer_ok);
+                                         smt_ok = (uu___2682_18211.smt_ok);
                                          umax_heuristic_ok =
-                                           (uu___2682_18234.umax_heuristic_ok);
-                                         tcenv = (uu___2682_18234.tcenv);
+                                           (uu___2682_18211.umax_heuristic_ok);
+                                         tcenv = (uu___2682_18211.tcenv);
                                          wl_implicits =
-                                           (uu___2682_18234.wl_implicits);
+                                           (uu___2682_18211.wl_implicits);
                                          repr_subcomp_allowed =
-                                           (uu___2682_18234.repr_subcomp_allowed)
+                                           (uu___2682_18211.repr_subcomp_allowed)
                                        }  in
-                                     let uu____18235 = solve env1 wl'1  in
-                                     (match uu____18235 with
-                                      | Success (uu____18238,imps') ->
+                                     let uu____18212 = solve env1 wl'1  in
+                                     (match uu____18212 with
+                                      | Success (uu____18215,imps') ->
                                           (FStar_Syntax_Unionfind.commit tx;
                                            FStar_Pervasives_Native.Some
-                                             ((let uu___2690_18242 = wl4  in
+                                             ((let uu___2690_18219 = wl4  in
                                                {
                                                  attempting =
-                                                   (uu___2690_18242.attempting);
+                                                   (uu___2690_18219.attempting);
                                                  wl_deferred =
-                                                   (uu___2690_18242.wl_deferred);
-                                                 ctr = (uu___2690_18242.ctr);
+                                                   (uu___2690_18219.wl_deferred);
+                                                 ctr = (uu___2690_18219.ctr);
                                                  defer_ok =
-                                                   (uu___2690_18242.defer_ok);
+                                                   (uu___2690_18219.defer_ok);
                                                  smt_ok =
-                                                   (uu___2690_18242.smt_ok);
+                                                   (uu___2690_18219.smt_ok);
                                                  umax_heuristic_ok =
-                                                   (uu___2690_18242.umax_heuristic_ok);
+                                                   (uu___2690_18219.umax_heuristic_ok);
                                                  tcenv =
-                                                   (uu___2690_18242.tcenv);
+                                                   (uu___2690_18219.tcenv);
                                                  wl_implicits =
                                                    (FStar_List.append
                                                       wl4.wl_implicits
                                                       (FStar_List.append imps
                                                          imps'));
                                                  repr_subcomp_allowed =
-                                                   (uu___2690_18242.repr_subcomp_allowed)
+                                                   (uu___2690_18219.repr_subcomp_allowed)
                                                })))
-                                      | Failed uu____18243 ->
+                                      | Failed uu____18220 ->
                                           (FStar_Syntax_Unionfind.rollback tx;
                                            FStar_Pervasives_Native.None))
-                                 | uu____18249 ->
+                                 | uu____18226 ->
                                      (FStar_Syntax_Unionfind.rollback tx;
                                       FStar_Pervasives_Native.None)))))
               in
@@ -6530,523 +6514,523 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
            | FStar_Pervasives_Native.None  ->
                FStar_Util.Inr FStar_Pervasives_Native.None
            | FStar_Pervasives_Native.Some (t1,t2) ->
-               ((let uu____18272 =
+               ((let uu____18249 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Rel")
                     in
-                 if uu____18272
+                 if uu____18249
                  then
-                   let uu____18277 = FStar_Syntax_Print.term_to_string t1  in
-                   let uu____18279 = FStar_Syntax_Print.term_to_string t2  in
+                   let uu____18254 = FStar_Syntax_Print.term_to_string t1  in
+                   let uu____18256 = FStar_Syntax_Print.term_to_string t2  in
                    FStar_Util.print2 "Trying match heuristic for %s vs. %s\n"
-                     uu____18277 uu____18279
+                     uu____18254 uu____18256
                  else ());
-                (let uu____18284 =
-                   let uu____18305 =
-                     let uu____18314 = FStar_Syntax_Util.unmeta t1  in
-                     (s1, uu____18314)  in
-                   let uu____18321 =
-                     let uu____18330 = FStar_Syntax_Util.unmeta t2  in
-                     (s2, uu____18330)  in
-                   (uu____18305, uu____18321)  in
-                 match uu____18284 with
-                 | ((uu____18360,{
+                (let uu____18261 =
+                   let uu____18282 =
+                     let uu____18291 = FStar_Syntax_Util.unmeta t1  in
+                     (s1, uu____18291)  in
+                   let uu____18298 =
+                     let uu____18307 = FStar_Syntax_Util.unmeta t2  in
+                     (s2, uu____18307)  in
+                   (uu____18282, uu____18298)  in
+                 match uu____18261 with
+                 | ((uu____18337,{
                                    FStar_Syntax_Syntax.n =
                                      FStar_Syntax_Syntax.Tm_match
                                      (scrutinee,branches);
-                                   FStar_Syntax_Syntax.pos = uu____18363;
-                                   FStar_Syntax_Syntax.vars = uu____18364;_}),
+                                   FStar_Syntax_Syntax.pos = uu____18340;
+                                   FStar_Syntax_Syntax.vars = uu____18341;_}),
                     (s,t)) ->
-                     let uu____18435 =
-                       let uu____18437 = is_flex scrutinee  in
-                       Prims.op_Negation uu____18437  in
-                     if uu____18435
+                     let uu____18412 =
+                       let uu____18414 = is_flex scrutinee  in
+                       Prims.op_Negation uu____18414  in
+                     if uu____18412
                      then
-                       ((let uu____18448 =
+                       ((let uu____18425 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel")
                             in
-                         if uu____18448
+                         if uu____18425
                          then
-                           let uu____18453 =
+                           let uu____18430 =
                              FStar_Syntax_Print.term_to_string scrutinee  in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____18453
+                             "match head %s is not a flex term\n" uu____18430
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____18472 =
+                         ((let uu____18449 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____18472
+                           if uu____18449
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____18487 =
+                         ((let uu____18464 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____18487
+                           if uu____18464
                            then
-                             let uu____18492 =
+                             let uu____18469 =
                                FStar_Syntax_Print.term_to_string scrutinee
                                 in
-                             let uu____18494 =
+                             let uu____18471 =
                                FStar_Syntax_Print.term_to_string t  in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____18492 uu____18494
+                               uu____18469 uu____18471
                            else ());
-                          (let pat_discriminates uu___25_18519 =
-                             match uu___25_18519 with
+                          (let pat_discriminates uu___25_18496 =
+                             match uu___25_18496 with
                              | ({
                                   FStar_Syntax_Syntax.v =
                                     FStar_Syntax_Syntax.Pat_constant
-                                    uu____18535;
-                                  FStar_Syntax_Syntax.p = uu____18536;_},FStar_Pervasives_Native.None
-                                ,uu____18537) -> true
+                                    uu____18512;
+                                  FStar_Syntax_Syntax.p = uu____18513;_},FStar_Pervasives_Native.None
+                                ,uu____18514) -> true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____18551;
-                                  FStar_Syntax_Syntax.p = uu____18552;_},FStar_Pervasives_Native.None
-                                ,uu____18553) -> true
-                             | uu____18580 -> false  in
+                                    FStar_Syntax_Syntax.Pat_cons uu____18528;
+                                  FStar_Syntax_Syntax.p = uu____18529;_},FStar_Pervasives_Native.None
+                                ,uu____18530) -> true
+                             | uu____18557 -> false  in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b  ->
                                      if pat_discriminates b
                                      then
-                                       let uu____18683 =
+                                       let uu____18660 =
                                          FStar_Syntax_Subst.open_branch b  in
-                                       match uu____18683 with
-                                       | (uu____18685,uu____18686,t') ->
-                                           let uu____18704 =
+                                       match uu____18660 with
+                                       | (uu____18662,uu____18663,t') ->
+                                           let uu____18681 =
                                              head_matches_delta env1 wl1 s t'
                                               in
-                                           (match uu____18704 with
-                                            | (FullMatch ,uu____18716) ->
+                                           (match uu____18681 with
+                                            | (FullMatch ,uu____18693) ->
                                                 true
                                             | (HeadMatch
-                                               uu____18730,uu____18731) ->
+                                               uu____18707,uu____18708) ->
                                                 true
-                                            | uu____18746 -> false)
+                                            | uu____18723 -> false)
                                      else false))
                               in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None  ->
-                               ((let uu____18783 =
+                               ((let uu____18760 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel")
                                     in
-                                 if uu____18783
+                                 if uu____18760
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____18794 =
+                                   let uu____18771 =
                                      FStar_Util.prefix_until
                                        (fun b  ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches
                                       in
-                                   match uu____18794 with
+                                   match uu____18771 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1,uu____18882,uu____18883) ->
+                                       (branches1,uu____18859,uu____18860) ->
                                        branches1
-                                   | uu____19028 -> branches  in
-                                 let uu____19083 =
+                                   | uu____19005 -> branches  in
+                                 let uu____19060 =
                                    FStar_Util.find_map try_branches
                                      (fun b  ->
-                                        let uu____19092 =
+                                        let uu____19069 =
                                           FStar_Syntax_Subst.open_branch b
                                            in
-                                        match uu____19092 with
-                                        | (p,uu____19096,uu____19097) ->
+                                        match uu____19069 with
+                                        | (p,uu____19073,uu____19074) ->
                                             try_solve_branch scrutinee p)
                                     in
                                  FStar_All.pipe_left
-                                   (fun uu____19126  ->
-                                      FStar_Util.Inr uu____19126) uu____19083))
+                                   (fun uu____19103  ->
+                                      FStar_Util.Inr uu____19103) uu____19060))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____19156 =
+                               let uu____19133 =
                                  FStar_Syntax_Subst.open_branch b  in
-                               (match uu____19156 with
-                                | (p,uu____19165,e) ->
-                                    ((let uu____19184 =
+                               (match uu____19133 with
+                                | (p,uu____19142,e) ->
+                                    ((let uu____19161 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel")
                                          in
-                                      if uu____19184
+                                      if uu____19161
                                       then
-                                        let uu____19189 =
+                                        let uu____19166 =
                                           FStar_Syntax_Print.pat_to_string p
                                            in
-                                        let uu____19191 =
+                                        let uu____19168 =
                                           FStar_Syntax_Print.term_to_string e
                                            in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____19189 uu____19191
+                                          uu____19166 uu____19168
                                       else ());
-                                     (let uu____19196 =
+                                     (let uu____19173 =
                                         try_solve_branch scrutinee p  in
                                       FStar_All.pipe_left
-                                        (fun uu____19211  ->
-                                           FStar_Util.Inr uu____19211)
-                                        uu____19196)))))
-                 | ((s,t),(uu____19214,{
+                                        (fun uu____19188  ->
+                                           FStar_Util.Inr uu____19188)
+                                        uu____19173)))))
+                 | ((s,t),(uu____19191,{
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_match
                                            (scrutinee,branches);
                                          FStar_Syntax_Syntax.pos =
-                                           uu____19217;
+                                           uu____19194;
                                          FStar_Syntax_Syntax.vars =
-                                           uu____19218;_}))
+                                           uu____19195;_}))
                      ->
-                     let uu____19287 =
-                       let uu____19289 = is_flex scrutinee  in
-                       Prims.op_Negation uu____19289  in
-                     if uu____19287
+                     let uu____19264 =
+                       let uu____19266 = is_flex scrutinee  in
+                       Prims.op_Negation uu____19266  in
+                     if uu____19264
                      then
-                       ((let uu____19300 =
+                       ((let uu____19277 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel")
                             in
-                         if uu____19300
+                         if uu____19277
                          then
-                           let uu____19305 =
+                           let uu____19282 =
                              FStar_Syntax_Print.term_to_string scrutinee  in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____19305
+                             "match head %s is not a flex term\n" uu____19282
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____19324 =
+                         ((let uu____19301 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____19324
+                           if uu____19301
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____19339 =
+                         ((let uu____19316 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel")
                               in
-                           if uu____19339
+                           if uu____19316
                            then
-                             let uu____19344 =
+                             let uu____19321 =
                                FStar_Syntax_Print.term_to_string scrutinee
                                 in
-                             let uu____19346 =
+                             let uu____19323 =
                                FStar_Syntax_Print.term_to_string t  in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____19344 uu____19346
+                               uu____19321 uu____19323
                            else ());
-                          (let pat_discriminates uu___25_19371 =
-                             match uu___25_19371 with
+                          (let pat_discriminates uu___25_19348 =
+                             match uu___25_19348 with
                              | ({
                                   FStar_Syntax_Syntax.v =
                                     FStar_Syntax_Syntax.Pat_constant
-                                    uu____19387;
-                                  FStar_Syntax_Syntax.p = uu____19388;_},FStar_Pervasives_Native.None
-                                ,uu____19389) -> true
+                                    uu____19364;
+                                  FStar_Syntax_Syntax.p = uu____19365;_},FStar_Pervasives_Native.None
+                                ,uu____19366) -> true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____19403;
-                                  FStar_Syntax_Syntax.p = uu____19404;_},FStar_Pervasives_Native.None
-                                ,uu____19405) -> true
-                             | uu____19432 -> false  in
+                                    FStar_Syntax_Syntax.Pat_cons uu____19380;
+                                  FStar_Syntax_Syntax.p = uu____19381;_},FStar_Pervasives_Native.None
+                                ,uu____19382) -> true
+                             | uu____19409 -> false  in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b  ->
                                      if pat_discriminates b
                                      then
-                                       let uu____19535 =
+                                       let uu____19512 =
                                          FStar_Syntax_Subst.open_branch b  in
-                                       match uu____19535 with
-                                       | (uu____19537,uu____19538,t') ->
-                                           let uu____19556 =
+                                       match uu____19512 with
+                                       | (uu____19514,uu____19515,t') ->
+                                           let uu____19533 =
                                              head_matches_delta env1 wl1 s t'
                                               in
-                                           (match uu____19556 with
-                                            | (FullMatch ,uu____19568) ->
+                                           (match uu____19533 with
+                                            | (FullMatch ,uu____19545) ->
                                                 true
                                             | (HeadMatch
-                                               uu____19582,uu____19583) ->
+                                               uu____19559,uu____19560) ->
                                                 true
-                                            | uu____19598 -> false)
+                                            | uu____19575 -> false)
                                      else false))
                               in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None  ->
-                               ((let uu____19635 =
+                               ((let uu____19612 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel")
                                     in
-                                 if uu____19635
+                                 if uu____19612
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____19646 =
+                                   let uu____19623 =
                                      FStar_Util.prefix_until
                                        (fun b  ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches
                                       in
-                                   match uu____19646 with
+                                   match uu____19623 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1,uu____19734,uu____19735) ->
+                                       (branches1,uu____19711,uu____19712) ->
                                        branches1
-                                   | uu____19880 -> branches  in
-                                 let uu____19935 =
+                                   | uu____19857 -> branches  in
+                                 let uu____19912 =
                                    FStar_Util.find_map try_branches
                                      (fun b  ->
-                                        let uu____19944 =
+                                        let uu____19921 =
                                           FStar_Syntax_Subst.open_branch b
                                            in
-                                        match uu____19944 with
-                                        | (p,uu____19948,uu____19949) ->
+                                        match uu____19921 with
+                                        | (p,uu____19925,uu____19926) ->
                                             try_solve_branch scrutinee p)
                                     in
                                  FStar_All.pipe_left
-                                   (fun uu____19978  ->
-                                      FStar_Util.Inr uu____19978) uu____19935))
+                                   (fun uu____19955  ->
+                                      FStar_Util.Inr uu____19955) uu____19912))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____20008 =
+                               let uu____19985 =
                                  FStar_Syntax_Subst.open_branch b  in
-                               (match uu____20008 with
-                                | (p,uu____20017,e) ->
-                                    ((let uu____20036 =
+                               (match uu____19985 with
+                                | (p,uu____19994,e) ->
+                                    ((let uu____20013 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel")
                                          in
-                                      if uu____20036
+                                      if uu____20013
                                       then
-                                        let uu____20041 =
+                                        let uu____20018 =
                                           FStar_Syntax_Print.pat_to_string p
                                            in
-                                        let uu____20043 =
+                                        let uu____20020 =
                                           FStar_Syntax_Print.term_to_string e
                                            in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____20041 uu____20043
+                                          uu____20018 uu____20020
                                       else ());
-                                     (let uu____20048 =
+                                     (let uu____20025 =
                                         try_solve_branch scrutinee p  in
                                       FStar_All.pipe_left
-                                        (fun uu____20063  ->
-                                           FStar_Util.Inr uu____20063)
-                                        uu____20048)))))
-                 | uu____20064 ->
-                     ((let uu____20086 =
+                                        (fun uu____20040  ->
+                                           FStar_Util.Inr uu____20040)
+                                        uu____20025)))))
+                 | uu____20041 ->
+                     ((let uu____20063 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env1)
                            (FStar_Options.Other "Rel")
                           in
-                       if uu____20086
+                       if uu____20063
                        then
-                         let uu____20091 = FStar_Syntax_Print.tag_of_term t1
+                         let uu____20068 = FStar_Syntax_Print.tag_of_term t1
                             in
-                         let uu____20093 = FStar_Syntax_Print.tag_of_term t2
+                         let uu____20070 = FStar_Syntax_Print.tag_of_term t2
                             in
                          FStar_Util.print2
                            "Heuristic not applicable: tag lhs=%s, rhs=%s\n"
-                           uu____20091 uu____20093
+                           uu____20068 uu____20070
                        else ());
                       FStar_Util.Inr FStar_Pervasives_Native.None)))
             in
          let rigid_rigid_delta env1 torig wl1 head1 head2 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig  in
-           (let uu____20139 =
+           (let uu____20116 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "RelDelta")
                in
-            if uu____20139
+            if uu____20116
             then
-              let uu____20144 = FStar_Syntax_Print.tag_of_term t1  in
-              let uu____20146 = FStar_Syntax_Print.tag_of_term t2  in
-              let uu____20148 = FStar_Syntax_Print.term_to_string t1  in
-              let uu____20150 = FStar_Syntax_Print.term_to_string t2  in
+              let uu____20121 = FStar_Syntax_Print.tag_of_term t1  in
+              let uu____20123 = FStar_Syntax_Print.tag_of_term t2  in
+              let uu____20125 = FStar_Syntax_Print.term_to_string t1  in
+              let uu____20127 = FStar_Syntax_Print.term_to_string t2  in
               FStar_Util.print4 "rigid_rigid_delta of %s-%s (%s, %s)\n"
-                uu____20144 uu____20146 uu____20148 uu____20150
+                uu____20121 uu____20123 uu____20125 uu____20127
             else ());
-           (let uu____20155 = head_matches_delta env1 wl1 t1 t2  in
-            match uu____20155 with
+           (let uu____20132 = head_matches_delta env1 wl1 t1 t2  in
+            match uu____20132 with
             | (m,o) ->
                 (match (m, o) with
-                 | (MisMatch uu____20186,uu____20187) ->
+                 | (MisMatch uu____20163,uu____20164) ->
                      let rec may_relate head =
-                       let uu____20215 =
-                         let uu____20216 = FStar_Syntax_Subst.compress head
+                       let uu____20192 =
+                         let uu____20193 = FStar_Syntax_Subst.compress head
                             in
-                         uu____20216.FStar_Syntax_Syntax.n  in
-                       match uu____20215 with
-                       | FStar_Syntax_Syntax.Tm_name uu____20220 -> true
-                       | FStar_Syntax_Syntax.Tm_match uu____20222 -> true
+                         uu____20193.FStar_Syntax_Syntax.n  in
+                       match uu____20192 with
+                       | FStar_Syntax_Syntax.Tm_name uu____20197 -> true
+                       | FStar_Syntax_Syntax.Tm_match uu____20199 -> true
                        | FStar_Syntax_Syntax.Tm_fvar fv ->
-                           let uu____20247 =
+                           let uu____20224 =
                              FStar_TypeChecker_Env.delta_depth_of_fv env1 fv
                               in
-                           (match uu____20247 with
+                           (match uu____20224 with
                             | FStar_Syntax_Syntax.Delta_equational_at_level
-                                uu____20249 -> true
-                            | FStar_Syntax_Syntax.Delta_abstract uu____20252
+                                uu____20226 -> true
+                            | FStar_Syntax_Syntax.Delta_abstract uu____20229
                                 ->
                                 problem.FStar_TypeChecker_Common.relation =
                                   FStar_TypeChecker_Common.EQ
-                            | uu____20253 -> false)
+                            | uu____20230 -> false)
                        | FStar_Syntax_Syntax.Tm_ascribed
-                           (t,uu____20256,uu____20257) -> may_relate t
-                       | FStar_Syntax_Syntax.Tm_uinst (t,uu____20299) ->
+                           (t,uu____20233,uu____20234) -> may_relate t
+                       | FStar_Syntax_Syntax.Tm_uinst (t,uu____20276) ->
                            may_relate t
-                       | FStar_Syntax_Syntax.Tm_meta (t,uu____20305) ->
+                       | FStar_Syntax_Syntax.Tm_meta (t,uu____20282) ->
                            may_relate t
-                       | uu____20310 -> false  in
-                     let uu____20312 =
+                       | uu____20287 -> false  in
+                     let uu____20289 =
                        try_match_heuristic env1 orig wl1 t1 t2 o  in
-                     (match uu____20312 with
+                     (match uu____20289 with
                       | FStar_Util.Inl _defer_ok ->
-                          let uu____20325 =
+                          let uu____20302 =
                             FStar_Thunk.mkv "delaying match heuristic"  in
-                          giveup_or_defer1 orig uu____20325
+                          giveup_or_defer1 orig uu____20302
                       | FStar_Util.Inr (FStar_Pervasives_Native.Some wl2) ->
                           solve env1 wl2
                       | FStar_Util.Inr (FStar_Pervasives_Native.None ) ->
-                          let uu____20335 =
+                          let uu____20312 =
                             ((may_relate head1) || (may_relate head2)) &&
                               wl1.smt_ok
                              in
-                          if uu____20335
+                          if uu____20312
                           then
-                            let uu____20338 =
+                            let uu____20315 =
                               guard_of_prob env1 wl1 problem t1 t2  in
-                            (match uu____20338 with
+                            (match uu____20315 with
                              | (guard,wl2) ->
-                                 let uu____20345 =
+                                 let uu____20322 =
                                    solve_prob orig
                                      (FStar_Pervasives_Native.Some guard) []
                                      wl2
                                     in
-                                 solve env1 uu____20345)
+                                 solve env1 uu____20322)
                           else
-                            (let uu____20348 =
+                            (let uu____20325 =
                                mklstr
-                                 (fun uu____20359  ->
-                                    let uu____20360 =
+                                 (fun uu____20336  ->
+                                    let uu____20337 =
                                       FStar_Syntax_Print.term_to_string head1
                                        in
-                                    let uu____20362 =
-                                      let uu____20364 =
-                                        let uu____20368 =
+                                    let uu____20339 =
+                                      let uu____20341 =
+                                        let uu____20345 =
                                           delta_depth_of_term env1 head1  in
-                                        FStar_Util.bind_opt uu____20368
+                                        FStar_Util.bind_opt uu____20345
                                           (fun x  ->
-                                             let uu____20375 =
+                                             let uu____20352 =
                                                FStar_Syntax_Print.delta_depth_to_string
                                                  x
                                                 in
                                              FStar_Pervasives_Native.Some
-                                               uu____20375)
+                                               uu____20352)
                                          in
-                                      FStar_Util.dflt "" uu____20364  in
-                                    let uu____20380 =
+                                      FStar_Util.dflt "" uu____20341  in
+                                    let uu____20357 =
                                       FStar_Syntax_Print.term_to_string head2
                                        in
-                                    let uu____20382 =
-                                      let uu____20384 =
-                                        let uu____20388 =
+                                    let uu____20359 =
+                                      let uu____20361 =
+                                        let uu____20365 =
                                           delta_depth_of_term env1 head2  in
-                                        FStar_Util.bind_opt uu____20388
+                                        FStar_Util.bind_opt uu____20365
                                           (fun x  ->
-                                             let uu____20395 =
+                                             let uu____20372 =
                                                FStar_Syntax_Print.delta_depth_to_string
                                                  x
                                                 in
                                              FStar_Pervasives_Native.Some
-                                               uu____20395)
+                                               uu____20372)
                                          in
-                                      FStar_Util.dflt "" uu____20384  in
+                                      FStar_Util.dflt "" uu____20361  in
                                     FStar_Util.format4
                                       "head mismatch (%s (%s) vs %s (%s))"
-                                      uu____20360 uu____20362 uu____20380
-                                      uu____20382)
+                                      uu____20337 uu____20339 uu____20357
+                                      uu____20359)
                                 in
-                             giveup env1 uu____20348 orig))
-                 | (HeadMatch (true ),uu____20401) when
+                             giveup env1 uu____20325 orig))
+                 | (HeadMatch (true ),uu____20378) when
                      problem.FStar_TypeChecker_Common.relation <>
                        FStar_TypeChecker_Common.EQ
                      ->
                      if wl1.smt_ok
                      then
-                       let uu____20416 = guard_of_prob env1 wl1 problem t1 t2
+                       let uu____20393 = guard_of_prob env1 wl1 problem t1 t2
                           in
-                       (match uu____20416 with
+                       (match uu____20393 with
                         | (guard,wl2) ->
-                            let uu____20423 =
+                            let uu____20400 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some guard) [] wl2
                                in
-                            solve env1 uu____20423)
+                            solve env1 uu____20400)
                      else
-                       (let uu____20426 =
+                       (let uu____20403 =
                           mklstr
-                            (fun uu____20433  ->
-                               let uu____20434 =
+                            (fun uu____20410  ->
+                               let uu____20411 =
                                  FStar_Syntax_Print.term_to_string t1  in
-                               let uu____20436 =
+                               let uu____20413 =
                                  FStar_Syntax_Print.term_to_string t2  in
                                FStar_Util.format2
                                  "head mismatch for subtyping (%s vs %s)"
-                                 uu____20434 uu____20436)
+                                 uu____20411 uu____20413)
                            in
-                        giveup env1 uu____20426 orig)
-                 | (uu____20439,FStar_Pervasives_Native.Some (t11,t21)) ->
+                        giveup env1 uu____20403 orig)
+                 | (uu____20416,FStar_Pervasives_Native.Some (t11,t21)) ->
                      solve_t env1
-                       (let uu___2865_20453 = problem  in
+                       (let uu___2865_20430 = problem  in
                         {
                           FStar_TypeChecker_Common.pid =
-                            (uu___2865_20453.FStar_TypeChecker_Common.pid);
+                            (uu___2865_20430.FStar_TypeChecker_Common.pid);
                           FStar_TypeChecker_Common.lhs = t11;
                           FStar_TypeChecker_Common.relation =
-                            (uu___2865_20453.FStar_TypeChecker_Common.relation);
+                            (uu___2865_20430.FStar_TypeChecker_Common.relation);
                           FStar_TypeChecker_Common.rhs = t21;
                           FStar_TypeChecker_Common.element =
-                            (uu___2865_20453.FStar_TypeChecker_Common.element);
+                            (uu___2865_20430.FStar_TypeChecker_Common.element);
                           FStar_TypeChecker_Common.logical_guard =
-                            (uu___2865_20453.FStar_TypeChecker_Common.logical_guard);
+                            (uu___2865_20430.FStar_TypeChecker_Common.logical_guard);
                           FStar_TypeChecker_Common.logical_guard_uvar =
-                            (uu___2865_20453.FStar_TypeChecker_Common.logical_guard_uvar);
+                            (uu___2865_20430.FStar_TypeChecker_Common.logical_guard_uvar);
                           FStar_TypeChecker_Common.reason =
-                            (uu___2865_20453.FStar_TypeChecker_Common.reason);
+                            (uu___2865_20430.FStar_TypeChecker_Common.reason);
                           FStar_TypeChecker_Common.loc =
-                            (uu___2865_20453.FStar_TypeChecker_Common.loc);
+                            (uu___2865_20430.FStar_TypeChecker_Common.loc);
                           FStar_TypeChecker_Common.rank =
-                            (uu___2865_20453.FStar_TypeChecker_Common.rank)
+                            (uu___2865_20430.FStar_TypeChecker_Common.rank)
                         }) wl1
                  | (HeadMatch need_unif,FStar_Pervasives_Native.None ) ->
                      rigid_heads_match env1 need_unif torig wl1 t1 t2
@@ -7055,197 +7039,196 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
             in
          let orig = FStar_TypeChecker_Common.TProb problem  in
          def_check_prob "solve_t'.2" orig;
-         (let uu____20480 =
+         (let uu____20457 =
             FStar_Util.physical_equality problem.FStar_TypeChecker_Common.lhs
               problem.FStar_TypeChecker_Common.rhs
              in
-          if uu____20480
+          if uu____20457
           then
-            let uu____20483 =
+            let uu____20460 =
               solve_prob orig FStar_Pervasives_Native.None [] wl  in
-            solve env uu____20483
+            solve env uu____20460
           else
             (let t1 = problem.FStar_TypeChecker_Common.lhs  in
              let t2 = problem.FStar_TypeChecker_Common.rhs  in
-             (let uu____20489 =
-                let uu____20492 = p_scope orig  in
-                FStar_List.map FStar_Pervasives_Native.fst uu____20492  in
+             (let uu____20466 =
+                let uu____20469 = p_scope orig  in
+                FStar_List.map FStar_Pervasives_Native.fst uu____20469  in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t1"
-                uu____20489 t1);
-             (let uu____20511 =
-                let uu____20514 = p_scope orig  in
-                FStar_List.map FStar_Pervasives_Native.fst uu____20514  in
+                uu____20466 t1);
+             (let uu____20488 =
+                let uu____20491 = p_scope orig  in
+                FStar_List.map FStar_Pervasives_Native.fst uu____20491  in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t2"
-                uu____20511 t2);
-             (let uu____20533 =
+                uu____20488 t2);
+             (let uu____20510 =
                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel")
                  in
-              if uu____20533
+              if uu____20510
               then
-                let uu____20537 =
+                let uu____20514 =
                   FStar_Util.string_of_int
                     problem.FStar_TypeChecker_Common.pid
                    in
-                let uu____20539 =
-                  let uu____20541 = FStar_Syntax_Print.tag_of_term t1  in
-                  let uu____20543 =
-                    let uu____20545 = FStar_Syntax_Print.term_to_string t1
+                let uu____20516 =
+                  let uu____20518 = FStar_Syntax_Print.tag_of_term t1  in
+                  let uu____20520 =
+                    let uu____20522 = FStar_Syntax_Print.term_to_string t1
                        in
-                    Prims.op_Hat "::" uu____20545  in
-                  Prims.op_Hat uu____20541 uu____20543  in
-                let uu____20548 =
-                  let uu____20550 = FStar_Syntax_Print.tag_of_term t2  in
-                  let uu____20552 =
-                    let uu____20554 = FStar_Syntax_Print.term_to_string t2
+                    Prims.op_Hat "::" uu____20522  in
+                  Prims.op_Hat uu____20518 uu____20520  in
+                let uu____20525 =
+                  let uu____20527 = FStar_Syntax_Print.tag_of_term t2  in
+                  let uu____20529 =
+                    let uu____20531 = FStar_Syntax_Print.term_to_string t2
                        in
-                    Prims.op_Hat "::" uu____20554  in
-                  Prims.op_Hat uu____20550 uu____20552  in
+                    Prims.op_Hat "::" uu____20531  in
+                  Prims.op_Hat uu____20527 uu____20529  in
                 FStar_Util.print4 "Attempting %s (%s vs %s); rel = (%s)\n"
-                  uu____20537 uu____20539 uu____20548
+                  uu____20514 uu____20516 uu____20525
                   (rel_to_string problem.FStar_TypeChecker_Common.relation)
               else ());
              (let r = FStar_TypeChecker_Env.get_range env  in
               match ((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))
               with
-              | (FStar_Syntax_Syntax.Tm_delayed uu____20561,uu____20562) ->
+              | (FStar_Syntax_Syntax.Tm_delayed uu____20538,uu____20539) ->
                   failwith "Impossible: terms were not compressed"
-              | (uu____20578,FStar_Syntax_Syntax.Tm_delayed uu____20579) ->
+              | (uu____20555,FStar_Syntax_Syntax.Tm_delayed uu____20556) ->
                   failwith "Impossible: terms were not compressed"
-              | (FStar_Syntax_Syntax.Tm_ascribed uu____20595,uu____20596) ->
-                  let uu____20623 =
-                    let uu___2896_20624 = problem  in
-                    let uu____20625 = FStar_Syntax_Util.unascribe t1  in
+              | (FStar_Syntax_Syntax.Tm_ascribed uu____20572,uu____20573) ->
+                  let uu____20600 =
+                    let uu___2896_20601 = problem  in
+                    let uu____20602 = FStar_Syntax_Util.unascribe t1  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2896_20624.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____20625;
+                        (uu___2896_20601.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu____20602;
                       FStar_TypeChecker_Common.relation =
-                        (uu___2896_20624.FStar_TypeChecker_Common.relation);
+                        (uu___2896_20601.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___2896_20624.FStar_TypeChecker_Common.rhs);
+                        (uu___2896_20601.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___2896_20624.FStar_TypeChecker_Common.element);
+                        (uu___2896_20601.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2896_20624.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2896_20601.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2896_20624.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2896_20601.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2896_20624.FStar_TypeChecker_Common.reason);
+                        (uu___2896_20601.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2896_20624.FStar_TypeChecker_Common.loc);
+                        (uu___2896_20601.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2896_20624.FStar_TypeChecker_Common.rank)
+                        (uu___2896_20601.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20623 wl
-              | (FStar_Syntax_Syntax.Tm_meta uu____20626,uu____20627) ->
-                  let uu____20634 =
-                    let uu___2902_20635 = problem  in
-                    let uu____20636 = FStar_Syntax_Util.unmeta t1  in
+                  solve_t' env uu____20600 wl
+              | (FStar_Syntax_Syntax.Tm_meta uu____20603,uu____20604) ->
+                  let uu____20611 =
+                    let uu___2902_20612 = problem  in
+                    let uu____20613 = FStar_Syntax_Util.unmeta t1  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2902_20635.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____20636;
+                        (uu___2902_20612.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu____20613;
                       FStar_TypeChecker_Common.relation =
-                        (uu___2902_20635.FStar_TypeChecker_Common.relation);
+                        (uu___2902_20612.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___2902_20635.FStar_TypeChecker_Common.rhs);
+                        (uu___2902_20612.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___2902_20635.FStar_TypeChecker_Common.element);
+                        (uu___2902_20612.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2902_20635.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2902_20612.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2902_20635.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2902_20612.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2902_20635.FStar_TypeChecker_Common.reason);
+                        (uu___2902_20612.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2902_20635.FStar_TypeChecker_Common.loc);
+                        (uu___2902_20612.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2902_20635.FStar_TypeChecker_Common.rank)
+                        (uu___2902_20612.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20634 wl
-              | (uu____20637,FStar_Syntax_Syntax.Tm_ascribed uu____20638) ->
-                  let uu____20665 =
-                    let uu___2908_20666 = problem  in
-                    let uu____20667 = FStar_Syntax_Util.unascribe t2  in
+                  solve_t' env uu____20611 wl
+              | (uu____20614,FStar_Syntax_Syntax.Tm_ascribed uu____20615) ->
+                  let uu____20642 =
+                    let uu___2908_20643 = problem  in
+                    let uu____20644 = FStar_Syntax_Util.unascribe t2  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2908_20666.FStar_TypeChecker_Common.pid);
+                        (uu___2908_20643.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___2908_20666.FStar_TypeChecker_Common.lhs);
+                        (uu___2908_20643.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___2908_20666.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____20667;
+                        (uu___2908_20643.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu____20644;
                       FStar_TypeChecker_Common.element =
-                        (uu___2908_20666.FStar_TypeChecker_Common.element);
+                        (uu___2908_20643.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2908_20666.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2908_20643.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2908_20666.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2908_20643.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2908_20666.FStar_TypeChecker_Common.reason);
+                        (uu___2908_20643.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2908_20666.FStar_TypeChecker_Common.loc);
+                        (uu___2908_20643.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2908_20666.FStar_TypeChecker_Common.rank)
+                        (uu___2908_20643.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20665 wl
-              | (uu____20668,FStar_Syntax_Syntax.Tm_meta uu____20669) ->
-                  let uu____20676 =
-                    let uu___2914_20677 = problem  in
-                    let uu____20678 = FStar_Syntax_Util.unmeta t2  in
+                  solve_t' env uu____20642 wl
+              | (uu____20645,FStar_Syntax_Syntax.Tm_meta uu____20646) ->
+                  let uu____20653 =
+                    let uu___2914_20654 = problem  in
+                    let uu____20655 = FStar_Syntax_Util.unmeta t2  in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___2914_20677.FStar_TypeChecker_Common.pid);
+                        (uu___2914_20654.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___2914_20677.FStar_TypeChecker_Common.lhs);
+                        (uu___2914_20654.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___2914_20677.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____20678;
+                        (uu___2914_20654.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu____20655;
                       FStar_TypeChecker_Common.element =
-                        (uu___2914_20677.FStar_TypeChecker_Common.element);
+                        (uu___2914_20654.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___2914_20677.FStar_TypeChecker_Common.logical_guard);
+                        (uu___2914_20654.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___2914_20677.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___2914_20654.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___2914_20677.FStar_TypeChecker_Common.reason);
+                        (uu___2914_20654.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___2914_20677.FStar_TypeChecker_Common.loc);
+                        (uu___2914_20654.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___2914_20677.FStar_TypeChecker_Common.rank)
+                        (uu___2914_20654.FStar_TypeChecker_Common.rank)
                     }  in
-                  solve_t' env uu____20676 wl
+                  solve_t' env uu____20653 wl
               | (FStar_Syntax_Syntax.Tm_quoted
-                 (t11,uu____20680),FStar_Syntax_Syntax.Tm_quoted
-                 (t21,uu____20682)) ->
-                  let uu____20691 =
+                 (t11,uu____20657),FStar_Syntax_Syntax.Tm_quoted
+                 (t21,uu____20659)) ->
+                  let uu____20668 =
                     solve_prob orig FStar_Pervasives_Native.None [] wl  in
-                  solve env uu____20691
-              | (FStar_Syntax_Syntax.Tm_bvar uu____20692,uu____20693) ->
+                  solve env uu____20668
+              | (FStar_Syntax_Syntax.Tm_bvar uu____20669,uu____20670) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
-              | (uu____20695,FStar_Syntax_Syntax.Tm_bvar uu____20696) ->
+              | (uu____20672,FStar_Syntax_Syntax.Tm_bvar uu____20673) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
               | (FStar_Syntax_Syntax.Tm_type u1,FStar_Syntax_Syntax.Tm_type
                  u2) -> solve_one_universe_eq env orig u1 u2 wl
               | (FStar_Syntax_Syntax.Tm_arrow
                  (bs1,c1),FStar_Syntax_Syntax.Tm_arrow (bs2,c2)) ->
-                  let mk_c c uu___26_20766 =
-                    match uu___26_20766 with
+                  let mk_c c uu___26_20743 =
+                    match uu___26_20743 with
                     | [] -> c
                     | bs ->
-                        let uu____20794 =
+                        let uu____20771 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (bs, c))
-                            FStar_Pervasives_Native.None
                             c.FStar_Syntax_Syntax.pos
                            in
-                        FStar_Syntax_Syntax.mk_Total uu____20794
+                        FStar_Syntax_Syntax.mk_Total uu____20771
                      in
-                  let uu____20805 =
+                  let uu____20782 =
                     match_num_binders (bs1, (mk_c c1)) (bs2, (mk_c c2))  in
-                  (match uu____20805 with
+                  (match uu____20782 with
                    | ((bs11,c11),(bs21,c21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1  ->
@@ -7259,10 +7242,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                     FStar_Syntax_Subst.subst_comp subst c21
                                      in
                                   let rel =
-                                    let uu____20954 =
+                                    let uu____20931 =
                                       FStar_Options.use_eq_at_higher_order ()
                                        in
-                                    if uu____20954
+                                    if uu____20931
                                     then FStar_TypeChecker_Common.EQ
                                     else
                                       problem.FStar_TypeChecker_Common.relation
@@ -7273,41 +7256,40 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_abs
                  (bs1,tbody1,lopt1),FStar_Syntax_Syntax.Tm_abs
                  (bs2,tbody2,lopt2)) ->
-                  let mk_t t l uu___27_21043 =
-                    match uu___27_21043 with
+                  let mk_t t l uu___27_21020 =
+                    match uu___27_21020 with
                     | [] -> t
                     | bs ->
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_abs (bs, t, l))
-                          FStar_Pervasives_Native.None
                           t.FStar_Syntax_Syntax.pos
                      in
-                  let uu____21085 =
+                  let uu____21062 =
                     match_num_binders (bs1, (mk_t tbody1 lopt1))
                       (bs2, (mk_t tbody2 lopt2))
                      in
-                  (match uu____21085 with
+                  (match uu____21062 with
                    | ((bs11,tbody11),(bs21,tbody21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1  ->
                             fun scope  ->
                               fun env1  ->
                                 fun subst  ->
-                                  let uu____21230 =
+                                  let uu____21207 =
                                     FStar_Syntax_Subst.subst subst tbody11
                                      in
-                                  let uu____21231 =
+                                  let uu____21208 =
                                     FStar_Syntax_Subst.subst subst tbody21
                                      in
-                                  mk_t_problem wl1 scope orig uu____21230
+                                  mk_t_problem wl1 scope orig uu____21207
                                     problem.FStar_TypeChecker_Common.relation
-                                    uu____21231 FStar_Pervasives_Native.None
+                                    uu____21208 FStar_Pervasives_Native.None
                                     "lambda co-domain"))
-              | (FStar_Syntax_Syntax.Tm_abs uu____21233,uu____21234) ->
+              | (FStar_Syntax_Syntax.Tm_abs uu____21210,uu____21211) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____21265 -> true
-                    | uu____21285 -> false  in
+                    | FStar_Syntax_Syntax.Tm_abs uu____21242 -> true
+                    | uu____21262 -> false  in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -7323,188 +7305,188 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____21345 =
+                      (let uu____21322 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3016_21353 = env  in
+                           (let uu___3016_21330 = env  in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3016_21353.FStar_TypeChecker_Env.solver);
+                                (uu___3016_21330.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3016_21353.FStar_TypeChecker_Env.range);
+                                (uu___3016_21330.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3016_21353.FStar_TypeChecker_Env.curmodule);
+                                (uu___3016_21330.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3016_21353.FStar_TypeChecker_Env.gamma);
+                                (uu___3016_21330.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3016_21353.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___3016_21330.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3016_21353.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___3016_21330.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3016_21353.FStar_TypeChecker_Env.modules);
+                                (uu___3016_21330.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3016_21353.FStar_TypeChecker_Env.sigtab);
+                                (uu___3016_21330.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3016_21353.FStar_TypeChecker_Env.attrtab);
+                                (uu___3016_21330.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3016_21353.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___3016_21330.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3016_21353.FStar_TypeChecker_Env.effects);
+                                (uu___3016_21330.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3016_21353.FStar_TypeChecker_Env.generalize);
+                                (uu___3016_21330.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3016_21353.FStar_TypeChecker_Env.letrecs);
+                                (uu___3016_21330.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3016_21353.FStar_TypeChecker_Env.top_level);
+                                (uu___3016_21330.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3016_21353.FStar_TypeChecker_Env.check_uvars);
+                                (uu___3016_21330.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3016_21353.FStar_TypeChecker_Env.use_eq);
+                                (uu___3016_21330.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3016_21353.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___3016_21330.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3016_21353.FStar_TypeChecker_Env.is_iface);
+                                (uu___3016_21330.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3016_21353.FStar_TypeChecker_Env.admit);
+                                (uu___3016_21330.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3016_21353.FStar_TypeChecker_Env.lax_universes);
+                                (uu___3016_21330.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3016_21353.FStar_TypeChecker_Env.phase1);
+                                (uu___3016_21330.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3016_21353.FStar_TypeChecker_Env.failhard);
+                                (uu___3016_21330.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3016_21353.FStar_TypeChecker_Env.nosynth);
+                                (uu___3016_21330.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3016_21353.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___3016_21330.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3016_21353.FStar_TypeChecker_Env.tc_term);
+                                (uu___3016_21330.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3016_21353.FStar_TypeChecker_Env.type_of);
+                                (uu___3016_21330.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3016_21353.FStar_TypeChecker_Env.universe_of);
+                                (uu___3016_21330.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3016_21353.FStar_TypeChecker_Env.check_type_of);
+                                (uu___3016_21330.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3016_21353.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___3016_21330.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3016_21353.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___3016_21330.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3016_21353.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___3016_21330.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3016_21353.FStar_TypeChecker_Env.proof_ns);
+                                (uu___3016_21330.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3016_21353.FStar_TypeChecker_Env.synth_hook);
+                                (uu___3016_21330.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3016_21353.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___3016_21330.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3016_21353.FStar_TypeChecker_Env.splice);
+                                (uu___3016_21330.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3016_21353.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___3016_21330.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3016_21353.FStar_TypeChecker_Env.postprocess);
+                                (uu___3016_21330.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3016_21353.FStar_TypeChecker_Env.identifier_info);
+                                (uu___3016_21330.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3016_21353.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___3016_21330.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3016_21353.FStar_TypeChecker_Env.dsenv);
+                                (uu___3016_21330.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3016_21353.FStar_TypeChecker_Env.nbe);
+                                (uu___3016_21330.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3016_21353.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___3016_21330.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3016_21353.FStar_TypeChecker_Env.erasable_types_tab)
+                                (uu___3016_21330.FStar_TypeChecker_Env.erasable_types_tab)
                             }) t
                           in
-                       match uu____21345 with
-                       | (uu____21358,ty,uu____21360) ->
+                       match uu____21322 with
+                       | (uu____21335,ty,uu____21337) ->
                            let ty1 =
                              let rec aux ty1 =
                                let ty2 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
                                    ty1
                                   in
-                               let uu____21369 =
-                                 let uu____21370 =
+                               let uu____21346 =
+                                 let uu____21347 =
                                    FStar_Syntax_Subst.compress ty2  in
-                                 uu____21370.FStar_Syntax_Syntax.n  in
-                               match uu____21369 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____21373 ->
-                                   let uu____21380 =
+                                 uu____21347.FStar_Syntax_Syntax.n  in
+                               match uu____21346 with
+                               | FStar_Syntax_Syntax.Tm_refine uu____21350 ->
+                                   let uu____21357 =
                                      FStar_Syntax_Util.unrefine ty2  in
-                                   aux uu____21380
-                               | uu____21381 -> ty2  in
+                                   aux uu____21357
+                               | uu____21358 -> ty2  in
                              aux ty  in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1
                               in
-                           ((let uu____21384 =
+                           ((let uu____21361 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel")
                                 in
-                             if uu____21384
+                             if uu____21361
                              then
-                               let uu____21389 =
+                               let uu____21366 =
                                  FStar_Syntax_Print.term_to_string t  in
-                               let uu____21391 =
-                                 let uu____21393 =
+                               let uu____21368 =
+                                 let uu____21370 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1
                                     in
                                  FStar_Syntax_Print.term_to_string
-                                   uu____21393
+                                   uu____21370
                                   in
-                               let uu____21394 =
+                               let uu____21371 =
                                  FStar_Syntax_Print.term_to_string r1  in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____21389 uu____21391 uu____21394
+                                 uu____21366 uu____21368 uu____21371
                              else ());
                             r1))
                      in
-                  let uu____21399 =
-                    let uu____21416 = maybe_eta t1  in
-                    let uu____21423 = maybe_eta t2  in
-                    (uu____21416, uu____21423)  in
-                  (match uu____21399 with
+                  let uu____21376 =
+                    let uu____21393 = maybe_eta t1  in
+                    let uu____21400 = maybe_eta t2  in
+                    (uu____21393, uu____21400)  in
+                  (match uu____21376 with
                    | (FStar_Util.Inl t11,FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3037_21465 = problem  in
+                         (let uu___3037_21442 = problem  in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3037_21465.FStar_TypeChecker_Common.pid);
+                              (uu___3037_21442.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3037_21465.FStar_TypeChecker_Common.relation);
+                              (uu___3037_21442.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3037_21465.FStar_TypeChecker_Common.element);
+                              (uu___3037_21442.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3037_21465.FStar_TypeChecker_Common.logical_guard);
+                              (uu___3037_21442.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3037_21465.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___3037_21442.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3037_21465.FStar_TypeChecker_Common.reason);
+                              (uu___3037_21442.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3037_21465.FStar_TypeChecker_Common.loc);
+                              (uu___3037_21442.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3037_21465.FStar_TypeChecker_Common.rank)
+                              (uu___3037_21442.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs,FStar_Util.Inr not_abs) ->
-                       let uu____21486 =
+                       let uu____21463 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21486
+                       if uu____21463
                        then
-                         let uu____21489 = destruct_flex_t not_abs wl  in
-                         (match uu____21489 with
+                         let uu____21466 = destruct_flex_t not_abs wl  in
+                         (match uu____21466 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7513,43 +7495,43 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3054_21506 = problem  in
+                              (let uu___3054_21483 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.pid);
+                                   (uu___3054_21483.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.relation);
+                                   (uu___3054_21483.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.element);
+                                   (uu___3054_21483.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3054_21483.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3054_21483.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.reason);
+                                   (uu___3054_21483.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.loc);
+                                   (uu___3054_21483.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3054_21506.FStar_TypeChecker_Common.rank)
+                                   (uu___3054_21483.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21509 =
+                            (let uu____21486 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21509 orig))
+                             giveup env uu____21486 orig))
                    | (FStar_Util.Inr not_abs,FStar_Util.Inl t_abs) ->
-                       let uu____21532 =
+                       let uu____21509 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21532
+                       if uu____21509
                        then
-                         let uu____21535 = destruct_flex_t not_abs wl  in
-                         (match uu____21535 with
+                         let uu____21512 = destruct_flex_t not_abs wl  in
+                         (match uu____21512 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7558,42 +7540,42 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3054_21552 = problem  in
+                              (let uu___3054_21529 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.pid);
+                                   (uu___3054_21529.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.relation);
+                                   (uu___3054_21529.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.element);
+                                   (uu___3054_21529.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3054_21529.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3054_21529.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.reason);
+                                   (uu___3054_21529.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.loc);
+                                   (uu___3054_21529.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3054_21552.FStar_TypeChecker_Common.rank)
+                                   (uu___3054_21529.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21555 =
+                            (let uu____21532 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21555 orig))
-                   | uu____21558 ->
+                             giveup env uu____21532 orig))
+                   | uu____21535 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
-              | (uu____21576,FStar_Syntax_Syntax.Tm_abs uu____21577) ->
+              | (uu____21553,FStar_Syntax_Syntax.Tm_abs uu____21554) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____21608 -> true
-                    | uu____21628 -> false  in
+                    | FStar_Syntax_Syntax.Tm_abs uu____21585 -> true
+                    | uu____21605 -> false  in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -7609,188 +7591,188 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____21688 =
+                      (let uu____21665 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3016_21696 = env  in
+                           (let uu___3016_21673 = env  in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3016_21696.FStar_TypeChecker_Env.solver);
+                                (uu___3016_21673.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3016_21696.FStar_TypeChecker_Env.range);
+                                (uu___3016_21673.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3016_21696.FStar_TypeChecker_Env.curmodule);
+                                (uu___3016_21673.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3016_21696.FStar_TypeChecker_Env.gamma);
+                                (uu___3016_21673.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3016_21696.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___3016_21673.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3016_21696.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___3016_21673.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3016_21696.FStar_TypeChecker_Env.modules);
+                                (uu___3016_21673.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3016_21696.FStar_TypeChecker_Env.sigtab);
+                                (uu___3016_21673.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3016_21696.FStar_TypeChecker_Env.attrtab);
+                                (uu___3016_21673.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3016_21696.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___3016_21673.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3016_21696.FStar_TypeChecker_Env.effects);
+                                (uu___3016_21673.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3016_21696.FStar_TypeChecker_Env.generalize);
+                                (uu___3016_21673.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3016_21696.FStar_TypeChecker_Env.letrecs);
+                                (uu___3016_21673.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3016_21696.FStar_TypeChecker_Env.top_level);
+                                (uu___3016_21673.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3016_21696.FStar_TypeChecker_Env.check_uvars);
+                                (uu___3016_21673.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3016_21696.FStar_TypeChecker_Env.use_eq);
+                                (uu___3016_21673.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3016_21696.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___3016_21673.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3016_21696.FStar_TypeChecker_Env.is_iface);
+                                (uu___3016_21673.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3016_21696.FStar_TypeChecker_Env.admit);
+                                (uu___3016_21673.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3016_21696.FStar_TypeChecker_Env.lax_universes);
+                                (uu___3016_21673.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3016_21696.FStar_TypeChecker_Env.phase1);
+                                (uu___3016_21673.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3016_21696.FStar_TypeChecker_Env.failhard);
+                                (uu___3016_21673.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3016_21696.FStar_TypeChecker_Env.nosynth);
+                                (uu___3016_21673.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3016_21696.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___3016_21673.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3016_21696.FStar_TypeChecker_Env.tc_term);
+                                (uu___3016_21673.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3016_21696.FStar_TypeChecker_Env.type_of);
+                                (uu___3016_21673.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3016_21696.FStar_TypeChecker_Env.universe_of);
+                                (uu___3016_21673.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3016_21696.FStar_TypeChecker_Env.check_type_of);
+                                (uu___3016_21673.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3016_21696.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___3016_21673.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3016_21696.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___3016_21673.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3016_21696.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___3016_21673.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3016_21696.FStar_TypeChecker_Env.proof_ns);
+                                (uu___3016_21673.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3016_21696.FStar_TypeChecker_Env.synth_hook);
+                                (uu___3016_21673.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3016_21696.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___3016_21673.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3016_21696.FStar_TypeChecker_Env.splice);
+                                (uu___3016_21673.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3016_21696.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___3016_21673.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3016_21696.FStar_TypeChecker_Env.postprocess);
+                                (uu___3016_21673.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3016_21696.FStar_TypeChecker_Env.identifier_info);
+                                (uu___3016_21673.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3016_21696.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___3016_21673.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3016_21696.FStar_TypeChecker_Env.dsenv);
+                                (uu___3016_21673.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3016_21696.FStar_TypeChecker_Env.nbe);
+                                (uu___3016_21673.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3016_21696.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___3016_21673.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3016_21696.FStar_TypeChecker_Env.erasable_types_tab)
+                                (uu___3016_21673.FStar_TypeChecker_Env.erasable_types_tab)
                             }) t
                           in
-                       match uu____21688 with
-                       | (uu____21701,ty,uu____21703) ->
+                       match uu____21665 with
+                       | (uu____21678,ty,uu____21680) ->
                            let ty1 =
                              let rec aux ty1 =
                                let ty2 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
                                    ty1
                                   in
-                               let uu____21712 =
-                                 let uu____21713 =
+                               let uu____21689 =
+                                 let uu____21690 =
                                    FStar_Syntax_Subst.compress ty2  in
-                                 uu____21713.FStar_Syntax_Syntax.n  in
-                               match uu____21712 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____21716 ->
-                                   let uu____21723 =
+                                 uu____21690.FStar_Syntax_Syntax.n  in
+                               match uu____21689 with
+                               | FStar_Syntax_Syntax.Tm_refine uu____21693 ->
+                                   let uu____21700 =
                                      FStar_Syntax_Util.unrefine ty2  in
-                                   aux uu____21723
-                               | uu____21724 -> ty2  in
+                                   aux uu____21700
+                               | uu____21701 -> ty2  in
                              aux ty  in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1
                               in
-                           ((let uu____21727 =
+                           ((let uu____21704 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel")
                                 in
-                             if uu____21727
+                             if uu____21704
                              then
-                               let uu____21732 =
+                               let uu____21709 =
                                  FStar_Syntax_Print.term_to_string t  in
-                               let uu____21734 =
-                                 let uu____21736 =
+                               let uu____21711 =
+                                 let uu____21713 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1
                                     in
                                  FStar_Syntax_Print.term_to_string
-                                   uu____21736
+                                   uu____21713
                                   in
-                               let uu____21737 =
+                               let uu____21714 =
                                  FStar_Syntax_Print.term_to_string r1  in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____21732 uu____21734 uu____21737
+                                 uu____21709 uu____21711 uu____21714
                              else ());
                             r1))
                      in
-                  let uu____21742 =
-                    let uu____21759 = maybe_eta t1  in
-                    let uu____21766 = maybe_eta t2  in
-                    (uu____21759, uu____21766)  in
-                  (match uu____21742 with
+                  let uu____21719 =
+                    let uu____21736 = maybe_eta t1  in
+                    let uu____21743 = maybe_eta t2  in
+                    (uu____21736, uu____21743)  in
+                  (match uu____21719 with
                    | (FStar_Util.Inl t11,FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3037_21808 = problem  in
+                         (let uu___3037_21785 = problem  in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3037_21808.FStar_TypeChecker_Common.pid);
+                              (uu___3037_21785.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3037_21808.FStar_TypeChecker_Common.relation);
+                              (uu___3037_21785.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3037_21808.FStar_TypeChecker_Common.element);
+                              (uu___3037_21785.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3037_21808.FStar_TypeChecker_Common.logical_guard);
+                              (uu___3037_21785.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3037_21808.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___3037_21785.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3037_21808.FStar_TypeChecker_Common.reason);
+                              (uu___3037_21785.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3037_21808.FStar_TypeChecker_Common.loc);
+                              (uu___3037_21785.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3037_21808.FStar_TypeChecker_Common.rank)
+                              (uu___3037_21785.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs,FStar_Util.Inr not_abs) ->
-                       let uu____21829 =
+                       let uu____21806 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21829
+                       if uu____21806
                        then
-                         let uu____21832 = destruct_flex_t not_abs wl  in
-                         (match uu____21832 with
+                         let uu____21809 = destruct_flex_t not_abs wl  in
+                         (match uu____21809 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7799,43 +7781,43 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3054_21849 = problem  in
+                              (let uu___3054_21826 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.pid);
+                                   (uu___3054_21826.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.relation);
+                                   (uu___3054_21826.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.element);
+                                   (uu___3054_21826.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3054_21826.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3054_21826.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.reason);
+                                   (uu___3054_21826.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.loc);
+                                   (uu___3054_21826.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3054_21849.FStar_TypeChecker_Common.rank)
+                                   (uu___3054_21826.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21852 =
+                            (let uu____21829 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21852 orig))
+                             giveup env uu____21829 orig))
                    | (FStar_Util.Inr not_abs,FStar_Util.Inl t_abs) ->
-                       let uu____21875 =
+                       let uu____21852 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ)
                           in
-                       if uu____21875
+                       if uu____21852
                        then
-                         let uu____21878 = destruct_flex_t not_abs wl  in
-                         (match uu____21878 with
+                         let uu____21855 = destruct_flex_t not_abs wl  in
+                         (match uu____21855 with
                           | (flex,wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7844,127 +7826,127 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3054_21895 = problem  in
+                              (let uu___3054_21872 = problem  in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.pid);
+                                   (uu___3054_21872.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.relation);
+                                   (uu___3054_21872.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.element);
+                                   (uu___3054_21872.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3054_21872.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3054_21872.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.reason);
+                                   (uu___3054_21872.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.loc);
+                                   (uu___3054_21872.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3054_21895.FStar_TypeChecker_Common.rank)
+                                   (uu___3054_21872.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____21898 =
+                            (let uu____21875 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction"
                                 in
-                             giveup env uu____21898 orig))
-                   | uu____21901 ->
+                             giveup env uu____21875 orig))
+                   | uu____21878 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
               | (FStar_Syntax_Syntax.Tm_refine
                  (x1,phi1),FStar_Syntax_Syntax.Tm_refine (x2,phi2)) ->
-                  let uu____21931 =
-                    let uu____21936 =
+                  let uu____21908 =
+                    let uu____21913 =
                       head_matches_delta env wl x1.FStar_Syntax_Syntax.sort
                         x2.FStar_Syntax_Syntax.sort
                        in
-                    match uu____21936 with
+                    match uu____21913 with
                     | (FullMatch ,FStar_Pervasives_Native.Some (t11,t21)) ->
-                        ((let uu___3077_21964 = x1  in
+                        ((let uu___3077_21941 = x1  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3077_21964.FStar_Syntax_Syntax.ppname);
+                              (uu___3077_21941.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3077_21964.FStar_Syntax_Syntax.index);
+                              (uu___3077_21941.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3079_21966 = x2  in
+                          (let uu___3079_21943 = x2  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3079_21966.FStar_Syntax_Syntax.ppname);
+                               (uu___3079_21943.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3079_21966.FStar_Syntax_Syntax.index);
+                               (uu___3079_21943.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | (HeadMatch uu____21967,FStar_Pervasives_Native.Some
+                    | (HeadMatch uu____21944,FStar_Pervasives_Native.Some
                        (t11,t21)) ->
-                        ((let uu___3077_21982 = x1  in
+                        ((let uu___3077_21959 = x1  in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3077_21982.FStar_Syntax_Syntax.ppname);
+                              (uu___3077_21959.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3077_21982.FStar_Syntax_Syntax.index);
+                              (uu___3077_21959.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3079_21984 = x2  in
+                          (let uu___3079_21961 = x2  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3079_21984.FStar_Syntax_Syntax.ppname);
+                               (uu___3079_21961.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3079_21984.FStar_Syntax_Syntax.index);
+                               (uu___3079_21961.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | uu____21985 -> (x1, x2)  in
-                  (match uu____21931 with
+                    | uu____21962 -> (x1, x2)  in
+                  (match uu____21908 with
                    | (x11,x21) ->
                        let t11 = FStar_Syntax_Util.refine x11 phi1  in
                        let t21 = FStar_Syntax_Util.refine x21 phi2  in
-                       let uu____22004 = as_refinement false env t11  in
-                       (match uu____22004 with
+                       let uu____21981 = as_refinement false env t11  in
+                       (match uu____21981 with
                         | (x12,phi11) ->
-                            let uu____22012 = as_refinement false env t21  in
-                            (match uu____22012 with
+                            let uu____21989 = as_refinement false env t21  in
+                            (match uu____21989 with
                              | (x22,phi21) ->
-                                 ((let uu____22021 =
+                                 ((let uu____21998 =
                                      FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "Rel")
                                       in
-                                   if uu____22021
+                                   if uu____21998
                                    then
-                                     ((let uu____22026 =
+                                     ((let uu____22003 =
                                          FStar_Syntax_Print.bv_to_string x12
                                           in
-                                       let uu____22028 =
+                                       let uu____22005 =
                                          FStar_Syntax_Print.term_to_string
                                            x12.FStar_Syntax_Syntax.sort
                                           in
-                                       let uu____22030 =
+                                       let uu____22007 =
                                          FStar_Syntax_Print.term_to_string
                                            phi11
                                           in
                                        FStar_Util.print3
-                                         "ref1 = (%s):(%s){%s}\n" uu____22026
-                                         uu____22028 uu____22030);
-                                      (let uu____22033 =
+                                         "ref1 = (%s):(%s){%s}\n" uu____22003
+                                         uu____22005 uu____22007);
+                                      (let uu____22010 =
                                          FStar_Syntax_Print.bv_to_string x22
                                           in
-                                       let uu____22035 =
+                                       let uu____22012 =
                                          FStar_Syntax_Print.term_to_string
                                            x22.FStar_Syntax_Syntax.sort
                                           in
-                                       let uu____22037 =
+                                       let uu____22014 =
                                          FStar_Syntax_Print.term_to_string
                                            phi21
                                           in
                                        FStar_Util.print3
-                                         "ref2 = (%s):(%s){%s}\n" uu____22033
-                                         uu____22035 uu____22037))
+                                         "ref2 = (%s):(%s){%s}\n" uu____22010
+                                         uu____22012 uu____22014))
                                    else ());
-                                  (let uu____22042 =
+                                  (let uu____22019 =
                                      mk_t_problem wl [] orig
                                        x12.FStar_Syntax_Syntax.sort
                                        problem.FStar_TypeChecker_Common.relation
@@ -7972,7 +7954,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                        problem.FStar_TypeChecker_Common.element
                                        "refinement base type"
                                       in
-                                   match uu____22042 with
+                                   match uu____22019 with
                                    | (base_prob,wl1) ->
                                        let x13 =
                                          FStar_Syntax_Syntax.freshen_bv x12
@@ -7992,12 +7974,12 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            x13
                                           in
                                        let mk_imp imp phi13 phi23 =
-                                         let uu____22113 = imp phi13 phi23
+                                         let uu____22090 = imp phi13 phi23
                                             in
-                                         FStar_All.pipe_right uu____22113
+                                         FStar_All.pipe_right uu____22090
                                            (guard_on_element wl1 problem x13)
                                           in
-                                       let fallback uu____22125 =
+                                       let fallback uu____22102 =
                                          let impl =
                                            if
                                              problem.FStar_TypeChecker_Common.relation
@@ -8013,52 +7995,52 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            FStar_Syntax_Util.mk_conj
                                              (p_guard base_prob) impl
                                             in
-                                         (let uu____22138 =
-                                            let uu____22141 = p_scope orig
+                                         (let uu____22115 =
+                                            let uu____22118 = p_scope orig
                                                in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____22141
+                                              uu____22118
                                              in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.1" uu____22138
+                                            (p_loc orig) "ref.1" uu____22115
                                             (p_guard base_prob));
-                                         (let uu____22160 =
-                                            let uu____22163 = p_scope orig
+                                         (let uu____22137 =
+                                            let uu____22140 = p_scope orig
                                                in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____22163
+                                              uu____22140
                                              in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.2" uu____22160
+                                            (p_loc orig) "ref.2" uu____22137
                                             impl);
                                          (let wl2 =
                                             solve_prob orig
                                               (FStar_Pervasives_Native.Some
                                                  guard) [] wl1
                                              in
-                                          let uu____22182 =
+                                          let uu____22159 =
                                             attempt [base_prob] wl2  in
-                                          solve env1 uu____22182)
+                                          solve env1 uu____22159)
                                           in
                                        let has_uvars =
-                                         (let uu____22187 =
-                                            let uu____22189 =
+                                         (let uu____22164 =
+                                            let uu____22166 =
                                               FStar_Syntax_Free.uvars phi12
                                                in
                                             FStar_Util.set_is_empty
-                                              uu____22189
+                                              uu____22166
                                              in
-                                          Prims.op_Negation uu____22187) ||
-                                           (let uu____22193 =
-                                              let uu____22195 =
+                                          Prims.op_Negation uu____22164) ||
+                                           (let uu____22170 =
+                                              let uu____22172 =
                                                 FStar_Syntax_Free.uvars phi22
                                                  in
                                               FStar_Util.set_is_empty
-                                                uu____22195
+                                                uu____22172
                                                in
-                                            Prims.op_Negation uu____22193)
+                                            Prims.op_Negation uu____22170)
                                           in
                                        if
                                          (problem.FStar_TypeChecker_Common.relation
@@ -8068,49 +8050,49 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                env1.FStar_TypeChecker_Env.uvar_subtyping)
                                               && has_uvars)
                                        then
-                                         let uu____22199 =
-                                           let uu____22204 =
-                                             let uu____22213 =
+                                         let uu____22176 =
+                                           let uu____22181 =
+                                             let uu____22190 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  x13
                                                 in
-                                             [uu____22213]  in
-                                           mk_t_problem wl1 uu____22204 orig
+                                             [uu____22190]  in
+                                           mk_t_problem wl1 uu____22181 orig
                                              phi12
                                              FStar_TypeChecker_Common.EQ
                                              phi22
                                              FStar_Pervasives_Native.None
                                              "refinement formula"
                                             in
-                                         (match uu____22199 with
+                                         (match uu____22176 with
                                           | (ref_prob,wl2) ->
                                               let tx =
                                                 FStar_Syntax_Unionfind.new_transaction
                                                   ()
                                                  in
-                                              let uu____22236 =
+                                              let uu____22213 =
                                                 solve env1
-                                                  (let uu___3122_22238 = wl2
+                                                  (let uu___3122_22215 = wl2
                                                       in
                                                    {
                                                      attempting = [ref_prob];
                                                      wl_deferred = [];
                                                      ctr =
-                                                       (uu___3122_22238.ctr);
+                                                       (uu___3122_22215.ctr);
                                                      defer_ok = false;
                                                      smt_ok =
-                                                       (uu___3122_22238.smt_ok);
+                                                       (uu___3122_22215.smt_ok);
                                                      umax_heuristic_ok =
-                                                       (uu___3122_22238.umax_heuristic_ok);
+                                                       (uu___3122_22215.umax_heuristic_ok);
                                                      tcenv =
-                                                       (uu___3122_22238.tcenv);
+                                                       (uu___3122_22215.tcenv);
                                                      wl_implicits =
-                                                       (uu___3122_22238.wl_implicits);
+                                                       (uu___3122_22215.wl_implicits);
                                                      repr_subcomp_allowed =
-                                                       (uu___3122_22238.repr_subcomp_allowed)
+                                                       (uu___3122_22215.repr_subcomp_allowed)
                                                    })
                                                  in
-                                              (match uu____22236 with
+                                              (match uu____22213 with
                                                | Failed (prob,msg) ->
                                                    (FStar_Syntax_Unionfind.rollback
                                                       tx;
@@ -8123,11 +8105,11 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                            wl2.smt_ok)
                                                     then giveup env1 msg prob
                                                     else fallback ())
-                                               | Success uu____22253 ->
+                                               | Success uu____22230 ->
                                                    (FStar_Syntax_Unionfind.commit
                                                       tx;
                                                     (let guard =
-                                                       let uu____22262 =
+                                                       let uu____22239 =
                                                          FStar_All.pipe_right
                                                            (p_guard ref_prob)
                                                            (guard_on_element
@@ -8135,7 +8117,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                           in
                                                        FStar_Syntax_Util.mk_conj
                                                          (p_guard base_prob)
-                                                         uu____22262
+                                                         uu____22239
                                                         in
                                                      let wl3 =
                                                        solve_prob orig
@@ -8143,43 +8125,43 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                             guard) [] wl2
                                                         in
                                                      let wl4 =
-                                                       let uu___3135_22271 =
+                                                       let uu___3135_22248 =
                                                          wl3  in
                                                        {
                                                          attempting =
-                                                           (uu___3135_22271.attempting);
+                                                           (uu___3135_22248.attempting);
                                                          wl_deferred =
-                                                           (uu___3135_22271.wl_deferred);
+                                                           (uu___3135_22248.wl_deferred);
                                                          ctr =
                                                            (wl3.ctr +
                                                               Prims.int_one);
                                                          defer_ok =
-                                                           (uu___3135_22271.defer_ok);
+                                                           (uu___3135_22248.defer_ok);
                                                          smt_ok =
-                                                           (uu___3135_22271.smt_ok);
+                                                           (uu___3135_22248.smt_ok);
                                                          umax_heuristic_ok =
-                                                           (uu___3135_22271.umax_heuristic_ok);
+                                                           (uu___3135_22248.umax_heuristic_ok);
                                                          tcenv =
-                                                           (uu___3135_22271.tcenv);
+                                                           (uu___3135_22248.tcenv);
                                                          wl_implicits =
-                                                           (uu___3135_22271.wl_implicits);
+                                                           (uu___3135_22248.wl_implicits);
                                                          repr_subcomp_allowed
                                                            =
-                                                           (uu___3135_22271.repr_subcomp_allowed)
+                                                           (uu___3135_22248.repr_subcomp_allowed)
                                                        }  in
-                                                     let uu____22273 =
+                                                     let uu____22250 =
                                                        attempt [base_prob]
                                                          wl4
                                                         in
-                                                     solve env1 uu____22273))))
+                                                     solve env1 uu____22250))))
                                        else fallback ())))))
               | (FStar_Syntax_Syntax.Tm_uvar
-                 uu____22276,FStar_Syntax_Syntax.Tm_uvar uu____22277) ->
-                  let uu____22302 = ensure_no_uvar_subst t1 wl  in
-                  (match uu____22302 with
+                 uu____22253,FStar_Syntax_Syntax.Tm_uvar uu____22254) ->
+                  let uu____22279 = ensure_no_uvar_subst t1 wl  in
+                  (match uu____22279 with
                    | (t11,wl1) ->
-                       let uu____22309 = ensure_no_uvar_subst t2 wl1  in
-                       (match uu____22309 with
+                       let uu____22286 = ensure_no_uvar_subst t2 wl1  in
+                       (match uu____22286 with
                         | (t21,wl2) ->
                             let f1 = destruct_flex_t' t11  in
                             let f2 = destruct_flex_t' t21  in
@@ -8187,32 +8169,32 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22318;
-                    FStar_Syntax_Syntax.pos = uu____22319;
-                    FStar_Syntax_Syntax.vars = uu____22320;_},uu____22321),FStar_Syntax_Syntax.Tm_uvar
-                 uu____22322) ->
-                  let uu____22371 = ensure_no_uvar_subst t1 wl  in
-                  (match uu____22371 with
+                      uu____22295;
+                    FStar_Syntax_Syntax.pos = uu____22296;
+                    FStar_Syntax_Syntax.vars = uu____22297;_},uu____22298),FStar_Syntax_Syntax.Tm_uvar
+                 uu____22299) ->
+                  let uu____22348 = ensure_no_uvar_subst t1 wl  in
+                  (match uu____22348 with
                    | (t11,wl1) ->
-                       let uu____22378 = ensure_no_uvar_subst t2 wl1  in
-                       (match uu____22378 with
+                       let uu____22355 = ensure_no_uvar_subst t2 wl1  in
+                       (match uu____22355 with
                         | (t21,wl2) ->
                             let f1 = destruct_flex_t' t11  in
                             let f2 = destruct_flex_t' t21  in
                             solve_t_flex_flex env orig wl2 f1 f2))
               | (FStar_Syntax_Syntax.Tm_uvar
-                 uu____22387,FStar_Syntax_Syntax.Tm_app
+                 uu____22364,FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22388;
-                    FStar_Syntax_Syntax.pos = uu____22389;
-                    FStar_Syntax_Syntax.vars = uu____22390;_},uu____22391))
+                      uu____22365;
+                    FStar_Syntax_Syntax.pos = uu____22366;
+                    FStar_Syntax_Syntax.vars = uu____22367;_},uu____22368))
                   ->
-                  let uu____22440 = ensure_no_uvar_subst t1 wl  in
-                  (match uu____22440 with
+                  let uu____22417 = ensure_no_uvar_subst t1 wl  in
+                  (match uu____22417 with
                    | (t11,wl1) ->
-                       let uu____22447 = ensure_no_uvar_subst t2 wl1  in
-                       (match uu____22447 with
+                       let uu____22424 = ensure_no_uvar_subst t2 wl1  in
+                       (match uu____22424 with
                         | (t21,wl2) ->
                             let f1 = destruct_flex_t' t11  in
                             let f2 = destruct_flex_t' t21  in
@@ -8220,232 +8202,232 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22456;
-                    FStar_Syntax_Syntax.pos = uu____22457;
-                    FStar_Syntax_Syntax.vars = uu____22458;_},uu____22459),FStar_Syntax_Syntax.Tm_app
+                      uu____22433;
+                    FStar_Syntax_Syntax.pos = uu____22434;
+                    FStar_Syntax_Syntax.vars = uu____22435;_},uu____22436),FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22460;
-                    FStar_Syntax_Syntax.pos = uu____22461;
-                    FStar_Syntax_Syntax.vars = uu____22462;_},uu____22463))
+                      uu____22437;
+                    FStar_Syntax_Syntax.pos = uu____22438;
+                    FStar_Syntax_Syntax.vars = uu____22439;_},uu____22440))
                   ->
-                  let uu____22536 = ensure_no_uvar_subst t1 wl  in
-                  (match uu____22536 with
+                  let uu____22513 = ensure_no_uvar_subst t1 wl  in
+                  (match uu____22513 with
                    | (t11,wl1) ->
-                       let uu____22543 = ensure_no_uvar_subst t2 wl1  in
-                       (match uu____22543 with
+                       let uu____22520 = ensure_no_uvar_subst t2 wl1  in
+                       (match uu____22520 with
                         | (t21,wl2) ->
                             let f1 = destruct_flex_t' t11  in
                             let f2 = destruct_flex_t' t21  in
                             solve_t_flex_flex env orig wl2 f1 f2))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____22552,uu____22553) when
+              | (FStar_Syntax_Syntax.Tm_uvar uu____22529,uu____22530) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____22566 = destruct_flex_t t1 wl  in
-                  (match uu____22566 with
+                  let uu____22543 = destruct_flex_t t1 wl  in
+                  (match uu____22543 with
                    | (f1,wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22573;
-                    FStar_Syntax_Syntax.pos = uu____22574;
-                    FStar_Syntax_Syntax.vars = uu____22575;_},uu____22576),uu____22577)
+                      uu____22550;
+                    FStar_Syntax_Syntax.pos = uu____22551;
+                    FStar_Syntax_Syntax.vars = uu____22552;_},uu____22553),uu____22554)
                   when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____22614 = destruct_flex_t t1 wl  in
-                  (match uu____22614 with
+                  let uu____22591 = destruct_flex_t t1 wl  in
+                  (match uu____22591 with
                    | (f1,wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
-              | (uu____22621,FStar_Syntax_Syntax.Tm_uvar uu____22622) when
+              | (uu____22598,FStar_Syntax_Syntax.Tm_uvar uu____22599) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
-              | (uu____22635,FStar_Syntax_Syntax.Tm_app
+              | (uu____22612,FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22636;
-                    FStar_Syntax_Syntax.pos = uu____22637;
-                    FStar_Syntax_Syntax.vars = uu____22638;_},uu____22639))
+                      uu____22613;
+                    FStar_Syntax_Syntax.pos = uu____22614;
+                    FStar_Syntax_Syntax.vars = uu____22615;_},uu____22616))
                   when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
               | (FStar_Syntax_Syntax.Tm_uvar
-                 uu____22676,FStar_Syntax_Syntax.Tm_arrow uu____22677) ->
+                 uu____22653,FStar_Syntax_Syntax.Tm_arrow uu____22654) ->
                   solve_t' env
-                    (let uu___3237_22705 = problem  in
+                    (let uu___3237_22682 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3237_22705.FStar_TypeChecker_Common.pid);
+                         (uu___3237_22682.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3237_22705.FStar_TypeChecker_Common.lhs);
+                         (uu___3237_22682.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3237_22705.FStar_TypeChecker_Common.rhs);
+                         (uu___3237_22682.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3237_22705.FStar_TypeChecker_Common.element);
+                         (uu___3237_22682.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3237_22705.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3237_22682.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3237_22705.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3237_22682.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3237_22705.FStar_TypeChecker_Common.reason);
+                         (uu___3237_22682.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3237_22705.FStar_TypeChecker_Common.loc);
+                         (uu___3237_22682.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3237_22705.FStar_TypeChecker_Common.rank)
+                         (uu___3237_22682.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22706;
-                    FStar_Syntax_Syntax.pos = uu____22707;
-                    FStar_Syntax_Syntax.vars = uu____22708;_},uu____22709),FStar_Syntax_Syntax.Tm_arrow
-                 uu____22710) ->
+                      uu____22683;
+                    FStar_Syntax_Syntax.pos = uu____22684;
+                    FStar_Syntax_Syntax.vars = uu____22685;_},uu____22686),FStar_Syntax_Syntax.Tm_arrow
+                 uu____22687) ->
                   solve_t' env
-                    (let uu___3237_22762 = problem  in
+                    (let uu___3237_22739 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3237_22762.FStar_TypeChecker_Common.pid);
+                         (uu___3237_22739.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3237_22762.FStar_TypeChecker_Common.lhs);
+                         (uu___3237_22739.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3237_22762.FStar_TypeChecker_Common.rhs);
+                         (uu___3237_22739.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3237_22762.FStar_TypeChecker_Common.element);
+                         (uu___3237_22739.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3237_22762.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3237_22739.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3237_22762.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3237_22739.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3237_22762.FStar_TypeChecker_Common.reason);
+                         (uu___3237_22739.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3237_22762.FStar_TypeChecker_Common.loc);
+                         (uu___3237_22739.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3237_22762.FStar_TypeChecker_Common.rank)
+                         (uu___3237_22739.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____22763,FStar_Syntax_Syntax.Tm_uvar uu____22764) ->
-                  let uu____22777 =
+              | (uu____22740,FStar_Syntax_Syntax.Tm_uvar uu____22741) ->
+                  let uu____22754 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22777
-              | (uu____22778,FStar_Syntax_Syntax.Tm_app
+                  solve env uu____22754
+              | (uu____22755,FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22779;
-                    FStar_Syntax_Syntax.pos = uu____22780;
-                    FStar_Syntax_Syntax.vars = uu____22781;_},uu____22782))
+                      uu____22756;
+                    FStar_Syntax_Syntax.pos = uu____22757;
+                    FStar_Syntax_Syntax.vars = uu____22758;_},uu____22759))
                   ->
-                  let uu____22819 =
+                  let uu____22796 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22819
-              | (FStar_Syntax_Syntax.Tm_uvar uu____22820,uu____22821) ->
-                  let uu____22834 =
+                  solve env uu____22796
+              | (FStar_Syntax_Syntax.Tm_uvar uu____22797,uu____22798) ->
+                  let uu____22811 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22834
+                  solve env uu____22811
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____22835;
-                    FStar_Syntax_Syntax.pos = uu____22836;
-                    FStar_Syntax_Syntax.vars = uu____22837;_},uu____22838),uu____22839)
+                      uu____22812;
+                    FStar_Syntax_Syntax.pos = uu____22813;
+                    FStar_Syntax_Syntax.vars = uu____22814;_},uu____22815),uu____22816)
                   ->
-                  let uu____22876 =
+                  let uu____22853 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl  in
-                  solve env uu____22876
-              | (FStar_Syntax_Syntax.Tm_refine uu____22877,uu____22878) ->
+                  solve env uu____22853
+              | (FStar_Syntax_Syntax.Tm_refine uu____22854,uu____22855) ->
                   let t21 =
-                    let uu____22886 = base_and_refinement env t2  in
-                    FStar_All.pipe_left force_refinement uu____22886  in
+                    let uu____22863 = base_and_refinement env t2  in
+                    FStar_All.pipe_left force_refinement uu____22863  in
                   solve_t env
-                    (let uu___3272_22912 = problem  in
+                    (let uu___3272_22889 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3272_22912.FStar_TypeChecker_Common.pid);
+                         (uu___3272_22889.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3272_22912.FStar_TypeChecker_Common.lhs);
+                         (uu___3272_22889.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
-                         (uu___3272_22912.FStar_TypeChecker_Common.relation);
+                         (uu___3272_22889.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs = t21;
                        FStar_TypeChecker_Common.element =
-                         (uu___3272_22912.FStar_TypeChecker_Common.element);
+                         (uu___3272_22889.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3272_22912.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3272_22889.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3272_22912.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3272_22889.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3272_22912.FStar_TypeChecker_Common.reason);
+                         (uu___3272_22889.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3272_22912.FStar_TypeChecker_Common.loc);
+                         (uu___3272_22889.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3272_22912.FStar_TypeChecker_Common.rank)
+                         (uu___3272_22889.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____22913,FStar_Syntax_Syntax.Tm_refine uu____22914) ->
+              | (uu____22890,FStar_Syntax_Syntax.Tm_refine uu____22891) ->
                   let t11 =
-                    let uu____22922 = base_and_refinement env t1  in
-                    FStar_All.pipe_left force_refinement uu____22922  in
+                    let uu____22899 = base_and_refinement env t1  in
+                    FStar_All.pipe_left force_refinement uu____22899  in
                   solve_t env
-                    (let uu___3279_22948 = problem  in
+                    (let uu___3279_22925 = problem  in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3279_22948.FStar_TypeChecker_Common.pid);
+                         (uu___3279_22925.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs = t11;
                        FStar_TypeChecker_Common.relation =
-                         (uu___3279_22948.FStar_TypeChecker_Common.relation);
+                         (uu___3279_22925.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3279_22948.FStar_TypeChecker_Common.rhs);
+                         (uu___3279_22925.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3279_22948.FStar_TypeChecker_Common.element);
+                         (uu___3279_22925.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3279_22948.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3279_22925.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3279_22948.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3279_22925.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3279_22948.FStar_TypeChecker_Common.reason);
+                         (uu___3279_22925.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3279_22948.FStar_TypeChecker_Common.loc);
+                         (uu___3279_22925.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3279_22948.FStar_TypeChecker_Common.rank)
+                         (uu___3279_22925.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_match
                  (s1,brs1),FStar_Syntax_Syntax.Tm_match (s2,brs2)) ->
-                  let by_smt uu____23030 =
-                    let uu____23031 = guard_of_prob env wl problem t1 t2  in
-                    match uu____23031 with
+                  let by_smt uu____23007 =
+                    let uu____23008 = guard_of_prob env wl problem t1 t2  in
+                    match uu____23008 with
                     | (guard,wl1) ->
-                        let uu____23038 =
+                        let uu____23015 =
                           solve_prob orig
                             (FStar_Pervasives_Native.Some guard) [] wl1
                            in
-                        solve env uu____23038
+                        solve env uu____23015
                      in
                   let rec solve_branches wl1 brs11 brs21 =
                     match (brs11, brs21) with
                     | (br1::rs1,br2::rs2) ->
-                        let uu____23257 = br1  in
-                        (match uu____23257 with
-                         | (p1,w1,uu____23286) ->
-                             let uu____23303 = br2  in
-                             (match uu____23303 with
-                              | (p2,w2,uu____23326) ->
-                                  let uu____23331 =
-                                    let uu____23333 =
+                        let uu____23234 = br1  in
+                        (match uu____23234 with
+                         | (p1,w1,uu____23263) ->
+                             let uu____23280 = br2  in
+                             (match uu____23280 with
+                              | (p2,w2,uu____23303) ->
+                                  let uu____23308 =
+                                    let uu____23310 =
                                       FStar_Syntax_Syntax.eq_pat p1 p2  in
-                                    Prims.op_Negation uu____23333  in
-                                  if uu____23331
+                                    Prims.op_Negation uu____23310  in
+                                  if uu____23308
                                   then FStar_Pervasives_Native.None
                                   else
-                                    (let uu____23360 =
+                                    (let uu____23337 =
                                        FStar_Syntax_Subst.open_branch' br1
                                         in
-                                     match uu____23360 with
+                                     match uu____23337 with
                                      | ((p11,w11,e1),s) ->
-                                         let uu____23397 = br2  in
-                                         (match uu____23397 with
+                                         let uu____23374 = br2  in
+                                         (match uu____23374 with
                                           | (p21,w21,e2) ->
                                               let w22 =
                                                 FStar_Util.map_opt w21
@@ -8455,24 +8437,24 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 FStar_Syntax_Subst.subst s e2
                                                  in
                                               let scope =
-                                                let uu____23430 =
+                                                let uu____23407 =
                                                   FStar_Syntax_Syntax.pat_bvs
                                                     p11
                                                    in
                                                 FStar_All.pipe_left
                                                   (FStar_List.map
                                                      FStar_Syntax_Syntax.mk_binder)
-                                                  uu____23430
+                                                  uu____23407
                                                  in
-                                              let uu____23435 =
+                                              let uu____23412 =
                                                 match (w11, w22) with
                                                 | (FStar_Pervasives_Native.Some
-                                                   uu____23466,FStar_Pervasives_Native.None
+                                                   uu____23443,FStar_Pervasives_Native.None
                                                    ) ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None
                                                    ,FStar_Pervasives_Native.Some
-                                                   uu____23487) ->
+                                                   uu____23464) ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None
                                                    ,FStar_Pervasives_Native.None
@@ -8482,7 +8464,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 | (FStar_Pervasives_Native.Some
                                                    w12,FStar_Pervasives_Native.Some
                                                    w23) ->
-                                                    let uu____23546 =
+                                                    let uu____23523 =
                                                       mk_t_problem wl1 scope
                                                         orig w12
                                                         FStar_TypeChecker_Common.EQ
@@ -8490,17 +8472,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                         FStar_Pervasives_Native.None
                                                         "when clause"
                                                        in
-                                                    (match uu____23546 with
+                                                    (match uu____23523 with
                                                      | (p,wl2) ->
                                                          FStar_Pervasives_Native.Some
                                                            ([(scope, p)],
                                                              wl2))
                                                  in
-                                              FStar_Util.bind_opt uu____23435
-                                                (fun uu____23618  ->
-                                                   match uu____23618 with
+                                              FStar_Util.bind_opt uu____23412
+                                                (fun uu____23595  ->
+                                                   match uu____23595 with
                                                    | (wprobs,wl2) ->
-                                                       let uu____23655 =
+                                                       let uu____23632 =
                                                          mk_t_problem wl2
                                                            scope orig e1
                                                            FStar_TypeChecker_Common.EQ
@@ -8508,10 +8490,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                            FStar_Pervasives_Native.None
                                                            "branch body"
                                                           in
-                                                       (match uu____23655
+                                                       (match uu____23632
                                                         with
                                                         | (prob,wl3) ->
-                                                            ((let uu____23676
+                                                            ((let uu____23653
                                                                 =
                                                                 FStar_All.pipe_left
                                                                   (FStar_TypeChecker_Env.debug
@@ -8519,14 +8501,14 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                   (FStar_Options.Other
                                                                     "Rel")
                                                                  in
-                                                              if uu____23676
+                                                              if uu____23653
                                                               then
-                                                                let uu____23681
+                                                                let uu____23658
                                                                   =
                                                                   prob_to_string
                                                                     env prob
                                                                    in
-                                                                let uu____23683
+                                                                let uu____23660
                                                                   =
                                                                   FStar_Syntax_Print.binders_to_string
                                                                     ", "
@@ -8534,20 +8516,20 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                    in
                                                                 FStar_Util.print2
                                                                   "Created problem for branches %s with scope %s\n"
-                                                                  uu____23681
-                                                                  uu____23683
+                                                                  uu____23658
+                                                                  uu____23660
                                                               else ());
-                                                             (let uu____23689
+                                                             (let uu____23666
                                                                 =
                                                                 solve_branches
                                                                   wl3 rs1 rs2
                                                                  in
                                                               FStar_Util.bind_opt
-                                                                uu____23689
+                                                                uu____23666
                                                                 (fun
-                                                                   uu____23725
+                                                                   uu____23702
                                                                     ->
-                                                                   match uu____23725
+                                                                   match uu____23702
                                                                    with
                                                                    | 
                                                                    (r1,wl4)
@@ -8559,117 +8541,117 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     wprobs r1)),
                                                                     wl4))))))))))
                     | ([],[]) -> FStar_Pervasives_Native.Some ([], wl1)
-                    | uu____23854 -> FStar_Pervasives_Native.None  in
-                  let uu____23895 = solve_branches wl brs1 brs2  in
-                  (match uu____23895 with
+                    | uu____23831 -> FStar_Pervasives_Native.None  in
+                  let uu____23872 = solve_branches wl brs1 brs2  in
+                  (match uu____23872 with
                    | FStar_Pervasives_Native.None  ->
                        if wl.smt_ok
                        then by_smt ()
                        else
-                         (let uu____23921 =
+                         (let uu____23898 =
                             FStar_Thunk.mkv "Tm_match branches don't match"
                              in
-                          giveup env uu____23921 orig)
+                          giveup env uu____23898 orig)
                    | FStar_Pervasives_Native.Some (sub_probs,wl1) ->
-                       let uu____23948 =
+                       let uu____23925 =
                          mk_t_problem wl1 [] orig s1
                            FStar_TypeChecker_Common.EQ s2
                            FStar_Pervasives_Native.None "match scrutinee"
                           in
-                       (match uu____23948 with
+                       (match uu____23925 with
                         | (sc_prob,wl2) ->
                             let sub_probs1 = ([], sc_prob) :: sub_probs  in
                             let formula =
-                              let uu____23982 =
+                              let uu____23959 =
                                 FStar_List.map
-                                  (fun uu____23994  ->
-                                     match uu____23994 with
+                                  (fun uu____23971  ->
+                                     match uu____23971 with
                                      | (scope,p) ->
                                          FStar_TypeChecker_Env.close_forall
                                            wl2.tcenv scope (p_guard p))
                                   sub_probs1
                                  in
-                              FStar_Syntax_Util.mk_conj_l uu____23982  in
+                              FStar_Syntax_Util.mk_conj_l uu____23959  in
                             let tx =
                               FStar_Syntax_Unionfind.new_transaction ()  in
                             let wl3 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some formula) [] wl2
                                in
-                            let uu____24003 =
-                              let uu____24004 =
-                                let uu____24005 =
+                            let uu____23980 =
+                              let uu____23981 =
+                                let uu____23982 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     sub_probs1
                                    in
-                                attempt uu____24005
-                                  (let uu___3378_24013 = wl3  in
+                                attempt uu____23982
+                                  (let uu___3378_23990 = wl3  in
                                    {
                                      attempting =
-                                       (uu___3378_24013.attempting);
+                                       (uu___3378_23990.attempting);
                                      wl_deferred =
-                                       (uu___3378_24013.wl_deferred);
-                                     ctr = (uu___3378_24013.ctr);
-                                     defer_ok = (uu___3378_24013.defer_ok);
+                                       (uu___3378_23990.wl_deferred);
+                                     ctr = (uu___3378_23990.ctr);
+                                     defer_ok = (uu___3378_23990.defer_ok);
                                      smt_ok = false;
                                      umax_heuristic_ok =
-                                       (uu___3378_24013.umax_heuristic_ok);
-                                     tcenv = (uu___3378_24013.tcenv);
+                                       (uu___3378_23990.umax_heuristic_ok);
+                                     tcenv = (uu___3378_23990.tcenv);
                                      wl_implicits =
-                                       (uu___3378_24013.wl_implicits);
+                                       (uu___3378_23990.wl_implicits);
                                      repr_subcomp_allowed =
-                                       (uu___3378_24013.repr_subcomp_allowed)
+                                       (uu___3378_23990.repr_subcomp_allowed)
                                    })
                                  in
-                              solve env uu____24004  in
-                            (match uu____24003 with
+                              solve env uu____23981  in
+                            (match uu____23980 with
                              | Success (ds,imp) ->
                                  (FStar_Syntax_Unionfind.commit tx;
                                   Success (ds, imp))
-                             | Failed uu____24018 ->
+                             | Failed uu____23995 ->
                                  (FStar_Syntax_Unionfind.rollback tx;
                                   if wl3.smt_ok
                                   then by_smt ()
                                   else
-                                    (let uu____24027 =
+                                    (let uu____24004 =
                                        FStar_Thunk.mkv
                                          "Could not unify matches without SMT"
                                         in
-                                     giveup env uu____24027 orig)))))
-              | (FStar_Syntax_Syntax.Tm_match uu____24030,uu____24031) ->
+                                     giveup env uu____24004 orig)))))
+              | (FStar_Syntax_Syntax.Tm_match uu____24007,uu____24008) ->
                   let head1 =
-                    let uu____24055 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24055
+                    let uu____24032 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24032
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24101 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24101
+                    let uu____24078 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24078
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24147 =
+                  ((let uu____24124 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24147
+                    if uu____24124
                     then
-                      let uu____24151 =
+                      let uu____24128 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24153 =
+                      let uu____24130 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24155 =
+                      let uu____24132 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24151 uu____24153 uu____24155
+                        uu____24128 uu____24130 uu____24132
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24169 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24169) &&
-                        (let uu____24173 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24173)
+                      (let uu____24146 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24146) &&
+                        (let uu____24150 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24150)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8692,9 +8674,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24192 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24192 = FStar_Syntax_Util.Equal  in
-                    let uu____24193 =
+                      let uu____24169 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24169 = FStar_Syntax_Util.Equal  in
+                    let uu____24170 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8703,72 +8685,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24193
+                    if uu____24170
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24197 = equal t1 t2  in
-                         (if uu____24197
+                         let uu____24174 = equal t1 t2  in
+                         (if uu____24174
                           then
-                            let uu____24200 =
+                            let uu____24177 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24200
+                            solve env uu____24177
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24205 =
-                            let uu____24212 = equal t1 t2  in
-                            if uu____24212
+                         (let uu____24182 =
+                            let uu____24189 = equal t1 t2  in
+                            if uu____24189
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24225 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24225 with
+                              (let uu____24202 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24202 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24205 with
+                          match uu____24182 with
                           | (guard,wl1) ->
-                              let uu____24246 = solve_prob orig guard [] wl1
+                              let uu____24223 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24246))
+                              solve env uu____24223))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_uinst uu____24249,uu____24250) ->
+              | (FStar_Syntax_Syntax.Tm_uinst uu____24226,uu____24227) ->
                   let head1 =
-                    let uu____24258 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24258
+                    let uu____24235 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24235
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24304 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24304
+                    let uu____24281 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24281
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24350 =
+                  ((let uu____24327 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24350
+                    if uu____24327
                     then
-                      let uu____24354 =
+                      let uu____24331 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24356 =
+                      let uu____24333 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24358 =
+                      let uu____24335 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24354 uu____24356 uu____24358
+                        uu____24331 uu____24333 uu____24335
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24372 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24372) &&
-                        (let uu____24376 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24376)
+                      (let uu____24349 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24349) &&
+                        (let uu____24353 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24353)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8791,9 +8773,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24395 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24395 = FStar_Syntax_Util.Equal  in
-                    let uu____24396 =
+                      let uu____24372 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24372 = FStar_Syntax_Util.Equal  in
+                    let uu____24373 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8802,72 +8784,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24396
+                    if uu____24373
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24400 = equal t1 t2  in
-                         (if uu____24400
+                         let uu____24377 = equal t1 t2  in
+                         (if uu____24377
                           then
-                            let uu____24403 =
+                            let uu____24380 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24403
+                            solve env uu____24380
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24408 =
-                            let uu____24415 = equal t1 t2  in
-                            if uu____24415
+                         (let uu____24385 =
+                            let uu____24392 = equal t1 t2  in
+                            if uu____24392
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24428 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24428 with
+                              (let uu____24405 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24405 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24408 with
+                          match uu____24385 with
                           | (guard,wl1) ->
-                              let uu____24449 = solve_prob orig guard [] wl1
+                              let uu____24426 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24449))
+                              solve env uu____24426))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_name uu____24452,uu____24453) ->
+              | (FStar_Syntax_Syntax.Tm_name uu____24429,uu____24430) ->
                   let head1 =
-                    let uu____24455 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24455
+                    let uu____24432 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24432
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24501 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24501
+                    let uu____24478 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24478
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24547 =
+                  ((let uu____24524 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24547
+                    if uu____24524
                     then
-                      let uu____24551 =
+                      let uu____24528 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24553 =
+                      let uu____24530 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24555 =
+                      let uu____24532 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24551 uu____24553 uu____24555
+                        uu____24528 uu____24530 uu____24532
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24569 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24569) &&
-                        (let uu____24573 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24573)
+                      (let uu____24546 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24546) &&
+                        (let uu____24550 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24550)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8890,9 +8872,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24592 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24592 = FStar_Syntax_Util.Equal  in
-                    let uu____24593 =
+                      let uu____24569 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24569 = FStar_Syntax_Util.Equal  in
+                    let uu____24570 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8901,72 +8883,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24593
+                    if uu____24570
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24597 = equal t1 t2  in
-                         (if uu____24597
+                         let uu____24574 = equal t1 t2  in
+                         (if uu____24574
                           then
-                            let uu____24600 =
+                            let uu____24577 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24600
+                            solve env uu____24577
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24605 =
-                            let uu____24612 = equal t1 t2  in
-                            if uu____24612
+                         (let uu____24582 =
+                            let uu____24589 = equal t1 t2  in
+                            if uu____24589
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24625 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24625 with
+                              (let uu____24602 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24602 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24605 with
+                          match uu____24582 with
                           | (guard,wl1) ->
-                              let uu____24646 = solve_prob orig guard [] wl1
+                              let uu____24623 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24646))
+                              solve env uu____24623))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_constant uu____24649,uu____24650) ->
+              | (FStar_Syntax_Syntax.Tm_constant uu____24626,uu____24627) ->
                   let head1 =
-                    let uu____24652 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24652
+                    let uu____24629 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24629
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24698 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24698
+                    let uu____24675 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24675
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24744 =
+                  ((let uu____24721 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24744
+                    if uu____24721
                     then
-                      let uu____24748 =
+                      let uu____24725 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24750 =
+                      let uu____24727 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24752 =
+                      let uu____24729 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24748 uu____24750 uu____24752
+                        uu____24725 uu____24727 uu____24729
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24766 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24766) &&
-                        (let uu____24770 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24770)
+                      (let uu____24743 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24743) &&
+                        (let uu____24747 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24747)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -8989,9 +8971,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24789 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24789 = FStar_Syntax_Util.Equal  in
-                    let uu____24790 =
+                      let uu____24766 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24766 = FStar_Syntax_Util.Equal  in
+                    let uu____24767 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9000,72 +8982,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24790
+                    if uu____24767
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24794 = equal t1 t2  in
-                         (if uu____24794
+                         let uu____24771 = equal t1 t2  in
+                         (if uu____24771
                           then
-                            let uu____24797 =
+                            let uu____24774 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24797
+                            solve env uu____24774
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24802 =
-                            let uu____24809 = equal t1 t2  in
-                            if uu____24809
+                         (let uu____24779 =
+                            let uu____24786 = equal t1 t2  in
+                            if uu____24786
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24822 = mk_eq2 wl env orig t1 t2  in
-                               match uu____24822 with
+                              (let uu____24799 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24799 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24802 with
+                          match uu____24779 with
                           | (guard,wl1) ->
-                              let uu____24843 = solve_prob orig guard [] wl1
+                              let uu____24820 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____24843))
+                              solve env uu____24820))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_fvar uu____24846,uu____24847) ->
+              | (FStar_Syntax_Syntax.Tm_fvar uu____24823,uu____24824) ->
                   let head1 =
-                    let uu____24849 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____24849
+                    let uu____24826 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____24826
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____24895 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____24895
+                    let uu____24872 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____24872
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____24941 =
+                  ((let uu____24918 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____24941
+                    if uu____24918
                     then
-                      let uu____24945 =
+                      let uu____24922 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____24947 =
+                      let uu____24924 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____24949 =
+                      let uu____24926 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24945 uu____24947 uu____24949
+                        uu____24922 uu____24924 uu____24926
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24963 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____24963) &&
-                        (let uu____24967 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____24967)
+                      (let uu____24940 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____24940) &&
+                        (let uu____24944 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____24944)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9088,9 +9070,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____24986 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____24986 = FStar_Syntax_Util.Equal  in
-                    let uu____24987 =
+                      let uu____24963 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____24963 = FStar_Syntax_Util.Equal  in
+                    let uu____24964 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9099,72 +9081,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____24987
+                    if uu____24964
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24991 = equal t1 t2  in
-                         (if uu____24991
+                         let uu____24968 = equal t1 t2  in
+                         (if uu____24968
                           then
-                            let uu____24994 =
+                            let uu____24971 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____24994
+                            solve env uu____24971
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24999 =
-                            let uu____25006 = equal t1 t2  in
-                            if uu____25006
+                         (let uu____24976 =
+                            let uu____24983 = equal t1 t2  in
+                            if uu____24983
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25019 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25019 with
+                              (let uu____24996 = mk_eq2 wl env orig t1 t2  in
+                               match uu____24996 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____24999 with
+                          match uu____24976 with
                           | (guard,wl1) ->
-                              let uu____25040 = solve_prob orig guard [] wl1
+                              let uu____25017 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25040))
+                              solve env uu____25017))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_app uu____25043,uu____25044) ->
+              | (FStar_Syntax_Syntax.Tm_app uu____25020,uu____25021) ->
                   let head1 =
-                    let uu____25062 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25062
+                    let uu____25039 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25039
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25108 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25108
+                    let uu____25085 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25085
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25154 =
+                  ((let uu____25131 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25154
+                    if uu____25131
                     then
-                      let uu____25158 =
+                      let uu____25135 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25160 =
+                      let uu____25137 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25162 =
+                      let uu____25139 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25158 uu____25160 uu____25162
+                        uu____25135 uu____25137 uu____25139
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25176 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25176) &&
-                        (let uu____25180 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25180)
+                      (let uu____25153 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25153) &&
+                        (let uu____25157 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25157)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9187,9 +9169,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25199 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25199 = FStar_Syntax_Util.Equal  in
-                    let uu____25200 =
+                      let uu____25176 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25176 = FStar_Syntax_Util.Equal  in
+                    let uu____25177 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9198,72 +9180,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25200
+                    if uu____25177
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25204 = equal t1 t2  in
-                         (if uu____25204
+                         let uu____25181 = equal t1 t2  in
+                         (if uu____25181
                           then
-                            let uu____25207 =
+                            let uu____25184 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25207
+                            solve env uu____25184
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25212 =
-                            let uu____25219 = equal t1 t2  in
-                            if uu____25219
+                         (let uu____25189 =
+                            let uu____25196 = equal t1 t2  in
+                            if uu____25196
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25232 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25232 with
+                              (let uu____25209 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25209 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25212 with
+                          match uu____25189 with
                           | (guard,wl1) ->
-                              let uu____25253 = solve_prob orig guard [] wl1
+                              let uu____25230 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25253))
+                              solve env uu____25230))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25256,FStar_Syntax_Syntax.Tm_match uu____25257) ->
+              | (uu____25233,FStar_Syntax_Syntax.Tm_match uu____25234) ->
                   let head1 =
-                    let uu____25281 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25281
+                    let uu____25258 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25258
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25327 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25327
+                    let uu____25304 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25304
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25373 =
+                  ((let uu____25350 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25373
+                    if uu____25350
                     then
-                      let uu____25377 =
+                      let uu____25354 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25379 =
+                      let uu____25356 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25381 =
+                      let uu____25358 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25377 uu____25379 uu____25381
+                        uu____25354 uu____25356 uu____25358
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25395 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25395) &&
-                        (let uu____25399 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25399)
+                      (let uu____25372 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25372) &&
+                        (let uu____25376 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25376)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9286,9 +9268,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25418 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25418 = FStar_Syntax_Util.Equal  in
-                    let uu____25419 =
+                      let uu____25395 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25395 = FStar_Syntax_Util.Equal  in
+                    let uu____25396 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9297,72 +9279,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25419
+                    if uu____25396
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25423 = equal t1 t2  in
-                         (if uu____25423
+                         let uu____25400 = equal t1 t2  in
+                         (if uu____25400
                           then
-                            let uu____25426 =
+                            let uu____25403 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25426
+                            solve env uu____25403
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25431 =
-                            let uu____25438 = equal t1 t2  in
-                            if uu____25438
+                         (let uu____25408 =
+                            let uu____25415 = equal t1 t2  in
+                            if uu____25415
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25451 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25451 with
+                              (let uu____25428 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25428 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25431 with
+                          match uu____25408 with
                           | (guard,wl1) ->
-                              let uu____25472 = solve_prob orig guard [] wl1
+                              let uu____25449 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25472))
+                              solve env uu____25449))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25475,FStar_Syntax_Syntax.Tm_uinst uu____25476) ->
+              | (uu____25452,FStar_Syntax_Syntax.Tm_uinst uu____25453) ->
                   let head1 =
-                    let uu____25484 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25484
+                    let uu____25461 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25461
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25530 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25530
+                    let uu____25507 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25507
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25576 =
+                  ((let uu____25553 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25576
+                    if uu____25553
                     then
-                      let uu____25580 =
+                      let uu____25557 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25582 =
+                      let uu____25559 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25584 =
+                      let uu____25561 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25580 uu____25582 uu____25584
+                        uu____25557 uu____25559 uu____25561
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25598 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25598) &&
-                        (let uu____25602 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25602)
+                      (let uu____25575 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25575) &&
+                        (let uu____25579 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25579)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9385,9 +9367,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25621 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25621 = FStar_Syntax_Util.Equal  in
-                    let uu____25622 =
+                      let uu____25598 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25598 = FStar_Syntax_Util.Equal  in
+                    let uu____25599 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9396,72 +9378,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25622
+                    if uu____25599
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25626 = equal t1 t2  in
-                         (if uu____25626
+                         let uu____25603 = equal t1 t2  in
+                         (if uu____25603
                           then
-                            let uu____25629 =
+                            let uu____25606 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25629
+                            solve env uu____25606
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25634 =
-                            let uu____25641 = equal t1 t2  in
-                            if uu____25641
+                         (let uu____25611 =
+                            let uu____25618 = equal t1 t2  in
+                            if uu____25618
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25654 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25654 with
+                              (let uu____25631 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25631 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25634 with
+                          match uu____25611 with
                           | (guard,wl1) ->
-                              let uu____25675 = solve_prob orig guard [] wl1
+                              let uu____25652 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25675))
+                              solve env uu____25652))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25678,FStar_Syntax_Syntax.Tm_name uu____25679) ->
+              | (uu____25655,FStar_Syntax_Syntax.Tm_name uu____25656) ->
                   let head1 =
-                    let uu____25681 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25681
+                    let uu____25658 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25658
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25727 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25727
+                    let uu____25704 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25704
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25767 =
+                  ((let uu____25744 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25767
+                    if uu____25744
                     then
-                      let uu____25771 =
+                      let uu____25748 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25773 =
+                      let uu____25750 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25775 =
+                      let uu____25752 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25771 uu____25773 uu____25775
+                        uu____25748 uu____25750 uu____25752
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25789 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25789) &&
-                        (let uu____25793 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25793)
+                      (let uu____25766 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25766) &&
+                        (let uu____25770 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25770)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9484,9 +9466,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25812 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25812 = FStar_Syntax_Util.Equal  in
-                    let uu____25813 =
+                      let uu____25789 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25789 = FStar_Syntax_Util.Equal  in
+                    let uu____25790 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9495,72 +9477,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25813
+                    if uu____25790
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____25817 = equal t1 t2  in
-                         (if uu____25817
+                         let uu____25794 = equal t1 t2  in
+                         (if uu____25794
                           then
-                            let uu____25820 =
+                            let uu____25797 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____25820
+                            solve env uu____25797
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____25825 =
-                            let uu____25832 = equal t1 t2  in
-                            if uu____25832
+                         (let uu____25802 =
+                            let uu____25809 = equal t1 t2  in
+                            if uu____25809
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____25845 = mk_eq2 wl env orig t1 t2  in
-                               match uu____25845 with
+                              (let uu____25822 = mk_eq2 wl env orig t1 t2  in
+                               match uu____25822 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____25825 with
+                          match uu____25802 with
                           | (guard,wl1) ->
-                              let uu____25866 = solve_prob orig guard [] wl1
+                              let uu____25843 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____25866))
+                              solve env uu____25843))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____25869,FStar_Syntax_Syntax.Tm_constant uu____25870) ->
+              | (uu____25846,FStar_Syntax_Syntax.Tm_constant uu____25847) ->
                   let head1 =
-                    let uu____25872 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____25872
+                    let uu____25849 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____25849
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____25912 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____25912
+                    let uu____25889 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____25889
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____25952 =
+                  ((let uu____25929 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____25952
+                    if uu____25929
                     then
-                      let uu____25956 =
+                      let uu____25933 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____25958 =
+                      let uu____25935 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____25960 =
+                      let uu____25937 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____25956 uu____25958 uu____25960
+                        uu____25933 uu____25935 uu____25937
                     else ());
                    (let no_free_uvars t =
-                      (let uu____25974 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____25974) &&
-                        (let uu____25978 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____25978)
+                      (let uu____25951 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____25951) &&
+                        (let uu____25955 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____25955)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9583,9 +9565,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____25997 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____25997 = FStar_Syntax_Util.Equal  in
-                    let uu____25998 =
+                      let uu____25974 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____25974 = FStar_Syntax_Util.Equal  in
+                    let uu____25975 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9594,72 +9576,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____25998
+                    if uu____25975
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____26002 = equal t1 t2  in
-                         (if uu____26002
+                         let uu____25979 = equal t1 t2  in
+                         (if uu____25979
                           then
-                            let uu____26005 =
+                            let uu____25982 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____26005
+                            solve env uu____25982
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____26010 =
-                            let uu____26017 = equal t1 t2  in
-                            if uu____26017
+                         (let uu____25987 =
+                            let uu____25994 = equal t1 t2  in
+                            if uu____25994
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____26030 = mk_eq2 wl env orig t1 t2  in
-                               match uu____26030 with
+                              (let uu____26007 = mk_eq2 wl env orig t1 t2  in
+                               match uu____26007 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____26010 with
+                          match uu____25987 with
                           | (guard,wl1) ->
-                              let uu____26051 = solve_prob orig guard [] wl1
+                              let uu____26028 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____26051))
+                              solve env uu____26028))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____26054,FStar_Syntax_Syntax.Tm_fvar uu____26055) ->
+              | (uu____26031,FStar_Syntax_Syntax.Tm_fvar uu____26032) ->
                   let head1 =
-                    let uu____26057 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____26057
+                    let uu____26034 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____26034
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____26103 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____26103
+                    let uu____26080 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____26080
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____26149 =
+                  ((let uu____26126 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____26149
+                    if uu____26126
                     then
-                      let uu____26153 =
+                      let uu____26130 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____26155 =
+                      let uu____26132 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____26157 =
+                      let uu____26134 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____26153 uu____26155 uu____26157
+                        uu____26130 uu____26132 uu____26134
                     else ());
                    (let no_free_uvars t =
-                      (let uu____26171 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____26171) &&
-                        (let uu____26175 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____26175)
+                      (let uu____26148 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____26148) &&
+                        (let uu____26152 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____26152)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9682,9 +9664,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____26194 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____26194 = FStar_Syntax_Util.Equal  in
-                    let uu____26195 =
+                      let uu____26171 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____26171 = FStar_Syntax_Util.Equal  in
+                    let uu____26172 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9693,72 +9675,72 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____26195
+                    if uu____26172
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____26199 = equal t1 t2  in
-                         (if uu____26199
+                         let uu____26176 = equal t1 t2  in
+                         (if uu____26176
                           then
-                            let uu____26202 =
+                            let uu____26179 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____26202
+                            solve env uu____26179
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____26207 =
-                            let uu____26214 = equal t1 t2  in
-                            if uu____26214
+                         (let uu____26184 =
+                            let uu____26191 = equal t1 t2  in
+                            if uu____26191
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____26227 = mk_eq2 wl env orig t1 t2  in
-                               match uu____26227 with
+                              (let uu____26204 = mk_eq2 wl env orig t1 t2  in
+                               match uu____26204 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____26207 with
+                          match uu____26184 with
                           | (guard,wl1) ->
-                              let uu____26248 = solve_prob orig guard [] wl1
+                              let uu____26225 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____26248))
+                              solve env uu____26225))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____26251,FStar_Syntax_Syntax.Tm_app uu____26252) ->
+              | (uu____26228,FStar_Syntax_Syntax.Tm_app uu____26229) ->
                   let head1 =
-                    let uu____26270 = FStar_Syntax_Util.head_and_args t1  in
-                    FStar_All.pipe_right uu____26270
+                    let uu____26247 = FStar_Syntax_Util.head_and_args t1  in
+                    FStar_All.pipe_right uu____26247
                       FStar_Pervasives_Native.fst
                      in
                   let head2 =
-                    let uu____26310 = FStar_Syntax_Util.head_and_args t2  in
-                    FStar_All.pipe_right uu____26310
+                    let uu____26287 = FStar_Syntax_Util.head_and_args t2  in
+                    FStar_All.pipe_right uu____26287
                       FStar_Pervasives_Native.fst
                      in
-                  ((let uu____26350 =
+                  ((let uu____26327 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel")
                        in
-                    if uu____26350
+                    if uu____26327
                     then
-                      let uu____26354 =
+                      let uu____26331 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid
                          in
-                      let uu____26356 =
+                      let uu____26333 =
                         FStar_Syntax_Print.term_to_string head1  in
-                      let uu____26358 =
+                      let uu____26335 =
                         FStar_Syntax_Print.term_to_string head2  in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____26354 uu____26356 uu____26358
+                        uu____26331 uu____26333 uu____26335
                     else ());
                    (let no_free_uvars t =
-                      (let uu____26372 = FStar_Syntax_Free.uvars t  in
-                       FStar_Util.set_is_empty uu____26372) &&
-                        (let uu____26376 = FStar_Syntax_Free.univs t  in
-                         FStar_Util.set_is_empty uu____26376)
+                      (let uu____26349 = FStar_Syntax_Free.uvars t  in
+                       FStar_Util.set_is_empty uu____26349) &&
+                        (let uu____26353 = FStar_Syntax_Free.univs t  in
+                         FStar_Util.set_is_empty uu____26353)
                        in
                     let equal t11 t21 =
                       let t12 =
@@ -9781,9 +9763,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21
                          in
-                      let uu____26395 = FStar_Syntax_Util.eq_tm t12 t22  in
-                      uu____26395 = FStar_Syntax_Util.Equal  in
-                    let uu____26396 =
+                      let uu____26372 = FStar_Syntax_Util.eq_tm t12 t22  in
+                      uu____26372 = FStar_Syntax_Util.Equal  in
+                    let uu____26373 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9792,88 +9774,88 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                          && (no_free_uvars t1))
                         && (no_free_uvars t2)
                        in
-                    if uu____26396
+                    if uu____26373
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____26400 = equal t1 t2  in
-                         (if uu____26400
+                         let uu____26377 = equal t1 t2  in
+                         (if uu____26377
                           then
-                            let uu____26403 =
+                            let uu____26380 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl
                                in
-                            solve env uu____26403
+                            solve env uu____26380
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____26408 =
-                            let uu____26415 = equal t1 t2  in
-                            if uu____26415
+                         (let uu____26385 =
+                            let uu____26392 = equal t1 t2  in
+                            if uu____26392
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____26428 = mk_eq2 wl env orig t1 t2  in
-                               match uu____26428 with
+                              (let uu____26405 = mk_eq2 wl env orig t1 t2  in
+                               match uu____26405 with
                                | (g,wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1))
                              in
-                          match uu____26408 with
+                          match uu____26385 with
                           | (guard,wl1) ->
-                              let uu____26449 = solve_prob orig guard [] wl1
+                              let uu____26426 = solve_prob orig guard [] wl1
                                  in
-                              solve env uu____26449))
+                              solve env uu____26426))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
               | (FStar_Syntax_Syntax.Tm_let
-                 uu____26452,FStar_Syntax_Syntax.Tm_let uu____26453) ->
-                  let uu____26480 = FStar_Syntax_Util.term_eq t1 t2  in
-                  if uu____26480
+                 uu____26429,FStar_Syntax_Syntax.Tm_let uu____26430) ->
+                  let uu____26457 = FStar_Syntax_Util.term_eq t1 t2  in
+                  if uu____26457
                   then
-                    let uu____26483 =
+                    let uu____26460 =
                       solve_prob orig FStar_Pervasives_Native.None [] wl  in
-                    solve env uu____26483
+                    solve env uu____26460
                   else
-                    (let uu____26486 = FStar_Thunk.mkv "Tm_let mismatch"  in
-                     giveup env uu____26486 orig)
-              | (FStar_Syntax_Syntax.Tm_let uu____26489,uu____26490) ->
-                  let uu____26504 =
-                    let uu____26510 =
-                      let uu____26512 = FStar_Syntax_Print.tag_of_term t1  in
-                      let uu____26514 = FStar_Syntax_Print.tag_of_term t2  in
-                      let uu____26516 = FStar_Syntax_Print.term_to_string t1
+                    (let uu____26463 = FStar_Thunk.mkv "Tm_let mismatch"  in
+                     giveup env uu____26463 orig)
+              | (FStar_Syntax_Syntax.Tm_let uu____26466,uu____26467) ->
+                  let uu____26481 =
+                    let uu____26487 =
+                      let uu____26489 = FStar_Syntax_Print.tag_of_term t1  in
+                      let uu____26491 = FStar_Syntax_Print.tag_of_term t2  in
+                      let uu____26493 = FStar_Syntax_Print.term_to_string t1
                          in
-                      let uu____26518 = FStar_Syntax_Print.term_to_string t2
-                         in
-                      FStar_Util.format4
-                        "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____26512 uu____26514 uu____26516 uu____26518
-                       in
-                    (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____26510)
-                     in
-                  FStar_Errors.raise_error uu____26504
-                    t1.FStar_Syntax_Syntax.pos
-              | (uu____26522,FStar_Syntax_Syntax.Tm_let uu____26523) ->
-                  let uu____26537 =
-                    let uu____26543 =
-                      let uu____26545 = FStar_Syntax_Print.tag_of_term t1  in
-                      let uu____26547 = FStar_Syntax_Print.tag_of_term t2  in
-                      let uu____26549 = FStar_Syntax_Print.term_to_string t1
-                         in
-                      let uu____26551 = FStar_Syntax_Print.term_to_string t2
+                      let uu____26495 = FStar_Syntax_Print.term_to_string t2
                          in
                       FStar_Util.format4
                         "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____26545 uu____26547 uu____26549 uu____26551
+                        uu____26489 uu____26491 uu____26493 uu____26495
                        in
                     (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____26543)
+                      uu____26487)
                      in
-                  FStar_Errors.raise_error uu____26537
+                  FStar_Errors.raise_error uu____26481
                     t1.FStar_Syntax_Syntax.pos
-              | uu____26555 ->
-                  let uu____26560 = FStar_Thunk.mkv "head tag mismatch"  in
-                  giveup env uu____26560 orig))))
+              | (uu____26499,FStar_Syntax_Syntax.Tm_let uu____26500) ->
+                  let uu____26514 =
+                    let uu____26520 =
+                      let uu____26522 = FStar_Syntax_Print.tag_of_term t1  in
+                      let uu____26524 = FStar_Syntax_Print.tag_of_term t2  in
+                      let uu____26526 = FStar_Syntax_Print.term_to_string t1
+                         in
+                      let uu____26528 = FStar_Syntax_Print.term_to_string t2
+                         in
+                      FStar_Util.format4
+                        "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
+                        uu____26522 uu____26524 uu____26526 uu____26528
+                       in
+                    (FStar_Errors.Fatal_UnificationNotWellFormed,
+                      uu____26520)
+                     in
+                  FStar_Errors.raise_error uu____26514
+                    t1.FStar_Syntax_Syntax.pos
+              | uu____26532 ->
+                  let uu____26537 = FStar_Thunk.mkv "head tag mismatch"  in
+                  giveup env uu____26537 orig))))
 
 and (solve_c :
   FStar_TypeChecker_Env.env ->
@@ -9891,154 +9873,152 @@ and (solve_c :
             reason
            in
         let solve_eq c1_comp c2_comp g_lift =
-          (let uu____26626 =
+          (let uu____26603 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "EQ")
               in
-           if uu____26626
+           if uu____26603
            then
-             let uu____26631 =
-               let uu____26633 = FStar_Syntax_Syntax.mk_Comp c1_comp  in
-               FStar_Syntax_Print.comp_to_string uu____26633  in
-             let uu____26634 =
-               let uu____26636 = FStar_Syntax_Syntax.mk_Comp c2_comp  in
-               FStar_Syntax_Print.comp_to_string uu____26636  in
+             let uu____26608 =
+               let uu____26610 = FStar_Syntax_Syntax.mk_Comp c1_comp  in
+               FStar_Syntax_Print.comp_to_string uu____26610  in
+             let uu____26611 =
+               let uu____26613 = FStar_Syntax_Syntax.mk_Comp c2_comp  in
+               FStar_Syntax_Print.comp_to_string uu____26613  in
              FStar_Util.print2
                "solve_c is using an equality constraint (%s vs %s)\n"
-               uu____26631 uu____26634
+               uu____26608 uu____26611
            else ());
-          (let uu____26640 =
-             let uu____26642 =
+          (let uu____26617 =
+             let uu____26619 =
                FStar_Ident.lid_equals c1_comp.FStar_Syntax_Syntax.effect_name
                  c2_comp.FStar_Syntax_Syntax.effect_name
                 in
-             Prims.op_Negation uu____26642  in
-           if uu____26640
+             Prims.op_Negation uu____26619  in
+           if uu____26617
            then
-             let uu____26645 =
+             let uu____26622 =
                mklstr
-                 (fun uu____26652  ->
-                    let uu____26653 =
+                 (fun uu____26629  ->
+                    let uu____26630 =
                       FStar_Syntax_Print.lid_to_string
                         c1_comp.FStar_Syntax_Syntax.effect_name
                        in
-                    let uu____26655 =
+                    let uu____26632 =
                       FStar_Syntax_Print.lid_to_string
                         c2_comp.FStar_Syntax_Syntax.effect_name
                        in
                     FStar_Util.format2 "incompatible effects: %s <> %s"
-                      uu____26653 uu____26655)
+                      uu____26630 uu____26632)
                 in
-             giveup env uu____26645 orig
+             giveup env uu____26622 orig
            else
              if
                (FStar_List.length c1_comp.FStar_Syntax_Syntax.effect_args) <>
                  (FStar_List.length c2_comp.FStar_Syntax_Syntax.effect_args)
              then
-               (let uu____26677 =
+               (let uu____26654 =
                   mklstr
-                    (fun uu____26684  ->
-                       let uu____26685 =
+                    (fun uu____26661  ->
+                       let uu____26662 =
                          FStar_Syntax_Print.args_to_string
                            c1_comp.FStar_Syntax_Syntax.effect_args
                           in
-                       let uu____26687 =
+                       let uu____26664 =
                          FStar_Syntax_Print.args_to_string
                            c2_comp.FStar_Syntax_Syntax.effect_args
                           in
                        FStar_Util.format2
                          "incompatible effect arguments: %s <> %s"
-                         uu____26685 uu____26687)
+                         uu____26662 uu____26664)
                    in
-                giveup env uu____26677 orig)
+                giveup env uu____26654 orig)
              else
-               (let uu____26692 =
+               (let uu____26669 =
                   FStar_List.fold_left2
-                    (fun uu____26713  ->
+                    (fun uu____26690  ->
                        fun u1  ->
                          fun u2  ->
-                           match uu____26713 with
+                           match uu____26690 with
                            | (univ_sub_probs,wl1) ->
-                               let uu____26734 =
-                                 let uu____26739 =
+                               let uu____26711 =
+                                 let uu____26716 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u1)
-                                     FStar_Pervasives_Native.None
                                      FStar_Range.dummyRange
                                     in
-                                 let uu____26740 =
+                                 let uu____26717 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u2)
-                                     FStar_Pervasives_Native.None
                                      FStar_Range.dummyRange
                                     in
-                                 sub_prob wl1 uu____26739
-                                   FStar_TypeChecker_Common.EQ uu____26740
+                                 sub_prob wl1 uu____26716
+                                   FStar_TypeChecker_Common.EQ uu____26717
                                    "effect universes"
                                   in
-                               (match uu____26734 with
+                               (match uu____26711 with
                                 | (p,wl2) ->
                                     ((FStar_List.append univ_sub_probs [p]),
                                       wl2))) ([], wl)
                     c1_comp.FStar_Syntax_Syntax.comp_univs
                     c2_comp.FStar_Syntax_Syntax.comp_univs
                    in
-                match uu____26692 with
+                match uu____26669 with
                 | (univ_sub_probs,wl1) ->
-                    let uu____26760 =
+                    let uu____26737 =
                       sub_prob wl1 c1_comp.FStar_Syntax_Syntax.result_typ
                         FStar_TypeChecker_Common.EQ
                         c2_comp.FStar_Syntax_Syntax.result_typ
                         "effect ret type"
                        in
-                    (match uu____26760 with
+                    (match uu____26737 with
                      | (ret_sub_prob,wl2) ->
-                         let uu____26768 =
+                         let uu____26745 =
                            FStar_List.fold_right2
-                             (fun uu____26805  ->
-                                fun uu____26806  ->
-                                  fun uu____26807  ->
-                                    match (uu____26805, uu____26806,
-                                            uu____26807)
+                             (fun uu____26782  ->
+                                fun uu____26783  ->
+                                  fun uu____26784  ->
+                                    match (uu____26782, uu____26783,
+                                            uu____26784)
                                     with
-                                    | ((a1,uu____26851),(a2,uu____26853),
+                                    | ((a1,uu____26828),(a2,uu____26830),
                                        (arg_sub_probs,wl3)) ->
-                                        let uu____26886 =
+                                        let uu____26863 =
                                           sub_prob wl3 a1
                                             FStar_TypeChecker_Common.EQ a2
                                             "effect arg"
                                            in
-                                        (match uu____26886 with
+                                        (match uu____26863 with
                                          | (p,wl4) ->
                                              ((p :: arg_sub_probs), wl4)))
                              c1_comp.FStar_Syntax_Syntax.effect_args
                              c2_comp.FStar_Syntax_Syntax.effect_args
                              ([], wl2)
                             in
-                         (match uu____26768 with
+                         (match uu____26745 with
                           | (arg_sub_probs,wl3) ->
                               let sub_probs =
-                                let uu____26913 =
-                                  let uu____26916 =
-                                    let uu____26919 =
+                                let uu____26890 =
+                                  let uu____26893 =
+                                    let uu____26896 =
                                       FStar_All.pipe_right
                                         g_lift.FStar_TypeChecker_Common.deferred
                                         (FStar_List.map
                                            FStar_Pervasives_Native.snd)
                                        in
                                     FStar_List.append arg_sub_probs
-                                      uu____26919
+                                      uu____26896
                                      in
                                   FStar_List.append [ret_sub_prob]
-                                    uu____26916
+                                    uu____26893
                                    in
-                                FStar_List.append univ_sub_probs uu____26913
+                                FStar_List.append univ_sub_probs uu____26890
                                  in
                               let guard =
                                 let guard =
-                                  let uu____26941 =
+                                  let uu____26918 =
                                     FStar_List.map p_guard sub_probs  in
-                                  FStar_Syntax_Util.mk_conj_l uu____26941  in
+                                  FStar_Syntax_Util.mk_conj_l uu____26918  in
                                 match g_lift.FStar_TypeChecker_Common.guard_f
                                 with
                                 | FStar_TypeChecker_Common.Trivial  -> guard
@@ -10046,93 +10026,93 @@ and (solve_c :
                                     FStar_Syntax_Util.mk_conj guard f
                                  in
                               let wl4 =
-                                let uu___3530_26950 = wl3  in
+                                let uu___3530_26927 = wl3  in
                                 {
-                                  attempting = (uu___3530_26950.attempting);
-                                  wl_deferred = (uu___3530_26950.wl_deferred);
-                                  ctr = (uu___3530_26950.ctr);
-                                  defer_ok = (uu___3530_26950.defer_ok);
-                                  smt_ok = (uu___3530_26950.smt_ok);
+                                  attempting = (uu___3530_26927.attempting);
+                                  wl_deferred = (uu___3530_26927.wl_deferred);
+                                  ctr = (uu___3530_26927.ctr);
+                                  defer_ok = (uu___3530_26927.defer_ok);
+                                  smt_ok = (uu___3530_26927.smt_ok);
                                   umax_heuristic_ok =
-                                    (uu___3530_26950.umax_heuristic_ok);
-                                  tcenv = (uu___3530_26950.tcenv);
+                                    (uu___3530_26927.umax_heuristic_ok);
+                                  tcenv = (uu___3530_26927.tcenv);
                                   wl_implicits =
                                     (FStar_List.append
                                        g_lift.FStar_TypeChecker_Common.implicits
                                        wl3.wl_implicits);
                                   repr_subcomp_allowed =
-                                    (uu___3530_26950.repr_subcomp_allowed)
+                                    (uu___3530_26927.repr_subcomp_allowed)
                                 }  in
                               let wl5 =
                                 solve_prob orig
                                   (FStar_Pervasives_Native.Some guard) [] wl4
                                  in
-                              let uu____26952 = attempt sub_probs wl5  in
-                              solve env uu____26952))))
+                              let uu____26929 = attempt sub_probs wl5  in
+                              solve env uu____26929))))
            in
         let solve_layered_sub c11 edge c21 =
-          (let uu____26970 =
+          (let uu____26947 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffects")
               in
-           if uu____26970
+           if uu____26947
            then
-             let uu____26975 =
-               let uu____26977 =
+             let uu____26952 =
+               let uu____26954 =
                  FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp  in
-               FStar_All.pipe_right uu____26977
+               FStar_All.pipe_right uu____26954
                  FStar_Syntax_Print.comp_to_string
                 in
-             let uu____26979 =
-               let uu____26981 =
+             let uu____26956 =
+               let uu____26958 =
                  FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp  in
-               FStar_All.pipe_right uu____26981
+               FStar_All.pipe_right uu____26958
                  FStar_Syntax_Print.comp_to_string
                 in
              FStar_Util.print2 "solve_layered_sub c1: %s and c2: %s\n"
-               uu____26975 uu____26979
+               uu____26952 uu____26956
            else ());
-          (let uu____26986 =
-             let uu____26991 =
-               let uu____26996 =
+          (let uu____26963 =
+             let uu____26968 =
+               let uu____26973 =
                  FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp  in
-               FStar_All.pipe_right uu____26996
+               FStar_All.pipe_right uu____26973
                  ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                     env)
                 in
-             FStar_All.pipe_right uu____26991
-               (fun uu____27013  ->
-                  match uu____27013 with
+             FStar_All.pipe_right uu____26968
+               (fun uu____26990  ->
+                  match uu____26990 with
                   | (c,g) ->
-                      let uu____27024 = FStar_Syntax_Util.comp_to_comp_typ c
+                      let uu____27001 = FStar_Syntax_Util.comp_to_comp_typ c
                          in
-                      (uu____27024, g))
+                      (uu____27001, g))
               in
-           match uu____26986 with
+           match uu____26963 with
            | (c12,g_lift) ->
-               ((let uu____27028 =
+               ((let uu____27005 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                      (FStar_Options.Other "LayeredEffects")
                     in
-                 if uu____27028
+                 if uu____27005
                  then
-                   let uu____27033 =
-                     let uu____27035 =
+                   let uu____27010 =
+                     let uu____27012 =
                        FStar_All.pipe_right c12 FStar_Syntax_Syntax.mk_Comp
                         in
-                     FStar_All.pipe_right uu____27035
+                     FStar_All.pipe_right uu____27012
                        FStar_Syntax_Print.comp_to_string
                       in
-                   let uu____27037 =
-                     let uu____27039 =
+                   let uu____27014 =
+                     let uu____27016 =
                        FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp
                         in
-                     FStar_All.pipe_right uu____27039
+                     FStar_All.pipe_right uu____27016
                        FStar_Syntax_Print.comp_to_string
                       in
                    FStar_Util.print2
                      "solve_layered_sub after lift c1: %s and c2: %s\n"
-                     uu____27033 uu____27037
+                     uu____27010 uu____27014
                  else ());
                 if
                   problem.FStar_TypeChecker_Common.relation =
@@ -10141,337 +10121,337 @@ and (solve_c :
                 else
                   (let r = FStar_TypeChecker_Env.get_range env  in
                    let wl1 =
-                     let uu___3550_27049 = wl  in
+                     let uu___3550_27026 = wl  in
                      {
-                       attempting = (uu___3550_27049.attempting);
-                       wl_deferred = (uu___3550_27049.wl_deferred);
-                       ctr = (uu___3550_27049.ctr);
-                       defer_ok = (uu___3550_27049.defer_ok);
-                       smt_ok = (uu___3550_27049.smt_ok);
+                       attempting = (uu___3550_27026.attempting);
+                       wl_deferred = (uu___3550_27026.wl_deferred);
+                       ctr = (uu___3550_27026.ctr);
+                       defer_ok = (uu___3550_27026.defer_ok);
+                       smt_ok = (uu___3550_27026.smt_ok);
                        umax_heuristic_ok =
-                         (uu___3550_27049.umax_heuristic_ok);
-                       tcenv = (uu___3550_27049.tcenv);
+                         (uu___3550_27026.umax_heuristic_ok);
+                       tcenv = (uu___3550_27026.tcenv);
                        wl_implicits =
                          (FStar_List.append
                             g_lift.FStar_TypeChecker_Common.implicits
                             wl.wl_implicits);
                        repr_subcomp_allowed =
-                         (uu___3550_27049.repr_subcomp_allowed)
+                         (uu___3550_27026.repr_subcomp_allowed)
                      }  in
-                   let uu____27050 =
+                   let uu____27027 =
                      let rec is_uvar t =
-                       let uu____27064 =
-                         let uu____27065 = FStar_Syntax_Subst.compress t  in
-                         uu____27065.FStar_Syntax_Syntax.n  in
-                       match uu____27064 with
-                       | FStar_Syntax_Syntax.Tm_uvar uu____27069 -> true
-                       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____27084) ->
+                       let uu____27041 =
+                         let uu____27042 = FStar_Syntax_Subst.compress t  in
+                         uu____27042.FStar_Syntax_Syntax.n  in
+                       match uu____27041 with
+                       | FStar_Syntax_Syntax.Tm_uvar uu____27046 -> true
+                       | FStar_Syntax_Syntax.Tm_uinst (t1,uu____27061) ->
                            is_uvar t1
-                       | FStar_Syntax_Syntax.Tm_app (t1,uu____27090) ->
+                       | FStar_Syntax_Syntax.Tm_app (t1,uu____27067) ->
                            is_uvar t1
-                       | uu____27115 -> false  in
+                       | uu____27092 -> false  in
                      FStar_List.fold_right2
-                       (fun uu____27149  ->
-                          fun uu____27150  ->
-                            fun uu____27151  ->
-                              match (uu____27149, uu____27150, uu____27151)
+                       (fun uu____27126  ->
+                          fun uu____27127  ->
+                            fun uu____27128  ->
+                              match (uu____27126, uu____27127, uu____27128)
                               with
-                              | ((a1,uu____27195),(a2,uu____27197),(is_sub_probs,wl2))
+                              | ((a1,uu____27172),(a2,uu____27174),(is_sub_probs,wl2))
                                   ->
-                                  let uu____27230 = is_uvar a1  in
-                                  if uu____27230
+                                  let uu____27207 = is_uvar a1  in
+                                  if uu____27207
                                   then
-                                    ((let uu____27240 =
+                                    ((let uu____27217 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env)
                                           (FStar_Options.Other
                                              "LayeredEffects")
                                          in
-                                      if uu____27240
+                                      if uu____27217
                                       then
-                                        let uu____27245 =
+                                        let uu____27222 =
                                           FStar_Syntax_Print.term_to_string
                                             a1
                                            in
-                                        let uu____27247 =
+                                        let uu____27224 =
                                           FStar_Syntax_Print.term_to_string
                                             a2
                                            in
                                         FStar_Util.print2
                                           "solve_layered_sub: adding index equality for %s and %s (since a1 uvar)\n"
-                                          uu____27245 uu____27247
+                                          uu____27222 uu____27224
                                       else ());
-                                     (let uu____27252 =
+                                     (let uu____27229 =
                                         sub_prob wl2 a1
                                           FStar_TypeChecker_Common.EQ a2
                                           "l.h.s. effect index uvar"
                                          in
-                                      match uu____27252 with
+                                      match uu____27229 with
                                       | (p,wl3) -> ((p :: is_sub_probs), wl3)))
                                   else (is_sub_probs, wl2))
                        c12.FStar_Syntax_Syntax.effect_args
                        c21.FStar_Syntax_Syntax.effect_args ([], wl1)
                       in
-                   match uu____27050 with
+                   match uu____27027 with
                    | (is_sub_probs,wl2) ->
-                       let uu____27280 =
+                       let uu____27257 =
                          sub_prob wl2 c12.FStar_Syntax_Syntax.result_typ
                            problem.FStar_TypeChecker_Common.relation
                            c21.FStar_Syntax_Syntax.result_typ "result type"
                           in
-                       (match uu____27280 with
+                       (match uu____27257 with
                         | (ret_sub_prob,wl3) ->
-                            let uu____27288 =
-                              let uu____27293 =
-                                let uu____27294 =
+                            let uu____27265 =
+                              let uu____27270 =
+                                let uu____27271 =
                                   FStar_All.pipe_right
                                     c21.FStar_Syntax_Syntax.effect_name
                                     (FStar_TypeChecker_Env.get_effect_decl
                                        env)
                                    in
-                                FStar_All.pipe_right uu____27294
+                                FStar_All.pipe_right uu____27271
                                   FStar_Syntax_Util.get_stronger_vc_combinator
                                  in
-                              FStar_All.pipe_right uu____27293
+                              FStar_All.pipe_right uu____27270
                                 (fun ts  ->
                                    FStar_TypeChecker_Env.inst_tscheme_with ts
                                      c21.FStar_Syntax_Syntax.comp_univs)
                                in
-                            (match uu____27288 with
-                             | (uu____27301,stronger_t) ->
+                            (match uu____27265 with
+                             | (uu____27278,stronger_t) ->
                                  let stronger_t_shape_error s =
-                                   let uu____27312 =
+                                   let uu____27289 =
                                      FStar_Ident.string_of_lid
                                        c21.FStar_Syntax_Syntax.effect_name
                                       in
-                                   let uu____27314 =
+                                   let uu____27291 =
                                      FStar_Syntax_Print.term_to_string
                                        stronger_t
                                       in
                                    FStar_Util.format3
                                      "Unexpected shape of stronger for %s, reason: %s (t:%s)"
-                                     uu____27312 s uu____27314
+                                     uu____27289 s uu____27291
                                     in
-                                 let uu____27317 =
-                                   let uu____27346 =
-                                     let uu____27347 =
+                                 let uu____27294 =
+                                   let uu____27323 =
+                                     let uu____27324 =
                                        FStar_Syntax_Subst.compress stronger_t
                                         in
-                                     uu____27347.FStar_Syntax_Syntax.n  in
-                                   match uu____27346 with
+                                     uu____27324.FStar_Syntax_Syntax.n  in
+                                   match uu____27323 with
                                    | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
                                        (FStar_List.length bs) >=
                                          (Prims.of_int (2))
                                        ->
-                                       let uu____27407 =
+                                       let uu____27384 =
                                          FStar_Syntax_Subst.open_comp bs c
                                           in
-                                       (match uu____27407 with
+                                       (match uu____27384 with
                                         | (bs',c3) ->
                                             let a = FStar_List.hd bs'  in
                                             let bs1 = FStar_List.tail bs'  in
-                                            let uu____27470 =
-                                              let uu____27489 =
+                                            let uu____27447 =
+                                              let uu____27466 =
                                                 FStar_All.pipe_right bs1
                                                   (FStar_List.splitAt
                                                      ((FStar_List.length bs1)
                                                         - Prims.int_one))
                                                  in
                                               FStar_All.pipe_right
-                                                uu____27489
-                                                (fun uu____27593  ->
-                                                   match uu____27593 with
+                                                uu____27466
+                                                (fun uu____27570  ->
+                                                   match uu____27570 with
                                                    | (l1,l2) ->
-                                                       let uu____27666 =
+                                                       let uu____27643 =
                                                          FStar_List.hd l2  in
-                                                       (l1, uu____27666))
+                                                       (l1, uu____27643))
                                                in
-                                            (match uu____27470 with
+                                            (match uu____27447 with
                                              | (rest_bs,f_b) ->
                                                  (a, rest_bs, f_b, c3)))
-                                   | uu____27771 ->
-                                       let uu____27772 =
-                                         let uu____27778 =
+                                   | uu____27748 ->
+                                       let uu____27749 =
+                                         let uu____27755 =
                                            stronger_t_shape_error
                                              "not an arrow or not enough binders"
                                             in
                                          (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                           uu____27778)
+                                           uu____27755)
                                           in
-                                       FStar_Errors.raise_error uu____27772 r
+                                       FStar_Errors.raise_error uu____27749 r
                                     in
-                                 (match uu____27317 with
+                                 (match uu____27294 with
                                   | (a_b,rest_bs,f_b,stronger_c) ->
-                                      let uu____27854 =
-                                        let uu____27861 =
-                                          let uu____27862 =
-                                            let uu____27863 =
-                                              let uu____27870 =
+                                      let uu____27831 =
+                                        let uu____27838 =
+                                          let uu____27839 =
+                                            let uu____27840 =
+                                              let uu____27847 =
                                                 FStar_All.pipe_right a_b
                                                   FStar_Pervasives_Native.fst
                                                  in
-                                              (uu____27870,
+                                              (uu____27847,
                                                 (c21.FStar_Syntax_Syntax.result_typ))
                                                in
                                             FStar_Syntax_Syntax.NT
-                                              uu____27863
+                                              uu____27840
                                              in
-                                          [uu____27862]  in
+                                          [uu____27839]  in
                                         FStar_TypeChecker_Env.uvars_for_binders
-                                          env rest_bs uu____27861
+                                          env rest_bs uu____27838
                                           (fun b  ->
-                                             let uu____27886 =
+                                             let uu____27863 =
                                                FStar_Syntax_Print.binder_to_string
                                                  b
                                                 in
-                                             let uu____27888 =
+                                             let uu____27865 =
                                                FStar_Ident.string_of_lid
                                                  c21.FStar_Syntax_Syntax.effect_name
                                                 in
-                                             let uu____27890 =
+                                             let uu____27867 =
                                                FStar_Range.string_of_range r
                                                 in
                                              FStar_Util.format3
                                                "implicit for binder %s in stronger of %s at %s"
-                                               uu____27886 uu____27888
-                                               uu____27890) r
+                                               uu____27863 uu____27865
+                                               uu____27867) r
                                          in
-                                      (match uu____27854 with
+                                      (match uu____27831 with
                                        | (rest_bs_uvars,g_uvars) ->
-                                           ((let uu____27900 =
+                                           ((let uu____27877 =
                                                FStar_All.pipe_left
                                                  (FStar_TypeChecker_Env.debug
                                                     env)
                                                  (FStar_Options.Other
                                                     "LayeredEffects")
                                                 in
-                                             if uu____27900
+                                             if uu____27877
                                              then
-                                               let uu____27905 =
+                                               let uu____27882 =
                                                  FStar_List.fold_left
                                                    (fun s  ->
                                                       fun u  ->
-                                                        let uu____27914 =
-                                                          let uu____27916 =
+                                                        let uu____27891 =
+                                                          let uu____27893 =
                                                             FStar_Syntax_Print.term_to_string
                                                               u
                                                              in
                                                           Prims.op_Hat ";;;;"
-                                                            uu____27916
+                                                            uu____27893
                                                            in
                                                         Prims.op_Hat s
-                                                          uu____27914) ""
+                                                          uu____27891) ""
                                                    rest_bs_uvars
                                                   in
                                                FStar_Util.print1
                                                  "Introduced uvars for subcomp: %s\n"
-                                                 uu____27905
+                                                 uu____27882
                                              else ());
                                             (let wl4 =
-                                               let uu___3622_27924 = wl3  in
+                                               let uu___3622_27901 = wl3  in
                                                {
                                                  attempting =
-                                                   (uu___3622_27924.attempting);
+                                                   (uu___3622_27901.attempting);
                                                  wl_deferred =
-                                                   (uu___3622_27924.wl_deferred);
-                                                 ctr = (uu___3622_27924.ctr);
+                                                   (uu___3622_27901.wl_deferred);
+                                                 ctr = (uu___3622_27901.ctr);
                                                  defer_ok =
-                                                   (uu___3622_27924.defer_ok);
+                                                   (uu___3622_27901.defer_ok);
                                                  smt_ok =
-                                                   (uu___3622_27924.smt_ok);
+                                                   (uu___3622_27901.smt_ok);
                                                  umax_heuristic_ok =
-                                                   (uu___3622_27924.umax_heuristic_ok);
+                                                   (uu___3622_27901.umax_heuristic_ok);
                                                  tcenv =
-                                                   (uu___3622_27924.tcenv);
+                                                   (uu___3622_27901.tcenv);
                                                  wl_implicits =
                                                    (FStar_List.append
                                                       g_uvars.FStar_TypeChecker_Common.implicits
                                                       wl3.wl_implicits);
                                                  repr_subcomp_allowed =
-                                                   (uu___3622_27924.repr_subcomp_allowed)
+                                                   (uu___3622_27901.repr_subcomp_allowed)
                                                }  in
                                              let substs =
                                                FStar_List.map2
                                                  (fun b  ->
                                                     fun t  ->
-                                                      let uu____27949 =
-                                                        let uu____27956 =
+                                                      let uu____27926 =
+                                                        let uu____27933 =
                                                           FStar_All.pipe_right
                                                             b
                                                             FStar_Pervasives_Native.fst
                                                            in
-                                                        (uu____27956, t)  in
+                                                        (uu____27933, t)  in
                                                       FStar_Syntax_Syntax.NT
-                                                        uu____27949) (a_b ::
+                                                        uu____27926) (a_b ::
                                                  rest_bs)
                                                  ((c21.FStar_Syntax_Syntax.result_typ)
                                                  :: rest_bs_uvars)
                                                 in
-                                             let uu____27973 =
+                                             let uu____27950 =
                                                let f_sort_is =
-                                                 let uu____27983 =
-                                                   let uu____27984 =
-                                                     let uu____27987 =
-                                                       let uu____27988 =
+                                                 let uu____27960 =
+                                                   let uu____27961 =
+                                                     let uu____27964 =
+                                                       let uu____27965 =
                                                          FStar_All.pipe_right
                                                            f_b
                                                            FStar_Pervasives_Native.fst
                                                           in
-                                                       uu____27988.FStar_Syntax_Syntax.sort
+                                                       uu____27965.FStar_Syntax_Syntax.sort
                                                         in
                                                      FStar_Syntax_Subst.compress
-                                                       uu____27987
+                                                       uu____27964
                                                       in
-                                                   uu____27984.FStar_Syntax_Syntax.n
+                                                   uu____27961.FStar_Syntax_Syntax.n
                                                     in
-                                                 match uu____27983 with
+                                                 match uu____27960 with
                                                  | FStar_Syntax_Syntax.Tm_app
-                                                     (uu____27999,uu____28000::is)
+                                                     (uu____27976,uu____27977::is)
                                                      ->
-                                                     let uu____28042 =
+                                                     let uu____28019 =
                                                        FStar_All.pipe_right
                                                          is
                                                          (FStar_List.map
                                                             FStar_Pervasives_Native.fst)
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____28042
+                                                       uu____28019
                                                        (FStar_List.map
                                                           (FStar_Syntax_Subst.subst
                                                              substs))
-                                                 | uu____28075 ->
-                                                     let uu____28076 =
-                                                       let uu____28082 =
+                                                 | uu____28052 ->
+                                                     let uu____28053 =
+                                                       let uu____28059 =
                                                          stronger_t_shape_error
                                                            "type of f is not a repr type"
                                                           in
                                                        (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                                         uu____28082)
+                                                         uu____28059)
                                                         in
                                                      FStar_Errors.raise_error
-                                                       uu____28076 r
+                                                       uu____28053 r
                                                   in
-                                               let uu____28088 =
+                                               let uu____28065 =
                                                  FStar_All.pipe_right
                                                    c12.FStar_Syntax_Syntax.effect_args
                                                    (FStar_List.map
                                                       FStar_Pervasives_Native.fst)
                                                   in
                                                FStar_List.fold_left2
-                                                 (fun uu____28123  ->
+                                                 (fun uu____28100  ->
                                                     fun f_sort_i  ->
                                                       fun c1_i  ->
-                                                        match uu____28123
+                                                        match uu____28100
                                                         with
                                                         | (ps,wl5) ->
-                                                            let uu____28144 =
+                                                            let uu____28121 =
                                                               sub_prob wl5
                                                                 f_sort_i
                                                                 FStar_TypeChecker_Common.EQ
                                                                 c1_i
                                                                 "indices of c1"
                                                                in
-                                                            (match uu____28144
+                                                            (match uu____28121
                                                              with
                                                              | (p,wl6) ->
                                                                  ((FStar_List.append
@@ -10479,64 +10459,64 @@ and (solve_c :
                                                                     [p]),
                                                                    wl6)))
                                                  ([], wl4) f_sort_is
-                                                 uu____28088
+                                                 uu____28065
                                                 in
-                                             match uu____27973 with
+                                             match uu____27950 with
                                              | (f_sub_probs,wl5) ->
                                                  let stronger_ct =
-                                                   let uu____28169 =
+                                                   let uu____28146 =
                                                      FStar_All.pipe_right
                                                        stronger_c
                                                        (FStar_Syntax_Subst.subst_comp
                                                           substs)
                                                       in
                                                    FStar_All.pipe_right
-                                                     uu____28169
+                                                     uu____28146
                                                      FStar_Syntax_Util.comp_to_comp_typ
                                                     in
-                                                 let uu____28170 =
+                                                 let uu____28147 =
                                                    let g_sort_is =
-                                                     let uu____28180 =
-                                                       let uu____28181 =
+                                                     let uu____28157 =
+                                                       let uu____28158 =
                                                          FStar_Syntax_Subst.compress
                                                            stronger_ct.FStar_Syntax_Syntax.result_typ
                                                           in
-                                                       uu____28181.FStar_Syntax_Syntax.n
+                                                       uu____28158.FStar_Syntax_Syntax.n
                                                         in
-                                                     match uu____28180 with
+                                                     match uu____28157 with
                                                      | FStar_Syntax_Syntax.Tm_app
-                                                         (uu____28186,uu____28187::is)
+                                                         (uu____28163,uu____28164::is)
                                                          ->
                                                          FStar_All.pipe_right
                                                            is
                                                            (FStar_List.map
                                                               FStar_Pervasives_Native.fst)
-                                                     | uu____28247 ->
-                                                         let uu____28248 =
-                                                           let uu____28254 =
+                                                     | uu____28224 ->
+                                                         let uu____28225 =
+                                                           let uu____28231 =
                                                              stronger_t_shape_error
                                                                "return type is not a repr type"
                                                               in
                                                            (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                                             uu____28254)
+                                                             uu____28231)
                                                             in
                                                          FStar_Errors.raise_error
-                                                           uu____28248 r
+                                                           uu____28225 r
                                                       in
-                                                   let uu____28260 =
+                                                   let uu____28237 =
                                                      FStar_All.pipe_right
                                                        c21.FStar_Syntax_Syntax.effect_args
                                                        (FStar_List.map
                                                           FStar_Pervasives_Native.fst)
                                                       in
                                                    FStar_List.fold_left2
-                                                     (fun uu____28295  ->
+                                                     (fun uu____28272  ->
                                                         fun g_sort_i  ->
                                                           fun c2_i  ->
-                                                            match uu____28295
+                                                            match uu____28272
                                                             with
                                                             | (ps,wl6) ->
-                                                                let uu____28316
+                                                                let uu____28293
                                                                   =
                                                                   sub_prob
                                                                     wl6
@@ -10545,35 +10525,35 @@ and (solve_c :
                                                                     c2_i
                                                                     "indices of c2"
                                                                    in
-                                                                (match uu____28316
+                                                                (match uu____28293
                                                                  with
                                                                  | (p,wl7) ->
                                                                     ((FStar_List.append
                                                                     ps [p]),
                                                                     wl7)))
                                                      ([], wl5) g_sort_is
-                                                     uu____28260
+                                                     uu____28237
                                                     in
-                                                 (match uu____28170 with
+                                                 (match uu____28147 with
                                                   | (g_sub_probs,wl6) ->
                                                       let fml =
-                                                        let uu____28343 =
-                                                          let uu____28348 =
+                                                        let uu____28320 =
+                                                          let uu____28325 =
                                                             FStar_List.hd
                                                               stronger_ct.FStar_Syntax_Syntax.comp_univs
                                                              in
-                                                          let uu____28349 =
-                                                            let uu____28350 =
+                                                          let uu____28326 =
+                                                            let uu____28327 =
                                                               FStar_List.hd
                                                                 stronger_ct.FStar_Syntax_Syntax.effect_args
                                                                in
                                                             FStar_Pervasives_Native.fst
-                                                              uu____28350
+                                                              uu____28327
                                                              in
-                                                          (uu____28348,
-                                                            uu____28349)
+                                                          (uu____28325,
+                                                            uu____28326)
                                                            in
-                                                        match uu____28343
+                                                        match uu____28320
                                                         with
                                                         | (u,wp) ->
                                                             FStar_TypeChecker_Env.pure_precondition_for_trivial_post
@@ -10583,10 +10563,10 @@ and (solve_c :
                                                               FStar_Range.dummyRange
                                                          in
                                                       let sub_probs =
-                                                        let uu____28378 =
-                                                          let uu____28381 =
-                                                            let uu____28384 =
-                                                              let uu____28387
+                                                        let uu____28355 =
+                                                          let uu____28358 =
+                                                            let uu____28361 =
+                                                              let uu____28364
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   g_lift.FStar_TypeChecker_Common.deferred
@@ -10595,28 +10575,28 @@ and (solve_c :
                                                                  in
                                                               FStar_List.append
                                                                 g_sub_probs
-                                                                uu____28387
+                                                                uu____28364
                                                                in
                                                             FStar_List.append
                                                               f_sub_probs
-                                                              uu____28384
+                                                              uu____28361
                                                              in
                                                           FStar_List.append
                                                             is_sub_probs
-                                                            uu____28381
+                                                            uu____28358
                                                            in
                                                         ret_sub_prob ::
-                                                          uu____28378
+                                                          uu____28355
                                                          in
                                                       let guard =
                                                         let guard =
-                                                          let uu____28411 =
+                                                          let uu____28388 =
                                                             FStar_List.map
                                                               p_guard
                                                               sub_probs
                                                              in
                                                           FStar_Syntax_Util.mk_conj_l
-                                                            uu____28411
+                                                            uu____28388
                                                            in
                                                         match g_lift.FStar_TypeChecker_Common.guard_f
                                                         with
@@ -10628,25 +10608,25 @@ and (solve_c :
                                                               guard f
                                                          in
                                                       let wl7 =
-                                                        let uu____28422 =
-                                                          let uu____28425 =
+                                                        let uu____28399 =
+                                                          let uu____28402 =
                                                             FStar_Syntax_Util.mk_conj
                                                               guard fml
                                                              in
                                                           FStar_All.pipe_left
-                                                            (fun uu____28428 
+                                                            (fun uu____28405 
                                                                ->
                                                                FStar_Pervasives_Native.Some
-                                                                 uu____28428)
-                                                            uu____28425
+                                                                 uu____28405)
+                                                            uu____28402
                                                            in
                                                         solve_prob orig
-                                                          uu____28422 [] wl6
+                                                          uu____28399 [] wl6
                                                          in
-                                                      let uu____28429 =
+                                                      let uu____28406 =
                                                         attempt sub_probs wl7
                                                          in
-                                                      solve env uu____28429))))))))))
+                                                      solve env uu____28406))))))))))
            in
         let solve_sub c11 edge c21 =
           if
@@ -10655,266 +10635,266 @@ and (solve_c :
           then failwith "impossible: solve_sub"
           else ();
           (let r = FStar_TypeChecker_Env.get_range env  in
-           let lift_c1 uu____28457 =
+           let lift_c1 uu____28434 =
              let univs =
                match c11.FStar_Syntax_Syntax.comp_univs with
                | [] ->
-                   let uu____28459 =
+                   let uu____28436 =
                      env.FStar_TypeChecker_Env.universe_of env
                        c11.FStar_Syntax_Syntax.result_typ
                       in
-                   [uu____28459]
+                   [uu____28436]
                | x -> x  in
              let c12 =
-               let uu___3690_28462 = c11  in
+               let uu___3690_28439 = c11  in
                {
                  FStar_Syntax_Syntax.comp_univs = univs;
                  FStar_Syntax_Syntax.effect_name =
-                   (uu___3690_28462.FStar_Syntax_Syntax.effect_name);
+                   (uu___3690_28439.FStar_Syntax_Syntax.effect_name);
                  FStar_Syntax_Syntax.result_typ =
-                   (uu___3690_28462.FStar_Syntax_Syntax.result_typ);
+                   (uu___3690_28439.FStar_Syntax_Syntax.result_typ);
                  FStar_Syntax_Syntax.effect_args =
-                   (uu___3690_28462.FStar_Syntax_Syntax.effect_args);
+                   (uu___3690_28439.FStar_Syntax_Syntax.effect_args);
                  FStar_Syntax_Syntax.flags =
-                   (uu___3690_28462.FStar_Syntax_Syntax.flags)
+                   (uu___3690_28439.FStar_Syntax_Syntax.flags)
                }  in
-             let uu____28463 =
-               let uu____28468 =
+             let uu____28440 =
+               let uu____28445 =
                  FStar_All.pipe_right
-                   (let uu___3693_28470 = c12  in
+                   (let uu___3693_28447 = c12  in
                     {
                       FStar_Syntax_Syntax.comp_univs = univs;
                       FStar_Syntax_Syntax.effect_name =
-                        (uu___3693_28470.FStar_Syntax_Syntax.effect_name);
+                        (uu___3693_28447.FStar_Syntax_Syntax.effect_name);
                       FStar_Syntax_Syntax.result_typ =
-                        (uu___3693_28470.FStar_Syntax_Syntax.result_typ);
+                        (uu___3693_28447.FStar_Syntax_Syntax.result_typ);
                       FStar_Syntax_Syntax.effect_args =
-                        (uu___3693_28470.FStar_Syntax_Syntax.effect_args);
+                        (uu___3693_28447.FStar_Syntax_Syntax.effect_args);
                       FStar_Syntax_Syntax.flags =
-                        (uu___3693_28470.FStar_Syntax_Syntax.flags)
+                        (uu___3693_28447.FStar_Syntax_Syntax.flags)
                     }) FStar_Syntax_Syntax.mk_Comp
                   in
-               FStar_All.pipe_right uu____28468
+               FStar_All.pipe_right uu____28445
                  ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                     env)
                 in
-             FStar_All.pipe_right uu____28463
-               (fun uu____28484  ->
-                  match uu____28484 with
+             FStar_All.pipe_right uu____28440
+               (fun uu____28461  ->
+                  match uu____28461 with
                   | (c,g) ->
-                      let uu____28491 =
-                        let uu____28493 = FStar_TypeChecker_Env.is_trivial g
+                      let uu____28468 =
+                        let uu____28470 = FStar_TypeChecker_Env.is_trivial g
                            in
-                        Prims.op_Negation uu____28493  in
-                      if uu____28491
+                        Prims.op_Negation uu____28470  in
+                      if uu____28468
                       then
-                        let uu____28496 =
-                          let uu____28502 =
-                            let uu____28504 =
+                        let uu____28473 =
+                          let uu____28479 =
+                            let uu____28481 =
                               FStar_Ident.string_of_lid
                                 c12.FStar_Syntax_Syntax.effect_name
                                in
-                            let uu____28506 =
+                            let uu____28483 =
                               FStar_Ident.string_of_lid
                                 c21.FStar_Syntax_Syntax.effect_name
                                in
                             FStar_Util.format2
                               "Lift between wp-effects (%s~>%s) should not have returned a non-trivial guard"
-                              uu____28504 uu____28506
+                              uu____28481 uu____28483
                              in
-                          (FStar_Errors.Fatal_UnexpectedEffect, uu____28502)
+                          (FStar_Errors.Fatal_UnexpectedEffect, uu____28479)
                            in
-                        FStar_Errors.raise_error uu____28496 r
+                        FStar_Errors.raise_error uu____28473 r
                       else FStar_Syntax_Util.comp_to_comp_typ c)
               in
-           let uu____28512 =
+           let uu____28489 =
              FStar_TypeChecker_Env.is_layered_effect env
                c21.FStar_Syntax_Syntax.effect_name
               in
-           if uu____28512
+           if uu____28489
            then solve_layered_sub c11 edge c21
            else
-             (let uu____28517 =
+             (let uu____28494 =
                 ((Prims.op_Negation wl.repr_subcomp_allowed) &&
-                   (let uu____28520 =
+                   (let uu____28497 =
                       FStar_Ident.lid_equals
                         c11.FStar_Syntax_Syntax.effect_name
                         c21.FStar_Syntax_Syntax.effect_name
                        in
-                    Prims.op_Negation uu____28520))
+                    Prims.op_Negation uu____28497))
                   &&
                   (FStar_TypeChecker_Env.is_reifiable_effect env
                      c21.FStar_Syntax_Syntax.effect_name)
                  in
-              if uu____28517
+              if uu____28494
               then
-                let uu____28523 =
+                let uu____28500 =
                   mklstr
-                    (fun uu____28530  ->
-                       let uu____28531 =
+                    (fun uu____28507  ->
+                       let uu____28508 =
                          FStar_Ident.string_of_lid
                            c11.FStar_Syntax_Syntax.effect_name
                           in
-                       let uu____28533 =
+                       let uu____28510 =
                          FStar_Ident.string_of_lid
                            c21.FStar_Syntax_Syntax.effect_name
                           in
                        FStar_Util.format2
                          "Cannot lift from %s to %s, it needs a lift\n"
-                         uu____28531 uu____28533)
+                         uu____28508 uu____28510)
                    in
-                giveup env uu____28523 orig
+                giveup env uu____28500 orig
               else
                 (let is_null_wp_2 =
                    FStar_All.pipe_right c21.FStar_Syntax_Syntax.flags
                      (FStar_Util.for_some
-                        (fun uu___28_28544  ->
-                           match uu___28_28544 with
+                        (fun uu___28_28521  ->
+                           match uu___28_28521 with
                            | FStar_Syntax_Syntax.TOTAL  -> true
                            | FStar_Syntax_Syntax.MLEFFECT  -> true
                            | FStar_Syntax_Syntax.SOMETRIVIAL  -> true
-                           | uu____28549 -> false))
+                           | uu____28526 -> false))
                     in
-                 let uu____28551 =
+                 let uu____28528 =
                    match ((c11.FStar_Syntax_Syntax.effect_args),
                            (c21.FStar_Syntax_Syntax.effect_args))
                    with
-                   | ((wp1,uu____28581)::uu____28582,(wp2,uu____28584)::uu____28585)
+                   | ((wp1,uu____28558)::uu____28559,(wp2,uu____28561)::uu____28562)
                        -> (wp1, wp2)
-                   | uu____28658 ->
-                       let uu____28683 =
-                         let uu____28689 =
-                           let uu____28691 =
+                   | uu____28635 ->
+                       let uu____28660 =
+                         let uu____28666 =
+                           let uu____28668 =
                              FStar_Syntax_Print.lid_to_string
                                c11.FStar_Syntax_Syntax.effect_name
                               in
-                           let uu____28693 =
+                           let uu____28670 =
                              FStar_Syntax_Print.lid_to_string
                                c21.FStar_Syntax_Syntax.effect_name
                               in
                            FStar_Util.format2
                              "Got effects %s and %s, expected normalized effects"
-                             uu____28691 uu____28693
+                             uu____28668 uu____28670
                             in
                          (FStar_Errors.Fatal_ExpectNormalizedEffect,
-                           uu____28689)
+                           uu____28666)
                           in
-                       FStar_Errors.raise_error uu____28683
+                       FStar_Errors.raise_error uu____28660
                          env.FStar_TypeChecker_Env.range
                     in
-                 match uu____28551 with
+                 match uu____28528 with
                  | (wpc1,wpc2) ->
-                     let uu____28703 = FStar_Util.physical_equality wpc1 wpc2
+                     let uu____28680 = FStar_Util.physical_equality wpc1 wpc2
                         in
-                     if uu____28703
+                     if uu____28680
                      then
-                       let uu____28706 =
+                       let uu____28683 =
                          problem_using_guard orig
                            c11.FStar_Syntax_Syntax.result_typ
                            problem.FStar_TypeChecker_Common.relation
                            c21.FStar_Syntax_Syntax.result_typ
                            FStar_Pervasives_Native.None "result type"
                           in
-                       solve_t env uu____28706 wl
+                       solve_t env uu____28683 wl
                      else
-                       (let uu____28710 =
-                          let uu____28717 =
+                       (let uu____28687 =
+                          let uu____28694 =
                             FStar_TypeChecker_Env.effect_decl_opt env
                               c21.FStar_Syntax_Syntax.effect_name
                              in
-                          FStar_Util.must uu____28717  in
-                        match uu____28710 with
+                          FStar_Util.must uu____28694  in
+                        match uu____28687 with
                         | (c2_decl,qualifiers) ->
-                            let uu____28738 =
+                            let uu____28715 =
                               FStar_All.pipe_right qualifiers
                                 (FStar_List.contains
                                    FStar_Syntax_Syntax.Reifiable)
                                in
-                            if uu____28738
+                            if uu____28715
                             then
                               let c1_repr =
-                                let uu____28745 =
-                                  let uu____28746 =
-                                    let uu____28747 = lift_c1 ()  in
-                                    FStar_Syntax_Syntax.mk_Comp uu____28747
+                                let uu____28722 =
+                                  let uu____28723 =
+                                    let uu____28724 = lift_c1 ()  in
+                                    FStar_Syntax_Syntax.mk_Comp uu____28724
                                      in
-                                  let uu____28748 =
+                                  let uu____28725 =
                                     env.FStar_TypeChecker_Env.universe_of env
                                       c11.FStar_Syntax_Syntax.result_typ
                                      in
                                   FStar_TypeChecker_Env.reify_comp env
-                                    uu____28746 uu____28748
+                                    uu____28723 uu____28725
                                    in
                                 norm_with_steps
                                   "FStar.TypeChecker.Rel.norm_with_steps.4"
                                   [FStar_TypeChecker_Env.UnfoldUntil
                                      FStar_Syntax_Syntax.delta_constant;
                                   FStar_TypeChecker_Env.Weak;
-                                  FStar_TypeChecker_Env.HNF] env uu____28745
+                                  FStar_TypeChecker_Env.HNF] env uu____28722
                                  in
                               let c2_repr =
-                                let uu____28751 =
-                                  let uu____28752 =
+                                let uu____28728 =
+                                  let uu____28729 =
                                     FStar_Syntax_Syntax.mk_Comp c21  in
-                                  let uu____28753 =
+                                  let uu____28730 =
                                     env.FStar_TypeChecker_Env.universe_of env
                                       c21.FStar_Syntax_Syntax.result_typ
                                      in
                                   FStar_TypeChecker_Env.reify_comp env
-                                    uu____28752 uu____28753
+                                    uu____28729 uu____28730
                                    in
                                 norm_with_steps
                                   "FStar.TypeChecker.Rel.norm_with_steps.5"
                                   [FStar_TypeChecker_Env.UnfoldUntil
                                      FStar_Syntax_Syntax.delta_constant;
                                   FStar_TypeChecker_Env.Weak;
-                                  FStar_TypeChecker_Env.HNF] env uu____28751
+                                  FStar_TypeChecker_Env.HNF] env uu____28728
                                  in
-                              let uu____28755 =
-                                let uu____28760 =
-                                  let uu____28762 =
+                              let uu____28732 =
+                                let uu____28737 =
+                                  let uu____28739 =
                                     FStar_Syntax_Print.term_to_string c1_repr
                                      in
-                                  let uu____28764 =
+                                  let uu____28741 =
                                     FStar_Syntax_Print.term_to_string c2_repr
                                      in
                                   FStar_Util.format2
-                                    "sub effect repr: %s <: %s" uu____28762
-                                    uu____28764
+                                    "sub effect repr: %s <: %s" uu____28739
+                                    uu____28741
                                    in
                                 sub_prob wl c1_repr
                                   problem.FStar_TypeChecker_Common.relation
-                                  c2_repr uu____28760
+                                  c2_repr uu____28737
                                  in
-                              (match uu____28755 with
+                              (match uu____28732 with
                                | (prob,wl1) ->
                                    let wl2 =
                                      solve_prob orig
                                        (FStar_Pervasives_Native.Some
                                           (p_guard prob)) [] wl1
                                       in
-                                   let uu____28770 = attempt [prob] wl2  in
-                                   solve env uu____28770)
+                                   let uu____28747 = attempt [prob] wl2  in
+                                   solve env uu____28747)
                             else
                               (let g =
                                  if env.FStar_TypeChecker_Env.lax
                                  then FStar_Syntax_Util.t_true
                                  else
                                    (let wpc1_2 =
-                                      let uu____28790 = lift_c1 ()  in
-                                      FStar_All.pipe_right uu____28790
+                                      let uu____28767 = lift_c1 ()  in
+                                      FStar_All.pipe_right uu____28767
                                         (fun ct  ->
                                            FStar_List.hd
                                              ct.FStar_Syntax_Syntax.effect_args)
                                        in
                                     if is_null_wp_2
                                     then
-                                      ((let uu____28813 =
+                                      ((let uu____28790 =
                                           FStar_All.pipe_left
                                             (FStar_TypeChecker_Env.debug env)
                                             (FStar_Options.Other "Rel")
                                            in
-                                        if uu____28813
+                                        if uu____28790
                                         then
                                           FStar_Util.print_string
                                             "Using trivial wp ... \n"
@@ -10925,39 +10905,34 @@ and (solve_c :
                                             c11.FStar_Syntax_Syntax.result_typ
                                            in
                                         let trivial =
-                                          let uu____28823 =
+                                          let uu____28800 =
                                             FStar_All.pipe_right c2_decl
                                               FStar_Syntax_Util.get_wp_trivial_combinator
                                              in
-                                          match uu____28823 with
+                                          match uu____28800 with
                                           | FStar_Pervasives_Native.None  ->
                                               failwith
                                                 "Rel doesn't yet handle undefined trivial combinator in an effect"
                                           | FStar_Pervasives_Native.Some t ->
                                               t
                                            in
-                                        let uu____28830 =
-                                          let uu____28837 =
-                                            let uu____28838 =
-                                              let uu____28855 =
-                                                FStar_TypeChecker_Env.inst_effect_fun_with
-                                                  [c1_univ] env c2_decl
-                                                  trivial
+                                        let uu____28807 =
+                                          let uu____28808 =
+                                            let uu____28825 =
+                                              FStar_TypeChecker_Env.inst_effect_fun_with
+                                                [c1_univ] env c2_decl trivial
+                                               in
+                                            let uu____28828 =
+                                              let uu____28839 =
+                                                FStar_Syntax_Syntax.as_arg
+                                                  c11.FStar_Syntax_Syntax.result_typ
                                                  in
-                                              let uu____28858 =
-                                                let uu____28869 =
-                                                  FStar_Syntax_Syntax.as_arg
-                                                    c11.FStar_Syntax_Syntax.result_typ
-                                                   in
-                                                [uu____28869; wpc1_2]  in
-                                              (uu____28855, uu____28858)  in
-                                            FStar_Syntax_Syntax.Tm_app
-                                              uu____28838
-                                             in
-                                          FStar_Syntax_Syntax.mk uu____28837
+                                              [uu____28839; wpc1_2]  in
+                                            (uu____28825, uu____28828)  in
+                                          FStar_Syntax_Syntax.Tm_app
+                                            uu____28808
                                            in
-                                        uu____28830
-                                          FStar_Pervasives_Native.None r))
+                                        FStar_Syntax_Syntax.mk uu____28807 r))
                                     else
                                       (let c2_univ =
                                          env.FStar_TypeChecker_Env.universe_of
@@ -10968,44 +10943,39 @@ and (solve_c :
                                          FStar_All.pipe_right c2_decl
                                            FStar_Syntax_Util.get_stronger_vc_combinator
                                           in
-                                       let uu____28918 =
-                                         let uu____28925 =
-                                           let uu____28926 =
-                                             let uu____28943 =
-                                               FStar_TypeChecker_Env.inst_effect_fun_with
-                                                 [c2_univ] env c2_decl
-                                                 stronger
+                                       let uu____28888 =
+                                         let uu____28889 =
+                                           let uu____28906 =
+                                             FStar_TypeChecker_Env.inst_effect_fun_with
+                                               [c2_univ] env c2_decl stronger
+                                              in
+                                           let uu____28909 =
+                                             let uu____28920 =
+                                               FStar_Syntax_Syntax.as_arg
+                                                 c21.FStar_Syntax_Syntax.result_typ
                                                 in
-                                             let uu____28946 =
-                                               let uu____28957 =
+                                             let uu____28929 =
+                                               let uu____28940 =
                                                  FStar_Syntax_Syntax.as_arg
-                                                   c21.FStar_Syntax_Syntax.result_typ
+                                                   wpc2
                                                   in
-                                               let uu____28966 =
-                                                 let uu____28977 =
-                                                   FStar_Syntax_Syntax.as_arg
-                                                     wpc2
-                                                    in
-                                                 [uu____28977; wpc1_2]  in
-                                               uu____28957 :: uu____28966  in
-                                             (uu____28943, uu____28946)  in
-                                           FStar_Syntax_Syntax.Tm_app
-                                             uu____28926
-                                            in
-                                         FStar_Syntax_Syntax.mk uu____28925
+                                               [uu____28940; wpc1_2]  in
+                                             uu____28920 :: uu____28929  in
+                                           (uu____28906, uu____28909)  in
+                                         FStar_Syntax_Syntax.Tm_app
+                                           uu____28889
                                           in
-                                       uu____28918
-                                         FStar_Pervasives_Native.None r))
+                                       FStar_Syntax_Syntax.mk uu____28888 r))
                                   in
-                               (let uu____29031 =
+                               (let uu____28994 =
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.debug env)
                                     (FStar_Options.Other "Rel")
                                    in
-                                if uu____29031
+                                if uu____28994
                                 then
-                                  let uu____29036 =
-                                    let uu____29038 =
+                                  let uu____28999 =
+                                    let uu____29001 =
                                       FStar_TypeChecker_Normalize.normalize
                                         [FStar_TypeChecker_Env.Iota;
                                         FStar_TypeChecker_Env.Eager_unfolding;
@@ -11013,250 +10983,250 @@ and (solve_c :
                                         FStar_TypeChecker_Env.Simplify] env g
                                        in
                                     FStar_Syntax_Print.term_to_string
-                                      uu____29038
+                                      uu____29001
                                      in
                                   FStar_Util.print1
                                     "WP guard (simplifed) is (%s)\n"
-                                    uu____29036
+                                    uu____28999
                                 else ());
-                               (let uu____29042 =
+                               (let uu____29005 =
                                   sub_prob wl
                                     c11.FStar_Syntax_Syntax.result_typ
                                     problem.FStar_TypeChecker_Common.relation
                                     c21.FStar_Syntax_Syntax.result_typ
                                     "result type"
                                    in
-                                match uu____29042 with
+                                match uu____29005 with
                                 | (base_prob,wl1) ->
                                     let wl2 =
-                                      let uu____29051 =
-                                        let uu____29054 =
+                                      let uu____29014 =
+                                        let uu____29017 =
                                           FStar_Syntax_Util.mk_conj
                                             (p_guard base_prob) g
                                            in
                                         FStar_All.pipe_left
-                                          (fun uu____29057  ->
+                                          (fun uu____29020  ->
                                              FStar_Pervasives_Native.Some
-                                               uu____29057) uu____29054
+                                               uu____29020) uu____29017
                                          in
-                                      solve_prob orig uu____29051 [] wl1  in
-                                    let uu____29058 = attempt [base_prob] wl2
+                                      solve_prob orig uu____29014 [] wl1  in
+                                    let uu____29021 = attempt [base_prob] wl2
                                        in
-                                    solve env uu____29058))))))
+                                    solve env uu____29021))))))
            in
-        let uu____29059 = FStar_Util.physical_equality c1 c2  in
-        if uu____29059
+        let uu____29022 = FStar_Util.physical_equality c1 c2  in
+        if uu____29022
         then
-          let uu____29062 =
+          let uu____29025 =
             solve_prob orig FStar_Pervasives_Native.None [] wl  in
-          solve env uu____29062
+          solve env uu____29025
         else
-          ((let uu____29066 =
+          ((let uu____29029 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Rel")
                in
-            if uu____29066
+            if uu____29029
             then
-              let uu____29071 = FStar_Syntax_Print.comp_to_string c1  in
-              let uu____29073 = FStar_Syntax_Print.comp_to_string c2  in
-              FStar_Util.print3 "solve_c %s %s %s\n" uu____29071
+              let uu____29034 = FStar_Syntax_Print.comp_to_string c1  in
+              let uu____29036 = FStar_Syntax_Print.comp_to_string c2  in
+              FStar_Util.print3 "solve_c %s %s %s\n" uu____29034
                 (rel_to_string problem.FStar_TypeChecker_Common.relation)
-                uu____29073
+                uu____29036
             else ());
-           (let uu____29078 =
-              let uu____29087 =
+           (let uu____29041 =
+              let uu____29050 =
                 FStar_TypeChecker_Normalize.ghost_to_pure env c1  in
-              let uu____29090 =
+              let uu____29053 =
                 FStar_TypeChecker_Normalize.ghost_to_pure env c2  in
-              (uu____29087, uu____29090)  in
-            match uu____29078 with
+              (uu____29050, uu____29053)  in
+            match uu____29041 with
             | (c11,c21) ->
                 (match ((c11.FStar_Syntax_Syntax.n),
                          (c21.FStar_Syntax_Syntax.n))
                  with
                  | (FStar_Syntax_Syntax.GTotal
-                    (t1,uu____29108),FStar_Syntax_Syntax.Total
-                    (t2,uu____29110)) when
+                    (t1,uu____29071),FStar_Syntax_Syntax.Total
+                    (t2,uu____29073)) when
                      FStar_TypeChecker_Env.non_informative env t2 ->
-                     let uu____29127 =
+                     let uu____29090 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____29127 wl
+                     solve_t env uu____29090 wl
                  | (FStar_Syntax_Syntax.GTotal
-                    uu____29129,FStar_Syntax_Syntax.Total uu____29130) ->
-                     let uu____29147 =
+                    uu____29092,FStar_Syntax_Syntax.Total uu____29093) ->
+                     let uu____29110 =
                        FStar_Thunk.mkv
                          "incompatible monad ordering: GTot </: Tot"
                         in
-                     giveup env uu____29147 orig
+                     giveup env uu____29110 orig
                  | (FStar_Syntax_Syntax.Total
-                    (t1,uu____29151),FStar_Syntax_Syntax.Total
-                    (t2,uu____29153)) ->
-                     let uu____29170 =
+                    (t1,uu____29114),FStar_Syntax_Syntax.Total
+                    (t2,uu____29116)) ->
+                     let uu____29133 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____29170 wl
+                     solve_t env uu____29133 wl
                  | (FStar_Syntax_Syntax.GTotal
-                    (t1,uu____29173),FStar_Syntax_Syntax.GTotal
-                    (t2,uu____29175)) ->
-                     let uu____29192 =
+                    (t1,uu____29136),FStar_Syntax_Syntax.GTotal
+                    (t2,uu____29138)) ->
+                     let uu____29155 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____29192 wl
+                     solve_t env uu____29155 wl
                  | (FStar_Syntax_Syntax.Total
-                    (t1,uu____29195),FStar_Syntax_Syntax.GTotal
-                    (t2,uu____29197)) when
+                    (t1,uu____29158),FStar_Syntax_Syntax.GTotal
+                    (t2,uu____29160)) when
                      problem.FStar_TypeChecker_Common.relation =
                        FStar_TypeChecker_Common.SUB
                      ->
-                     let uu____29214 =
+                     let uu____29177 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type"
                         in
-                     solve_t env uu____29214 wl
+                     solve_t env uu____29177 wl
                  | (FStar_Syntax_Syntax.Total
-                    (t1,uu____29217),FStar_Syntax_Syntax.GTotal
-                    (t2,uu____29219)) ->
-                     let uu____29236 = FStar_Thunk.mkv "GTot =/= Tot"  in
-                     giveup env uu____29236 orig
+                    (t1,uu____29180),FStar_Syntax_Syntax.GTotal
+                    (t2,uu____29182)) ->
+                     let uu____29199 = FStar_Thunk.mkv "GTot =/= Tot"  in
+                     giveup env uu____29199 orig
                  | (FStar_Syntax_Syntax.GTotal
-                    uu____29239,FStar_Syntax_Syntax.Comp uu____29240) ->
-                     let uu____29249 =
-                       let uu___3818_29252 = problem  in
-                       let uu____29255 =
-                         let uu____29256 =
+                    uu____29202,FStar_Syntax_Syntax.Comp uu____29203) ->
+                     let uu____29212 =
+                       let uu___3818_29215 = problem  in
+                       let uu____29218 =
+                         let uu____29219 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29256
+                           uu____29219
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3818_29252.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____29255;
+                           (uu___3818_29215.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu____29218;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3818_29252.FStar_TypeChecker_Common.relation);
+                           (uu___3818_29215.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3818_29252.FStar_TypeChecker_Common.rhs);
+                           (uu___3818_29215.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3818_29252.FStar_TypeChecker_Common.element);
+                           (uu___3818_29215.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3818_29252.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3818_29215.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3818_29252.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3818_29215.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3818_29252.FStar_TypeChecker_Common.reason);
+                           (uu___3818_29215.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3818_29252.FStar_TypeChecker_Common.loc);
+                           (uu___3818_29215.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3818_29252.FStar_TypeChecker_Common.rank)
+                           (uu___3818_29215.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29249 wl
+                     solve_c env uu____29212 wl
                  | (FStar_Syntax_Syntax.Total
-                    uu____29257,FStar_Syntax_Syntax.Comp uu____29258) ->
-                     let uu____29267 =
-                       let uu___3818_29270 = problem  in
-                       let uu____29273 =
-                         let uu____29274 =
+                    uu____29220,FStar_Syntax_Syntax.Comp uu____29221) ->
+                     let uu____29230 =
+                       let uu___3818_29233 = problem  in
+                       let uu____29236 =
+                         let uu____29237 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29274
+                           uu____29237
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3818_29270.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____29273;
+                           (uu___3818_29233.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu____29236;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3818_29270.FStar_TypeChecker_Common.relation);
+                           (uu___3818_29233.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3818_29270.FStar_TypeChecker_Common.rhs);
+                           (uu___3818_29233.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3818_29270.FStar_TypeChecker_Common.element);
+                           (uu___3818_29233.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3818_29270.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3818_29233.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3818_29270.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3818_29233.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3818_29270.FStar_TypeChecker_Common.reason);
+                           (uu___3818_29233.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3818_29270.FStar_TypeChecker_Common.loc);
+                           (uu___3818_29233.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3818_29270.FStar_TypeChecker_Common.rank)
+                           (uu___3818_29233.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29267 wl
+                     solve_c env uu____29230 wl
                  | (FStar_Syntax_Syntax.Comp
-                    uu____29275,FStar_Syntax_Syntax.GTotal uu____29276) ->
-                     let uu____29285 =
-                       let uu___3830_29288 = problem  in
-                       let uu____29291 =
-                         let uu____29292 =
+                    uu____29238,FStar_Syntax_Syntax.GTotal uu____29239) ->
+                     let uu____29248 =
+                       let uu___3830_29251 = problem  in
+                       let uu____29254 =
+                         let uu____29255 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29292
+                           uu____29255
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3830_29288.FStar_TypeChecker_Common.pid);
+                           (uu___3830_29251.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3830_29288.FStar_TypeChecker_Common.lhs);
+                           (uu___3830_29251.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3830_29288.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____29291;
+                           (uu___3830_29251.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu____29254;
                          FStar_TypeChecker_Common.element =
-                           (uu___3830_29288.FStar_TypeChecker_Common.element);
+                           (uu___3830_29251.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3830_29288.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3830_29251.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3830_29288.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3830_29251.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3830_29288.FStar_TypeChecker_Common.reason);
+                           (uu___3830_29251.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3830_29288.FStar_TypeChecker_Common.loc);
+                           (uu___3830_29251.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3830_29288.FStar_TypeChecker_Common.rank)
+                           (uu___3830_29251.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29285 wl
+                     solve_c env uu____29248 wl
                  | (FStar_Syntax_Syntax.Comp
-                    uu____29293,FStar_Syntax_Syntax.Total uu____29294) ->
-                     let uu____29303 =
-                       let uu___3830_29306 = problem  in
-                       let uu____29309 =
-                         let uu____29310 =
+                    uu____29256,FStar_Syntax_Syntax.Total uu____29257) ->
+                     let uu____29266 =
+                       let uu___3830_29269 = problem  in
+                       let uu____29272 =
+                         let uu____29273 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21  in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____29310
+                           uu____29273
                           in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3830_29306.FStar_TypeChecker_Common.pid);
+                           (uu___3830_29269.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3830_29306.FStar_TypeChecker_Common.lhs);
+                           (uu___3830_29269.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3830_29306.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____29309;
+                           (uu___3830_29269.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu____29272;
                          FStar_TypeChecker_Common.element =
-                           (uu___3830_29306.FStar_TypeChecker_Common.element);
+                           (uu___3830_29269.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3830_29306.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3830_29269.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3830_29306.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3830_29269.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3830_29306.FStar_TypeChecker_Common.reason);
+                           (uu___3830_29269.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3830_29306.FStar_TypeChecker_Common.loc);
+                           (uu___3830_29269.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3830_29306.FStar_TypeChecker_Common.rank)
+                           (uu___3830_29269.FStar_TypeChecker_Common.rank)
                        }  in
-                     solve_c env uu____29303 wl
+                     solve_c env uu____29266 wl
                  | (FStar_Syntax_Syntax.Comp
-                    uu____29311,FStar_Syntax_Syntax.Comp uu____29312) ->
-                     let uu____29313 =
+                    uu____29274,FStar_Syntax_Syntax.Comp uu____29275) ->
+                     let uu____29276 =
                        (((FStar_Syntax_Util.is_ml_comp c11) &&
                            (FStar_Syntax_Util.is_ml_comp c21))
                           ||
@@ -11269,16 +11239,16 @@ and (solve_c :
                             (problem.FStar_TypeChecker_Common.relation =
                                FStar_TypeChecker_Common.SUB))
                         in
-                     if uu____29313
+                     if uu____29276
                      then
-                       let uu____29316 =
+                       let uu____29279 =
                          problem_using_guard orig
                            (FStar_Syntax_Util.comp_result c11)
                            problem.FStar_TypeChecker_Common.relation
                            (FStar_Syntax_Util.comp_result c21)
                            FStar_Pervasives_Native.None "result type"
                           in
-                       solve_t env uu____29316 wl
+                       solve_t env uu____29279 wl
                      else
                        (let c1_comp =
                           FStar_TypeChecker_Env.comp_to_comp_typ env c11  in
@@ -11288,26 +11258,26 @@ and (solve_c :
                           problem.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                         then
-                          let uu____29323 =
-                            let uu____29328 =
+                          let uu____29286 =
+                            let uu____29291 =
                               FStar_Ident.lid_equals
                                 c1_comp.FStar_Syntax_Syntax.effect_name
                                 c2_comp.FStar_Syntax_Syntax.effect_name
                                in
-                            if uu____29328
+                            if uu____29291
                             then (c1_comp, c2_comp)
                             else
-                              (let uu____29337 =
+                              (let uu____29300 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c11
                                   in
-                               let uu____29338 =
+                               let uu____29301 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c21
                                   in
-                               (uu____29337, uu____29338))
+                               (uu____29300, uu____29301))
                              in
-                          match uu____29323 with
+                          match uu____29286 with
                           | (c1_comp1,c2_comp1) ->
                               solve_eq c1_comp1 c2_comp1
                                 FStar_TypeChecker_Env.trivial_guard
@@ -11320,61 +11290,61 @@ and (solve_c :
                              FStar_TypeChecker_Env.unfold_effect_abbrev env
                                c21
                               in
-                           (let uu____29346 =
+                           (let uu____29309 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Rel")
                                in
-                            if uu____29346
+                            if uu____29309
                             then
-                              let uu____29351 =
+                              let uu____29314 =
                                 FStar_Ident.string_of_lid
                                   c12.FStar_Syntax_Syntax.effect_name
                                  in
-                              let uu____29353 =
+                              let uu____29316 =
                                 FStar_Ident.string_of_lid
                                   c22.FStar_Syntax_Syntax.effect_name
                                  in
                               FStar_Util.print2 "solve_c for %s and %s\n"
-                                uu____29351 uu____29353
+                                uu____29314 uu____29316
                             else ());
-                           (let uu____29358 =
+                           (let uu____29321 =
                               FStar_TypeChecker_Env.monad_leq env
                                 c12.FStar_Syntax_Syntax.effect_name
                                 c22.FStar_Syntax_Syntax.effect_name
                                in
-                            match uu____29358 with
+                            match uu____29321 with
                             | FStar_Pervasives_Native.None  ->
-                                let uu____29361 =
+                                let uu____29324 =
                                   mklstr
-                                    (fun uu____29368  ->
-                                       let uu____29369 =
+                                    (fun uu____29331  ->
+                                       let uu____29332 =
                                          FStar_Syntax_Print.lid_to_string
                                            c12.FStar_Syntax_Syntax.effect_name
                                           in
-                                       let uu____29371 =
+                                       let uu____29334 =
                                          FStar_Syntax_Print.lid_to_string
                                            c22.FStar_Syntax_Syntax.effect_name
                                           in
                                        FStar_Util.format2
                                          "incompatible monad ordering: %s </: %s"
-                                         uu____29369 uu____29371)
+                                         uu____29332 uu____29334)
                                    in
-                                giveup env uu____29361 orig
+                                giveup env uu____29324 orig
                             | FStar_Pervasives_Native.Some edge ->
                                 solve_sub c12 edge c22))))))
 
 let (print_pending_implicits :
   FStar_TypeChecker_Common.guard_t -> Prims.string) =
   fun g  ->
-    let uu____29382 =
+    let uu____29345 =
       FStar_All.pipe_right g.FStar_TypeChecker_Common.implicits
         (FStar_List.map
            (fun i  ->
               FStar_Syntax_Print.term_to_string
                 i.FStar_TypeChecker_Common.imp_tm))
        in
-    FStar_All.pipe_right uu____29382 (FStar_String.concat ", ")
+    FStar_All.pipe_right uu____29345 (FStar_String.concat ", ")
   
 let (ineqs_to_string :
   (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe *
@@ -11382,25 +11352,25 @@ let (ineqs_to_string :
   =
   fun ineqs  ->
     let vars =
-      let uu____29432 =
+      let uu____29395 =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst ineqs)
           (FStar_List.map FStar_Syntax_Print.univ_to_string)
          in
-      FStar_All.pipe_right uu____29432 (FStar_String.concat ", ")  in
+      FStar_All.pipe_right uu____29395 (FStar_String.concat ", ")  in
     let ineqs1 =
-      let uu____29457 =
+      let uu____29420 =
         FStar_All.pipe_right (FStar_Pervasives_Native.snd ineqs)
           (FStar_List.map
-             (fun uu____29488  ->
-                match uu____29488 with
+             (fun uu____29451  ->
+                match uu____29451 with
                 | (u1,u2) ->
-                    let uu____29496 = FStar_Syntax_Print.univ_to_string u1
+                    let uu____29459 = FStar_Syntax_Print.univ_to_string u1
                        in
-                    let uu____29498 = FStar_Syntax_Print.univ_to_string u2
+                    let uu____29461 = FStar_Syntax_Print.univ_to_string u2
                        in
-                    FStar_Util.format2 "%s < %s" uu____29496 uu____29498))
+                    FStar_Util.format2 "%s < %s" uu____29459 uu____29461))
          in
-      FStar_All.pipe_right uu____29457 (FStar_String.concat ", ")  in
+      FStar_All.pipe_right uu____29420 (FStar_String.concat ", ")  in
     FStar_Util.format2 "Solving for {%s}; inequalities are {%s}" vars ineqs1
   
 let (guard_to_string :
@@ -11413,15 +11383,15 @@ let (guard_to_string :
               (g.FStar_TypeChecker_Common.deferred),
               (g.FStar_TypeChecker_Common.univ_ineqs))
       with
-      | (FStar_TypeChecker_Common.Trivial ,[],(uu____29535,[])) when
-          let uu____29562 = FStar_Options.print_implicits ()  in
-          Prims.op_Negation uu____29562 -> "{}"
-      | uu____29565 ->
+      | (FStar_TypeChecker_Common.Trivial ,[],(uu____29498,[])) when
+          let uu____29525 = FStar_Options.print_implicits ()  in
+          Prims.op_Negation uu____29525 -> "{}"
+      | uu____29528 ->
           let form =
             match g.FStar_TypeChecker_Common.guard_f with
             | FStar_TypeChecker_Common.Trivial  -> "trivial"
             | FStar_TypeChecker_Common.NonTrivial f ->
-                let uu____29592 =
+                let uu____29555 =
                   ((FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                       (FStar_Options.Other "Rel"))
                      ||
@@ -11429,25 +11399,25 @@ let (guard_to_string :
                         FStar_Options.Extreme))
                     || (FStar_Options.print_implicits ())
                    in
-                if uu____29592
+                if uu____29555
                 then FStar_TypeChecker_Normalize.term_to_string env f
                 else "non-trivial"
              in
           let carry =
-            let uu____29604 =
+            let uu____29567 =
               FStar_List.map
-                (fun uu____29617  ->
-                   match uu____29617 with
-                   | (uu____29624,x) -> prob_to_string env x)
+                (fun uu____29580  ->
+                   match uu____29580 with
+                   | (uu____29587,x) -> prob_to_string env x)
                 g.FStar_TypeChecker_Common.deferred
                in
-            FStar_All.pipe_right uu____29604 (FStar_String.concat ",\n")  in
+            FStar_All.pipe_right uu____29567 (FStar_String.concat ",\n")  in
           let imps = print_pending_implicits g  in
-          let uu____29635 =
+          let uu____29598 =
             ineqs_to_string g.FStar_TypeChecker_Common.univ_ineqs  in
           FStar_Util.format4
             "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n"
-            form carry uu____29635 imps
+            form carry uu____29598 imps
   
 let (new_t_problem :
   worklist ->
@@ -11466,25 +11436,25 @@ let (new_t_problem :
             fun elt  ->
               fun loc  ->
                 let reason =
-                  let uu____29692 =
+                  let uu____29655 =
                     (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                        (FStar_Options.Other "ExplainRel"))
                       ||
                       (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "Rel"))
                      in
-                  if uu____29692
+                  if uu____29655
                   then
-                    let uu____29700 =
+                    let uu____29663 =
                       FStar_TypeChecker_Normalize.term_to_string env lhs  in
-                    let uu____29702 =
+                    let uu____29665 =
                       FStar_TypeChecker_Normalize.term_to_string env rhs  in
-                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____29700
-                      (rel_to_string rel) uu____29702
+                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____29663
+                      (rel_to_string rel) uu____29665
                   else "TOP"  in
-                let uu____29708 =
+                let uu____29671 =
                   new_problem wl env lhs rel rhs elt loc reason  in
-                match uu____29708 with
+                match uu____29671 with
                 | (p,wl1) ->
                     (def_check_prob (Prims.op_Hat "new_t_problem." reason)
                        (FStar_TypeChecker_Common.TProb p);
@@ -11505,19 +11475,19 @@ let (new_t_prob :
         fun rel  ->
           fun t2  ->
             let x =
-              let uu____29768 =
-                let uu____29771 = FStar_TypeChecker_Env.get_range env  in
+              let uu____29731 =
+                let uu____29734 = FStar_TypeChecker_Env.get_range env  in
                 FStar_All.pipe_left
-                  (fun uu____29774  ->
-                     FStar_Pervasives_Native.Some uu____29774) uu____29771
+                  (fun uu____29737  ->
+                     FStar_Pervasives_Native.Some uu____29737) uu____29734
                  in
-              FStar_Syntax_Syntax.new_bv uu____29768 t1  in
-            let uu____29775 =
-              let uu____29780 = FStar_TypeChecker_Env.get_range env  in
+              FStar_Syntax_Syntax.new_bv uu____29731 t1  in
+            let uu____29738 =
+              let uu____29743 = FStar_TypeChecker_Env.get_range env  in
               new_t_problem wl env t1 rel t2 (FStar_Pervasives_Native.Some x)
-                uu____29780
+                uu____29743
                in
-            match uu____29775 with | (p,wl1) -> (p, x, wl1)
+            match uu____29738 with | (p,wl1) -> (p, x, wl1)
   
 let (solve_and_commit :
   FStar_TypeChecker_Env.env ->
@@ -11533,55 +11503,55 @@ let (solve_and_commit :
     fun probs  ->
       fun err  ->
         let tx = FStar_Syntax_Unionfind.new_transaction ()  in
-        (let uu____29838 =
+        (let uu____29801 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "RelBench")
             in
-         if uu____29838
+         if uu____29801
          then
-           let uu____29843 =
+           let uu____29806 =
              FStar_Common.string_of_list
                (fun p  -> FStar_Util.string_of_int (p_pid p))
                probs.attempting
               in
-           FStar_Util.print1 "solving problems %s {\n" uu____29843
+           FStar_Util.print1 "solving problems %s {\n" uu____29806
          else ());
-        (let uu____29850 =
-           FStar_Util.record_time (fun uu____29857  -> solve env probs)  in
-         match uu____29850 with
+        (let uu____29813 =
+           FStar_Util.record_time (fun uu____29820  -> solve env probs)  in
+         match uu____29813 with
          | (sol,ms) ->
-             ((let uu____29869 =
+             ((let uu____29832 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "RelBench")
                   in
-               if uu____29869
+               if uu____29832
                then
-                 let uu____29874 = FStar_Util.string_of_int ms  in
-                 FStar_Util.print1 "} solved in %s ms\n" uu____29874
+                 let uu____29837 = FStar_Util.string_of_int ms  in
+                 FStar_Util.print1 "} solved in %s ms\n" uu____29837
                else ());
               (match sol with
                | Success (deferred,implicits) ->
-                   let uu____29887 =
+                   let uu____29850 =
                      FStar_Util.record_time
-                       (fun uu____29894  -> FStar_Syntax_Unionfind.commit tx)
+                       (fun uu____29857  -> FStar_Syntax_Unionfind.commit tx)
                       in
-                   (match uu____29887 with
+                   (match uu____29850 with
                     | ((),ms1) ->
-                        ((let uu____29905 =
+                        ((let uu____29868 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelBench")
                              in
-                          if uu____29905
+                          if uu____29868
                           then
-                            let uu____29910 = FStar_Util.string_of_int ms1
+                            let uu____29873 = FStar_Util.string_of_int ms1
                                in
                             FStar_Util.print1 "committed in %s ms\n"
-                              uu____29910
+                              uu____29873
                           else ());
                          FStar_Pervasives_Native.Some (deferred, implicits)))
                | Failed (d,s) ->
-                   ((let uu____29922 =
+                   ((let uu____29885 =
                        (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "ExplainRel"))
                          ||
@@ -11589,11 +11559,11 @@ let (solve_and_commit :
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "Rel"))
                         in
-                     if uu____29922
+                     if uu____29885
                      then
-                       let uu____29929 = explain env d s  in
+                       let uu____29892 = explain env d s  in
                        FStar_All.pipe_left FStar_Util.print_string
-                         uu____29929
+                         uu____29892
                      else ());
                     (let result = err (d, s)  in
                      FStar_Syntax_Unionfind.rollback tx; result)))))
@@ -11607,14 +11577,14 @@ let (simplify_guard :
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial  -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          ((let uu____29955 =
+          ((let uu____29918 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Simplification")
                in
-            if uu____29955
+            if uu____29918
             then
-              let uu____29960 = FStar_Syntax_Print.term_to_string f  in
-              FStar_Util.print1 "Simplifying guard %s\n" uu____29960
+              let uu____29923 = FStar_Syntax_Print.term_to_string f  in
+              FStar_Util.print1 "Simplifying guard %s\n" uu____29923
             else ());
            (let f1 =
               norm_with_steps "FStar.TypeChecker.Rel.norm_with_steps.6"
@@ -11624,34 +11594,34 @@ let (simplify_guard :
                 FStar_TypeChecker_Env.Primops;
                 FStar_TypeChecker_Env.NoFullNorm] env f
                in
-            (let uu____29968 =
+            (let uu____29931 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Simplification")
                 in
-             if uu____29968
+             if uu____29931
              then
-               let uu____29973 = FStar_Syntax_Print.term_to_string f1  in
-               FStar_Util.print1 "Simplified guard to %s\n" uu____29973
+               let uu____29936 = FStar_Syntax_Print.term_to_string f1  in
+               FStar_Util.print1 "Simplified guard to %s\n" uu____29936
              else ());
             (let f2 =
-               let uu____29979 =
-                 let uu____29980 = FStar_Syntax_Util.unmeta f1  in
-                 uu____29980.FStar_Syntax_Syntax.n  in
-               match uu____29979 with
+               let uu____29942 =
+                 let uu____29943 = FStar_Syntax_Util.unmeta f1  in
+                 uu____29943.FStar_Syntax_Syntax.n  in
+               match uu____29942 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
                    -> FStar_TypeChecker_Common.Trivial
-               | uu____29984 -> FStar_TypeChecker_Common.NonTrivial f1  in
-             let uu___3947_29985 = g  in
+               | uu____29947 -> FStar_TypeChecker_Common.NonTrivial f1  in
+             let uu___3947_29948 = g  in
              {
                FStar_TypeChecker_Common.guard_f = f2;
                FStar_TypeChecker_Common.deferred =
-                 (uu___3947_29985.FStar_TypeChecker_Common.deferred);
+                 (uu___3947_29948.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs =
-                 (uu___3947_29985.FStar_TypeChecker_Common.univ_ineqs);
+                 (uu___3947_29948.FStar_TypeChecker_Common.univ_ineqs);
                FStar_TypeChecker_Common.implicits =
-                 (uu___3947_29985.FStar_TypeChecker_Common.implicits)
+                 (uu___3947_29948.FStar_TypeChecker_Common.implicits)
              })))
   
 let (with_guard :
@@ -11667,27 +11637,27 @@ let (with_guard :
         match dopt with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred,implicits) ->
-            let uu____30028 =
-              let uu____30029 =
-                let uu____30030 =
+            let uu____29991 =
+              let uu____29992 =
+                let uu____29993 =
                   FStar_All.pipe_right (p_guard prob)
-                    (fun uu____30031  ->
-                       FStar_TypeChecker_Common.NonTrivial uu____30031)
+                    (fun uu____29994  ->
+                       FStar_TypeChecker_Common.NonTrivial uu____29994)
                    in
                 {
-                  FStar_TypeChecker_Common.guard_f = uu____30030;
+                  FStar_TypeChecker_Common.guard_f = uu____29993;
                   FStar_TypeChecker_Common.deferred = deferred;
                   FStar_TypeChecker_Common.univ_ineqs = ([], []);
                   FStar_TypeChecker_Common.implicits = implicits
                 }  in
-              simplify_guard env uu____30029  in
+              simplify_guard env uu____29992  in
             FStar_All.pipe_left
-              (fun uu____30038  -> FStar_Pervasives_Native.Some uu____30038)
-              uu____30028
+              (fun uu____30001  -> FStar_Pervasives_Native.Some uu____30001)
+              uu____29991
   
 let with_guard_no_simp :
-  'uuuuuu30048 .
-    'uuuuuu30048 ->
+  'uuuuuu30011 .
+    'uuuuuu30011 ->
       FStar_TypeChecker_Common.prob ->
         (FStar_TypeChecker_Common.deferred *
           FStar_TypeChecker_Common.implicits) FStar_Pervasives_Native.option
@@ -11699,19 +11669,19 @@ let with_guard_no_simp :
         match dopt with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred,implicits) ->
-            let uu____30088 =
-              let uu____30089 =
+            let uu____30051 =
+              let uu____30052 =
                 FStar_All.pipe_right (p_guard prob)
-                  (fun uu____30090  ->
-                     FStar_TypeChecker_Common.NonTrivial uu____30090)
+                  (fun uu____30053  ->
+                     FStar_TypeChecker_Common.NonTrivial uu____30053)
                  in
               {
-                FStar_TypeChecker_Common.guard_f = uu____30089;
+                FStar_TypeChecker_Common.guard_f = uu____30052;
                 FStar_TypeChecker_Common.deferred = deferred;
                 FStar_TypeChecker_Common.univ_ineqs = ([], []);
                 FStar_TypeChecker_Common.implicits = implicits
               }  in
-            FStar_Pervasives_Native.Some uu____30088
+            FStar_Pervasives_Native.Some uu____30051
   
 let (try_teq :
   Prims.bool ->
@@ -11724,41 +11694,41 @@ let (try_teq :
     fun env  ->
       fun t1  ->
         fun t2  ->
-          (let uu____30123 =
+          (let uu____30086 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel")
               in
-           if uu____30123
+           if uu____30086
            then
-             let uu____30128 = FStar_Syntax_Print.term_to_string t1  in
-             let uu____30130 = FStar_Syntax_Print.term_to_string t2  in
-             FStar_Util.print2 "try_teq of %s and %s {\n" uu____30128
-               uu____30130
+             let uu____30091 = FStar_Syntax_Print.term_to_string t1  in
+             let uu____30093 = FStar_Syntax_Print.term_to_string t2  in
+             FStar_Util.print2 "try_teq of %s and %s {\n" uu____30091
+               uu____30093
            else ());
-          (let uu____30135 =
-             let uu____30140 = FStar_TypeChecker_Env.get_range env  in
+          (let uu____30098 =
+             let uu____30103 = FStar_TypeChecker_Env.get_range env  in
              new_t_problem (empty_worklist env) env t1
                FStar_TypeChecker_Common.EQ t2 FStar_Pervasives_Native.None
-               uu____30140
+               uu____30103
               in
-           match uu____30135 with
+           match uu____30098 with
            | (prob,wl) ->
                let g =
-                 let uu____30148 =
+                 let uu____30111 =
                    solve_and_commit env (singleton wl prob smt_ok)
-                     (fun uu____30156  -> FStar_Pervasives_Native.None)
+                     (fun uu____30119  -> FStar_Pervasives_Native.None)
                     in
-                 FStar_All.pipe_left (with_guard env prob) uu____30148  in
-               ((let uu____30174 =
+                 FStar_All.pipe_left (with_guard env prob) uu____30111  in
+               ((let uu____30137 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                      (FStar_Options.Other "Rel")
                     in
-                 if uu____30174
+                 if uu____30137
                  then
-                   let uu____30179 =
+                   let uu____30142 =
                      FStar_Common.string_of_option (guard_to_string env) g
                       in
-                   FStar_Util.print1 "} res = %s\n" uu____30179
+                   FStar_Util.print1 "} res = %s\n" uu____30142
                  else ());
                 g))
   
@@ -11770,29 +11740,29 @@ let (teq :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____30200 = try_teq true env t1 t2  in
-        match uu____30200 with
+        let uu____30163 = try_teq true env t1 t2  in
+        match uu____30163 with
         | FStar_Pervasives_Native.None  ->
-            ((let uu____30205 = FStar_TypeChecker_Env.get_range env  in
-              let uu____30206 =
+            ((let uu____30168 = FStar_TypeChecker_Env.get_range env  in
+              let uu____30169 =
                 FStar_TypeChecker_Err.basic_type_error env
                   FStar_Pervasives_Native.None t2 t1
                  in
-              FStar_Errors.log_issue uu____30205 uu____30206);
+              FStar_Errors.log_issue uu____30168 uu____30169);
              FStar_TypeChecker_Common.trivial_guard)
         | FStar_Pervasives_Native.Some g ->
-            ((let uu____30214 =
+            ((let uu____30177 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel")
                  in
-              if uu____30214
+              if uu____30177
               then
-                let uu____30219 = FStar_Syntax_Print.term_to_string t1  in
-                let uu____30221 = FStar_Syntax_Print.term_to_string t2  in
-                let uu____30223 = guard_to_string env g  in
+                let uu____30182 = FStar_Syntax_Print.term_to_string t1  in
+                let uu____30184 = FStar_Syntax_Print.term_to_string t2  in
+                let uu____30186 = guard_to_string env g  in
                 FStar_Util.print3
-                  "teq of %s and %s succeeded with guard %s\n" uu____30219
-                  uu____30221 uu____30223
+                  "teq of %s and %s succeeded with guard %s\n" uu____30182
+                  uu____30184 uu____30186
               else ());
              g)
   
@@ -11805,47 +11775,47 @@ let (get_teq_predicate :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        (let uu____30247 =
+        (let uu____30210 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____30247
+         if uu____30210
          then
-           let uu____30252 = FStar_Syntax_Print.term_to_string t1  in
-           let uu____30254 = FStar_Syntax_Print.term_to_string t2  in
-           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu____30252
-             uu____30254
+           let uu____30215 = FStar_Syntax_Print.term_to_string t1  in
+           let uu____30217 = FStar_Syntax_Print.term_to_string t2  in
+           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu____30215
+             uu____30217
          else ());
-        (let uu____30259 =
+        (let uu____30222 =
            new_t_prob (empty_worklist env) env t1 FStar_TypeChecker_Common.EQ
              t2
             in
-         match uu____30259 with
+         match uu____30222 with
          | (prob,x,wl) ->
              let g =
-               let uu____30274 =
+               let uu____30237 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____30283  -> FStar_Pervasives_Native.None)
+                   (fun uu____30246  -> FStar_Pervasives_Native.None)
                   in
-               FStar_All.pipe_left (with_guard env prob) uu____30274  in
-             ((let uu____30301 =
+               FStar_All.pipe_left (with_guard env prob) uu____30237  in
+             ((let uu____30264 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel")
                   in
-               if uu____30301
+               if uu____30264
                then
-                 let uu____30306 =
+                 let uu____30269 =
                    FStar_Common.string_of_option (guard_to_string env) g  in
-                 FStar_Util.print1 "} res teq predicate = %s\n" uu____30306
+                 FStar_Util.print1 "} res teq predicate = %s\n" uu____30269
                else ());
               (match g with
                | FStar_Pervasives_Native.None  ->
                    FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some g1 ->
-                   let uu____30314 =
-                     let uu____30315 = FStar_Syntax_Syntax.mk_binder x  in
-                     FStar_TypeChecker_Env.abstract_guard uu____30315 g1  in
-                   FStar_Pervasives_Native.Some uu____30314)))
+                   let uu____30277 =
+                     let uu____30278 = FStar_Syntax_Syntax.mk_binder x  in
+                     FStar_TypeChecker_Env.abstract_guard uu____30278 g1  in
+                   FStar_Pervasives_Native.Some uu____30277)))
   
 let (subtype_fail :
   FStar_TypeChecker_Env.env ->
@@ -11856,12 +11826,12 @@ let (subtype_fail :
     fun e  ->
       fun t1  ->
         fun t2  ->
-          let uu____30337 = FStar_TypeChecker_Env.get_range env  in
-          let uu____30338 =
+          let uu____30300 = FStar_TypeChecker_Env.get_range env  in
+          let uu____30301 =
             FStar_TypeChecker_Err.basic_type_error env
               (FStar_Pervasives_Native.Some e) t2 t1
              in
-          FStar_Errors.log_issue uu____30337 uu____30338
+          FStar_Errors.log_issue uu____30300 uu____30301
   
 let (sub_comp :
   FStar_TypeChecker_Env.env ->
@@ -11876,68 +11846,68 @@ let (sub_comp :
           if env.FStar_TypeChecker_Env.use_eq
           then FStar_TypeChecker_Common.EQ
           else FStar_TypeChecker_Common.SUB  in
-        (let uu____30367 =
+        (let uu____30330 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____30367
+         if uu____30330
          then
-           let uu____30372 = FStar_Syntax_Print.comp_to_string c1  in
-           let uu____30374 = FStar_Syntax_Print.comp_to_string c2  in
+           let uu____30335 = FStar_Syntax_Print.comp_to_string c1  in
+           let uu____30337 = FStar_Syntax_Print.comp_to_string c2  in
            FStar_Util.print3 "sub_comp of %s --and-- %s --with-- %s\n"
-             uu____30372 uu____30374
+             uu____30335 uu____30337
              (if rel = FStar_TypeChecker_Common.EQ then "EQ" else "SUB")
          else ());
-        (let uu____30385 =
-           let uu____30392 = FStar_TypeChecker_Env.get_range env  in
+        (let uu____30348 =
+           let uu____30355 = FStar_TypeChecker_Env.get_range env  in
            new_problem (empty_worklist env) env c1 rel c2
-             FStar_Pervasives_Native.None uu____30392 "sub_comp"
+             FStar_Pervasives_Native.None uu____30355 "sub_comp"
             in
-         match uu____30385 with
+         match uu____30348 with
          | (prob,wl) ->
              let wl1 =
-               let uu___4018_30403 = wl  in
+               let uu___4018_30366 = wl  in
                {
-                 attempting = (uu___4018_30403.attempting);
-                 wl_deferred = (uu___4018_30403.wl_deferred);
-                 ctr = (uu___4018_30403.ctr);
-                 defer_ok = (uu___4018_30403.defer_ok);
-                 smt_ok = (uu___4018_30403.smt_ok);
-                 umax_heuristic_ok = (uu___4018_30403.umax_heuristic_ok);
-                 tcenv = (uu___4018_30403.tcenv);
-                 wl_implicits = (uu___4018_30403.wl_implicits);
+                 attempting = (uu___4018_30366.attempting);
+                 wl_deferred = (uu___4018_30366.wl_deferred);
+                 ctr = (uu___4018_30366.ctr);
+                 defer_ok = (uu___4018_30366.defer_ok);
+                 smt_ok = (uu___4018_30366.smt_ok);
+                 umax_heuristic_ok = (uu___4018_30366.umax_heuristic_ok);
+                 tcenv = (uu___4018_30366.tcenv);
+                 wl_implicits = (uu___4018_30366.wl_implicits);
                  repr_subcomp_allowed = true
                }  in
              let prob1 = FStar_TypeChecker_Common.CProb prob  in
              (def_check_prob "sub_comp" prob1;
-              (let uu____30408 =
+              (let uu____30371 =
                  FStar_Util.record_time
-                   (fun uu____30420  ->
-                      let uu____30421 =
+                   (fun uu____30383  ->
+                      let uu____30384 =
                         solve_and_commit env (singleton wl1 prob1 true)
-                          (fun uu____30430  -> FStar_Pervasives_Native.None)
+                          (fun uu____30393  -> FStar_Pervasives_Native.None)
                          in
-                      FStar_All.pipe_left (with_guard env prob1) uu____30421)
+                      FStar_All.pipe_left (with_guard env prob1) uu____30384)
                   in
-               match uu____30408 with
+               match uu____30371 with
                | (r,ms) ->
-                   ((let uu____30458 =
+                   ((let uu____30421 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "RelBench")
                         in
-                     if uu____30458
+                     if uu____30421
                      then
-                       let uu____30463 = FStar_Syntax_Print.comp_to_string c1
+                       let uu____30426 = FStar_Syntax_Print.comp_to_string c1
                           in
-                       let uu____30465 = FStar_Syntax_Print.comp_to_string c2
+                       let uu____30428 = FStar_Syntax_Print.comp_to_string c2
                           in
-                       let uu____30467 = FStar_Util.string_of_int ms  in
+                       let uu____30430 = FStar_Util.string_of_int ms  in
                        FStar_Util.print4
                          "sub_comp of %s --and-- %s --with-- %s --- solved in %s ms\n"
-                         uu____30463 uu____30465
+                         uu____30426 uu____30428
                          (if rel = FStar_TypeChecker_Common.EQ
                           then "EQ"
-                          else "SUB") uu____30467
+                          else "SUB") uu____30430
                      else ());
                     r))))
   
@@ -11950,53 +11920,53 @@ let (solve_universe_inequalities' :
   =
   fun tx  ->
     fun env  ->
-      fun uu____30505  ->
-        match uu____30505 with
+      fun uu____30468  ->
+        match uu____30468 with
         | (variables,ineqs) ->
             let fail u1 u2 =
               FStar_Syntax_Unionfind.rollback tx;
-              (let uu____30548 =
-                 let uu____30554 =
-                   let uu____30556 = FStar_Syntax_Print.univ_to_string u1  in
-                   let uu____30558 = FStar_Syntax_Print.univ_to_string u2  in
+              (let uu____30511 =
+                 let uu____30517 =
+                   let uu____30519 = FStar_Syntax_Print.univ_to_string u1  in
+                   let uu____30521 = FStar_Syntax_Print.univ_to_string u2  in
                    FStar_Util.format2 "Universe %s and %s are incompatible"
-                     uu____30556 uu____30558
+                     uu____30519 uu____30521
                     in
-                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____30554)  in
-               let uu____30562 = FStar_TypeChecker_Env.get_range env  in
-               FStar_Errors.raise_error uu____30548 uu____30562)
+                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____30517)  in
+               let uu____30525 = FStar_TypeChecker_Env.get_range env  in
+               FStar_Errors.raise_error uu____30511 uu____30525)
                in
             let equiv v v' =
-              let uu____30575 =
-                let uu____30580 = FStar_Syntax_Subst.compress_univ v  in
-                let uu____30581 = FStar_Syntax_Subst.compress_univ v'  in
-                (uu____30580, uu____30581)  in
-              match uu____30575 with
+              let uu____30538 =
+                let uu____30543 = FStar_Syntax_Subst.compress_univ v  in
+                let uu____30544 = FStar_Syntax_Subst.compress_univ v'  in
+                (uu____30543, uu____30544)  in
+              match uu____30538 with
               | (FStar_Syntax_Syntax.U_unif v0,FStar_Syntax_Syntax.U_unif
                  v0') -> FStar_Syntax_Unionfind.univ_equiv v0 v0'
-              | uu____30605 -> false  in
+              | uu____30568 -> false  in
             let sols =
               FStar_All.pipe_right variables
                 (FStar_List.collect
                    (fun v  ->
-                      let uu____30636 = FStar_Syntax_Subst.compress_univ v
+                      let uu____30599 = FStar_Syntax_Subst.compress_univ v
                          in
-                      match uu____30636 with
-                      | FStar_Syntax_Syntax.U_unif uu____30643 ->
+                      match uu____30599 with
+                      | FStar_Syntax_Syntax.U_unif uu____30606 ->
                           let lower_bounds_of_v =
                             FStar_All.pipe_right ineqs
                               (FStar_List.collect
-                                 (fun uu____30674  ->
-                                    match uu____30674 with
+                                 (fun uu____30637  ->
+                                    match uu____30637 with
                                     | (u,v') ->
-                                        let uu____30683 = equiv v v'  in
-                                        if uu____30683
+                                        let uu____30646 = equiv v v'  in
+                                        if uu____30646
                                         then
-                                          let uu____30688 =
+                                          let uu____30651 =
                                             FStar_All.pipe_right variables
                                               (FStar_Util.for_some (equiv u))
                                              in
-                                          (if uu____30688 then [] else [u])
+                                          (if uu____30651 then [] else [u])
                                         else []))
                              in
                           let lb =
@@ -12005,43 +11975,43 @@ let (solve_universe_inequalities' :
                               (FStar_Syntax_Syntax.U_max lower_bounds_of_v)
                              in
                           [(lb, v)]
-                      | uu____30709 -> []))
+                      | uu____30672 -> []))
                in
-            let uu____30714 =
+            let uu____30677 =
               let wl =
-                let uu___4061_30718 = empty_worklist env  in
+                let uu___4061_30681 = empty_worklist env  in
                 {
-                  attempting = (uu___4061_30718.attempting);
-                  wl_deferred = (uu___4061_30718.wl_deferred);
-                  ctr = (uu___4061_30718.ctr);
+                  attempting = (uu___4061_30681.attempting);
+                  wl_deferred = (uu___4061_30681.wl_deferred);
+                  ctr = (uu___4061_30681.ctr);
                   defer_ok = false;
-                  smt_ok = (uu___4061_30718.smt_ok);
-                  umax_heuristic_ok = (uu___4061_30718.umax_heuristic_ok);
-                  tcenv = (uu___4061_30718.tcenv);
-                  wl_implicits = (uu___4061_30718.wl_implicits);
+                  smt_ok = (uu___4061_30681.smt_ok);
+                  umax_heuristic_ok = (uu___4061_30681.umax_heuristic_ok);
+                  tcenv = (uu___4061_30681.tcenv);
+                  wl_implicits = (uu___4061_30681.wl_implicits);
                   repr_subcomp_allowed =
-                    (uu___4061_30718.repr_subcomp_allowed)
+                    (uu___4061_30681.repr_subcomp_allowed)
                 }  in
               FStar_All.pipe_right sols
                 (FStar_List.map
-                   (fun uu____30737  ->
-                      match uu____30737 with
+                   (fun uu____30700  ->
+                      match uu____30700 with
                       | (lb,v) ->
-                          let uu____30744 =
+                          let uu____30707 =
                             solve_universe_eq (~- Prims.int_one) wl lb v  in
-                          (match uu____30744 with
+                          (match uu____30707 with
                            | USolved wl1 -> ()
-                           | uu____30747 -> fail lb v)))
+                           | uu____30710 -> fail lb v)))
                in
-            let rec check_ineq uu____30758 =
-              match uu____30758 with
+            let rec check_ineq uu____30721 =
+              match uu____30721 with
               | (u,v) ->
                   let u1 =
                     FStar_TypeChecker_Normalize.normalize_universe env u  in
                   let v1 =
                     FStar_TypeChecker_Normalize.normalize_universe env v  in
                   (match (u1, v1) with
-                   | (FStar_Syntax_Syntax.U_zero ,uu____30770) -> true
+                   | (FStar_Syntax_Syntax.U_zero ,uu____30733) -> true
                    | (FStar_Syntax_Syntax.U_succ
                       u0,FStar_Syntax_Syntax.U_succ v0) ->
                        check_ineq (u0, v0)
@@ -12052,70 +12022,70 @@ let (solve_universe_inequalities' :
                       u0,FStar_Syntax_Syntax.U_unif v0) ->
                        FStar_Syntax_Unionfind.univ_equiv u0 v0
                    | (FStar_Syntax_Syntax.U_name
-                      uu____30798,FStar_Syntax_Syntax.U_succ v0) ->
+                      uu____30761,FStar_Syntax_Syntax.U_succ v0) ->
                        check_ineq (u1, v0)
                    | (FStar_Syntax_Syntax.U_unif
-                      uu____30800,FStar_Syntax_Syntax.U_succ v0) ->
+                      uu____30763,FStar_Syntax_Syntax.U_succ v0) ->
                        check_ineq (u1, v0)
-                   | (FStar_Syntax_Syntax.U_max us,uu____30813) ->
+                   | (FStar_Syntax_Syntax.U_max us,uu____30776) ->
                        FStar_All.pipe_right us
                          (FStar_Util.for_all (fun u2  -> check_ineq (u2, v1)))
-                   | (uu____30821,FStar_Syntax_Syntax.U_max vs) ->
+                   | (uu____30784,FStar_Syntax_Syntax.U_max vs) ->
                        FStar_All.pipe_right vs
                          (FStar_Util.for_some
                             (fun v2  -> check_ineq (u1, v2)))
-                   | uu____30830 -> false)
+                   | uu____30793 -> false)
                in
-            let uu____30836 =
+            let uu____30799 =
               FStar_All.pipe_right ineqs
                 (FStar_Util.for_all
-                   (fun uu____30853  ->
-                      match uu____30853 with
+                   (fun uu____30816  ->
+                      match uu____30816 with
                       | (u,v) ->
-                          let uu____30861 = check_ineq (u, v)  in
-                          if uu____30861
+                          let uu____30824 = check_ineq (u, v)  in
+                          if uu____30824
                           then true
                           else
-                            ((let uu____30869 =
+                            ((let uu____30832 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   (FStar_Options.Other "GenUniverses")
                                  in
-                              if uu____30869
+                              if uu____30832
                               then
-                                let uu____30874 =
+                                let uu____30837 =
                                   FStar_Syntax_Print.univ_to_string u  in
-                                let uu____30876 =
+                                let uu____30839 =
                                   FStar_Syntax_Print.univ_to_string v  in
-                                FStar_Util.print2 "%s </= %s" uu____30874
-                                  uu____30876
+                                FStar_Util.print2 "%s </= %s" uu____30837
+                                  uu____30839
                               else ());
                              false)))
                in
-            if uu____30836
+            if uu____30799
             then ()
             else
-              ((let uu____30886 =
+              ((let uu____30849 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "GenUniverses")
                    in
-                if uu____30886
+                if uu____30849
                 then
-                  ((let uu____30892 = ineqs_to_string (variables, ineqs)  in
+                  ((let uu____30855 = ineqs_to_string (variables, ineqs)  in
                     FStar_Util.print1
                       "Partially solved inequality constraints are: %s\n"
-                      uu____30892);
+                      uu____30855);
                    FStar_Syntax_Unionfind.rollback tx;
-                   (let uu____30904 = ineqs_to_string (variables, ineqs)  in
+                   (let uu____30867 = ineqs_to_string (variables, ineqs)  in
                     FStar_Util.print1
                       "Original solved inequality constraints are: %s\n"
-                      uu____30904))
+                      uu____30867))
                 else ());
-               (let uu____30917 = FStar_TypeChecker_Env.get_range env  in
+               (let uu____30880 = FStar_TypeChecker_Env.get_range env  in
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_FailToSolveUniverseInEquality,
                     "Failed to solve universe inequalities for inductives")
-                  uu____30917))
+                  uu____30880))
   
 let (solve_universe_inequalities :
   FStar_TypeChecker_Env.env ->
@@ -12138,8 +12108,8 @@ let (try_solve_deferred_constraints :
     fun smt_ok  ->
       fun env  ->
         fun g  ->
-          let fail uu____30997 =
-            match uu____30997 with
+          let fail uu____30960 =
+            match uu____30960 with
             | (d,s) ->
                 let msg = explain env d s  in
                 FStar_Errors.raise_error
@@ -12147,69 +12117,69 @@ let (try_solve_deferred_constraints :
                   (p_loc d)
              in
           let wl =
-            let uu___4139_31020 =
+            let uu___4139_30983 =
               wl_of_guard env g.FStar_TypeChecker_Common.deferred  in
             {
-              attempting = (uu___4139_31020.attempting);
-              wl_deferred = (uu___4139_31020.wl_deferred);
-              ctr = (uu___4139_31020.ctr);
+              attempting = (uu___4139_30983.attempting);
+              wl_deferred = (uu___4139_30983.wl_deferred);
+              ctr = (uu___4139_30983.ctr);
               defer_ok;
               smt_ok;
-              umax_heuristic_ok = (uu___4139_31020.umax_heuristic_ok);
-              tcenv = (uu___4139_31020.tcenv);
-              wl_implicits = (uu___4139_31020.wl_implicits);
-              repr_subcomp_allowed = (uu___4139_31020.repr_subcomp_allowed)
+              umax_heuristic_ok = (uu___4139_30983.umax_heuristic_ok);
+              tcenv = (uu___4139_30983.tcenv);
+              wl_implicits = (uu___4139_30983.wl_implicits);
+              repr_subcomp_allowed = (uu___4139_30983.repr_subcomp_allowed)
             }  in
-          (let uu____31023 =
+          (let uu____30986 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel")
               in
-           if uu____31023
+           if uu____30986
            then
-             let uu____31028 = FStar_Util.string_of_bool defer_ok  in
-             let uu____31030 = wl_to_string wl  in
-             let uu____31032 =
+             let uu____30991 = FStar_Util.string_of_bool defer_ok  in
+             let uu____30993 = wl_to_string wl  in
+             let uu____30995 =
                FStar_Util.string_of_int
                  (FStar_List.length g.FStar_TypeChecker_Common.implicits)
                 in
              FStar_Util.print3
                "Trying to solve carried problems (defer_ok=%s): begin\n\t%s\nend\n and %s implicits\n"
-               uu____31028 uu____31030 uu____31032
+               uu____30991 uu____30993 uu____30995
            else ());
           (let g1 =
-             let uu____31038 = solve_and_commit env wl fail  in
-             match uu____31038 with
+             let uu____31001 = solve_and_commit env wl fail  in
+             match uu____31001 with
              | FStar_Pervasives_Native.Some
-                 (uu____31045::uu____31046,uu____31047) when
+                 (uu____31008::uu____31009,uu____31010) when
                  Prims.op_Negation defer_ok ->
                  failwith
                    "Impossible: Unexpected deferred constraints remain"
              | FStar_Pervasives_Native.Some (deferred,imps) ->
-                 let uu___4154_31076 = g  in
+                 let uu___4154_31039 = g  in
                  {
                    FStar_TypeChecker_Common.guard_f =
-                     (uu___4154_31076.FStar_TypeChecker_Common.guard_f);
+                     (uu___4154_31039.FStar_TypeChecker_Common.guard_f);
                    FStar_TypeChecker_Common.deferred = deferred;
                    FStar_TypeChecker_Common.univ_ineqs =
-                     (uu___4154_31076.FStar_TypeChecker_Common.univ_ineqs);
+                     (uu___4154_31039.FStar_TypeChecker_Common.univ_ineqs);
                    FStar_TypeChecker_Common.implicits =
                      (FStar_List.append g.FStar_TypeChecker_Common.implicits
                         imps)
                  }
-             | uu____31077 ->
+             | uu____31040 ->
                  failwith "Impossible: should have raised a failure already"
               in
            solve_universe_inequalities env
              g1.FStar_TypeChecker_Common.univ_ineqs;
-           (let uu___4159_31086 = g1  in
+           (let uu___4159_31049 = g1  in
             {
               FStar_TypeChecker_Common.guard_f =
-                (uu___4159_31086.FStar_TypeChecker_Common.guard_f);
+                (uu___4159_31049.FStar_TypeChecker_Common.guard_f);
               FStar_TypeChecker_Common.deferred =
-                (uu___4159_31086.FStar_TypeChecker_Common.deferred);
+                (uu___4159_31049.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs = ([], []);
               FStar_TypeChecker_Common.implicits =
-                (uu___4159_31086.FStar_TypeChecker_Common.implicits)
+                (uu___4159_31049.FStar_TypeChecker_Common.implicits)
             }))
   
 let (solve_deferred_constraints' :
@@ -12251,21 +12221,21 @@ let (discharge_guard' :
              in
           let g1 = solve_deferred_constraints' use_smt env g  in
           let ret_g =
-            let uu___4174_31183 = g1  in
+            let uu___4174_31146 = g1  in
             {
               FStar_TypeChecker_Common.guard_f =
                 FStar_TypeChecker_Common.Trivial;
               FStar_TypeChecker_Common.deferred =
-                (uu___4174_31183.FStar_TypeChecker_Common.deferred);
+                (uu___4174_31146.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___4174_31183.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___4174_31146.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___4174_31183.FStar_TypeChecker_Common.implicits)
+                (uu___4174_31146.FStar_TypeChecker_Common.implicits)
             }  in
-          let uu____31184 =
-            let uu____31186 = FStar_TypeChecker_Env.should_verify env  in
-            Prims.op_Negation uu____31186  in
-          if uu____31184
+          let uu____31147 =
+            let uu____31149 = FStar_TypeChecker_Env.should_verify env  in
+            Prims.op_Negation uu____31149  in
+          if uu____31147
           then FStar_Pervasives_Native.Some ret_g
           else
             (match g1.FStar_TypeChecker_Common.guard_f with
@@ -12274,49 +12244,49 @@ let (discharge_guard' :
              | FStar_TypeChecker_Common.NonTrivial vc ->
                  (if debug
                   then
-                    (let uu____31198 = FStar_TypeChecker_Env.get_range env
+                    (let uu____31161 = FStar_TypeChecker_Env.get_range env
                         in
-                     let uu____31199 =
-                       let uu____31201 = FStar_Syntax_Print.term_to_string vc
+                     let uu____31162 =
+                       let uu____31164 = FStar_Syntax_Print.term_to_string vc
                           in
                        FStar_Util.format1 "Before normalization VC=\n%s\n"
-                         uu____31201
+                         uu____31164
                         in
-                     FStar_Errors.diag uu____31198 uu____31199)
+                     FStar_Errors.diag uu____31161 uu____31162)
                   else ();
                   (let vc1 =
-                     let uu____31207 =
-                       let uu____31211 =
-                         let uu____31213 =
+                     let uu____31170 =
+                       let uu____31174 =
+                         let uu____31176 =
                            FStar_TypeChecker_Env.current_module env  in
-                         FStar_Ident.string_of_lid uu____31213  in
-                       FStar_Pervasives_Native.Some uu____31211  in
+                         FStar_Ident.string_of_lid uu____31176  in
+                       FStar_Pervasives_Native.Some uu____31174  in
                      FStar_Profiling.profile
-                       (fun uu____31216  ->
+                       (fun uu____31179  ->
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.Eager_unfolding;
                             FStar_TypeChecker_Env.Simplify;
                             FStar_TypeChecker_Env.Primops] env vc)
-                       uu____31207 "FStar.TypeChecker.Rel.vc_normalization"
+                       uu____31170 "FStar.TypeChecker.Rel.vc_normalization"
                       in
                    if debug
                    then
-                     (let uu____31220 = FStar_TypeChecker_Env.get_range env
+                     (let uu____31183 = FStar_TypeChecker_Env.get_range env
                          in
-                      let uu____31221 =
-                        let uu____31223 =
+                      let uu____31184 =
+                        let uu____31186 =
                           FStar_Syntax_Print.term_to_string vc1  in
                         FStar_Util.format1 "After normalization VC=\n%s\n"
-                          uu____31223
+                          uu____31186
                          in
-                      FStar_Errors.diag uu____31220 uu____31221)
+                      FStar_Errors.diag uu____31183 uu____31184)
                    else ();
-                   (let uu____31229 = FStar_TypeChecker_Env.get_range env  in
-                    FStar_TypeChecker_Env.def_check_closed_in_env uu____31229
+                   (let uu____31192 = FStar_TypeChecker_Env.get_range env  in
+                    FStar_TypeChecker_Env.def_check_closed_in_env uu____31192
                       "discharge_guard'" env vc1);
-                   (let uu____31231 =
+                   (let uu____31194 =
                       FStar_TypeChecker_Common.check_trivial vc1  in
-                    match uu____31231 with
+                    match uu____31194 with
                     | FStar_TypeChecker_Common.Trivial  ->
                         FStar_Pervasives_Native.Some ret_g
                     | FStar_TypeChecker_Common.NonTrivial vc2 ->
@@ -12324,78 +12294,78 @@ let (discharge_guard' :
                         then
                           (if debug
                            then
-                             (let uu____31240 =
+                             (let uu____31203 =
                                 FStar_TypeChecker_Env.get_range env  in
-                              let uu____31241 =
-                                let uu____31243 =
+                              let uu____31204 =
+                                let uu____31206 =
                                   FStar_Syntax_Print.term_to_string vc2  in
                                 FStar_Util.format1
                                   "Cannot solve without SMT : %s\n"
-                                  uu____31243
+                                  uu____31206
                                  in
-                              FStar_Errors.diag uu____31240 uu____31241)
+                              FStar_Errors.diag uu____31203 uu____31204)
                            else ();
                            FStar_Pervasives_Native.None)
                         else
                           (if debug
                            then
-                             (let uu____31253 =
+                             (let uu____31216 =
                                 FStar_TypeChecker_Env.get_range env  in
-                              let uu____31254 =
-                                let uu____31256 =
+                              let uu____31217 =
+                                let uu____31219 =
                                   FStar_Syntax_Print.term_to_string vc2  in
                                 FStar_Util.format1 "Checking VC=\n%s\n"
-                                  uu____31256
+                                  uu____31219
                                  in
-                              FStar_Errors.diag uu____31253 uu____31254)
+                              FStar_Errors.diag uu____31216 uu____31217)
                            else ();
                            (let vcs =
-                              let uu____31270 = FStar_Options.use_tactics ()
+                              let uu____31233 = FStar_Options.use_tactics ()
                                  in
-                              if uu____31270
+                              if uu____31233
                               then
                                 FStar_Options.with_saved_options
-                                  (fun uu____31292  ->
-                                     (let uu____31294 =
+                                  (fun uu____31255  ->
+                                     (let uu____31257 =
                                         FStar_Options.set_options
                                           "--no_tactics"
                                          in
                                       FStar_All.pipe_left
-                                        (fun uu____31296  -> ()) uu____31294);
+                                        (fun uu____31259  -> ()) uu____31257);
                                      (let vcs =
                                         (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.preprocess
                                           env vc2
                                          in
                                       FStar_All.pipe_right vcs
                                         (FStar_List.map
-                                           (fun uu____31339  ->
-                                              match uu____31339 with
+                                           (fun uu____31302  ->
+                                              match uu____31302 with
                                               | (env1,goal,opts) ->
-                                                  let uu____31355 =
+                                                  let uu____31318 =
                                                     norm_with_steps
                                                       "FStar.TypeChecker.Rel.norm_with_steps.7"
                                                       [FStar_TypeChecker_Env.Simplify;
                                                       FStar_TypeChecker_Env.Primops]
                                                       env1 goal
                                                      in
-                                                  (env1, uu____31355, opts)))))
+                                                  (env1, uu____31318, opts)))))
                               else
-                                (let uu____31359 =
-                                   let uu____31366 = FStar_Options.peek ()
+                                (let uu____31322 =
+                                   let uu____31329 = FStar_Options.peek ()
                                       in
-                                   (env, vc2, uu____31366)  in
-                                 [uu____31359])
+                                   (env, vc2, uu____31329)  in
+                                 [uu____31322])
                                in
                             FStar_All.pipe_right vcs
                               (FStar_List.iter
-                                 (fun uu____31399  ->
-                                    match uu____31399 with
+                                 (fun uu____31362  ->
+                                    match uu____31362 with
                                     | (env1,goal,opts) ->
-                                        let uu____31409 =
+                                        let uu____31372 =
                                           FStar_TypeChecker_Common.check_trivial
                                             goal
                                            in
-                                        (match uu____31409 with
+                                        (match uu____31372 with
                                          | FStar_TypeChecker_Common.Trivial 
                                              ->
                                              if debug
@@ -12409,43 +12379,43 @@ let (discharge_guard' :
                                               FStar_Options.set opts;
                                               if debug
                                               then
-                                                (let uu____31420 =
+                                                (let uu____31383 =
                                                    FStar_TypeChecker_Env.get_range
                                                      env1
                                                     in
-                                                 let uu____31421 =
-                                                   let uu____31423 =
+                                                 let uu____31384 =
+                                                   let uu____31386 =
                                                      FStar_Syntax_Print.term_to_string
                                                        goal1
                                                       in
-                                                   let uu____31425 =
+                                                   let uu____31388 =
                                                      FStar_TypeChecker_Env.string_of_proof_ns
                                                        env1
                                                       in
                                                    FStar_Util.format2
                                                      "Trying to solve:\n> %s\nWith proof_ns:\n %s\n"
-                                                     uu____31423 uu____31425
+                                                     uu____31386 uu____31388
                                                     in
                                                  FStar_Errors.diag
-                                                   uu____31420 uu____31421)
+                                                   uu____31383 uu____31384)
                                               else ();
                                               if debug
                                               then
-                                                (let uu____31432 =
+                                                (let uu____31395 =
                                                    FStar_TypeChecker_Env.get_range
                                                      env1
                                                     in
-                                                 let uu____31433 =
-                                                   let uu____31435 =
+                                                 let uu____31396 =
+                                                   let uu____31398 =
                                                      FStar_Syntax_Print.term_to_string
                                                        goal1
                                                       in
                                                    FStar_Util.format1
                                                      "Before calling solver VC=\n%s\n"
-                                                     uu____31435
+                                                     uu____31398
                                                     in
                                                  FStar_Errors.diag
-                                                   uu____31432 uu____31433)
+                                                   uu____31395 uu____31396)
                                               else ();
                                               (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.solve
                                                 use_env_range_msg env1 goal1;
@@ -12458,15 +12428,15 @@ let (discharge_guard_no_smt :
   =
   fun env  ->
     fun g  ->
-      let uu____31453 =
+      let uu____31416 =
         discharge_guard' FStar_Pervasives_Native.None env g false  in
-      match uu____31453 with
+      match uu____31416 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None  ->
-          let uu____31462 = FStar_TypeChecker_Env.get_range env  in
+          let uu____31425 = FStar_TypeChecker_Env.get_range env  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExpectTrivialPreCondition,
-              "Expected a trivial pre-condition") uu____31462
+              "Expected a trivial pre-condition") uu____31425
   
 let (discharge_guard :
   FStar_TypeChecker_Env.env ->
@@ -12474,9 +12444,9 @@ let (discharge_guard :
   =
   fun env  ->
     fun g  ->
-      let uu____31476 =
+      let uu____31439 =
         discharge_guard' FStar_Pervasives_Native.None env g true  in
-      match uu____31476 with
+      match uu____31439 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None  ->
           failwith
@@ -12491,8 +12461,8 @@ let (teq_nosmt :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31506 = try_teq false env t1 t2  in
-        match uu____31506 with
+        let uu____31469 = try_teq false env t1 t2  in
+        match uu____31469 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some g ->
             discharge_guard' FStar_Pervasives_Native.None env g false
@@ -12508,26 +12478,26 @@ let (resolve_implicits' :
       fun forcelax  ->
         fun g  ->
           let rec unresolved ctx_u =
-            let uu____31550 =
+            let uu____31513 =
               FStar_Syntax_Unionfind.find
                 ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                in
-            match uu____31550 with
+            match uu____31513 with
             | FStar_Pervasives_Native.Some r ->
                 (match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta with
                  | FStar_Pervasives_Native.None  -> false
-                 | FStar_Pervasives_Native.Some uu____31563 ->
-                     let uu____31576 =
-                       let uu____31577 = FStar_Syntax_Subst.compress r  in
-                       uu____31577.FStar_Syntax_Syntax.n  in
-                     (match uu____31576 with
-                      | FStar_Syntax_Syntax.Tm_uvar (ctx_u',uu____31582) ->
+                 | FStar_Pervasives_Native.Some uu____31526 ->
+                     let uu____31539 =
+                       let uu____31540 = FStar_Syntax_Subst.compress r  in
+                       uu____31540.FStar_Syntax_Syntax.n  in
+                     (match uu____31539 with
+                      | FStar_Syntax_Syntax.Tm_uvar (ctx_u',uu____31545) ->
                           unresolved ctx_u'
-                      | uu____31599 -> false))
+                      | uu____31562 -> false))
             | FStar_Pervasives_Native.None  -> true  in
           let rec until_fixpoint acc implicits =
-            let uu____31623 = acc  in
-            match uu____31623 with
+            let uu____31586 = acc  in
+            match uu____31586 with
             | (out,changed) ->
                 (match implicits with
                  | [] ->
@@ -12535,8 +12505,8 @@ let (resolve_implicits' :
                      then out
                      else until_fixpoint ([], false) out
                  | hd::tl ->
-                     let uu____31642 = hd  in
-                     (match uu____31642 with
+                     let uu____31605 = hd  in
+                     (match uu____31605 with
                       | { FStar_TypeChecker_Common.imp_reason = reason;
                           FStar_TypeChecker_Common.imp_uvar = ctx_u;
                           FStar_TypeChecker_Common.imp_tm = tm;
@@ -12546,8 +12516,8 @@ let (resolve_implicits' :
                               FStar_Syntax_Syntax.Allow_unresolved
                           then until_fixpoint (out, true) tl
                           else
-                            (let uu____31653 = unresolved ctx_u  in
-                             if uu____31653
+                            (let uu____31616 = unresolved ctx_u  in
+                             if uu____31616
                              then
                                match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta
                                with
@@ -12556,19 +12526,19 @@ let (resolve_implicits' :
                                | FStar_Pervasives_Native.Some (env_dyn,tau)
                                    ->
                                    let env1 = FStar_Dyn.undyn env_dyn  in
-                                   ((let uu____31677 =
+                                   ((let uu____31640 =
                                        FStar_TypeChecker_Env.debug env1
                                          (FStar_Options.Other "Tac")
                                         in
-                                     if uu____31677
+                                     if uu____31640
                                      then
-                                       let uu____31681 =
+                                       let uu____31644 =
                                          FStar_Syntax_Print.ctx_uvar_to_string
                                            ctx_u
                                           in
                                        FStar_Util.print1
                                          "Running tactic for meta-arg %s\n"
-                                         uu____31681
+                                         uu____31644
                                      else ());
                                     (let t =
                                        env1.FStar_TypeChecker_Env.synth_hook
@@ -12577,9 +12547,9 @@ let (resolve_implicits' :
                                          tau
                                         in
                                      let extra =
-                                       let uu____31690 = teq_nosmt env1 t tm
+                                       let uu____31653 = teq_nosmt env1 t tm
                                           in
-                                       match uu____31690 with
+                                       match uu____31653 with
                                        | FStar_Pervasives_Native.None  ->
                                            failwith
                                              "resolve_implicits: unifying with an unresolved uvar failed?"
@@ -12587,40 +12557,40 @@ let (resolve_implicits' :
                                            g1.FStar_TypeChecker_Common.implicits
                                         in
                                      let ctx_u1 =
-                                       let uu___4287_31700 = ctx_u  in
+                                       let uu___4287_31663 = ctx_u  in
                                        {
                                          FStar_Syntax_Syntax.ctx_uvar_head =
-                                           (uu___4287_31700.FStar_Syntax_Syntax.ctx_uvar_head);
+                                           (uu___4287_31663.FStar_Syntax_Syntax.ctx_uvar_head);
                                          FStar_Syntax_Syntax.ctx_uvar_gamma =
-                                           (uu___4287_31700.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                           (uu___4287_31663.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                          FStar_Syntax_Syntax.ctx_uvar_binders
                                            =
-                                           (uu___4287_31700.FStar_Syntax_Syntax.ctx_uvar_binders);
+                                           (uu___4287_31663.FStar_Syntax_Syntax.ctx_uvar_binders);
                                          FStar_Syntax_Syntax.ctx_uvar_typ =
-                                           (uu___4287_31700.FStar_Syntax_Syntax.ctx_uvar_typ);
+                                           (uu___4287_31663.FStar_Syntax_Syntax.ctx_uvar_typ);
                                          FStar_Syntax_Syntax.ctx_uvar_reason
                                            =
-                                           (uu___4287_31700.FStar_Syntax_Syntax.ctx_uvar_reason);
+                                           (uu___4287_31663.FStar_Syntax_Syntax.ctx_uvar_reason);
                                          FStar_Syntax_Syntax.ctx_uvar_should_check
                                            =
-                                           (uu___4287_31700.FStar_Syntax_Syntax.ctx_uvar_should_check);
+                                           (uu___4287_31663.FStar_Syntax_Syntax.ctx_uvar_should_check);
                                          FStar_Syntax_Syntax.ctx_uvar_range =
-                                           (uu___4287_31700.FStar_Syntax_Syntax.ctx_uvar_range);
+                                           (uu___4287_31663.FStar_Syntax_Syntax.ctx_uvar_range);
                                          FStar_Syntax_Syntax.ctx_uvar_meta =
                                            FStar_Pervasives_Native.None
                                        }  in
                                      let hd1 =
-                                       let uu___4290_31708 = hd  in
+                                       let uu___4290_31671 = hd  in
                                        {
                                          FStar_TypeChecker_Common.imp_reason
                                            =
-                                           (uu___4290_31708.FStar_TypeChecker_Common.imp_reason);
+                                           (uu___4290_31671.FStar_TypeChecker_Common.imp_reason);
                                          FStar_TypeChecker_Common.imp_uvar =
                                            ctx_u1;
                                          FStar_TypeChecker_Common.imp_tm =
-                                           (uu___4290_31708.FStar_TypeChecker_Common.imp_tm);
+                                           (uu___4290_31671.FStar_TypeChecker_Common.imp_tm);
                                          FStar_TypeChecker_Common.imp_range =
-                                           (uu___4290_31708.FStar_TypeChecker_Common.imp_range)
+                                           (uu___4290_31671.FStar_TypeChecker_Common.imp_range)
                                        }  in
                                      until_fixpoint (out, true)
                                        (FStar_List.append extra tl)))
@@ -12631,104 +12601,104 @@ let (resolve_implicits' :
                                then until_fixpoint (out, true) tl
                                else
                                  (let env1 =
-                                    let uu___4294_31719 = env  in
+                                    let uu___4294_31682 = env  in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.solver);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.range);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.curmodule);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
                                         (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.modules);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.sigtab);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.attrtab);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.effects);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.generalize);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.letrecs);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.top_level);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.check_uvars);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.check_uvars);
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.use_eq);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.is_iface);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.admit);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.lax);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.phase1);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.failhard);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.nosynth);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.tc_term);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.type_of);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.universe_of);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.splice);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.postprocess);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.dsenv);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.nbe);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___4294_31682.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___4294_31719.FStar_TypeChecker_Env.erasable_types_tab)
+                                        (uu___4294_31682.FStar_TypeChecker_Env.erasable_types_tab)
                                     }  in
                                   let tm1 =
                                     norm_with_steps
@@ -12738,138 +12708,138 @@ let (resolve_implicits' :
                                   let env2 =
                                     if forcelax
                                     then
-                                      let uu___4299_31724 = env1  in
+                                      let uu___4299_31687 = env1  in
                                       {
                                         FStar_TypeChecker_Env.solver =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.solver);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.solver);
                                         FStar_TypeChecker_Env.range =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.range);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.range);
                                         FStar_TypeChecker_Env.curmodule =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.curmodule);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.curmodule);
                                         FStar_TypeChecker_Env.gamma =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.gamma);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.gamma);
                                         FStar_TypeChecker_Env.gamma_sig =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.gamma_sig);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.gamma_sig);
                                         FStar_TypeChecker_Env.gamma_cache =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.gamma_cache);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.gamma_cache);
                                         FStar_TypeChecker_Env.modules =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.modules);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.modules);
                                         FStar_TypeChecker_Env.expected_typ =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.expected_typ);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.expected_typ);
                                         FStar_TypeChecker_Env.sigtab =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.sigtab);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.sigtab);
                                         FStar_TypeChecker_Env.attrtab =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.attrtab);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.attrtab);
                                         FStar_TypeChecker_Env.instantiate_imp
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.instantiate_imp);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.instantiate_imp);
                                         FStar_TypeChecker_Env.effects =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.effects);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.effects);
                                         FStar_TypeChecker_Env.generalize =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.generalize);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.generalize);
                                         FStar_TypeChecker_Env.letrecs =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.letrecs);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.letrecs);
                                         FStar_TypeChecker_Env.top_level =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.top_level);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.top_level);
                                         FStar_TypeChecker_Env.check_uvars =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.check_uvars);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.check_uvars);
                                         FStar_TypeChecker_Env.use_eq =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.use_eq);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.use_eq);
                                         FStar_TypeChecker_Env.use_eq_strict =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.use_eq_strict);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.use_eq_strict);
                                         FStar_TypeChecker_Env.is_iface =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.is_iface);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.is_iface);
                                         FStar_TypeChecker_Env.admit =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.admit);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.admit);
                                         FStar_TypeChecker_Env.lax = true;
                                         FStar_TypeChecker_Env.lax_universes =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.lax_universes);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.lax_universes);
                                         FStar_TypeChecker_Env.phase1 =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.phase1);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.phase1);
                                         FStar_TypeChecker_Env.failhard =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.failhard);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.failhard);
                                         FStar_TypeChecker_Env.nosynth =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.nosynth);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.nosynth);
                                         FStar_TypeChecker_Env.uvar_subtyping
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.uvar_subtyping);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.uvar_subtyping);
                                         FStar_TypeChecker_Env.tc_term =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.tc_term);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.tc_term);
                                         FStar_TypeChecker_Env.type_of =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.type_of);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.type_of);
                                         FStar_TypeChecker_Env.universe_of =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.universe_of);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.universe_of);
                                         FStar_TypeChecker_Env.check_type_of =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.check_type_of);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.check_type_of);
                                         FStar_TypeChecker_Env.use_bv_sorts =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.use_bv_sorts);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.use_bv_sorts);
                                         FStar_TypeChecker_Env.qtbl_name_and_index
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.qtbl_name_and_index);
                                         FStar_TypeChecker_Env.normalized_eff_names
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.normalized_eff_names);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.normalized_eff_names);
                                         FStar_TypeChecker_Env.fv_delta_depths
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.fv_delta_depths);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.fv_delta_depths);
                                         FStar_TypeChecker_Env.proof_ns =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.proof_ns);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.proof_ns);
                                         FStar_TypeChecker_Env.synth_hook =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.synth_hook);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.synth_hook);
                                         FStar_TypeChecker_Env.try_solve_implicits_hook
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                         FStar_TypeChecker_Env.splice =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.splice);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.splice);
                                         FStar_TypeChecker_Env.mpreprocess =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.mpreprocess);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.mpreprocess);
                                         FStar_TypeChecker_Env.postprocess =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.postprocess);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.postprocess);
                                         FStar_TypeChecker_Env.identifier_info
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.identifier_info);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.identifier_info);
                                         FStar_TypeChecker_Env.tc_hooks =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.tc_hooks);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.tc_hooks);
                                         FStar_TypeChecker_Env.dsenv =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.dsenv);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.dsenv);
                                         FStar_TypeChecker_Env.nbe =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.nbe);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.nbe);
                                         FStar_TypeChecker_Env.strict_args_tab
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.strict_args_tab);
+                                          (uu___4299_31687.FStar_TypeChecker_Env.strict_args_tab);
                                         FStar_TypeChecker_Env.erasable_types_tab
                                           =
-                                          (uu___4299_31724.FStar_TypeChecker_Env.erasable_types_tab)
+                                          (uu___4299_31687.FStar_TypeChecker_Env.erasable_types_tab)
                                       }
                                     else env1  in
-                                  (let uu____31729 =
+                                  (let uu____31692 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Rel")
                                       in
-                                   if uu____31729
+                                   if uu____31692
                                    then
-                                     let uu____31734 =
+                                     let uu____31697 =
                                        FStar_Syntax_Print.uvar_to_string
                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                                         in
-                                     let uu____31736 =
+                                     let uu____31699 =
                                        FStar_Syntax_Print.term_to_string tm1
                                         in
-                                     let uu____31738 =
+                                     let uu____31701 =
                                        FStar_Syntax_Print.term_to_string
                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
                                         in
-                                     let uu____31740 =
+                                     let uu____31703 =
                                        FStar_Range.string_of_range r  in
                                      FStar_Util.print5
                                        "Checking uvar %s resolved to %s at type %s, introduce for %s at %s\n"
-                                       uu____31734 uu____31736 uu____31738
-                                       reason uu____31740
+                                       uu____31697 uu____31699 uu____31701
+                                       reason uu____31703
                                    else ());
                                   (let g1 =
                                      try
-                                       (fun uu___4305_31747  ->
+                                       (fun uu___4305_31710  ->
                                           match () with
                                           | () ->
                                               env2.FStar_TypeChecker_Env.check_type_of
@@ -12878,59 +12848,59 @@ let (resolve_implicits' :
                                          ()
                                      with
                                      | e when FStar_Errors.handleable e ->
-                                         ((let uu____31754 =
-                                             let uu____31764 =
-                                               let uu____31772 =
-                                                 let uu____31774 =
+                                         ((let uu____31717 =
+                                             let uu____31727 =
+                                               let uu____31735 =
+                                                 let uu____31737 =
                                                    FStar_Syntax_Print.uvar_to_string
                                                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_head
                                                     in
-                                                 let uu____31776 =
+                                                 let uu____31739 =
                                                    FStar_TypeChecker_Normalize.term_to_string
                                                      env2 tm1
                                                     in
-                                                 let uu____31778 =
+                                                 let uu____31741 =
                                                    FStar_TypeChecker_Normalize.term_to_string
                                                      env2
                                                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
                                                     in
                                                  FStar_Util.format3
                                                    "Failed while checking implicit %s set to %s of expected type %s"
-                                                   uu____31774 uu____31776
-                                                   uu____31778
+                                                   uu____31737 uu____31739
+                                                   uu____31741
                                                   in
                                                (FStar_Errors.Error_BadImplicit,
-                                                 uu____31772, r)
+                                                 uu____31735, r)
                                                 in
-                                             [uu____31764]  in
+                                             [uu____31727]  in
                                            FStar_Errors.add_errors
-                                             uu____31754);
+                                             uu____31717);
                                           FStar_Exn.raise e)
                                       in
                                    let g' =
-                                     let uu____31797 =
+                                     let uu____31760 =
                                        discharge_guard'
                                          (FStar_Pervasives_Native.Some
-                                            (fun uu____31808  ->
-                                               let uu____31809 =
+                                            (fun uu____31771  ->
+                                               let uu____31772 =
                                                  FStar_Syntax_Print.term_to_string
                                                    tm1
                                                   in
-                                               let uu____31811 =
+                                               let uu____31774 =
                                                  FStar_Range.string_of_range
                                                    r
                                                   in
-                                               let uu____31813 =
+                                               let uu____31776 =
                                                  FStar_Range.string_of_range
                                                    tm1.FStar_Syntax_Syntax.pos
                                                   in
                                                FStar_Util.format4
                                                  "%s (Introduced at %s for %s resolved at %s)"
-                                                 uu____31809 uu____31811
-                                                 reason uu____31813)) env2 g1
+                                                 uu____31772 uu____31774
+                                                 reason uu____31776)) env2 g1
                                          true
                                         in
-                                     match uu____31797 with
+                                     match uu____31760 with
                                      | FStar_Pervasives_Native.Some g2 -> g2
                                      | FStar_Pervasives_Native.None  ->
                                          failwith
@@ -12941,18 +12911,18 @@ let (resolve_implicits' :
                                          g'.FStar_TypeChecker_Common.implicits
                                          out), true) tl)))))
              in
-          let uu___4317_31821 = g  in
-          let uu____31822 =
+          let uu___4317_31784 = g  in
+          let uu____31785 =
             until_fixpoint ([], false) g.FStar_TypeChecker_Common.implicits
              in
           {
             FStar_TypeChecker_Common.guard_f =
-              (uu___4317_31821.FStar_TypeChecker_Common.guard_f);
+              (uu___4317_31784.FStar_TypeChecker_Common.guard_f);
             FStar_TypeChecker_Common.deferred =
-              (uu___4317_31821.FStar_TypeChecker_Common.deferred);
+              (uu___4317_31784.FStar_TypeChecker_Common.deferred);
             FStar_TypeChecker_Common.univ_ineqs =
-              (uu___4317_31821.FStar_TypeChecker_Common.univ_ineqs);
-            FStar_TypeChecker_Common.implicits = uu____31822
+              (uu___4317_31784.FStar_TypeChecker_Common.univ_ineqs);
+            FStar_TypeChecker_Common.implicits = uu____31785
           }
   
 let (resolve_implicits :
@@ -12974,31 +12944,31 @@ let (force_trivial_guard :
   fun env  ->
     fun g  ->
       let g1 =
-        let uu____31862 = solve_deferred_constraints env g  in
-        FStar_All.pipe_right uu____31862 (resolve_implicits env)  in
+        let uu____31825 = solve_deferred_constraints env g  in
+        FStar_All.pipe_right uu____31825 (resolve_implicits env)  in
       match g1.FStar_TypeChecker_Common.implicits with
       | [] ->
-          let uu____31863 = discharge_guard env g1  in
-          FStar_All.pipe_left (fun uu____31864  -> ()) uu____31863
-      | imp::uu____31866 ->
-          let uu____31869 =
-            let uu____31875 =
-              let uu____31877 =
+          let uu____31826 = discharge_guard env g1  in
+          FStar_All.pipe_left (fun uu____31827  -> ()) uu____31826
+      | imp::uu____31829 ->
+          let uu____31832 =
+            let uu____31838 =
+              let uu____31840 =
                 FStar_Syntax_Print.uvar_to_string
                   (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
                  in
-              let uu____31879 =
+              let uu____31842 =
                 FStar_TypeChecker_Normalize.term_to_string env
                   (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
                  in
               FStar_Util.format3
                 "Failed to resolve implicit argument %s of type %s introduced for %s"
-                uu____31877 uu____31879
+                uu____31840 uu____31842
                 imp.FStar_TypeChecker_Common.imp_reason
                in
-            (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____31875)
+            (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____31838)
              in
-          FStar_Errors.raise_error uu____31869
+          FStar_Errors.raise_error uu____31832
             imp.FStar_TypeChecker_Common.imp_range
   
 let (teq_force :
@@ -13008,8 +12978,8 @@ let (teq_force :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31899 = teq env t1 t2  in
-        force_trivial_guard env uu____31899
+        let uu____31862 = teq env t1 t2  in
+        force_trivial_guard env uu____31862
   
 let (teq_nosmt_force :
   FStar_TypeChecker_Env.env ->
@@ -13018,8 +12988,8 @@ let (teq_nosmt_force :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____31918 = teq_nosmt env t1 t2  in
-        match uu____31918 with
+        let uu____31881 = teq_nosmt env t1 t2  in
+        match uu____31881 with
         | FStar_Pervasives_Native.None  -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)
   
@@ -13029,15 +12999,15 @@ let (universe_inequality :
   =
   fun u1  ->
     fun u2  ->
-      let uu___4342_31937 = FStar_TypeChecker_Common.trivial_guard  in
+      let uu___4342_31900 = FStar_TypeChecker_Common.trivial_guard  in
       {
         FStar_TypeChecker_Common.guard_f =
-          (uu___4342_31937.FStar_TypeChecker_Common.guard_f);
+          (uu___4342_31900.FStar_TypeChecker_Common.guard_f);
         FStar_TypeChecker_Common.deferred =
-          (uu___4342_31937.FStar_TypeChecker_Common.deferred);
+          (uu___4342_31900.FStar_TypeChecker_Common.deferred);
         FStar_TypeChecker_Common.univ_ineqs = ([], [(u1, u2)]);
         FStar_TypeChecker_Common.implicits =
-          (uu___4342_31937.FStar_TypeChecker_Common.implicits)
+          (uu___4342_31900.FStar_TypeChecker_Common.implicits)
       }
   
 let (check_subtyping :
@@ -13050,48 +13020,48 @@ let (check_subtyping :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        (let uu____31973 =
+        (let uu____31936 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____31973
+         if uu____31936
          then
-           let uu____31978 =
+           let uu____31941 =
              FStar_TypeChecker_Normalize.term_to_string env t1  in
-           let uu____31980 =
+           let uu____31943 =
              FStar_TypeChecker_Normalize.term_to_string env t2  in
-           FStar_Util.print2 "check_subtyping of %s and %s\n" uu____31978
-             uu____31980
+           FStar_Util.print2 "check_subtyping of %s and %s\n" uu____31941
+             uu____31943
          else ());
-        (let uu____31985 =
+        (let uu____31948 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2
             in
-         match uu____31985 with
+         match uu____31948 with
          | (prob,x,wl) ->
              let g =
-               let uu____32004 =
+               let uu____31967 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____32013  -> FStar_Pervasives_Native.None)
+                   (fun uu____31976  -> FStar_Pervasives_Native.None)
                   in
-               FStar_All.pipe_left (with_guard env prob) uu____32004  in
-             ((let uu____32031 =
+               FStar_All.pipe_left (with_guard env prob) uu____31967  in
+             ((let uu____31994 =
                  (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "Rel"))
                    && (FStar_Util.is_some g)
                   in
-               if uu____32031
+               if uu____31994
                then
-                 let uu____32036 =
+                 let uu____31999 =
                    FStar_TypeChecker_Normalize.term_to_string env t1  in
-                 let uu____32038 =
+                 let uu____32001 =
                    FStar_TypeChecker_Normalize.term_to_string env t2  in
-                 let uu____32040 =
-                   let uu____32042 = FStar_Util.must g  in
-                   guard_to_string env uu____32042  in
+                 let uu____32003 =
+                   let uu____32005 = FStar_Util.must g  in
+                   guard_to_string env uu____32005  in
                  FStar_Util.print3
                    "check_subtyping succeeded: %s <: %s\n\tguard is %s\n"
-                   uu____32036 uu____32038 uu____32040
+                   uu____31999 uu____32001 uu____32003
                else ());
               (match g with
                | FStar_Pervasives_Native.None  ->
@@ -13108,14 +13078,14 @@ let (get_subtyping_predicate :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____32079 = check_subtyping env t1 t2  in
-        match uu____32079 with
+        let uu____32042 = check_subtyping env t1 t2  in
+        match uu____32042 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x,g) ->
-            let uu____32098 =
-              let uu____32099 = FStar_Syntax_Syntax.mk_binder x  in
-              FStar_TypeChecker_Env.abstract_guard uu____32099 g  in
-            FStar_Pervasives_Native.Some uu____32098
+            let uu____32061 =
+              let uu____32062 = FStar_Syntax_Syntax.mk_binder x  in
+              FStar_TypeChecker_Env.abstract_guard uu____32062 g  in
+            FStar_Pervasives_Native.Some uu____32061
   
 let (get_subtyping_prop :
   FStar_TypeChecker_Env.env ->
@@ -13126,16 +13096,16 @@ let (get_subtyping_prop :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____32118 = check_subtyping env t1 t2  in
-        match uu____32118 with
+        let uu____32081 = check_subtyping env t1 t2  in
+        match uu____32081 with
         | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x,g) ->
-            let uu____32137 =
-              let uu____32138 =
-                let uu____32139 = FStar_Syntax_Syntax.mk_binder x  in
-                [uu____32139]  in
-              FStar_TypeChecker_Env.close_guard env uu____32138 g  in
-            FStar_Pervasives_Native.Some uu____32137
+            let uu____32100 =
+              let uu____32101 =
+                let uu____32102 = FStar_Syntax_Syntax.mk_binder x  in
+                [uu____32102]  in
+              FStar_TypeChecker_Env.close_guard env uu____32101 g  in
+            FStar_Pervasives_Native.Some uu____32100
   
 let (subtype_nosmt :
   FStar_TypeChecker_Env.env ->
@@ -13146,39 +13116,39 @@ let (subtype_nosmt :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        (let uu____32177 =
+        (let uu____32140 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel")
             in
-         if uu____32177
+         if uu____32140
          then
-           let uu____32182 =
+           let uu____32145 =
              FStar_TypeChecker_Normalize.term_to_string env t1  in
-           let uu____32184 =
+           let uu____32147 =
              FStar_TypeChecker_Normalize.term_to_string env t2  in
-           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____32182
-             uu____32184
+           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____32145
+             uu____32147
          else ());
-        (let uu____32189 =
+        (let uu____32152 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2
             in
-         match uu____32189 with
+         match uu____32152 with
          | (prob,x,wl) ->
              let g =
-               let uu____32204 =
+               let uu____32167 =
                  solve_and_commit env (singleton wl prob false)
-                   (fun uu____32213  -> FStar_Pervasives_Native.None)
+                   (fun uu____32176  -> FStar_Pervasives_Native.None)
                   in
-               FStar_All.pipe_left (with_guard env prob) uu____32204  in
+               FStar_All.pipe_left (with_guard env prob) uu____32167  in
              (match g with
               | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some g1 ->
                   let g2 =
-                    let uu____32234 =
-                      let uu____32235 = FStar_Syntax_Syntax.mk_binder x  in
-                      [uu____32235]  in
-                    FStar_TypeChecker_Env.close_guard env uu____32234 g1  in
+                    let uu____32197 =
+                      let uu____32198 = FStar_Syntax_Syntax.mk_binder x  in
+                      [uu____32198]  in
+                    FStar_TypeChecker_Env.close_guard env uu____32197 g1  in
                   discharge_guard' FStar_Pervasives_Native.None env g2 false))
   
 let (subtype_nosmt_force :
@@ -13188,8 +13158,8 @@ let (subtype_nosmt_force :
   fun env  ->
     fun t1  ->
       fun t2  ->
-        let uu____32276 = subtype_nosmt env t1 t2  in
-        match uu____32276 with
+        let uu____32239 = subtype_nosmt env t1 t2  in
+        match uu____32239 with
         | FStar_Pervasives_Native.None  -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)
   

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -320,8 +320,7 @@ let tc_lex_t :
                let t1 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_type
-                      (FStar_Syntax_Syntax.U_name u))
-                   FStar_Pervasives_Native.None r
+                      (FStar_Syntax_Syntax.U_name u)) r
                   in
                let t2 = FStar_Syntax_Subst.close_univ_vars [u] t1  in
                let tc =
@@ -344,21 +343,19 @@ let tc_lex_t :
                   in
                let lex_top_t =
                  let uu____339 =
-                   let uu____346 =
+                   let uu____340 =
                      let uu____347 =
-                       let uu____354 =
-                         let uu____357 =
-                           FStar_Ident.set_lid_range
-                             FStar_Parser_Const.lex_t_lid r1
-                            in
-                         FStar_Syntax_Syntax.fvar uu____357
-                           FStar_Syntax_Syntax.delta_constant
-                           FStar_Pervasives_Native.None
+                       let uu____350 =
+                         FStar_Ident.set_lid_range
+                           FStar_Parser_Const.lex_t_lid r1
                           in
-                       (uu____354, [FStar_Syntax_Syntax.U_name utop])  in
-                     FStar_Syntax_Syntax.Tm_uinst uu____347  in
-                   FStar_Syntax_Syntax.mk uu____346  in
-                 uu____339 FStar_Pervasives_Native.None r1  in
+                       FStar_Syntax_Syntax.fvar uu____350
+                         FStar_Syntax_Syntax.delta_constant
+                         FStar_Pervasives_Native.None
+                        in
+                     (uu____347, [FStar_Syntax_Syntax.U_name utop])  in
+                   FStar_Syntax_Syntax.Tm_uinst uu____340  in
+                 FStar_Syntax_Syntax.mk uu____339 r1  in
                let lex_top_t1 =
                  FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t  in
                let dc_lextop =
@@ -384,70 +381,64 @@ let tc_lex_t :
                   in
                let lex_cons_t =
                  let a =
-                   let uu____372 =
+                   let uu____365 =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_type
-                          (FStar_Syntax_Syntax.U_name ucons1))
-                       FStar_Pervasives_Native.None r2
+                          (FStar_Syntax_Syntax.U_name ucons1)) r2
                       in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____372
+                     (FStar_Pervasives_Native.Some r2) uu____365
                     in
                  let hd =
-                   let uu____374 = FStar_Syntax_Syntax.bv_to_name a  in
+                   let uu____367 = FStar_Syntax_Syntax.bv_to_name a  in
                    FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____374
+                     (FStar_Pervasives_Native.Some r2) uu____367
                     in
                  let tl =
-                   let uu____376 =
-                     let uu____377 =
-                       let uu____384 =
-                         let uu____385 =
-                           let uu____392 =
-                             let uu____395 =
-                               FStar_Ident.set_lid_range
-                                 FStar_Parser_Const.lex_t_lid r2
-                                in
-                             FStar_Syntax_Syntax.fvar uu____395
-                               FStar_Syntax_Syntax.delta_constant
-                               FStar_Pervasives_Native.None
-                              in
-                           (uu____392, [FStar_Syntax_Syntax.U_name ucons2])
-                            in
-                         FStar_Syntax_Syntax.Tm_uinst uu____385  in
-                       FStar_Syntax_Syntax.mk uu____384  in
-                     uu____377 FStar_Pervasives_Native.None r2  in
-                   FStar_Syntax_Syntax.new_bv
-                     (FStar_Pervasives_Native.Some r2) uu____376
-                    in
-                 let res =
-                   let uu____401 =
-                     let uu____408 =
-                       let uu____409 =
-                         let uu____416 =
-                           let uu____419 =
+                   let uu____369 =
+                     let uu____370 =
+                       let uu____371 =
+                         let uu____378 =
+                           let uu____381 =
                              FStar_Ident.set_lid_range
                                FStar_Parser_Const.lex_t_lid r2
                               in
-                           FStar_Syntax_Syntax.fvar uu____419
+                           FStar_Syntax_Syntax.fvar uu____381
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None
                             in
-                         (uu____416,
-                           [FStar_Syntax_Syntax.U_max
-                              [FStar_Syntax_Syntax.U_name ucons1;
-                              FStar_Syntax_Syntax.U_name ucons2]])
+                         (uu____378, [FStar_Syntax_Syntax.U_name ucons2])  in
+                       FStar_Syntax_Syntax.Tm_uinst uu____371  in
+                     FStar_Syntax_Syntax.mk uu____370 r2  in
+                   FStar_Syntax_Syntax.new_bv
+                     (FStar_Pervasives_Native.Some r2) uu____369
+                    in
+                 let res =
+                   let uu____387 =
+                     let uu____388 =
+                       let uu____395 =
+                         let uu____398 =
+                           FStar_Ident.set_lid_range
+                             FStar_Parser_Const.lex_t_lid r2
+                            in
+                         FStar_Syntax_Syntax.fvar uu____398
+                           FStar_Syntax_Syntax.delta_constant
+                           FStar_Pervasives_Native.None
                           in
-                       FStar_Syntax_Syntax.Tm_uinst uu____409  in
-                     FStar_Syntax_Syntax.mk uu____408  in
-                   uu____401 FStar_Pervasives_Native.None r2  in
-                 let uu____422 = FStar_Syntax_Syntax.mk_Total res  in
+                       (uu____395,
+                         [FStar_Syntax_Syntax.U_max
+                            [FStar_Syntax_Syntax.U_name ucons1;
+                            FStar_Syntax_Syntax.U_name ucons2]])
+                        in
+                     FStar_Syntax_Syntax.Tm_uinst uu____388  in
+                   FStar_Syntax_Syntax.mk uu____387 r2  in
+                 let uu____401 = FStar_Syntax_Syntax.mk_Total res  in
                  FStar_Syntax_Util.arrow
                    [(a,
                       (FStar_Pervasives_Native.Some
                          FStar_Syntax_Syntax.imp_tag));
                    (hd, FStar_Pervasives_Native.None);
-                   (tl, FStar_Pervasives_Native.None)] uu____422
+                   (tl, FStar_Pervasives_Native.None)] uu____401
                   in
                let lex_cons_t1 =
                  FStar_Syntax_Subst.close_univ_vars [ucons1; ucons2]
@@ -466,28 +457,28 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigattrs = [];
                    FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  }  in
-               let uu____461 = FStar_TypeChecker_Env.get_range env  in
+               let uu____440 = FStar_TypeChecker_Env.get_range env  in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_bundle
                       ([tc; dc_lextop; dc_lexcons], lids));
-                 FStar_Syntax_Syntax.sigrng = uu____461;
+                 FStar_Syntax_Syntax.sigrng = uu____440;
                  FStar_Syntax_Syntax.sigquals = [];
                  FStar_Syntax_Syntax.sigmeta =
                    FStar_Syntax_Syntax.default_sigmeta;
                  FStar_Syntax_Syntax.sigattrs = [];
                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                }
-           | uu____466 ->
+           | uu____445 ->
                let err_msg =
-                 let uu____471 =
-                   let uu____473 =
+                 let uu____450 =
+                   let uu____452 =
                      FStar_Syntax_Syntax.mk_sigelt
                        (FStar_Syntax_Syntax.Sig_bundle (ses, lids))
                       in
-                   FStar_Syntax_Print.sigelt_to_string uu____473  in
+                   FStar_Syntax_Print.sigelt_to_string uu____452  in
                  FStar_Util.format1 "Invalid (re)definition of lex_t: %s\n"
-                   uu____471
+                   uu____450
                   in
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_InvalidRedefinitionOfLexT, err_msg)
@@ -500,13 +491,13 @@ let (tc_type_common :
         FStar_Range.range -> FStar_Syntax_Syntax.tscheme)
   =
   fun env  ->
-    fun uu____498  ->
+    fun uu____477  ->
       fun expected_typ  ->
         fun r  ->
-          match uu____498 with
+          match uu____477 with
           | (uvs,t) ->
-              let uu____511 = FStar_Syntax_Subst.open_univ_vars uvs t  in
-              (match uu____511 with
+              let uu____490 = FStar_Syntax_Subst.open_univ_vars uvs t  in
+              (match uu____490 with
                | (uvs1,t1) ->
                    let env1 = FStar_TypeChecker_Env.push_univ_vars env uvs1
                       in
@@ -516,24 +507,24 @@ let (tc_type_common :
                       in
                    if uvs1 = []
                    then
-                     let uu____523 =
+                     let uu____502 =
                        FStar_TypeChecker_Util.generalize_universes env1 t2
                         in
-                     (match uu____523 with
+                     (match uu____502 with
                       | (uvs2,t3) ->
                           (FStar_TypeChecker_Util.check_uvars r t3;
                            (uvs2, t3)))
                    else
-                     (let uu____541 =
-                        let uu____544 =
+                     (let uu____520 =
+                        let uu____523 =
                           FStar_All.pipe_right t2
                             (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                env1)
                            in
-                        FStar_All.pipe_right uu____544
+                        FStar_All.pipe_right uu____523
                           (FStar_Syntax_Subst.close_univ_vars uvs1)
                          in
-                      (uvs1, uu____541)))
+                      (uvs1, uu____520)))
   
 let (tc_declare_typ :
   FStar_TypeChecker_Env.env ->
@@ -543,10 +534,10 @@ let (tc_declare_typ :
   fun env  ->
     fun ts  ->
       fun r  ->
-        let uu____567 =
-          let uu____568 = FStar_Syntax_Util.type_u ()  in
-          FStar_All.pipe_right uu____568 FStar_Pervasives_Native.fst  in
-        tc_type_common env ts uu____567 r
+        let uu____546 =
+          let uu____547 = FStar_Syntax_Util.type_u ()  in
+          FStar_All.pipe_right uu____547 FStar_Pervasives_Native.fst  in
+        tc_type_common env ts uu____546 r
   
 let (tc_assume :
   FStar_TypeChecker_Env.env ->
@@ -556,10 +547,10 @@ let (tc_assume :
   fun env  ->
     fun ts  ->
       fun r  ->
-        let uu____593 =
-          let uu____594 = FStar_Syntax_Util.type_u ()  in
-          FStar_All.pipe_right uu____594 FStar_Pervasives_Native.fst  in
-        tc_type_common env ts uu____593 r
+        let uu____572 =
+          let uu____573 = FStar_Syntax_Util.type_u ()  in
+          FStar_All.pipe_right uu____573 FStar_Pervasives_Native.fst  in
+        tc_type_common env ts uu____572 r
   
 let (tc_inductive' :
   FStar_TypeChecker_Env.env ->
@@ -575,40 +566,40 @@ let (tc_inductive' :
       fun quals  ->
         fun attrs  ->
           fun lids  ->
-            (let uu____652 =
+            (let uu____631 =
                FStar_TypeChecker_Env.debug env FStar_Options.Low  in
-             if uu____652
+             if uu____631
              then
-               let uu____655 =
+               let uu____634 =
                  FStar_Common.string_of_list
                    FStar_Syntax_Print.sigelt_to_string ses
                   in
-               FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu____655
+               FStar_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n" uu____634
              else ());
-            (let uu____660 =
+            (let uu____639 =
                FStar_TypeChecker_TcInductive.check_inductive_well_typedness
                  env ses quals lids
                 in
-             match uu____660 with
+             match uu____639 with
              | (sig_bndle,tcs,datas) ->
                  let attrs' =
                    FStar_Syntax_Util.remove_attr
                      FStar_Parser_Const.erasable_attr attrs
                     in
                  let data_ops_ses =
-                   let uu____694 =
+                   let uu____673 =
                      FStar_List.map
                        (FStar_TypeChecker_TcInductive.mk_data_operations
                           quals attrs' env tcs) datas
                       in
-                   FStar_All.pipe_right uu____694 FStar_List.flatten  in
-                 ((let uu____708 =
+                   FStar_All.pipe_right uu____673 FStar_List.flatten  in
+                 ((let uu____687 =
                      (FStar_Options.no_positivity ()) ||
-                       (let uu____711 =
+                       (let uu____690 =
                           FStar_TypeChecker_Env.should_verify env  in
-                        Prims.op_Negation uu____711)
+                        Prims.op_Negation uu____690)
                       in
-                   if uu____708
+                   if uu____687
                    then ()
                    else
                      (let env1 =
@@ -621,94 +612,94 @@ let (tc_inductive' :
                               in
                            if Prims.op_Negation b
                            then
-                             let uu____728 =
+                             let uu____707 =
                                match ty.FStar_Syntax_Syntax.sigel with
                                | FStar_Syntax_Syntax.Sig_inductive_typ
-                                   (lid,uu____738,uu____739,uu____740,uu____741,uu____742)
+                                   (lid,uu____717,uu____718,uu____719,uu____720,uu____721)
                                    -> (lid, (ty.FStar_Syntax_Syntax.sigrng))
-                               | uu____751 -> failwith "Impossible!"  in
-                             match uu____728 with
+                               | uu____730 -> failwith "Impossible!"  in
+                             match uu____707 with
                              | (lid,r) ->
-                                 let uu____759 =
-                                   let uu____765 =
-                                     let uu____767 =
-                                       let uu____769 =
+                                 let uu____738 =
+                                   let uu____744 =
+                                     let uu____746 =
+                                       let uu____748 =
                                          FStar_Ident.string_of_lid lid  in
-                                       Prims.op_Hat uu____769
+                                       Prims.op_Hat uu____748
                                          " does not satisfy the positivity condition"
                                         in
-                                     Prims.op_Hat "Inductive type " uu____767
+                                     Prims.op_Hat "Inductive type " uu____746
                                       in
                                    (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                                     uu____765)
+                                     uu____744)
                                     in
-                                 FStar_Errors.log_issue r uu____759
+                                 FStar_Errors.log_issue r uu____738
                            else ()) tcs;
                       FStar_List.iter
                         (fun d  ->
-                           let uu____783 =
+                           let uu____762 =
                              match d.FStar_Syntax_Syntax.sigel with
                              | FStar_Syntax_Syntax.Sig_datacon
-                                 (data_lid,uu____793,uu____794,ty_lid,uu____796,uu____797)
+                                 (data_lid,uu____772,uu____773,ty_lid,uu____775,uu____776)
                                  -> (data_lid, ty_lid)
-                             | uu____804 -> failwith "Impossible"  in
-                           match uu____783 with
+                             | uu____783 -> failwith "Impossible"  in
+                           match uu____762 with
                            | (data_lid,ty_lid) ->
-                               let uu____812 =
+                               let uu____791 =
                                  (FStar_Ident.lid_equals ty_lid
                                     FStar_Parser_Const.exn_lid)
                                    &&
-                                   (let uu____815 =
+                                   (let uu____794 =
                                       FStar_TypeChecker_TcInductive.check_exn_positivity
                                         data_lid env1
                                        in
-                                    Prims.op_Negation uu____815)
+                                    Prims.op_Negation uu____794)
                                   in
-                               if uu____812
+                               if uu____791
                                then
-                                 let uu____818 =
-                                   let uu____824 =
-                                     let uu____826 =
-                                       let uu____828 =
+                                 let uu____797 =
+                                   let uu____803 =
+                                     let uu____805 =
+                                       let uu____807 =
                                          FStar_Ident.string_of_lid data_lid
                                           in
-                                       Prims.op_Hat uu____828
+                                       Prims.op_Hat uu____807
                                          " does not satisfy the positivity condition"
                                         in
-                                     Prims.op_Hat "Exception " uu____826  in
+                                     Prims.op_Hat "Exception " uu____805  in
                                    (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                                     uu____824)
+                                     uu____803)
                                     in
                                  FStar_Errors.log_issue
-                                   d.FStar_Syntax_Syntax.sigrng uu____818
+                                   d.FStar_Syntax_Syntax.sigrng uu____797
                                else ()) datas));
                   (let skip_haseq =
-                     let skip_prims_type uu____843 =
+                     let skip_prims_type uu____822 =
                        let lid =
                          let ty = FStar_List.hd tcs  in
                          match ty.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                             (lid,uu____848,uu____849,uu____850,uu____851,uu____852)
+                             (lid,uu____827,uu____828,uu____829,uu____830,uu____831)
                              -> lid
-                         | uu____861 -> failwith "Impossible"  in
+                         | uu____840 -> failwith "Impossible"  in
                        FStar_List.existsb
                          (fun s  ->
-                            let uu____868 =
-                              let uu____870 = FStar_Ident.ident_of_lid lid
+                            let uu____847 =
+                              let uu____849 = FStar_Ident.ident_of_lid lid
                                  in
-                              FStar_Ident.text_of_id uu____870  in
-                            s = uu____868)
+                              FStar_Ident.text_of_id uu____849  in
+                            s = uu____847)
                          FStar_TypeChecker_TcInductive.early_prims_inductives
                         in
                      let is_noeq =
                        FStar_List.existsb
                          (fun q  -> q = FStar_Syntax_Syntax.Noeq) quals
                         in
-                     let is_erasable uu____882 =
-                       let uu____883 =
-                         let uu____886 = FStar_List.hd tcs  in
-                         uu____886.FStar_Syntax_Syntax.sigattrs  in
-                       FStar_Syntax_Util.has_attribute uu____883
+                     let is_erasable uu____861 =
+                       let uu____862 =
+                         let uu____865 = FStar_List.hd tcs  in
+                         uu____865.FStar_Syntax_Syntax.sigattrs  in
+                       FStar_Syntax_Util.has_attribute uu____862
                          FStar_Parser_Const.erasable_attr
                         in
                      ((((FStar_List.length tcs) = Prims.int_zero) ||
@@ -755,18 +746,18 @@ let (tc_inductive :
         fun attrs  ->
           fun lids  ->
             let env1 = FStar_TypeChecker_Env.push env "tc_inductive"  in
-            let pop uu____976 =
-              let uu____977 = FStar_TypeChecker_Env.pop env1 "tc_inductive"
+            let pop uu____955 =
+              let uu____956 = FStar_TypeChecker_Env.pop env1 "tc_inductive"
                  in
               ()  in
             try
-              (fun uu___203_987  ->
+              (fun uu___203_966  ->
                  match () with
                  | () ->
-                     let uu____994 = tc_inductive' env1 ses quals attrs lids
+                     let uu____973 = tc_inductive' env1 ses quals attrs lids
                         in
-                     FStar_All.pipe_right uu____994 (fun r  -> pop (); r)) ()
-            with | uu___202_1025 -> (pop (); FStar_Exn.raise uu___202_1025)
+                     FStar_All.pipe_right uu____973 (fun r  -> pop (); r)) ()
+            with | uu___202_1004 -> (pop (); FStar_Exn.raise uu___202_1004)
   
 let (check_must_erase_attribute :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
@@ -774,16 +765,16 @@ let (check_must_erase_attribute :
     fun se  ->
       match se.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-          let uu____1056 =
-            let uu____1058 = FStar_Options.ide ()  in
-            Prims.op_Negation uu____1058  in
-          if uu____1056
+          let uu____1035 =
+            let uu____1037 = FStar_Options.ide ()  in
+            Prims.op_Negation uu____1037  in
+          if uu____1035
           then
-            let uu____1061 =
-              let uu____1066 = FStar_TypeChecker_Env.dsenv env  in
-              let uu____1067 = FStar_TypeChecker_Env.current_module env  in
-              FStar_Syntax_DsEnv.iface_decls uu____1066 uu____1067  in
-            (match uu____1061 with
+            let uu____1040 =
+              let uu____1045 = FStar_TypeChecker_Env.dsenv env  in
+              let uu____1046 = FStar_TypeChecker_Env.current_module env  in
+              FStar_Syntax_DsEnv.iface_decls uu____1045 uu____1046  in
+            (match uu____1040 with
              | FStar_Pervasives_Native.None  -> ()
              | FStar_Pervasives_Native.Some iface_decls ->
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
@@ -792,15 +783,15 @@ let (check_must_erase_attribute :
                          let lbname =
                            FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
                          let has_iface_val =
-                           let uu____1091 =
-                             let uu____1099 =
-                               let uu____1105 =
+                           let uu____1070 =
+                             let uu____1078 =
+                               let uu____1084 =
                                  FStar_Ident.ident_of_lid
                                    (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   in
-                               FStar_Parser_AST.decl_is_val uu____1105  in
-                             FStar_Util.for_some uu____1099  in
-                           FStar_All.pipe_right iface_decls uu____1091  in
+                               FStar_Parser_AST.decl_is_val uu____1084  in
+                             FStar_Util.for_some uu____1078  in
+                           FStar_All.pipe_right iface_decls uu____1070  in
                          if has_iface_val
                          then
                            let must_erase =
@@ -813,46 +804,46 @@ let (check_must_erase_attribute :
                               in
                            (if must_erase && (Prims.op_Negation has_attr)
                             then
-                              let uu____1115 =
+                              let uu____1094 =
                                 FStar_Syntax_Syntax.range_of_fv lbname  in
-                              let uu____1116 =
-                                let uu____1122 =
-                                  let uu____1124 =
+                              let uu____1095 =
+                                let uu____1101 =
+                                  let uu____1103 =
                                     FStar_Syntax_Print.fv_to_string lbname
                                      in
-                                  let uu____1126 =
+                                  let uu____1105 =
                                     FStar_Syntax_Print.fv_to_string lbname
                                      in
                                   FStar_Util.format2
                                     "Values of type `%s` will be erased during extraction, but its interface hides this fact. Add the `must_erase_for_extraction` attribute to the `val %s` declaration for this symbol in the interface"
-                                    uu____1124 uu____1126
+                                    uu____1103 uu____1105
                                    in
                                 (FStar_Errors.Error_MustEraseMissing,
-                                  uu____1122)
+                                  uu____1101)
                                  in
-                              FStar_Errors.log_issue uu____1115 uu____1116
+                              FStar_Errors.log_issue uu____1094 uu____1095
                             else
                               if has_attr && (Prims.op_Negation must_erase)
                               then
-                                (let uu____1133 =
+                                (let uu____1112 =
                                    FStar_Syntax_Syntax.range_of_fv lbname  in
-                                 let uu____1134 =
-                                   let uu____1140 =
-                                     let uu____1142 =
+                                 let uu____1113 =
+                                   let uu____1119 =
+                                     let uu____1121 =
                                        FStar_Syntax_Print.fv_to_string lbname
                                         in
                                      FStar_Util.format1
                                        "Values of type `%s` cannot be erased during extraction, but the `must_erase_for_extraction` attribute claims that it can. Please remove the attribute."
-                                       uu____1142
+                                       uu____1121
                                       in
                                    (FStar_Errors.Error_MustEraseMissing,
-                                     uu____1140)
+                                     uu____1119)
                                     in
-                                 FStar_Errors.log_issue uu____1133 uu____1134)
+                                 FStar_Errors.log_issue uu____1112 uu____1113)
                               else ())
                          else ())))
           else ()
-      | uu____1152 -> ()
+      | uu____1131 -> ()
   
 let (unembed_optionstate_knot :
   FStar_Options.optionstate FStar_Syntax_Embeddings.embedding
@@ -863,33 +854,33 @@ let (unembed_optionstate :
     FStar_Options.optionstate FStar_Pervasives_Native.option)
   =
   fun t  ->
-    let uu____1182 =
-      let uu____1189 =
-        let uu____1192 = FStar_ST.op_Bang unembed_optionstate_knot  in
-        FStar_Util.must uu____1192  in
-      FStar_Syntax_Embeddings.unembed uu____1189 t  in
-    uu____1182 true FStar_Syntax_Embeddings.id_norm_cb
+    let uu____1161 =
+      let uu____1168 =
+        let uu____1171 = FStar_ST.op_Bang unembed_optionstate_knot  in
+        FStar_Util.must uu____1171  in
+      FStar_Syntax_Embeddings.unembed uu____1168 t  in
+    uu____1161 true FStar_Syntax_Embeddings.id_norm_cb
   
 let proc_check_with :
   'a . FStar_Syntax_Syntax.attribute Prims.list -> (unit -> 'a) -> 'a =
   fun attrs  ->
     fun kont  ->
-      let uu____1254 =
+      let uu____1233 =
         FStar_Syntax_Util.get_attribute FStar_Parser_Const.check_with_lid
           attrs
          in
-      match uu____1254 with
+      match uu____1233 with
       | FStar_Pervasives_Native.None  -> kont ()
       | FStar_Pervasives_Native.Some ((a1,FStar_Pervasives_Native.None )::[])
           ->
           FStar_Options.with_saved_options
-            (fun uu____1282  ->
-               (let uu____1284 =
-                  let uu____1285 = unembed_optionstate a1  in
-                  FStar_All.pipe_right uu____1285 FStar_Util.must  in
-                FStar_Options.set uu____1284);
+            (fun uu____1261  ->
+               (let uu____1263 =
+                  let uu____1264 = unembed_optionstate a1  in
+                  FStar_All.pipe_right uu____1264 FStar_Util.must  in
+                FStar_Options.set uu____1263);
                kont ())
-      | uu____1290 -> failwith "huh?"
+      | uu____1269 -> failwith "huh?"
   
 let (tc_decls_knot :
   (FStar_TypeChecker_Env.env ->
@@ -909,179 +900,179 @@ let (tc_decl' :
       let env = env0  in
       FStar_TypeChecker_Util.check_sigelt_quals env se;
       proc_check_with se.FStar_Syntax_Syntax.sigattrs
-        (fun uu____1402  ->
+        (fun uu____1381  ->
            let r = se.FStar_Syntax_Syntax.sigrng  in
            let se1 =
-             let uu____1405 = FStar_Options.record_options ()  in
-             if uu____1405
+             let uu____1384 = FStar_Options.record_options ()  in
+             if uu____1384
              then
-               let uu___250_1408 = se  in
-               let uu____1409 =
-                 let uu____1412 = FStar_Options.peek ()  in
-                 FStar_Pervasives_Native.Some uu____1412  in
+               let uu___250_1387 = se  in
+               let uu____1388 =
+                 let uu____1391 = FStar_Options.peek ()  in
+                 FStar_Pervasives_Native.Some uu____1391  in
                {
                  FStar_Syntax_Syntax.sigel =
-                   (uu___250_1408.FStar_Syntax_Syntax.sigel);
+                   (uu___250_1387.FStar_Syntax_Syntax.sigel);
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___250_1408.FStar_Syntax_Syntax.sigrng);
+                   (uu___250_1387.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___250_1408.FStar_Syntax_Syntax.sigquals);
+                   (uu___250_1387.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___250_1408.FStar_Syntax_Syntax.sigmeta);
+                   (uu___250_1387.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___250_1408.FStar_Syntax_Syntax.sigattrs);
-                 FStar_Syntax_Syntax.sigopts = uu____1409
+                   (uu___250_1387.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopts = uu____1388
                }
              else se  in
            match se1.FStar_Syntax_Syntax.sigel with
-           | FStar_Syntax_Syntax.Sig_inductive_typ uu____1425 ->
+           | FStar_Syntax_Syntax.Sig_inductive_typ uu____1404 ->
                failwith "Impossible bare data-constructor"
-           | FStar_Syntax_Syntax.Sig_datacon uu____1453 ->
+           | FStar_Syntax_Syntax.Sig_datacon uu____1432 ->
                failwith "Impossible bare data-constructor"
-           | FStar_Syntax_Syntax.Sig_fail (uu____1480,false ,uu____1481) when
-               (let uu____1496 = FStar_TypeChecker_Env.should_verify env  in
-                Prims.op_Negation uu____1496) ||
+           | FStar_Syntax_Syntax.Sig_fail (uu____1459,false ,uu____1460) when
+               (let uu____1475 = FStar_TypeChecker_Env.should_verify env  in
+                Prims.op_Negation uu____1475) ||
                  (FStar_Options.admit_smt_queries ())
                -> ([], [], env)
            | FStar_Syntax_Syntax.Sig_fail (expected_errors,lax,ses) ->
                let env' =
                  if lax
                  then
-                   let uu___268_1519 = env  in
+                   let uu___268_1498 = env  in
                    {
                      FStar_TypeChecker_Env.solver =
-                       (uu___268_1519.FStar_TypeChecker_Env.solver);
+                       (uu___268_1498.FStar_TypeChecker_Env.solver);
                      FStar_TypeChecker_Env.range =
-                       (uu___268_1519.FStar_TypeChecker_Env.range);
+                       (uu___268_1498.FStar_TypeChecker_Env.range);
                      FStar_TypeChecker_Env.curmodule =
-                       (uu___268_1519.FStar_TypeChecker_Env.curmodule);
+                       (uu___268_1498.FStar_TypeChecker_Env.curmodule);
                      FStar_TypeChecker_Env.gamma =
-                       (uu___268_1519.FStar_TypeChecker_Env.gamma);
+                       (uu___268_1498.FStar_TypeChecker_Env.gamma);
                      FStar_TypeChecker_Env.gamma_sig =
-                       (uu___268_1519.FStar_TypeChecker_Env.gamma_sig);
+                       (uu___268_1498.FStar_TypeChecker_Env.gamma_sig);
                      FStar_TypeChecker_Env.gamma_cache =
-                       (uu___268_1519.FStar_TypeChecker_Env.gamma_cache);
+                       (uu___268_1498.FStar_TypeChecker_Env.gamma_cache);
                      FStar_TypeChecker_Env.modules =
-                       (uu___268_1519.FStar_TypeChecker_Env.modules);
+                       (uu___268_1498.FStar_TypeChecker_Env.modules);
                      FStar_TypeChecker_Env.expected_typ =
-                       (uu___268_1519.FStar_TypeChecker_Env.expected_typ);
+                       (uu___268_1498.FStar_TypeChecker_Env.expected_typ);
                      FStar_TypeChecker_Env.sigtab =
-                       (uu___268_1519.FStar_TypeChecker_Env.sigtab);
+                       (uu___268_1498.FStar_TypeChecker_Env.sigtab);
                      FStar_TypeChecker_Env.attrtab =
-                       (uu___268_1519.FStar_TypeChecker_Env.attrtab);
+                       (uu___268_1498.FStar_TypeChecker_Env.attrtab);
                      FStar_TypeChecker_Env.instantiate_imp =
-                       (uu___268_1519.FStar_TypeChecker_Env.instantiate_imp);
+                       (uu___268_1498.FStar_TypeChecker_Env.instantiate_imp);
                      FStar_TypeChecker_Env.effects =
-                       (uu___268_1519.FStar_TypeChecker_Env.effects);
+                       (uu___268_1498.FStar_TypeChecker_Env.effects);
                      FStar_TypeChecker_Env.generalize =
-                       (uu___268_1519.FStar_TypeChecker_Env.generalize);
+                       (uu___268_1498.FStar_TypeChecker_Env.generalize);
                      FStar_TypeChecker_Env.letrecs =
-                       (uu___268_1519.FStar_TypeChecker_Env.letrecs);
+                       (uu___268_1498.FStar_TypeChecker_Env.letrecs);
                      FStar_TypeChecker_Env.top_level =
-                       (uu___268_1519.FStar_TypeChecker_Env.top_level);
+                       (uu___268_1498.FStar_TypeChecker_Env.top_level);
                      FStar_TypeChecker_Env.check_uvars =
-                       (uu___268_1519.FStar_TypeChecker_Env.check_uvars);
+                       (uu___268_1498.FStar_TypeChecker_Env.check_uvars);
                      FStar_TypeChecker_Env.use_eq =
-                       (uu___268_1519.FStar_TypeChecker_Env.use_eq);
+                       (uu___268_1498.FStar_TypeChecker_Env.use_eq);
                      FStar_TypeChecker_Env.use_eq_strict =
-                       (uu___268_1519.FStar_TypeChecker_Env.use_eq_strict);
+                       (uu___268_1498.FStar_TypeChecker_Env.use_eq_strict);
                      FStar_TypeChecker_Env.is_iface =
-                       (uu___268_1519.FStar_TypeChecker_Env.is_iface);
+                       (uu___268_1498.FStar_TypeChecker_Env.is_iface);
                      FStar_TypeChecker_Env.admit =
-                       (uu___268_1519.FStar_TypeChecker_Env.admit);
+                       (uu___268_1498.FStar_TypeChecker_Env.admit);
                      FStar_TypeChecker_Env.lax = true;
                      FStar_TypeChecker_Env.lax_universes =
-                       (uu___268_1519.FStar_TypeChecker_Env.lax_universes);
+                       (uu___268_1498.FStar_TypeChecker_Env.lax_universes);
                      FStar_TypeChecker_Env.phase1 =
-                       (uu___268_1519.FStar_TypeChecker_Env.phase1);
+                       (uu___268_1498.FStar_TypeChecker_Env.phase1);
                      FStar_TypeChecker_Env.failhard =
-                       (uu___268_1519.FStar_TypeChecker_Env.failhard);
+                       (uu___268_1498.FStar_TypeChecker_Env.failhard);
                      FStar_TypeChecker_Env.nosynth =
-                       (uu___268_1519.FStar_TypeChecker_Env.nosynth);
+                       (uu___268_1498.FStar_TypeChecker_Env.nosynth);
                      FStar_TypeChecker_Env.uvar_subtyping =
-                       (uu___268_1519.FStar_TypeChecker_Env.uvar_subtyping);
+                       (uu___268_1498.FStar_TypeChecker_Env.uvar_subtyping);
                      FStar_TypeChecker_Env.tc_term =
-                       (uu___268_1519.FStar_TypeChecker_Env.tc_term);
+                       (uu___268_1498.FStar_TypeChecker_Env.tc_term);
                      FStar_TypeChecker_Env.type_of =
-                       (uu___268_1519.FStar_TypeChecker_Env.type_of);
+                       (uu___268_1498.FStar_TypeChecker_Env.type_of);
                      FStar_TypeChecker_Env.universe_of =
-                       (uu___268_1519.FStar_TypeChecker_Env.universe_of);
+                       (uu___268_1498.FStar_TypeChecker_Env.universe_of);
                      FStar_TypeChecker_Env.check_type_of =
-                       (uu___268_1519.FStar_TypeChecker_Env.check_type_of);
+                       (uu___268_1498.FStar_TypeChecker_Env.check_type_of);
                      FStar_TypeChecker_Env.use_bv_sorts =
-                       (uu___268_1519.FStar_TypeChecker_Env.use_bv_sorts);
+                       (uu___268_1498.FStar_TypeChecker_Env.use_bv_sorts);
                      FStar_TypeChecker_Env.qtbl_name_and_index =
-                       (uu___268_1519.FStar_TypeChecker_Env.qtbl_name_and_index);
+                       (uu___268_1498.FStar_TypeChecker_Env.qtbl_name_and_index);
                      FStar_TypeChecker_Env.normalized_eff_names =
-                       (uu___268_1519.FStar_TypeChecker_Env.normalized_eff_names);
+                       (uu___268_1498.FStar_TypeChecker_Env.normalized_eff_names);
                      FStar_TypeChecker_Env.fv_delta_depths =
-                       (uu___268_1519.FStar_TypeChecker_Env.fv_delta_depths);
+                       (uu___268_1498.FStar_TypeChecker_Env.fv_delta_depths);
                      FStar_TypeChecker_Env.proof_ns =
-                       (uu___268_1519.FStar_TypeChecker_Env.proof_ns);
+                       (uu___268_1498.FStar_TypeChecker_Env.proof_ns);
                      FStar_TypeChecker_Env.synth_hook =
-                       (uu___268_1519.FStar_TypeChecker_Env.synth_hook);
+                       (uu___268_1498.FStar_TypeChecker_Env.synth_hook);
                      FStar_TypeChecker_Env.try_solve_implicits_hook =
-                       (uu___268_1519.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                       (uu___268_1498.FStar_TypeChecker_Env.try_solve_implicits_hook);
                      FStar_TypeChecker_Env.splice =
-                       (uu___268_1519.FStar_TypeChecker_Env.splice);
+                       (uu___268_1498.FStar_TypeChecker_Env.splice);
                      FStar_TypeChecker_Env.mpreprocess =
-                       (uu___268_1519.FStar_TypeChecker_Env.mpreprocess);
+                       (uu___268_1498.FStar_TypeChecker_Env.mpreprocess);
                      FStar_TypeChecker_Env.postprocess =
-                       (uu___268_1519.FStar_TypeChecker_Env.postprocess);
+                       (uu___268_1498.FStar_TypeChecker_Env.postprocess);
                      FStar_TypeChecker_Env.identifier_info =
-                       (uu___268_1519.FStar_TypeChecker_Env.identifier_info);
+                       (uu___268_1498.FStar_TypeChecker_Env.identifier_info);
                      FStar_TypeChecker_Env.tc_hooks =
-                       (uu___268_1519.FStar_TypeChecker_Env.tc_hooks);
+                       (uu___268_1498.FStar_TypeChecker_Env.tc_hooks);
                      FStar_TypeChecker_Env.dsenv =
-                       (uu___268_1519.FStar_TypeChecker_Env.dsenv);
+                       (uu___268_1498.FStar_TypeChecker_Env.dsenv);
                      FStar_TypeChecker_Env.nbe =
-                       (uu___268_1519.FStar_TypeChecker_Env.nbe);
+                       (uu___268_1498.FStar_TypeChecker_Env.nbe);
                      FStar_TypeChecker_Env.strict_args_tab =
-                       (uu___268_1519.FStar_TypeChecker_Env.strict_args_tab);
+                       (uu___268_1498.FStar_TypeChecker_Env.strict_args_tab);
                      FStar_TypeChecker_Env.erasable_types_tab =
-                       (uu___268_1519.FStar_TypeChecker_Env.erasable_types_tab)
+                       (uu___268_1498.FStar_TypeChecker_Env.erasable_types_tab)
                    }
                  else env  in
                let env'1 = FStar_TypeChecker_Env.push env' "expect_failure"
                   in
-               ((let uu____1526 =
+               ((let uu____1505 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Low  in
-                 if uu____1526
+                 if uu____1505
                  then
-                   let uu____1529 =
-                     let uu____1531 =
+                   let uu____1508 =
+                     let uu____1510 =
                        FStar_List.map FStar_Util.string_of_int
                          expected_errors
                         in
                      FStar_All.pipe_left (FStar_String.concat "; ")
-                       uu____1531
+                       uu____1510
                       in
-                   FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____1529
+                   FStar_Util.print1 ">> Expecting errors: [%s]\n" uu____1508
                  else ());
-                (let uu____1545 =
+                (let uu____1524 =
                    FStar_Errors.catch_errors
-                     (fun uu____1575  ->
+                     (fun uu____1554  ->
                         FStar_Options.with_saved_options
-                          (fun uu____1588  ->
-                             let uu____1589 =
-                               let uu____1610 =
+                          (fun uu____1567  ->
+                             let uu____1568 =
+                               let uu____1589 =
                                  FStar_ST.op_Bang tc_decls_knot  in
-                               FStar_Util.must uu____1610  in
-                             uu____1589 env'1 ses))
+                               FStar_Util.must uu____1589  in
+                             uu____1568 env'1 ses))
                     in
-                 match uu____1545 with
-                 | (errs,uu____1719) ->
-                     ((let uu____1749 =
+                 match uu____1524 with
+                 | (errs,uu____1698) ->
+                     ((let uu____1728 =
                          (FStar_Options.print_expected_failures ()) ||
                            (FStar_TypeChecker_Env.debug env FStar_Options.Low)
                           in
-                       if uu____1749
+                       if uu____1728
                        then
                          (FStar_Util.print_string ">> Got issues: [\n";
                           FStar_List.iter FStar_Errors.print_issue errs;
                           FStar_Util.print_string ">>]\n")
                        else ());
-                      (let uu____1758 =
+                      (let uu____1737 =
                          FStar_TypeChecker_Env.pop env'1 "expect_failure"  in
                        let actual_errors =
                          FStar_List.concatMap
@@ -1096,47 +1087,47 @@ let (tc_decl' :
                                se1.FStar_Syntax_Syntax.sigrng
                                (FStar_Errors.Error_DidNotFail,
                                  "This top-level definition was expected to fail, but it succeeded"))
-                        | uu____1772 ->
+                        | uu____1751 ->
                             if expected_errors <> []
                             then
-                              let uu____1780 =
+                              let uu____1759 =
                                 FStar_Errors.find_multiset_discrepancy
                                   expected_errors actual_errors
                                  in
-                              (match uu____1780 with
+                              (match uu____1759 with
                                | FStar_Pervasives_Native.None  -> ()
                                | FStar_Pervasives_Native.Some (e,n1,n2) ->
                                    (FStar_List.iter FStar_Errors.print_issue
                                       errs;
-                                    (let uu____1820 =
-                                       let uu____1826 =
-                                         let uu____1828 =
+                                    (let uu____1799 =
+                                       let uu____1805 =
+                                         let uu____1807 =
                                            FStar_Common.string_of_list
                                              FStar_Util.string_of_int
                                              expected_errors
                                             in
-                                         let uu____1831 =
+                                         let uu____1810 =
                                            FStar_Common.string_of_list
                                              FStar_Util.string_of_int
                                              actual_errors
                                             in
-                                         let uu____1834 =
+                                         let uu____1813 =
                                            FStar_Util.string_of_int e  in
-                                         let uu____1836 =
+                                         let uu____1815 =
                                            FStar_Util.string_of_int n2  in
-                                         let uu____1838 =
+                                         let uu____1817 =
                                            FStar_Util.string_of_int n1  in
                                          FStar_Util.format5
                                            "This top-level definition was expected to raise error codes %s, but it raised %s. Error #%s was raised %s times, instead of %s."
-                                           uu____1828 uu____1831 uu____1834
-                                           uu____1836 uu____1838
+                                           uu____1807 uu____1810 uu____1813
+                                           uu____1815 uu____1817
                                           in
                                        (FStar_Errors.Error_DidNotFail,
-                                         uu____1826)
+                                         uu____1805)
                                         in
                                      FStar_Errors.log_issue
                                        se1.FStar_Syntax_Syntax.sigrng
-                                       uu____1820)))
+                                       uu____1799)))
                             else ());
                        ([], [], env)))))
            | FStar_Syntax_Syntax.Sig_bundle (ses,lids) when
@@ -1151,172 +1142,172 @@ let (tc_decl' :
            | FStar_Syntax_Syntax.Sig_bundle (ses,lids) ->
                let env1 = FStar_TypeChecker_Env.set_range env r  in
                let ses1 =
-                 let uu____1881 =
+                 let uu____1860 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env1)
                     in
-                 if uu____1881
+                 if uu____1860
                  then
                    let ses1 =
-                     let uu____1889 =
-                       let uu____1890 =
-                         let uu____1891 =
+                     let uu____1868 =
+                       let uu____1869 =
+                         let uu____1870 =
                            tc_inductive
-                             (let uu___310_1900 = env1  in
+                             (let uu___310_1879 = env1  in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___310_1900.FStar_TypeChecker_Env.solver);
+                                  (uu___310_1879.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___310_1900.FStar_TypeChecker_Env.range);
+                                  (uu___310_1879.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___310_1900.FStar_TypeChecker_Env.curmodule);
+                                  (uu___310_1879.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___310_1900.FStar_TypeChecker_Env.gamma);
+                                  (uu___310_1879.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___310_1900.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___310_1879.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___310_1900.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___310_1879.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___310_1900.FStar_TypeChecker_Env.modules);
+                                  (uu___310_1879.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___310_1900.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___310_1879.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___310_1900.FStar_TypeChecker_Env.sigtab);
+                                  (uu___310_1879.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___310_1900.FStar_TypeChecker_Env.attrtab);
+                                  (uu___310_1879.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___310_1900.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___310_1879.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___310_1900.FStar_TypeChecker_Env.effects);
+                                  (uu___310_1879.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___310_1900.FStar_TypeChecker_Env.generalize);
+                                  (uu___310_1879.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___310_1900.FStar_TypeChecker_Env.letrecs);
+                                  (uu___310_1879.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___310_1900.FStar_TypeChecker_Env.top_level);
+                                  (uu___310_1879.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___310_1900.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___310_1879.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___310_1900.FStar_TypeChecker_Env.use_eq);
+                                  (uu___310_1879.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___310_1900.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___310_1879.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___310_1900.FStar_TypeChecker_Env.is_iface);
+                                  (uu___310_1879.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___310_1900.FStar_TypeChecker_Env.admit);
+                                  (uu___310_1879.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___310_1900.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___310_1879.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___310_1900.FStar_TypeChecker_Env.failhard);
+                                  (uu___310_1879.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___310_1900.FStar_TypeChecker_Env.nosynth);
+                                  (uu___310_1879.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___310_1900.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___310_1879.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___310_1900.FStar_TypeChecker_Env.tc_term);
+                                  (uu___310_1879.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___310_1900.FStar_TypeChecker_Env.type_of);
+                                  (uu___310_1879.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___310_1900.FStar_TypeChecker_Env.universe_of);
+                                  (uu___310_1879.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___310_1900.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___310_1879.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___310_1900.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___310_1879.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___310_1900.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___310_1879.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___310_1900.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___310_1879.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___310_1900.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___310_1879.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___310_1900.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___310_1879.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___310_1900.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___310_1879.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___310_1900.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___310_1879.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___310_1900.FStar_TypeChecker_Env.splice);
+                                  (uu___310_1879.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___310_1900.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___310_1879.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___310_1900.FStar_TypeChecker_Env.postprocess);
+                                  (uu___310_1879.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___310_1900.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___310_1879.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___310_1900.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___310_1879.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___310_1900.FStar_TypeChecker_Env.dsenv);
+                                  (uu___310_1879.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___310_1900.FStar_TypeChecker_Env.nbe);
+                                  (uu___310_1879.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___310_1900.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___310_1879.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___310_1900.FStar_TypeChecker_Env.erasable_types_tab)
+                                  (uu___310_1879.FStar_TypeChecker_Env.erasable_types_tab)
                               }) ses se1.FStar_Syntax_Syntax.sigquals
                              se1.FStar_Syntax_Syntax.sigattrs lids
                             in
-                         FStar_All.pipe_right uu____1891
+                         FStar_All.pipe_right uu____1870
                            FStar_Pervasives_Native.fst
                           in
-                       FStar_All.pipe_right uu____1890
+                       FStar_All.pipe_right uu____1869
                          (FStar_TypeChecker_Normalize.elim_uvars env1)
                         in
-                     FStar_All.pipe_right uu____1889
+                     FStar_All.pipe_right uu____1868
                        FStar_Syntax_Util.ses_of_sigbundle
                       in
-                   ((let uu____1914 =
+                   ((let uu____1893 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                          (FStar_Options.Other "TwoPhases")
                         in
-                     if uu____1914
+                     if uu____1893
                      then
-                       let uu____1919 =
+                       let uu____1898 =
                          FStar_Syntax_Print.sigelt_to_string
-                           (let uu___314_1923 = se1  in
+                           (let uu___314_1902 = se1  in
                             {
                               FStar_Syntax_Syntax.sigel =
                                 (FStar_Syntax_Syntax.Sig_bundle (ses1, lids));
                               FStar_Syntax_Syntax.sigrng =
-                                (uu___314_1923.FStar_Syntax_Syntax.sigrng);
+                                (uu___314_1902.FStar_Syntax_Syntax.sigrng);
                               FStar_Syntax_Syntax.sigquals =
-                                (uu___314_1923.FStar_Syntax_Syntax.sigquals);
+                                (uu___314_1902.FStar_Syntax_Syntax.sigquals);
                               FStar_Syntax_Syntax.sigmeta =
-                                (uu___314_1923.FStar_Syntax_Syntax.sigmeta);
+                                (uu___314_1902.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
-                                (uu___314_1923.FStar_Syntax_Syntax.sigattrs);
+                                (uu___314_1902.FStar_Syntax_Syntax.sigattrs);
                               FStar_Syntax_Syntax.sigopts =
-                                (uu___314_1923.FStar_Syntax_Syntax.sigopts)
+                                (uu___314_1902.FStar_Syntax_Syntax.sigopts)
                             })
                           in
                        FStar_Util.print1 "Inductive after phase 1: %s\n"
-                         uu____1919
+                         uu____1898
                      else ());
                     ses1)
                  else ses  in
-               let uu____1933 =
+               let uu____1912 =
                  tc_inductive env1 ses1 se1.FStar_Syntax_Syntax.sigquals
                    se1.FStar_Syntax_Syntax.sigattrs lids
                   in
-               (match uu____1933 with
+               (match uu____1912 with
                 | (sigbndle,projectors_ses) ->
                     let sigbndle1 =
-                      let uu___321_1957 = sigbndle  in
+                      let uu___321_1936 = sigbndle  in
                       {
                         FStar_Syntax_Syntax.sigel =
-                          (uu___321_1957.FStar_Syntax_Syntax.sigel);
+                          (uu___321_1936.FStar_Syntax_Syntax.sigel);
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___321_1957.FStar_Syntax_Syntax.sigrng);
+                          (uu___321_1936.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___321_1957.FStar_Syntax_Syntax.sigquals);
+                          (uu___321_1936.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___321_1957.FStar_Syntax_Syntax.sigmeta);
+                          (uu___321_1936.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
                           (se1.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___321_1957.FStar_Syntax_Syntax.sigopts)
+                          (uu___321_1936.FStar_Syntax_Syntax.sigopts)
                       }  in
                     ([sigbndle1], projectors_ses, env0))
            | FStar_Syntax_Syntax.Sig_pragma p ->
@@ -1325,229 +1316,229 @@ let (tc_decl' :
                let is_unelaborated_dm4f =
                  match ne.FStar_Syntax_Syntax.combinators with
                  | FStar_Syntax_Syntax.DM4F_eff combs ->
-                     let uu____1973 =
-                       let uu____1976 =
+                     let uu____1952 =
+                       let uu____1955 =
                          FStar_All.pipe_right
                            combs.FStar_Syntax_Syntax.ret_wp
                            FStar_Pervasives_Native.snd
                           in
-                       FStar_All.pipe_right uu____1976
+                       FStar_All.pipe_right uu____1955
                          FStar_Syntax_Subst.compress
                         in
-                     (match uu____1973 with
+                     (match uu____1952 with
                       | {
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_unknown ;
-                          FStar_Syntax_Syntax.pos = uu____1992;
-                          FStar_Syntax_Syntax.vars = uu____1993;_} -> true
-                      | uu____1997 -> false)
-                 | uu____2001 -> false  in
+                          FStar_Syntax_Syntax.pos = uu____1971;
+                          FStar_Syntax_Syntax.vars = uu____1972;_} -> true
+                      | uu____1976 -> false)
+                 | uu____1980 -> false  in
                if is_unelaborated_dm4f
                then
                  let env1 = FStar_TypeChecker_Env.set_range env r  in
-                 let uu____2015 =
+                 let uu____1994 =
                    FStar_TypeChecker_TcEffect.dmff_cps_and_elaborate env1 ne
                     in
-                 (match uu____2015 with
+                 (match uu____1994 with
                   | (ses,ne1,lift_from_pure_opt) ->
                       let effect_and_lift_ses =
                         match lift_from_pure_opt with
                         | FStar_Pervasives_Native.Some lift ->
-                            [(let uu___346_2054 = se1  in
+                            [(let uu___346_2033 = se1  in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___346_2054.FStar_Syntax_Syntax.sigrng);
+                                  (uu___346_2033.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___346_2054.FStar_Syntax_Syntax.sigquals);
+                                  (uu___346_2033.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___346_2054.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___346_2033.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___346_2054.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___346_2033.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___346_2054.FStar_Syntax_Syntax.sigopts)
+                                  (uu___346_2033.FStar_Syntax_Syntax.sigopts)
                               });
                             lift]
                         | FStar_Pervasives_Native.None  ->
-                            [(let uu___349_2056 = se1  in
+                            [(let uu___349_2035 = se1  in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___349_2056.FStar_Syntax_Syntax.sigrng);
+                                  (uu___349_2035.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___349_2056.FStar_Syntax_Syntax.sigquals);
+                                  (uu___349_2035.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___349_2056.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___349_2035.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___349_2056.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___349_2035.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___349_2056.FStar_Syntax_Syntax.sigopts)
+                                  (uu___349_2035.FStar_Syntax_Syntax.sigopts)
                               })]
                          in
                       ([], (FStar_List.append ses effect_and_lift_ses), env0))
                else
                  (let ne1 =
-                    let uu____2064 =
+                    let uu____2043 =
                       (FStar_Options.use_two_phase_tc ()) &&
                         (FStar_TypeChecker_Env.should_verify env)
                        in
-                    if uu____2064
+                    if uu____2043
                     then
                       let ne1 =
-                        let uu____2068 =
-                          let uu____2069 =
-                            let uu____2070 =
+                        let uu____2047 =
+                          let uu____2048 =
+                            let uu____2049 =
                               FStar_TypeChecker_TcEffect.tc_eff_decl
-                                (let uu___353_2073 = env  in
+                                (let uu___353_2052 = env  in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___353_2073.FStar_TypeChecker_Env.solver);
+                                     (uu___353_2052.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___353_2073.FStar_TypeChecker_Env.range);
+                                     (uu___353_2052.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___353_2073.FStar_TypeChecker_Env.curmodule);
+                                     (uu___353_2052.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___353_2073.FStar_TypeChecker_Env.gamma);
+                                     (uu___353_2052.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___353_2073.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___353_2052.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___353_2073.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___353_2052.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___353_2073.FStar_TypeChecker_Env.modules);
+                                     (uu___353_2052.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___353_2073.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___353_2052.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___353_2073.FStar_TypeChecker_Env.sigtab);
+                                     (uu___353_2052.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___353_2073.FStar_TypeChecker_Env.attrtab);
+                                     (uu___353_2052.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___353_2073.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___353_2052.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___353_2073.FStar_TypeChecker_Env.effects);
+                                     (uu___353_2052.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___353_2073.FStar_TypeChecker_Env.generalize);
+                                     (uu___353_2052.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___353_2073.FStar_TypeChecker_Env.letrecs);
+                                     (uu___353_2052.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___353_2073.FStar_TypeChecker_Env.top_level);
+                                     (uu___353_2052.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___353_2073.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___353_2052.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___353_2073.FStar_TypeChecker_Env.use_eq);
+                                     (uu___353_2052.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___353_2073.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___353_2052.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___353_2073.FStar_TypeChecker_Env.is_iface);
+                                     (uu___353_2052.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___353_2073.FStar_TypeChecker_Env.admit);
+                                     (uu___353_2052.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___353_2073.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___353_2052.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 = true;
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___353_2073.FStar_TypeChecker_Env.failhard);
+                                     (uu___353_2052.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___353_2073.FStar_TypeChecker_Env.nosynth);
+                                     (uu___353_2052.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___353_2073.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___353_2052.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___353_2073.FStar_TypeChecker_Env.tc_term);
+                                     (uu___353_2052.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___353_2073.FStar_TypeChecker_Env.type_of);
+                                     (uu___353_2052.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___353_2073.FStar_TypeChecker_Env.universe_of);
+                                     (uu___353_2052.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___353_2073.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___353_2052.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___353_2073.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___353_2052.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___353_2073.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___353_2052.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___353_2073.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___353_2052.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___353_2073.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___353_2052.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___353_2073.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___353_2052.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___353_2073.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___353_2052.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___353_2073.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___353_2052.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___353_2073.FStar_TypeChecker_Env.splice);
+                                     (uu___353_2052.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___353_2073.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___353_2052.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___353_2073.FStar_TypeChecker_Env.postprocess);
+                                     (uu___353_2052.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___353_2073.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___353_2052.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___353_2073.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___353_2052.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___353_2073.FStar_TypeChecker_Env.dsenv);
+                                     (uu___353_2052.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___353_2073.FStar_TypeChecker_Env.nbe);
+                                     (uu___353_2052.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___353_2073.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___353_2052.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___353_2073.FStar_TypeChecker_Env.erasable_types_tab)
+                                     (uu___353_2052.FStar_TypeChecker_Env.erasable_types_tab)
                                  }) ne se1.FStar_Syntax_Syntax.sigquals
                                in
-                            FStar_All.pipe_right uu____2070
+                            FStar_All.pipe_right uu____2049
                               (fun ne1  ->
-                                 let uu___356_2079 = se1  in
+                                 let uu___356_2058 = se1  in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                    FStar_Syntax_Syntax.sigrng =
-                                     (uu___356_2079.FStar_Syntax_Syntax.sigrng);
+                                     (uu___356_2058.FStar_Syntax_Syntax.sigrng);
                                    FStar_Syntax_Syntax.sigquals =
-                                     (uu___356_2079.FStar_Syntax_Syntax.sigquals);
+                                     (uu___356_2058.FStar_Syntax_Syntax.sigquals);
                                    FStar_Syntax_Syntax.sigmeta =
-                                     (uu___356_2079.FStar_Syntax_Syntax.sigmeta);
+                                     (uu___356_2058.FStar_Syntax_Syntax.sigmeta);
                                    FStar_Syntax_Syntax.sigattrs =
-                                     (uu___356_2079.FStar_Syntax_Syntax.sigattrs);
+                                     (uu___356_2058.FStar_Syntax_Syntax.sigattrs);
                                    FStar_Syntax_Syntax.sigopts =
-                                     (uu___356_2079.FStar_Syntax_Syntax.sigopts)
+                                     (uu___356_2058.FStar_Syntax_Syntax.sigopts)
                                  })
                              in
-                          FStar_All.pipe_right uu____2069
+                          FStar_All.pipe_right uu____2048
                             (FStar_TypeChecker_Normalize.elim_uvars env)
                            in
-                        FStar_All.pipe_right uu____2068
+                        FStar_All.pipe_right uu____2047
                           FStar_Syntax_Util.eff_decl_of_new_effect
                          in
-                      ((let uu____2081 =
+                      ((let uu____2060 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "TwoPhases")
                            in
-                        if uu____2081
+                        if uu____2060
                         then
-                          let uu____2086 =
+                          let uu____2065 =
                             FStar_Syntax_Print.sigelt_to_string
-                              (let uu___360_2090 = se1  in
+                              (let uu___360_2069 = se1  in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___360_2090.FStar_Syntax_Syntax.sigrng);
+                                   (uu___360_2069.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals =
-                                   (uu___360_2090.FStar_Syntax_Syntax.sigquals);
+                                   (uu___360_2069.FStar_Syntax_Syntax.sigquals);
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___360_2090.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___360_2069.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___360_2090.FStar_Syntax_Syntax.sigattrs);
+                                   (uu___360_2069.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (uu___360_2090.FStar_Syntax_Syntax.sigopts)
+                                   (uu___360_2069.FStar_Syntax_Syntax.sigopts)
                                })
                              in
                           FStar_Util.print1 "Effect decl after phase 1: %s\n"
-                            uu____2086
+                            uu____2065
                         else ());
                        ne1)
                     else ne  in
@@ -1556,567 +1547,567 @@ let (tc_decl' :
                       se1.FStar_Syntax_Syntax.sigquals
                      in
                   let se2 =
-                    let uu___365_2098 = se1  in
+                    let uu___365_2077 = se1  in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_new_effect ne2);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___365_2098.FStar_Syntax_Syntax.sigrng);
+                        (uu___365_2077.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___365_2098.FStar_Syntax_Syntax.sigquals);
+                        (uu___365_2077.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___365_2098.FStar_Syntax_Syntax.sigmeta);
+                        (uu___365_2077.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___365_2098.FStar_Syntax_Syntax.sigattrs);
+                        (uu___365_2077.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___365_2098.FStar_Syntax_Syntax.sigopts)
+                        (uu___365_2077.FStar_Syntax_Syntax.sigopts)
                     }  in
                   ([se2], [], env0))
            | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                let sub1 = FStar_TypeChecker_TcEffect.tc_lift env sub r  in
                let se2 =
-                 let uu___371_2106 = se1  in
+                 let uu___371_2085 = se1  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_sub_effect sub1);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___371_2106.FStar_Syntax_Syntax.sigrng);
+                     (uu___371_2085.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___371_2106.FStar_Syntax_Syntax.sigquals);
+                     (uu___371_2085.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___371_2106.FStar_Syntax_Syntax.sigmeta);
+                     (uu___371_2085.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___371_2106.FStar_Syntax_Syntax.sigattrs);
+                     (uu___371_2085.FStar_Syntax_Syntax.sigattrs);
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___371_2106.FStar_Syntax_Syntax.sigopts)
+                     (uu___371_2085.FStar_Syntax_Syntax.sigopts)
                  }  in
                ([se2], [], env)
            | FStar_Syntax_Syntax.Sig_effect_abbrev (lid,uvs,tps,c,flags) ->
-               let uu____2120 =
-                 let uu____2129 =
+               let uu____2099 =
+                 let uu____2108 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env)
                     in
-                 if uu____2129
+                 if uu____2108
                  then
-                   let uu____2140 =
-                     let uu____2141 =
-                       let uu____2142 =
+                   let uu____2119 =
+                     let uu____2120 =
+                       let uu____2121 =
                          FStar_TypeChecker_TcEffect.tc_effect_abbrev
-                           (let uu___382_2153 = env  in
+                           (let uu___382_2132 = env  in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___382_2153.FStar_TypeChecker_Env.solver);
+                                (uu___382_2132.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___382_2153.FStar_TypeChecker_Env.range);
+                                (uu___382_2132.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___382_2153.FStar_TypeChecker_Env.curmodule);
+                                (uu___382_2132.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___382_2153.FStar_TypeChecker_Env.gamma);
+                                (uu___382_2132.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___382_2153.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___382_2132.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___382_2153.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___382_2132.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___382_2153.FStar_TypeChecker_Env.modules);
+                                (uu___382_2132.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
-                                (uu___382_2153.FStar_TypeChecker_Env.expected_typ);
+                                (uu___382_2132.FStar_TypeChecker_Env.expected_typ);
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___382_2153.FStar_TypeChecker_Env.sigtab);
+                                (uu___382_2132.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___382_2153.FStar_TypeChecker_Env.attrtab);
+                                (uu___382_2132.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___382_2153.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___382_2132.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___382_2153.FStar_TypeChecker_Env.effects);
+                                (uu___382_2132.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___382_2153.FStar_TypeChecker_Env.generalize);
+                                (uu___382_2132.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___382_2153.FStar_TypeChecker_Env.letrecs);
+                                (uu___382_2132.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___382_2153.FStar_TypeChecker_Env.top_level);
+                                (uu___382_2132.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___382_2153.FStar_TypeChecker_Env.check_uvars);
+                                (uu___382_2132.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___382_2153.FStar_TypeChecker_Env.use_eq);
+                                (uu___382_2132.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___382_2153.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___382_2132.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___382_2153.FStar_TypeChecker_Env.is_iface);
+                                (uu___382_2132.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___382_2153.FStar_TypeChecker_Env.admit);
+                                (uu___382_2132.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___382_2153.FStar_TypeChecker_Env.lax_universes);
+                                (uu___382_2132.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 = true;
                               FStar_TypeChecker_Env.failhard =
-                                (uu___382_2153.FStar_TypeChecker_Env.failhard);
+                                (uu___382_2132.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___382_2153.FStar_TypeChecker_Env.nosynth);
+                                (uu___382_2132.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___382_2153.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___382_2132.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___382_2153.FStar_TypeChecker_Env.tc_term);
+                                (uu___382_2132.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___382_2153.FStar_TypeChecker_Env.type_of);
+                                (uu___382_2132.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___382_2153.FStar_TypeChecker_Env.universe_of);
+                                (uu___382_2132.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___382_2153.FStar_TypeChecker_Env.check_type_of);
+                                (uu___382_2132.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___382_2153.FStar_TypeChecker_Env.use_bv_sorts);
+                                (uu___382_2132.FStar_TypeChecker_Env.use_bv_sorts);
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___382_2153.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___382_2132.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___382_2153.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___382_2132.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___382_2153.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___382_2132.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___382_2153.FStar_TypeChecker_Env.proof_ns);
+                                (uu___382_2132.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___382_2153.FStar_TypeChecker_Env.synth_hook);
+                                (uu___382_2132.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___382_2153.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___382_2132.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___382_2153.FStar_TypeChecker_Env.splice);
+                                (uu___382_2132.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___382_2153.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___382_2132.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___382_2153.FStar_TypeChecker_Env.postprocess);
+                                (uu___382_2132.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___382_2153.FStar_TypeChecker_Env.identifier_info);
+                                (uu___382_2132.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___382_2153.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___382_2132.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___382_2153.FStar_TypeChecker_Env.dsenv);
+                                (uu___382_2132.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___382_2153.FStar_TypeChecker_Env.nbe);
+                                (uu___382_2132.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___382_2153.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___382_2132.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___382_2153.FStar_TypeChecker_Env.erasable_types_tab)
+                                (uu___382_2132.FStar_TypeChecker_Env.erasable_types_tab)
                             }) (lid, uvs, tps, c) r
                           in
-                       FStar_All.pipe_right uu____2142
-                         (fun uu____2170  ->
-                            match uu____2170 with
+                       FStar_All.pipe_right uu____2121
+                         (fun uu____2149  ->
+                            match uu____2149 with
                             | (lid1,uvs1,tps1,c1) ->
-                                let uu___389_2183 = se1  in
+                                let uu___389_2162 = se1  in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_effect_abbrev
                                        (lid1, uvs1, tps1, c1, flags));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___389_2183.FStar_Syntax_Syntax.sigrng);
+                                    (uu___389_2162.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___389_2183.FStar_Syntax_Syntax.sigquals);
+                                    (uu___389_2162.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___389_2183.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___389_2162.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___389_2183.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___389_2162.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___389_2183.FStar_Syntax_Syntax.sigopts)
+                                    (uu___389_2162.FStar_Syntax_Syntax.sigopts)
                                 })
                         in
-                     FStar_All.pipe_right uu____2141
+                     FStar_All.pipe_right uu____2120
                        (FStar_TypeChecker_Normalize.elim_uvars env)
                       in
-                   FStar_All.pipe_right uu____2140
+                   FStar_All.pipe_right uu____2119
                      (fun se2  ->
                         match se2.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_effect_abbrev
-                            (lid1,uvs1,tps1,c1,uu____2213) ->
+                            (lid1,uvs1,tps1,c1,uu____2192) ->
                             (lid1, uvs1, tps1, c1)
-                        | uu____2218 ->
+                        | uu____2197 ->
                             failwith
                               "Did not expect Sig_effect_abbrev to not be one after phase 1")
                  else (lid, uvs, tps, c)  in
-               (match uu____2120 with
+               (match uu____2099 with
                 | (lid1,uvs1,tps1,c1) ->
-                    let uu____2244 =
+                    let uu____2223 =
                       FStar_TypeChecker_TcEffect.tc_effect_abbrev env
                         (lid1, uvs1, tps1, c1) r
                        in
-                    (match uu____2244 with
+                    (match uu____2223 with
                      | (lid2,uvs2,tps2,c2) ->
                          let se2 =
-                           let uu___410_2268 = se1  in
+                           let uu___410_2247 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
                                   (lid2, uvs2, tps2, c2, flags));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___410_2268.FStar_Syntax_Syntax.sigrng);
+                               (uu___410_2247.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___410_2268.FStar_Syntax_Syntax.sigquals);
+                               (uu___410_2247.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___410_2268.FStar_Syntax_Syntax.sigmeta);
+                               (uu___410_2247.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___410_2268.FStar_Syntax_Syntax.sigattrs);
+                               (uu___410_2247.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___410_2268.FStar_Syntax_Syntax.sigopts)
+                               (uu___410_2247.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ([se2], [], env0)))
            | FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____2275,uu____2276,uu____2277) when
+               (uu____2254,uu____2255,uu____2256) when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_2282  ->
-                       match uu___0_2282 with
+                    (fun uu___0_2261  ->
+                       match uu___0_2261 with
                        | FStar_Syntax_Syntax.OnlyName  -> true
-                       | uu____2285 -> false))
+                       | uu____2264 -> false))
                -> ([], [], env0)
-           | FStar_Syntax_Syntax.Sig_let (uu____2291,uu____2292) when
+           | FStar_Syntax_Syntax.Sig_let (uu____2270,uu____2271) when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_2301  ->
-                       match uu___0_2301 with
+                    (fun uu___0_2280  ->
+                       match uu___0_2280 with
                        | FStar_Syntax_Syntax.OnlyName  -> true
-                       | uu____2304 -> false))
+                       | uu____2283 -> false))
                -> ([], [], env0)
            | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
                let env1 = FStar_TypeChecker_Env.set_range env r  in
-               ((let uu____2315 = FStar_TypeChecker_Env.lid_exists env1 lid
+               ((let uu____2294 = FStar_TypeChecker_Env.lid_exists env1 lid
                     in
-                 if uu____2315
+                 if uu____2294
                  then
-                   let uu____2318 =
-                     let uu____2324 =
-                       let uu____2326 = FStar_Ident.string_of_lid lid  in
+                   let uu____2297 =
+                     let uu____2303 =
+                       let uu____2305 = FStar_Ident.string_of_lid lid  in
                        FStar_Util.format1
                          "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                         uu____2326
+                         uu____2305
                         in
                      (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
-                       uu____2324)
+                       uu____2303)
                       in
-                   FStar_Errors.raise_error uu____2318 r
+                   FStar_Errors.raise_error uu____2297 r
                  else ());
-                (let uu____2332 =
-                   let uu____2341 =
+                (let uu____2311 =
+                   let uu____2320 =
                      (FStar_Options.use_two_phase_tc ()) &&
                        (FStar_TypeChecker_Env.should_verify env1)
                       in
-                   if uu____2341
+                   if uu____2320
                    then
-                     let uu____2352 =
+                     let uu____2331 =
                        tc_declare_typ
-                         (let uu___434_2355 = env1  in
+                         (let uu___434_2334 = env1  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___434_2355.FStar_TypeChecker_Env.solver);
+                              (uu___434_2334.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___434_2355.FStar_TypeChecker_Env.range);
+                              (uu___434_2334.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___434_2355.FStar_TypeChecker_Env.curmodule);
+                              (uu___434_2334.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___434_2355.FStar_TypeChecker_Env.gamma);
+                              (uu___434_2334.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___434_2355.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___434_2334.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___434_2355.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___434_2334.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___434_2355.FStar_TypeChecker_Env.modules);
+                              (uu___434_2334.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___434_2355.FStar_TypeChecker_Env.expected_typ);
+                              (uu___434_2334.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___434_2355.FStar_TypeChecker_Env.sigtab);
+                              (uu___434_2334.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___434_2355.FStar_TypeChecker_Env.attrtab);
+                              (uu___434_2334.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___434_2355.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___434_2334.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___434_2355.FStar_TypeChecker_Env.effects);
+                              (uu___434_2334.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___434_2355.FStar_TypeChecker_Env.generalize);
+                              (uu___434_2334.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___434_2355.FStar_TypeChecker_Env.letrecs);
+                              (uu___434_2334.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___434_2355.FStar_TypeChecker_Env.top_level);
+                              (uu___434_2334.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___434_2355.FStar_TypeChecker_Env.check_uvars);
+                              (uu___434_2334.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___434_2355.FStar_TypeChecker_Env.use_eq);
+                              (uu___434_2334.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___434_2355.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___434_2334.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___434_2355.FStar_TypeChecker_Env.is_iface);
+                              (uu___434_2334.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___434_2355.FStar_TypeChecker_Env.admit);
+                              (uu___434_2334.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___434_2355.FStar_TypeChecker_Env.lax_universes);
+                              (uu___434_2334.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___434_2355.FStar_TypeChecker_Env.failhard);
+                              (uu___434_2334.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___434_2355.FStar_TypeChecker_Env.nosynth);
+                              (uu___434_2334.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___434_2355.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___434_2334.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___434_2355.FStar_TypeChecker_Env.tc_term);
+                              (uu___434_2334.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___434_2355.FStar_TypeChecker_Env.type_of);
+                              (uu___434_2334.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___434_2355.FStar_TypeChecker_Env.universe_of);
+                              (uu___434_2334.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___434_2355.FStar_TypeChecker_Env.check_type_of);
+                              (uu___434_2334.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___434_2355.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___434_2334.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___434_2355.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___434_2334.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___434_2355.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___434_2334.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___434_2355.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___434_2334.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___434_2355.FStar_TypeChecker_Env.proof_ns);
+                              (uu___434_2334.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___434_2355.FStar_TypeChecker_Env.synth_hook);
+                              (uu___434_2334.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___434_2355.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___434_2334.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___434_2355.FStar_TypeChecker_Env.splice);
+                              (uu___434_2334.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___434_2355.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___434_2334.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___434_2355.FStar_TypeChecker_Env.postprocess);
+                              (uu___434_2334.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___434_2355.FStar_TypeChecker_Env.identifier_info);
+                              (uu___434_2334.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___434_2355.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___434_2334.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___434_2355.FStar_TypeChecker_Env.dsenv);
+                              (uu___434_2334.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___434_2355.FStar_TypeChecker_Env.nbe);
+                              (uu___434_2334.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___434_2355.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___434_2334.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___434_2355.FStar_TypeChecker_Env.erasable_types_tab)
+                              (uu___434_2334.FStar_TypeChecker_Env.erasable_types_tab)
                           }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng
                         in
-                     match uu____2352 with
+                     match uu____2331 with
                      | (uvs1,t1) ->
-                         ((let uu____2381 =
+                         ((let uu____2360 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "TwoPhases")
                               in
-                           if uu____2381
+                           if uu____2360
                            then
-                             let uu____2386 =
+                             let uu____2365 =
                                FStar_Syntax_Print.term_to_string t1  in
-                             let uu____2388 =
+                             let uu____2367 =
                                FStar_Syntax_Print.univ_names_to_string uvs1
                                 in
                              FStar_Util.print2
                                "Val declaration after phase 1: %s and uvs: %s\n"
-                               uu____2386 uu____2388
+                               uu____2365 uu____2367
                            else ());
                           (uvs1, t1))
                    else (uvs, t)  in
-                 match uu____2332 with
+                 match uu____2311 with
                  | (uvs1,t1) ->
-                     let uu____2423 =
+                     let uu____2402 =
                        tc_declare_typ env1 (uvs1, t1)
                          se1.FStar_Syntax_Syntax.sigrng
                         in
-                     (match uu____2423 with
+                     (match uu____2402 with
                       | (uvs2,t2) ->
-                          ([(let uu___447_2453 = se1  in
+                          ([(let uu___447_2432 = se1  in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_declare_typ
                                     (lid, uvs2, t2));
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___447_2453.FStar_Syntax_Syntax.sigrng);
+                                 (uu___447_2432.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___447_2453.FStar_Syntax_Syntax.sigquals);
+                                 (uu___447_2432.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___447_2453.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___447_2432.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___447_2453.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___447_2432.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___447_2453.FStar_Syntax_Syntax.sigopts)
+                                 (uu___447_2432.FStar_Syntax_Syntax.sigopts)
                              })], [], env0))))
            | FStar_Syntax_Syntax.Sig_assume (lid,uvs,t) ->
-               ((let uu____2458 =
-                   let uu____2464 =
-                     let uu____2466 = FStar_Syntax_Print.lid_to_string lid
+               ((let uu____2437 =
+                   let uu____2443 =
+                     let uu____2445 = FStar_Syntax_Print.lid_to_string lid
                         in
                      FStar_Util.format1 "Admitting a top-level assumption %s"
-                       uu____2466
+                       uu____2445
                       in
-                   (FStar_Errors.Warning_WarnOnUse, uu____2464)  in
-                 FStar_Errors.log_issue r uu____2458);
+                   (FStar_Errors.Warning_WarnOnUse, uu____2443)  in
+                 FStar_Errors.log_issue r uu____2437);
                 (let env1 = FStar_TypeChecker_Env.set_range env r  in
-                 let uu____2471 =
-                   let uu____2480 =
+                 let uu____2450 =
+                   let uu____2459 =
                      (FStar_Options.use_two_phase_tc ()) &&
                        (FStar_TypeChecker_Env.should_verify env1)
                       in
-                   if uu____2480
+                   if uu____2459
                    then
-                     let uu____2491 =
+                     let uu____2470 =
                        tc_assume
-                         (let uu___457_2494 = env1  in
+                         (let uu___457_2473 = env1  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___457_2494.FStar_TypeChecker_Env.solver);
+                              (uu___457_2473.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___457_2494.FStar_TypeChecker_Env.range);
+                              (uu___457_2473.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___457_2494.FStar_TypeChecker_Env.curmodule);
+                              (uu___457_2473.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___457_2494.FStar_TypeChecker_Env.gamma);
+                              (uu___457_2473.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___457_2494.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___457_2473.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___457_2494.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___457_2473.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___457_2494.FStar_TypeChecker_Env.modules);
+                              (uu___457_2473.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___457_2494.FStar_TypeChecker_Env.expected_typ);
+                              (uu___457_2473.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___457_2494.FStar_TypeChecker_Env.sigtab);
+                              (uu___457_2473.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___457_2494.FStar_TypeChecker_Env.attrtab);
+                              (uu___457_2473.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___457_2494.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___457_2473.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___457_2494.FStar_TypeChecker_Env.effects);
+                              (uu___457_2473.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___457_2494.FStar_TypeChecker_Env.generalize);
+                              (uu___457_2473.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___457_2494.FStar_TypeChecker_Env.letrecs);
+                              (uu___457_2473.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___457_2494.FStar_TypeChecker_Env.top_level);
+                              (uu___457_2473.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___457_2494.FStar_TypeChecker_Env.check_uvars);
+                              (uu___457_2473.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___457_2494.FStar_TypeChecker_Env.use_eq);
+                              (uu___457_2473.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___457_2494.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___457_2473.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___457_2494.FStar_TypeChecker_Env.is_iface);
+                              (uu___457_2473.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___457_2494.FStar_TypeChecker_Env.admit);
+                              (uu___457_2473.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___457_2494.FStar_TypeChecker_Env.lax_universes);
+                              (uu___457_2473.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___457_2494.FStar_TypeChecker_Env.failhard);
+                              (uu___457_2473.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___457_2494.FStar_TypeChecker_Env.nosynth);
+                              (uu___457_2473.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___457_2494.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___457_2473.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___457_2494.FStar_TypeChecker_Env.tc_term);
+                              (uu___457_2473.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___457_2494.FStar_TypeChecker_Env.type_of);
+                              (uu___457_2473.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___457_2494.FStar_TypeChecker_Env.universe_of);
+                              (uu___457_2473.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___457_2494.FStar_TypeChecker_Env.check_type_of);
+                              (uu___457_2473.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___457_2494.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___457_2473.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___457_2494.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___457_2473.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___457_2494.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___457_2473.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___457_2494.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___457_2473.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___457_2494.FStar_TypeChecker_Env.proof_ns);
+                              (uu___457_2473.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___457_2494.FStar_TypeChecker_Env.synth_hook);
+                              (uu___457_2473.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___457_2494.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___457_2473.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___457_2494.FStar_TypeChecker_Env.splice);
+                              (uu___457_2473.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___457_2494.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___457_2473.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___457_2494.FStar_TypeChecker_Env.postprocess);
+                              (uu___457_2473.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___457_2494.FStar_TypeChecker_Env.identifier_info);
+                              (uu___457_2473.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___457_2494.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___457_2473.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___457_2494.FStar_TypeChecker_Env.dsenv);
+                              (uu___457_2473.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___457_2494.FStar_TypeChecker_Env.nbe);
+                              (uu___457_2473.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___457_2494.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___457_2473.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___457_2494.FStar_TypeChecker_Env.erasable_types_tab)
+                              (uu___457_2473.FStar_TypeChecker_Env.erasable_types_tab)
                           }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng
                         in
-                     match uu____2491 with
+                     match uu____2470 with
                      | (uvs1,t1) ->
-                         ((let uu____2520 =
+                         ((let uu____2499 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "TwoPhases")
                               in
-                           if uu____2520
+                           if uu____2499
                            then
-                             let uu____2525 =
+                             let uu____2504 =
                                FStar_Syntax_Print.term_to_string t1  in
-                             let uu____2527 =
+                             let uu____2506 =
                                FStar_Syntax_Print.univ_names_to_string uvs1
                                 in
                              FStar_Util.print2
                                "Assume after phase 1: %s and uvs: %s\n"
-                               uu____2525 uu____2527
+                               uu____2504 uu____2506
                            else ());
                           (uvs1, t1))
                    else (uvs, t)  in
-                 match uu____2471 with
+                 match uu____2450 with
                  | (uvs1,t1) ->
-                     let uu____2562 =
+                     let uu____2541 =
                        tc_assume env1 (uvs1, t1)
                          se1.FStar_Syntax_Syntax.sigrng
                         in
-                     (match uu____2562 with
+                     (match uu____2541 with
                       | (uvs2,t2) ->
-                          ([(let uu___470_2592 = se1  in
+                          ([(let uu___470_2571 = se1  in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_assume
                                     (lid, uvs2, t2));
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___470_2592.FStar_Syntax_Syntax.sigrng);
+                                 (uu___470_2571.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___470_2592.FStar_Syntax_Syntax.sigquals);
+                                 (uu___470_2571.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___470_2592.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___470_2571.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___470_2592.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___470_2571.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___470_2592.FStar_Syntax_Syntax.sigopts)
+                                 (uu___470_2571.FStar_Syntax_Syntax.sigopts)
                              })], [], env0))))
            | FStar_Syntax_Syntax.Sig_splice (lids,t) ->
-               ((let uu____2600 = FStar_Options.debug_any ()  in
-                 if uu____2600
+               ((let uu____2579 = FStar_Options.debug_any ()  in
+                 if uu____2579
                  then
-                   let uu____2603 =
+                   let uu____2582 =
                      FStar_Ident.string_of_lid
                        env.FStar_TypeChecker_Env.curmodule
                       in
-                   let uu____2605 = FStar_Syntax_Print.term_to_string t  in
-                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____2603
-                     uu____2605
+                   let uu____2584 = FStar_Syntax_Print.term_to_string t  in
+                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____2582
+                     uu____2584
                  else ());
-                (let uu____2610 =
+                (let uu____2589 =
                    FStar_TypeChecker_TcTerm.tc_tactic
                      FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_decls
                      env t
                     in
-                 match uu____2610 with
-                 | (t1,uu____2628,g) ->
+                 match uu____2589 with
+                 | (t1,uu____2607,g) ->
                      (FStar_TypeChecker_Rel.force_trivial_guard env g;
                       (let ses =
                          env.FStar_TypeChecker_Env.splice env
@@ -2128,135 +2119,135 @@ let (tc_decl' :
                           in
                        FStar_List.iter
                          (fun lid  ->
-                            let uu____2642 =
+                            let uu____2621 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids'
                                in
-                            match uu____2642 with
+                            match uu____2621 with
                             | FStar_Pervasives_Native.None  when
                                 Prims.op_Negation
                                   env.FStar_TypeChecker_Env.nosynth
                                 ->
-                                let uu____2645 =
-                                  let uu____2651 =
-                                    let uu____2653 =
+                                let uu____2624 =
+                                  let uu____2630 =
+                                    let uu____2632 =
                                       FStar_Ident.string_of_lid lid  in
-                                    let uu____2655 =
-                                      let uu____2657 =
+                                    let uu____2634 =
+                                      let uu____2636 =
                                         FStar_List.map
                                           FStar_Ident.string_of_lid lids'
                                          in
                                       FStar_All.pipe_left
-                                        (FStar_String.concat ", ") uu____2657
+                                        (FStar_String.concat ", ") uu____2636
                                        in
                                     FStar_Util.format2
                                       "Splice declared the name %s but it was not defined.\nThose defined were: %s"
-                                      uu____2653 uu____2655
+                                      uu____2632 uu____2634
                                      in
                                   (FStar_Errors.Fatal_SplicedUndef,
-                                    uu____2651)
+                                    uu____2630)
                                    in
-                                FStar_Errors.raise_error uu____2645 r
-                            | uu____2669 -> ()) lids;
+                                FStar_Errors.raise_error uu____2624 r
+                            | uu____2648 -> ()) lids;
                        (let dsenv =
                           FStar_List.fold_left
                             FStar_Syntax_DsEnv.push_sigelt_force
                             env.FStar_TypeChecker_Env.dsenv ses
                            in
                         let env1 =
-                          let uu___490_2674 = env  in
+                          let uu___490_2653 = env  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___490_2674.FStar_TypeChecker_Env.solver);
+                              (uu___490_2653.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___490_2674.FStar_TypeChecker_Env.range);
+                              (uu___490_2653.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___490_2674.FStar_TypeChecker_Env.curmodule);
+                              (uu___490_2653.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___490_2674.FStar_TypeChecker_Env.gamma);
+                              (uu___490_2653.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___490_2674.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___490_2653.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___490_2674.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___490_2653.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___490_2674.FStar_TypeChecker_Env.modules);
+                              (uu___490_2653.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___490_2674.FStar_TypeChecker_Env.expected_typ);
+                              (uu___490_2653.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___490_2674.FStar_TypeChecker_Env.sigtab);
+                              (uu___490_2653.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___490_2674.FStar_TypeChecker_Env.attrtab);
+                              (uu___490_2653.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___490_2674.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___490_2653.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___490_2674.FStar_TypeChecker_Env.effects);
+                              (uu___490_2653.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___490_2674.FStar_TypeChecker_Env.generalize);
+                              (uu___490_2653.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___490_2674.FStar_TypeChecker_Env.letrecs);
+                              (uu___490_2653.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___490_2674.FStar_TypeChecker_Env.top_level);
+                              (uu___490_2653.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___490_2674.FStar_TypeChecker_Env.check_uvars);
+                              (uu___490_2653.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___490_2674.FStar_TypeChecker_Env.use_eq);
+                              (uu___490_2653.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___490_2674.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___490_2653.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___490_2674.FStar_TypeChecker_Env.is_iface);
+                              (uu___490_2653.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___490_2674.FStar_TypeChecker_Env.admit);
+                              (uu___490_2653.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax =
-                              (uu___490_2674.FStar_TypeChecker_Env.lax);
+                              (uu___490_2653.FStar_TypeChecker_Env.lax);
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___490_2674.FStar_TypeChecker_Env.lax_universes);
+                              (uu___490_2653.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =
-                              (uu___490_2674.FStar_TypeChecker_Env.phase1);
+                              (uu___490_2653.FStar_TypeChecker_Env.phase1);
                             FStar_TypeChecker_Env.failhard =
-                              (uu___490_2674.FStar_TypeChecker_Env.failhard);
+                              (uu___490_2653.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___490_2674.FStar_TypeChecker_Env.nosynth);
+                              (uu___490_2653.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___490_2674.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___490_2653.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___490_2674.FStar_TypeChecker_Env.tc_term);
+                              (uu___490_2653.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___490_2674.FStar_TypeChecker_Env.type_of);
+                              (uu___490_2653.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___490_2674.FStar_TypeChecker_Env.universe_of);
+                              (uu___490_2653.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___490_2674.FStar_TypeChecker_Env.check_type_of);
+                              (uu___490_2653.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___490_2674.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___490_2653.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___490_2674.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___490_2653.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___490_2674.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___490_2653.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___490_2674.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___490_2653.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___490_2674.FStar_TypeChecker_Env.proof_ns);
+                              (uu___490_2653.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___490_2674.FStar_TypeChecker_Env.synth_hook);
+                              (uu___490_2653.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___490_2674.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___490_2653.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___490_2674.FStar_TypeChecker_Env.splice);
+                              (uu___490_2653.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___490_2674.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___490_2653.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___490_2674.FStar_TypeChecker_Env.postprocess);
+                              (uu___490_2653.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___490_2674.FStar_TypeChecker_Env.identifier_info);
+                              (uu___490_2653.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___490_2674.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___490_2653.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv = dsenv;
                             FStar_TypeChecker_Env.nbe =
-                              (uu___490_2674.FStar_TypeChecker_Env.nbe);
+                              (uu___490_2653.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___490_2674.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___490_2653.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___490_2674.FStar_TypeChecker_Env.erasable_types_tab)
+                              (uu___490_2653.FStar_TypeChecker_Env.erasable_types_tab)
                           }  in
                         ([], ses, env1))))))
            | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
@@ -2271,12 +2262,12 @@ let (tc_decl' :
                          (fun x  ->
                             Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))
                         in
-                     let uu____2742 =
-                       let uu____2744 =
-                         let uu____2753 = drop_logic val_q  in
-                         let uu____2756 = drop_logic q'  in
-                         (uu____2753, uu____2756)  in
-                       match uu____2744 with
+                     let uu____2721 =
+                       let uu____2723 =
+                         let uu____2732 = drop_logic val_q  in
+                         let uu____2735 = drop_logic q'  in
+                         (uu____2732, uu____2735)  in
+                       match uu____2723 with
                        | (val_q1,q'1) ->
                            ((FStar_List.length val_q1) =
                               (FStar_List.length q'1))
@@ -2284,139 +2275,136 @@ let (tc_decl' :
                              (FStar_List.forall2
                                 FStar_Syntax_Util.qualifier_equal val_q1 q'1)
                         in
-                     if uu____2742
+                     if uu____2721
                      then FStar_Pervasives_Native.Some q'
                      else
-                       (let uu____2783 =
-                          let uu____2789 =
-                            let uu____2791 =
+                       (let uu____2762 =
+                          let uu____2768 =
+                            let uu____2770 =
                               FStar_Syntax_Print.lid_to_string l  in
-                            let uu____2793 =
+                            let uu____2772 =
                               FStar_Syntax_Print.quals_to_string val_q  in
-                            let uu____2795 =
+                            let uu____2774 =
                               FStar_Syntax_Print.quals_to_string q'  in
                             FStar_Util.format3
                               "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                              uu____2791 uu____2793 uu____2795
+                              uu____2770 uu____2772 uu____2774
                              in
                           (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
-                            uu____2789)
+                            uu____2768)
                            in
-                        FStar_Errors.raise_error uu____2783 r)
+                        FStar_Errors.raise_error uu____2762 r)
                   in
                let rename_parameters lb =
                  let rename_in_typ def typ =
                    let typ1 = FStar_Syntax_Subst.compress typ  in
                    let def_bs =
-                     let uu____2832 =
-                       let uu____2833 = FStar_Syntax_Subst.compress def  in
-                       uu____2833.FStar_Syntax_Syntax.n  in
-                     match uu____2832 with
+                     let uu____2811 =
+                       let uu____2812 = FStar_Syntax_Subst.compress def  in
+                       uu____2812.FStar_Syntax_Syntax.n  in
+                     match uu____2811 with
                      | FStar_Syntax_Syntax.Tm_abs
-                         (binders,uu____2845,uu____2846) -> binders
-                     | uu____2871 -> []  in
+                         (binders,uu____2824,uu____2825) -> binders
+                     | uu____2850 -> []  in
                    match typ1 with
                    | {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
                          (val_bs,c);
                        FStar_Syntax_Syntax.pos = r1;
-                       FStar_Syntax_Syntax.vars = uu____2883;_} ->
+                       FStar_Syntax_Syntax.vars = uu____2862;_} ->
                        let has_auto_name bv =
-                         let uu____2913 =
+                         let uu____2892 =
                            FStar_Ident.text_of_id
                              bv.FStar_Syntax_Syntax.ppname
                             in
-                         FStar_Util.starts_with uu____2913
+                         FStar_Util.starts_with uu____2892
                            FStar_Ident.reserved_prefix
                           in
                        let rec rename_binders def_bs1 val_bs1 =
                          match (def_bs1, val_bs1) with
-                         | ([],uu____2990) -> val_bs1
-                         | (uu____3021,[]) -> val_bs1
-                         | ((body_bv,uu____3053)::bt,(val_bv,aqual)::vt) ->
-                             let uu____3110 =
-                               let uu____3117 =
-                                 let uu____3124 = has_auto_name body_bv  in
-                                 let uu____3126 = has_auto_name val_bv  in
-                                 (uu____3124, uu____3126)  in
-                               match uu____3117 with
-                               | (true ,uu____3136) -> (val_bv, aqual)
+                         | ([],uu____2969) -> val_bs1
+                         | (uu____3000,[]) -> val_bs1
+                         | ((body_bv,uu____3032)::bt,(val_bv,aqual)::vt) ->
+                             let uu____3089 =
+                               let uu____3096 =
+                                 let uu____3103 = has_auto_name body_bv  in
+                                 let uu____3105 = has_auto_name val_bv  in
+                                 (uu____3103, uu____3105)  in
+                               match uu____3096 with
+                               | (true ,uu____3115) -> (val_bv, aqual)
                                | (false ,true ) ->
-                                   let uu____3147 =
-                                     let uu___559_3148 = val_bv  in
-                                     let uu____3149 =
-                                       let uu____3150 =
-                                         let uu____3156 =
+                                   let uu____3126 =
+                                     let uu___559_3127 = val_bv  in
+                                     let uu____3128 =
+                                       let uu____3129 =
+                                         let uu____3135 =
                                            FStar_Ident.text_of_id
                                              body_bv.FStar_Syntax_Syntax.ppname
                                             in
-                                         let uu____3158 =
+                                         let uu____3137 =
                                            FStar_Ident.range_of_id
                                              val_bv.FStar_Syntax_Syntax.ppname
                                             in
-                                         (uu____3156, uu____3158)  in
-                                       FStar_Ident.mk_ident uu____3150  in
+                                         (uu____3135, uu____3137)  in
+                                       FStar_Ident.mk_ident uu____3129  in
                                      {
                                        FStar_Syntax_Syntax.ppname =
-                                         uu____3149;
+                                         uu____3128;
                                        FStar_Syntax_Syntax.index =
-                                         (uu___559_3148.FStar_Syntax_Syntax.index);
+                                         (uu___559_3127.FStar_Syntax_Syntax.index);
                                        FStar_Syntax_Syntax.sort =
-                                         (uu___559_3148.FStar_Syntax_Syntax.sort)
+                                         (uu___559_3127.FStar_Syntax_Syntax.sort)
                                      }  in
-                                   (uu____3147, aqual)
+                                   (uu____3126, aqual)
                                | (false ,false ) -> (val_bv, aqual)  in
-                             let uu____3168 = rename_binders bt vt  in
-                             uu____3110 :: uu____3168
+                             let uu____3147 = rename_binders bt vt  in
+                             uu____3089 :: uu____3147
                           in
-                       let uu____3183 =
-                         let uu____3190 =
-                           let uu____3191 =
-                             let uu____3206 = rename_binders def_bs val_bs
-                                in
-                             (uu____3206, c)  in
-                           FStar_Syntax_Syntax.Tm_arrow uu____3191  in
-                         FStar_Syntax_Syntax.mk uu____3190  in
-                       uu____3183 FStar_Pervasives_Native.None r1
-                   | uu____3225 -> typ1  in
-                 let uu___565_3226 = lb  in
-                 let uu____3227 =
+                       let uu____3162 =
+                         let uu____3163 =
+                           let uu____3178 = rename_binders def_bs val_bs  in
+                           (uu____3178, c)  in
+                         FStar_Syntax_Syntax.Tm_arrow uu____3163  in
+                       FStar_Syntax_Syntax.mk uu____3162 r1
+                   | uu____3197 -> typ1  in
+                 let uu___565_3198 = lb  in
+                 let uu____3199 =
                    rename_in_typ lb.FStar_Syntax_Syntax.lbdef
                      lb.FStar_Syntax_Syntax.lbtyp
                     in
                  {
                    FStar_Syntax_Syntax.lbname =
-                     (uu___565_3226.FStar_Syntax_Syntax.lbname);
+                     (uu___565_3198.FStar_Syntax_Syntax.lbname);
                    FStar_Syntax_Syntax.lbunivs =
-                     (uu___565_3226.FStar_Syntax_Syntax.lbunivs);
-                   FStar_Syntax_Syntax.lbtyp = uu____3227;
+                     (uu___565_3198.FStar_Syntax_Syntax.lbunivs);
+                   FStar_Syntax_Syntax.lbtyp = uu____3199;
                    FStar_Syntax_Syntax.lbeff =
-                     (uu___565_3226.FStar_Syntax_Syntax.lbeff);
+                     (uu___565_3198.FStar_Syntax_Syntax.lbeff);
                    FStar_Syntax_Syntax.lbdef =
-                     (uu___565_3226.FStar_Syntax_Syntax.lbdef);
+                     (uu___565_3198.FStar_Syntax_Syntax.lbdef);
                    FStar_Syntax_Syntax.lbattrs =
-                     (uu___565_3226.FStar_Syntax_Syntax.lbattrs);
+                     (uu___565_3198.FStar_Syntax_Syntax.lbattrs);
                    FStar_Syntax_Syntax.lbpos =
-                     (uu___565_3226.FStar_Syntax_Syntax.lbpos)
+                     (uu___565_3198.FStar_Syntax_Syntax.lbpos)
                  }  in
-               let uu____3230 =
+               let uu____3202 =
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                    (FStar_List.fold_left
-                      (fun uu____3285  ->
+                      (fun uu____3257  ->
                          fun lb  ->
-                           match uu____3285 with
+                           match uu____3257 with
                            | (gen,lbs1,quals_opt) ->
                                let lbname =
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname
                                   in
-                               let uu____3331 =
-                                 let uu____3343 =
+                               let uu____3303 =
+                                 let uu____3315 =
                                    FStar_TypeChecker_Env.try_lookup_val_decl
                                      env1
                                      (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                     in
-                                 match uu____3343 with
+                                 match uu____3315 with
                                  | FStar_Pervasives_Native.None  ->
                                      if lb.FStar_Syntax_Syntax.lbunivs <> []
                                      then (false, lb, quals_opt)
@@ -2433,7 +2421,7 @@ let (tc_decl' :
                                        with
                                        | FStar_Syntax_Syntax.Tm_unknown  ->
                                            lb.FStar_Syntax_Syntax.lbdef
-                                       | uu____3423 ->
+                                       | uu____3395 ->
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_ascribed
                                                 ((lb.FStar_Syntax_Syntax.lbdef),
@@ -2441,7 +2429,6 @@ let (tc_decl' :
                                                       (lb.FStar_Syntax_Syntax.lbtyp)),
                                                     FStar_Pervasives_Native.None),
                                                   FStar_Pervasives_Native.None))
-                                             FStar_Pervasives_Native.None
                                              (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.pos
                                         in
                                      (if
@@ -2456,16 +2443,16 @@ let (tc_decl' :
                                             "Inline universes are incoherent with annotation from val declaration")
                                           r
                                       else ();
-                                      (let uu____3470 =
+                                      (let uu____3442 =
                                          FStar_Syntax_Syntax.mk_lb
                                            ((FStar_Util.Inr lbname), uvs,
                                              FStar_Parser_Const.effect_ALL_lid,
                                              tval, def, [],
                                              (lb.FStar_Syntax_Syntax.lbpos))
                                           in
-                                       (false, uu____3470, quals_opt1)))
+                                       (false, uu____3442, quals_opt1)))
                                   in
-                               (match uu____3331 with
+                               (match uu____3303 with
                                 | (gen1,lb1,quals_opt1) ->
                                     (gen1, (lb1 :: lbs1), quals_opt1)))
                       (true, [],
@@ -2475,38 +2462,38 @@ let (tc_decl' :
                            FStar_Pervasives_Native.Some
                              (se1.FStar_Syntax_Syntax.sigquals))))
                   in
-               (match uu____3230 with
+               (match uu____3202 with
                 | (should_generalize,lbs',quals_opt) ->
                     let quals =
                       match quals_opt with
                       | FStar_Pervasives_Native.None  ->
                           [FStar_Syntax_Syntax.Visible_default]
                       | FStar_Pervasives_Native.Some q ->
-                          let uu____3574 =
+                          let uu____3546 =
                             FStar_All.pipe_right q
                               (FStar_Util.for_some
-                                 (fun uu___1_3580  ->
-                                    match uu___1_3580 with
+                                 (fun uu___1_3552  ->
+                                    match uu___1_3552 with
                                     | FStar_Syntax_Syntax.Irreducible  ->
                                         true
                                     | FStar_Syntax_Syntax.Visible_default  ->
                                         true
                                     | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
                                          -> true
-                                    | uu____3585 -> false))
+                                    | uu____3557 -> false))
                              in
-                          if uu____3574
+                          if uu____3546
                           then q
                           else FStar_Syntax_Syntax.Visible_default :: q
                        in
                     let lbs'1 = FStar_List.rev lbs'  in
-                    let uu____3595 =
-                      let uu____3604 =
+                    let uu____3567 =
+                      let uu____3576 =
                         FStar_Syntax_Util.extract_attr'
                           FStar_Parser_Const.preprocess_with
                           se1.FStar_Syntax_Syntax.sigattrs
                          in
-                      match uu____3604 with
+                      match uu____3576 with
                       | FStar_Pervasives_Native.None  ->
                           ((se1.FStar_Syntax_Syntax.sigattrs),
                             FStar_Pervasives_Native.None)
@@ -2520,55 +2507,55 @@ let (tc_decl' :
                            ((se1.FStar_Syntax_Syntax.sigattrs),
                              FStar_Pervasives_Native.None))
                        in
-                    (match uu____3595 with
+                    (match uu____3567 with
                      | (attrs,pre_tau) ->
                          let se2 =
-                           let uu___623_3709 = se1  in
+                           let uu___623_3681 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
-                               (uu___623_3709.FStar_Syntax_Syntax.sigel);
+                               (uu___623_3681.FStar_Syntax_Syntax.sigel);
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___623_3709.FStar_Syntax_Syntax.sigrng);
+                               (uu___623_3681.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___623_3709.FStar_Syntax_Syntax.sigquals);
+                               (uu___623_3681.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___623_3709.FStar_Syntax_Syntax.sigmeta);
+                               (uu___623_3681.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs = attrs;
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___623_3709.FStar_Syntax_Syntax.sigopts)
+                               (uu___623_3681.FStar_Syntax_Syntax.sigopts)
                            }  in
                          let preprocess_lb tau lb =
                            let lbdef =
                              FStar_TypeChecker_Env.preprocess env1 tau
                                lb.FStar_Syntax_Syntax.lbdef
                               in
-                           (let uu____3723 =
+                           (let uu____3695 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "TwoPhases")
                                in
-                            if uu____3723
+                            if uu____3695
                             then
-                              let uu____3728 =
+                              let uu____3700 =
                                 FStar_Syntax_Print.term_to_string lbdef  in
                               FStar_Util.print1 "lb preprocessed into: %s\n"
-                                uu____3728
+                                uu____3700
                             else ());
-                           (let uu___632_3733 = lb  in
+                           (let uu___632_3705 = lb  in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___632_3733.FStar_Syntax_Syntax.lbname);
+                                (uu___632_3705.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___632_3733.FStar_Syntax_Syntax.lbunivs);
+                                (uu___632_3705.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___632_3733.FStar_Syntax_Syntax.lbtyp);
+                                (uu___632_3705.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___632_3733.FStar_Syntax_Syntax.lbeff);
+                                (uu___632_3705.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___632_3733.FStar_Syntax_Syntax.lbattrs);
+                                (uu___632_3705.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___632_3733.FStar_Syntax_Syntax.lbpos)
+                                (uu___632_3705.FStar_Syntax_Syntax.lbpos)
                             })
                             in
                          let lbs'2 =
@@ -2577,381 +2564,378 @@ let (tc_decl' :
                                FStar_List.map (preprocess_lb tau) lbs'1
                            | FStar_Pervasives_Native.None  -> lbs'1  in
                          let e =
-                           let uu____3743 =
-                             let uu____3750 =
-                               let uu____3751 =
-                                 let uu____3765 =
-                                   FStar_Syntax_Syntax.mk
-                                     (FStar_Syntax_Syntax.Tm_constant
-                                        FStar_Const.Const_unit)
-                                     FStar_Pervasives_Native.None r
-                                    in
-                                 (((FStar_Pervasives_Native.fst lbs), lbs'2),
-                                   uu____3765)
+                           let uu____3715 =
+                             let uu____3716 =
+                               let uu____3730 =
+                                 FStar_Syntax_Syntax.mk
+                                   (FStar_Syntax_Syntax.Tm_constant
+                                      FStar_Const.Const_unit) r
                                   in
-                               FStar_Syntax_Syntax.Tm_let uu____3751  in
-                             FStar_Syntax_Syntax.mk uu____3750  in
-                           uu____3743 FStar_Pervasives_Native.None r  in
+                               (((FStar_Pervasives_Native.fst lbs), lbs'2),
+                                 uu____3730)
+                                in
+                             FStar_Syntax_Syntax.Tm_let uu____3716  in
+                           FStar_Syntax_Syntax.mk uu____3715 r  in
                          let env' =
-                           let uu___639_3784 = env1  in
+                           let uu___639_3749 = env1  in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___639_3784.FStar_TypeChecker_Env.solver);
+                               (uu___639_3749.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___639_3784.FStar_TypeChecker_Env.range);
+                               (uu___639_3749.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___639_3784.FStar_TypeChecker_Env.curmodule);
+                               (uu___639_3749.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___639_3784.FStar_TypeChecker_Env.gamma);
+                               (uu___639_3749.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___639_3784.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___639_3749.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___639_3784.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___639_3749.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___639_3784.FStar_TypeChecker_Env.modules);
+                               (uu___639_3749.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___639_3784.FStar_TypeChecker_Env.expected_typ);
+                               (uu___639_3749.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___639_3784.FStar_TypeChecker_Env.sigtab);
+                               (uu___639_3749.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___639_3784.FStar_TypeChecker_Env.attrtab);
+                               (uu___639_3749.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___639_3784.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___639_3749.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___639_3784.FStar_TypeChecker_Env.effects);
+                               (uu___639_3749.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
                                should_generalize;
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___639_3784.FStar_TypeChecker_Env.letrecs);
+                               (uu___639_3749.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level = true;
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___639_3784.FStar_TypeChecker_Env.check_uvars);
+                               (uu___639_3749.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___639_3784.FStar_TypeChecker_Env.use_eq);
+                               (uu___639_3749.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___639_3784.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___639_3749.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___639_3784.FStar_TypeChecker_Env.is_iface);
+                               (uu___639_3749.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___639_3784.FStar_TypeChecker_Env.admit);
+                               (uu___639_3749.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax =
-                               (uu___639_3784.FStar_TypeChecker_Env.lax);
+                               (uu___639_3749.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___639_3784.FStar_TypeChecker_Env.lax_universes);
+                               (uu___639_3749.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___639_3784.FStar_TypeChecker_Env.phase1);
+                               (uu___639_3749.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___639_3784.FStar_TypeChecker_Env.failhard);
+                               (uu___639_3749.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___639_3784.FStar_TypeChecker_Env.nosynth);
+                               (uu___639_3749.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___639_3784.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___639_3749.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___639_3784.FStar_TypeChecker_Env.tc_term);
+                               (uu___639_3749.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___639_3784.FStar_TypeChecker_Env.type_of);
+                               (uu___639_3749.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___639_3784.FStar_TypeChecker_Env.universe_of);
+                               (uu___639_3749.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___639_3784.FStar_TypeChecker_Env.check_type_of);
+                               (uu___639_3749.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___639_3784.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___639_3749.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___639_3784.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___639_3749.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___639_3784.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___639_3749.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___639_3784.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___639_3749.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___639_3784.FStar_TypeChecker_Env.proof_ns);
+                               (uu___639_3749.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___639_3784.FStar_TypeChecker_Env.synth_hook);
+                               (uu___639_3749.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___639_3784.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___639_3749.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___639_3784.FStar_TypeChecker_Env.splice);
+                               (uu___639_3749.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___639_3784.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___639_3749.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___639_3784.FStar_TypeChecker_Env.postprocess);
+                               (uu___639_3749.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___639_3784.FStar_TypeChecker_Env.identifier_info);
+                               (uu___639_3749.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___639_3784.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___639_3749.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___639_3784.FStar_TypeChecker_Env.dsenv);
+                               (uu___639_3749.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___639_3784.FStar_TypeChecker_Env.nbe);
+                               (uu___639_3749.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___639_3784.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___639_3749.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___639_3784.FStar_TypeChecker_Env.erasable_types_tab)
+                               (uu___639_3749.FStar_TypeChecker_Env.erasable_types_tab)
                            }  in
                          let e1 =
-                           let uu____3787 =
+                           let uu____3752 =
                              (FStar_Options.use_two_phase_tc ()) &&
                                (FStar_TypeChecker_Env.should_verify env')
                               in
-                           if uu____3787
+                           if uu____3752
                            then
                              let drop_lbtyp e_lax =
-                               let uu____3796 =
-                                 let uu____3797 =
+                               let uu____3761 =
+                                 let uu____3762 =
                                    FStar_Syntax_Subst.compress e_lax  in
-                                 uu____3797.FStar_Syntax_Syntax.n  in
-                               match uu____3796 with
+                                 uu____3762.FStar_Syntax_Syntax.n  in
+                               match uu____3761 with
                                | FStar_Syntax_Syntax.Tm_let
                                    ((false ,lb::[]),e2) ->
                                    let lb_unannotated =
-                                     let uu____3819 =
-                                       let uu____3820 =
+                                     let uu____3784 =
+                                       let uu____3785 =
                                          FStar_Syntax_Subst.compress e  in
-                                       uu____3820.FStar_Syntax_Syntax.n  in
-                                     match uu____3819 with
+                                       uu____3785.FStar_Syntax_Syntax.n  in
+                                     match uu____3784 with
                                      | FStar_Syntax_Syntax.Tm_let
-                                         ((uu____3824,lb1::[]),uu____3826) ->
-                                         let uu____3842 =
-                                           let uu____3843 =
+                                         ((uu____3789,lb1::[]),uu____3791) ->
+                                         let uu____3807 =
+                                           let uu____3808 =
                                              FStar_Syntax_Subst.compress
                                                lb1.FStar_Syntax_Syntax.lbtyp
                                               in
-                                           uu____3843.FStar_Syntax_Syntax.n
+                                           uu____3808.FStar_Syntax_Syntax.n
                                             in
-                                         (match uu____3842 with
+                                         (match uu____3807 with
                                           | FStar_Syntax_Syntax.Tm_unknown 
                                               -> true
-                                          | uu____3848 -> false)
-                                     | uu____3850 ->
+                                          | uu____3813 -> false)
+                                     | uu____3815 ->
                                          failwith
                                            "Impossible: first phase lb and second phase lb differ in structure!"
                                       in
                                    if lb_unannotated
                                    then
-                                     let uu___664_3854 = e_lax  in
+                                     let uu___664_3819 = e_lax  in
                                      {
                                        FStar_Syntax_Syntax.n =
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((false,
-                                               [(let uu___666_3869 = lb  in
+                                               [(let uu___666_3834 = lb  in
                                                  {
                                                    FStar_Syntax_Syntax.lbname
                                                      =
-                                                     (uu___666_3869.FStar_Syntax_Syntax.lbname);
+                                                     (uu___666_3834.FStar_Syntax_Syntax.lbname);
                                                    FStar_Syntax_Syntax.lbunivs
                                                      =
-                                                     (uu___666_3869.FStar_Syntax_Syntax.lbunivs);
+                                                     (uu___666_3834.FStar_Syntax_Syntax.lbunivs);
                                                    FStar_Syntax_Syntax.lbtyp
                                                      =
                                                      FStar_Syntax_Syntax.tun;
                                                    FStar_Syntax_Syntax.lbeff
                                                      =
-                                                     (uu___666_3869.FStar_Syntax_Syntax.lbeff);
+                                                     (uu___666_3834.FStar_Syntax_Syntax.lbeff);
                                                    FStar_Syntax_Syntax.lbdef
                                                      =
-                                                     (uu___666_3869.FStar_Syntax_Syntax.lbdef);
+                                                     (uu___666_3834.FStar_Syntax_Syntax.lbdef);
                                                    FStar_Syntax_Syntax.lbattrs
                                                      =
-                                                     (uu___666_3869.FStar_Syntax_Syntax.lbattrs);
+                                                     (uu___666_3834.FStar_Syntax_Syntax.lbattrs);
                                                    FStar_Syntax_Syntax.lbpos
                                                      =
-                                                     (uu___666_3869.FStar_Syntax_Syntax.lbpos)
+                                                     (uu___666_3834.FStar_Syntax_Syntax.lbpos)
                                                  })]), e2));
                                        FStar_Syntax_Syntax.pos =
-                                         (uu___664_3854.FStar_Syntax_Syntax.pos);
+                                         (uu___664_3819.FStar_Syntax_Syntax.pos);
                                        FStar_Syntax_Syntax.vars =
-                                         (uu___664_3854.FStar_Syntax_Syntax.vars)
+                                         (uu___664_3819.FStar_Syntax_Syntax.vars)
                                      }
                                    else e_lax
-                               | uu____3872 -> e_lax  in
-                             let uu____3873 =
+                               | uu____3837 -> e_lax  in
+                             let uu____3838 =
                                FStar_Util.record_time
-                                 (fun uu____3881  ->
-                                    let uu____3882 =
-                                      let uu____3883 =
-                                        let uu____3884 =
+                                 (fun uu____3846  ->
+                                    let uu____3847 =
+                                      let uu____3848 =
+                                        let uu____3849 =
                                           FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                                            (let uu___670_3893 = env'  in
+                                            (let uu___670_3858 = env'  in
                                              {
                                                FStar_TypeChecker_Env.solver =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.solver);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.solver);
                                                FStar_TypeChecker_Env.range =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.range);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.range);
                                                FStar_TypeChecker_Env.curmodule
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.curmodule);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.curmodule);
                                                FStar_TypeChecker_Env.gamma =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.gamma);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.gamma);
                                                FStar_TypeChecker_Env.gamma_sig
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.gamma_sig);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.gamma_sig);
                                                FStar_TypeChecker_Env.gamma_cache
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.gamma_cache);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.gamma_cache);
                                                FStar_TypeChecker_Env.modules
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.modules);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.modules);
                                                FStar_TypeChecker_Env.expected_typ
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.expected_typ);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.expected_typ);
                                                FStar_TypeChecker_Env.sigtab =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.sigtab);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.sigtab);
                                                FStar_TypeChecker_Env.attrtab
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.attrtab);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.attrtab);
                                                FStar_TypeChecker_Env.instantiate_imp
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.instantiate_imp);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.instantiate_imp);
                                                FStar_TypeChecker_Env.effects
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.effects);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.effects);
                                                FStar_TypeChecker_Env.generalize
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.generalize);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.generalize);
                                                FStar_TypeChecker_Env.letrecs
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.letrecs);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.letrecs);
                                                FStar_TypeChecker_Env.top_level
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.top_level);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.top_level);
                                                FStar_TypeChecker_Env.check_uvars
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.check_uvars);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.check_uvars);
                                                FStar_TypeChecker_Env.use_eq =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.use_eq);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.use_eq);
                                                FStar_TypeChecker_Env.use_eq_strict
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.use_eq_strict);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.use_eq_strict);
                                                FStar_TypeChecker_Env.is_iface
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.is_iface);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.is_iface);
                                                FStar_TypeChecker_Env.admit =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.admit);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.admit);
                                                FStar_TypeChecker_Env.lax =
                                                  true;
                                                FStar_TypeChecker_Env.lax_universes
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.lax_universes);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.lax_universes);
                                                FStar_TypeChecker_Env.phase1 =
                                                  true;
                                                FStar_TypeChecker_Env.failhard
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.failhard);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.failhard);
                                                FStar_TypeChecker_Env.nosynth
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.nosynth);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.nosynth);
                                                FStar_TypeChecker_Env.uvar_subtyping
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.uvar_subtyping);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.uvar_subtyping);
                                                FStar_TypeChecker_Env.tc_term
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.tc_term);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.tc_term);
                                                FStar_TypeChecker_Env.type_of
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.type_of);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.type_of);
                                                FStar_TypeChecker_Env.universe_of
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.universe_of);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.universe_of);
                                                FStar_TypeChecker_Env.check_type_of
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.check_type_of);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.check_type_of);
                                                FStar_TypeChecker_Env.use_bv_sorts
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.use_bv_sorts);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.use_bv_sorts);
                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                FStar_TypeChecker_Env.normalized_eff_names
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.normalized_eff_names);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.normalized_eff_names);
                                                FStar_TypeChecker_Env.fv_delta_depths
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.fv_delta_depths);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.fv_delta_depths);
                                                FStar_TypeChecker_Env.proof_ns
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.proof_ns);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.proof_ns);
                                                FStar_TypeChecker_Env.synth_hook
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.synth_hook);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.synth_hook);
                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                FStar_TypeChecker_Env.splice =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.splice);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.splice);
                                                FStar_TypeChecker_Env.mpreprocess
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.mpreprocess);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.mpreprocess);
                                                FStar_TypeChecker_Env.postprocess
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.postprocess);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.postprocess);
                                                FStar_TypeChecker_Env.identifier_info
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.identifier_info);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.identifier_info);
                                                FStar_TypeChecker_Env.tc_hooks
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.tc_hooks);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.tc_hooks);
                                                FStar_TypeChecker_Env.dsenv =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.dsenv);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.dsenv);
                                                FStar_TypeChecker_Env.nbe =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.nbe);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.nbe);
                                                FStar_TypeChecker_Env.strict_args_tab
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.strict_args_tab);
+                                                 (uu___670_3858.FStar_TypeChecker_Env.strict_args_tab);
                                                FStar_TypeChecker_Env.erasable_types_tab
                                                  =
-                                                 (uu___670_3893.FStar_TypeChecker_Env.erasable_types_tab)
+                                                 (uu___670_3858.FStar_TypeChecker_Env.erasable_types_tab)
                                              }) e
                                            in
-                                        FStar_All.pipe_right uu____3884
-                                          (fun uu____3906  ->
-                                             match uu____3906 with
-                                             | (e1,uu____3914,uu____3915) ->
+                                        FStar_All.pipe_right uu____3849
+                                          (fun uu____3871  ->
+                                             match uu____3871 with
+                                             | (e1,uu____3879,uu____3880) ->
                                                  e1)
                                          in
-                                      FStar_All.pipe_right uu____3883
+                                      FStar_All.pipe_right uu____3848
                                         (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                            env')
                                        in
-                                    FStar_All.pipe_right uu____3882
+                                    FStar_All.pipe_right uu____3847
                                       drop_lbtyp)
                                 in
-                             match uu____3873 with
+                             match uu____3838 with
                              | (e1,ms) ->
-                                 ((let uu____3921 =
+                                 ((let uu____3886 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env1)
                                        (FStar_Options.Other "TwoPhases")
                                       in
-                                   if uu____3921
+                                   if uu____3886
                                    then
-                                     let uu____3926 =
+                                     let uu____3891 =
                                        FStar_Syntax_Print.term_to_string e1
                                         in
                                      FStar_Util.print1
                                        "Let binding after phase 1: %s\n"
-                                       uu____3926
+                                       uu____3891
                                    else ());
-                                  (let uu____3932 =
+                                  (let uu____3897 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env1)
                                        (FStar_Options.Other "TCDeclTime")
                                       in
-                                   if uu____3932
+                                   if uu____3897
                                    then
-                                     let uu____3937 =
+                                     let uu____3902 =
                                        FStar_Util.string_of_int ms  in
                                      FStar_Util.print1
                                        "Let binding elaborated (phase 1) in %s milliseconds\n"
-                                       uu____3937
+                                       uu____3902
                                    else ());
                                   e1)
                            else e  in
-                         let uu____3944 =
-                           let uu____3953 =
+                         let uu____3909 =
+                           let uu____3918 =
                              FStar_Syntax_Util.extract_attr'
                                FStar_Parser_Const.postprocess_with
                                se2.FStar_Syntax_Syntax.sigattrs
                               in
-                           match uu____3953 with
+                           match uu____3918 with
                            | FStar_Pervasives_Native.None  ->
                                ((se2.FStar_Syntax_Syntax.sigattrs),
                                  FStar_Pervasives_Native.None)
@@ -2965,22 +2949,22 @@ let (tc_decl' :
                                 ((se2.FStar_Syntax_Syntax.sigattrs),
                                   FStar_Pervasives_Native.None))
                             in
-                         (match uu____3944 with
+                         (match uu____3909 with
                           | (attrs1,post_tau) ->
                               let se3 =
-                                let uu___700_4058 = se2  in
+                                let uu___700_4023 = se2  in
                                 {
                                   FStar_Syntax_Syntax.sigel =
-                                    (uu___700_4058.FStar_Syntax_Syntax.sigel);
+                                    (uu___700_4023.FStar_Syntax_Syntax.sigel);
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___700_4058.FStar_Syntax_Syntax.sigrng);
+                                    (uu___700_4023.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___700_4058.FStar_Syntax_Syntax.sigquals);
+                                    (uu___700_4023.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___700_4058.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___700_4023.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs = attrs1;
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___700_4058.FStar_Syntax_Syntax.sigopts)
+                                    (uu___700_4023.FStar_Syntax_Syntax.sigopts)
                                 }  in
                               let postprocess_lb tau lb =
                                 let lbdef =
@@ -2988,58 +2972,58 @@ let (tc_decl' :
                                     lb.FStar_Syntax_Syntax.lbtyp
                                     lb.FStar_Syntax_Syntax.lbdef
                                    in
-                                let uu___707_4071 = lb  in
+                                let uu___707_4036 = lb  in
                                 {
                                   FStar_Syntax_Syntax.lbname =
-                                    (uu___707_4071.FStar_Syntax_Syntax.lbname);
+                                    (uu___707_4036.FStar_Syntax_Syntax.lbname);
                                   FStar_Syntax_Syntax.lbunivs =
-                                    (uu___707_4071.FStar_Syntax_Syntax.lbunivs);
+                                    (uu___707_4036.FStar_Syntax_Syntax.lbunivs);
                                   FStar_Syntax_Syntax.lbtyp =
-                                    (uu___707_4071.FStar_Syntax_Syntax.lbtyp);
+                                    (uu___707_4036.FStar_Syntax_Syntax.lbtyp);
                                   FStar_Syntax_Syntax.lbeff =
-                                    (uu___707_4071.FStar_Syntax_Syntax.lbeff);
+                                    (uu___707_4036.FStar_Syntax_Syntax.lbeff);
                                   FStar_Syntax_Syntax.lbdef = lbdef;
                                   FStar_Syntax_Syntax.lbattrs =
-                                    (uu___707_4071.FStar_Syntax_Syntax.lbattrs);
+                                    (uu___707_4036.FStar_Syntax_Syntax.lbattrs);
                                   FStar_Syntax_Syntax.lbpos =
-                                    (uu___707_4071.FStar_Syntax_Syntax.lbpos)
+                                    (uu___707_4036.FStar_Syntax_Syntax.lbpos)
                                 }  in
-                              let uu____4072 =
+                              let uu____4037 =
                                 FStar_Util.record_time
-                                  (fun uu____4091  ->
+                                  (fun uu____4056  ->
                                      FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
                                        env' e1)
                                  in
-                              (match uu____4072 with
+                              (match uu____4037 with
                                | (r1,ms) ->
-                                   ((let uu____4119 =
+                                   ((let uu____4084 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "TCDeclTime")
                                         in
-                                     if uu____4119
+                                     if uu____4084
                                      then
-                                       let uu____4124 =
+                                       let uu____4089 =
                                          FStar_Util.string_of_int ms  in
                                        FStar_Util.print1
                                          "Let binding typechecked in phase 2 in %s milliseconds\n"
-                                         uu____4124
+                                         uu____4089
                                      else ());
-                                    (let uu____4129 =
+                                    (let uu____4094 =
                                        match r1 with
                                        | ({
                                             FStar_Syntax_Syntax.n =
                                               FStar_Syntax_Syntax.Tm_let
                                               (lbs1,e2);
                                             FStar_Syntax_Syntax.pos =
-                                              uu____4154;
+                                              uu____4119;
                                             FStar_Syntax_Syntax.vars =
-                                              uu____4155;_},uu____4156,g)
+                                              uu____4120;_},uu____4121,g)
                                            when
                                            FStar_TypeChecker_Env.is_trivial g
                                            ->
                                            let lbs2 =
-                                             let uu____4186 =
+                                             let uu____4151 =
                                                FStar_All.pipe_right
                                                  (FStar_Pervasives_Native.snd
                                                     lbs1)
@@ -3047,10 +3031,10 @@ let (tc_decl' :
                                                     rename_parameters)
                                                 in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs1), uu____4186)
+                                                 lbs1), uu____4151)
                                               in
                                            let lbs3 =
-                                             let uu____4210 =
+                                             let uu____4175 =
                                                match post_tau with
                                                | FStar_Pervasives_Native.Some
                                                    tau ->
@@ -3064,40 +3048,40 @@ let (tc_decl' :
                                                      lbs2
                                                 in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs2), uu____4210)
+                                                 lbs2), uu____4175)
                                               in
                                            let quals1 =
                                              match e2.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_meta
-                                                 (uu____4233,FStar_Syntax_Syntax.Meta_desugared
+                                                 (uu____4198,FStar_Syntax_Syntax.Meta_desugared
                                                   (FStar_Syntax_Syntax.Masked_effect
                                                   ))
                                                  ->
                                                  FStar_Syntax_Syntax.HasMaskedEffect
                                                  :: quals
-                                             | uu____4238 -> quals  in
-                                           ((let uu___737_4247 = se3  in
+                                             | uu____4203 -> quals  in
+                                           ((let uu___737_4212 = se3  in
                                              {
                                                FStar_Syntax_Syntax.sigel =
                                                  (FStar_Syntax_Syntax.Sig_let
                                                     (lbs3, lids));
                                                FStar_Syntax_Syntax.sigrng =
-                                                 (uu___737_4247.FStar_Syntax_Syntax.sigrng);
+                                                 (uu___737_4212.FStar_Syntax_Syntax.sigrng);
                                                FStar_Syntax_Syntax.sigquals =
                                                  quals1;
                                                FStar_Syntax_Syntax.sigmeta =
-                                                 (uu___737_4247.FStar_Syntax_Syntax.sigmeta);
+                                                 (uu___737_4212.FStar_Syntax_Syntax.sigmeta);
                                                FStar_Syntax_Syntax.sigattrs =
-                                                 (uu___737_4247.FStar_Syntax_Syntax.sigattrs);
+                                                 (uu___737_4212.FStar_Syntax_Syntax.sigattrs);
                                                FStar_Syntax_Syntax.sigopts =
-                                                 (uu___737_4247.FStar_Syntax_Syntax.sigopts)
+                                                 (uu___737_4212.FStar_Syntax_Syntax.sigopts)
                                              }), lbs3)
-                                       | uu____4250 ->
+                                       | uu____4215 ->
                                            failwith
                                              "impossible (typechecking should preserve Tm_let)"
                                         in
-                                     match uu____4129 with
+                                     match uu____4094 with
                                      | (se4,lbs1) ->
                                          (FStar_All.pipe_right
                                             (FStar_Pervasives_Native.snd lbs1)
@@ -3110,263 +3094,263 @@ let (tc_decl' :
                                                   FStar_TypeChecker_Env.insert_fv_info
                                                     env1 fv
                                                     lb.FStar_Syntax_Syntax.lbtyp));
-                                          (let uu____4306 = log env1  in
-                                           if uu____4306
+                                          (let uu____4271 = log env1  in
+                                           if uu____4271
                                            then
-                                             let uu____4309 =
-                                               let uu____4311 =
+                                             let uu____4274 =
+                                               let uu____4276 =
                                                  FStar_All.pipe_right
                                                    (FStar_Pervasives_Native.snd
                                                       lbs1)
                                                    (FStar_List.map
                                                       (fun lb  ->
                                                          let should_log =
-                                                           let uu____4331 =
-                                                             let uu____4340 =
-                                                               let uu____4341
+                                                           let uu____4296 =
+                                                             let uu____4305 =
+                                                               let uu____4306
                                                                  =
-                                                                 let uu____4344
+                                                                 let uu____4309
                                                                    =
                                                                    FStar_Util.right
                                                                     lb.FStar_Syntax_Syntax.lbname
                                                                     in
-                                                                 uu____4344.FStar_Syntax_Syntax.fv_name
+                                                                 uu____4309.FStar_Syntax_Syntax.fv_name
                                                                   in
-                                                               uu____4341.FStar_Syntax_Syntax.v
+                                                               uu____4306.FStar_Syntax_Syntax.v
                                                                 in
                                                              FStar_TypeChecker_Env.try_lookup_val_decl
                                                                env1
-                                                               uu____4340
+                                                               uu____4305
                                                               in
-                                                           match uu____4331
+                                                           match uu____4296
                                                            with
                                                            | FStar_Pervasives_Native.None
                                                                 -> true
-                                                           | uu____4353 ->
+                                                           | uu____4318 ->
                                                                false
                                                             in
                                                          if should_log
                                                          then
-                                                           let uu____4365 =
+                                                           let uu____4330 =
                                                              FStar_Syntax_Print.lbname_to_string
                                                                lb.FStar_Syntax_Syntax.lbname
                                                               in
-                                                           let uu____4367 =
+                                                           let uu____4332 =
                                                              FStar_Syntax_Print.term_to_string
                                                                lb.FStar_Syntax_Syntax.lbtyp
                                                               in
                                                            FStar_Util.format2
                                                              "let %s : %s"
-                                                             uu____4365
-                                                             uu____4367
+                                                             uu____4330
+                                                             uu____4332
                                                          else ""))
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____4311
+                                                 uu____4276
                                                  (FStar_String.concat "\n")
                                                 in
                                              FStar_Util.print1 "%s\n"
-                                               uu____4309
+                                               uu____4274
                                            else ());
                                           check_must_erase_attribute env0 se4;
                                           ([se4], [], env0))))))))
-           | FStar_Syntax_Syntax.Sig_polymonadic_bind (m,n,p,t,uu____4390) ->
+           | FStar_Syntax_Syntax.Sig_polymonadic_bind (m,n,p,t,uu____4355) ->
                let t1 =
-                 let uu____4392 =
+                 let uu____4357 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env)
                     in
-                 if uu____4392
+                 if uu____4357
                  then
-                   let uu____4395 =
-                     let uu____4400 =
-                       let uu____4401 =
-                         let uu____4402 =
+                   let uu____4360 =
+                     let uu____4365 =
+                       let uu____4366 =
+                         let uu____4367 =
                            FStar_TypeChecker_TcEffect.tc_polymonadic_bind
-                             (let uu___762_4409 = env  in
+                             (let uu___762_4374 = env  in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___762_4409.FStar_TypeChecker_Env.solver);
+                                  (uu___762_4374.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___762_4409.FStar_TypeChecker_Env.range);
+                                  (uu___762_4374.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___762_4409.FStar_TypeChecker_Env.curmodule);
+                                  (uu___762_4374.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___762_4409.FStar_TypeChecker_Env.gamma);
+                                  (uu___762_4374.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___762_4409.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___762_4374.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___762_4409.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___762_4374.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___762_4409.FStar_TypeChecker_Env.modules);
+                                  (uu___762_4374.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___762_4409.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___762_4374.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___762_4409.FStar_TypeChecker_Env.sigtab);
+                                  (uu___762_4374.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___762_4409.FStar_TypeChecker_Env.attrtab);
+                                  (uu___762_4374.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___762_4409.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___762_4374.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___762_4409.FStar_TypeChecker_Env.effects);
+                                  (uu___762_4374.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___762_4409.FStar_TypeChecker_Env.generalize);
+                                  (uu___762_4374.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___762_4409.FStar_TypeChecker_Env.letrecs);
+                                  (uu___762_4374.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___762_4409.FStar_TypeChecker_Env.top_level);
+                                  (uu___762_4374.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___762_4409.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___762_4374.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___762_4409.FStar_TypeChecker_Env.use_eq);
+                                  (uu___762_4374.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___762_4409.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___762_4374.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___762_4409.FStar_TypeChecker_Env.is_iface);
+                                  (uu___762_4374.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___762_4409.FStar_TypeChecker_Env.admit);
+                                  (uu___762_4374.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___762_4409.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___762_4374.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___762_4409.FStar_TypeChecker_Env.failhard);
+                                  (uu___762_4374.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___762_4409.FStar_TypeChecker_Env.nosynth);
+                                  (uu___762_4374.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___762_4409.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___762_4374.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___762_4409.FStar_TypeChecker_Env.tc_term);
+                                  (uu___762_4374.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___762_4409.FStar_TypeChecker_Env.type_of);
+                                  (uu___762_4374.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___762_4409.FStar_TypeChecker_Env.universe_of);
+                                  (uu___762_4374.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___762_4409.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___762_4374.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___762_4409.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___762_4374.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___762_4409.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___762_4374.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___762_4409.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___762_4374.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___762_4409.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___762_4374.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___762_4409.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___762_4374.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___762_4409.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___762_4374.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___762_4409.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___762_4374.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___762_4409.FStar_TypeChecker_Env.splice);
+                                  (uu___762_4374.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___762_4409.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___762_4374.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___762_4409.FStar_TypeChecker_Env.postprocess);
+                                  (uu___762_4374.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___762_4409.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___762_4374.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___762_4409.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___762_4374.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___762_4409.FStar_TypeChecker_Env.dsenv);
+                                  (uu___762_4374.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___762_4409.FStar_TypeChecker_Env.nbe);
+                                  (uu___762_4374.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___762_4409.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___762_4374.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___762_4409.FStar_TypeChecker_Env.erasable_types_tab)
+                                  (uu___762_4374.FStar_TypeChecker_Env.erasable_types_tab)
                               }) m n p t
                             in
-                         FStar_All.pipe_right uu____4402
-                           (fun uu____4420  ->
-                              match uu____4420 with
+                         FStar_All.pipe_right uu____4367
+                           (fun uu____4385  ->
+                              match uu____4385 with
                               | (t1,ty) ->
-                                  let uu___767_4427 = se1  in
+                                  let uu___767_4392 = se1  in
                                   {
                                     FStar_Syntax_Syntax.sigel =
                                       (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                          (m, n, p, t1, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (uu___767_4427.FStar_Syntax_Syntax.sigrng);
+                                      (uu___767_4392.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (uu___767_4427.FStar_Syntax_Syntax.sigquals);
+                                      (uu___767_4392.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (uu___767_4427.FStar_Syntax_Syntax.sigmeta);
+                                      (uu___767_4392.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (uu___767_4427.FStar_Syntax_Syntax.sigattrs);
+                                      (uu___767_4392.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (uu___767_4427.FStar_Syntax_Syntax.sigopts)
+                                      (uu___767_4392.FStar_Syntax_Syntax.sigopts)
                                   })
                           in
-                       FStar_All.pipe_right uu____4401
+                       FStar_All.pipe_right uu____4366
                          (FStar_TypeChecker_Normalize.elim_uvars env)
                         in
-                     FStar_All.pipe_right uu____4400
+                     FStar_All.pipe_right uu____4365
                        (fun se2  ->
                           match se2.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                              (uu____4443,uu____4444,uu____4445,t1,ty) ->
+                              (uu____4408,uu____4409,uu____4410,t1,ty) ->
                               (t1, ty)
-                          | uu____4448 ->
+                          | uu____4413 ->
                               failwith
                                 "Impossible! tc for Sig_polymonadic_bind must be a Sig_polymonadic_bind")
                       in
-                   match uu____4395 with
+                   match uu____4360 with
                    | (t1,ty) ->
-                       ((let uu____4457 =
+                       ((let uu____4422 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "TwoPhases")
                             in
-                         if uu____4457
+                         if uu____4422
                          then
-                           let uu____4462 =
+                           let uu____4427 =
                              FStar_Syntax_Print.sigelt_to_string
-                               (let uu___782_4466 = se1  in
+                               (let uu___782_4431 = se1  in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                        (m, n, p, t1, ty));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___782_4466.FStar_Syntax_Syntax.sigrng);
+                                    (uu___782_4431.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___782_4466.FStar_Syntax_Syntax.sigquals);
+                                    (uu___782_4431.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___782_4466.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___782_4431.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___782_4466.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___782_4431.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___782_4466.FStar_Syntax_Syntax.sigopts)
+                                    (uu___782_4431.FStar_Syntax_Syntax.sigopts)
                                 })
                               in
                            FStar_Util.print1
                              "Polymonadic bind after phase 1: %s\n"
-                             uu____4462
+                             uu____4427
                          else ());
                         t1)
                  else t  in
-               let uu____4472 =
+               let uu____4437 =
                  FStar_TypeChecker_TcEffect.tc_polymonadic_bind env m n p t1
                   in
-               (match uu____4472 with
+               (match uu____4437 with
                 | (t2,ty) ->
                     let se2 =
-                      let uu___789_4490 = se1  in
+                      let uu___789_4455 = se1  in
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_bind
                              (m, n, p, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___789_4490.FStar_Syntax_Syntax.sigrng);
+                          (uu___789_4455.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___789_4490.FStar_Syntax_Syntax.sigquals);
+                          (uu___789_4455.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___789_4490.FStar_Syntax_Syntax.sigmeta);
+                          (uu___789_4455.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (uu___789_4490.FStar_Syntax_Syntax.sigattrs);
+                          (uu___789_4455.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___789_4490.FStar_Syntax_Syntax.sigopts)
+                          (uu___789_4455.FStar_Syntax_Syntax.sigopts)
                       }  in
                     ([se2], [], env0)))
   
@@ -3379,26 +3363,26 @@ let (tc_decl :
   fun env  ->
     fun se  ->
       let env1 = set_hint_correlator env se  in
-      (let uu____4528 =
-         let uu____4530 =
+      (let uu____4493 =
+         let uu____4495 =
            FStar_Ident.string_of_lid env1.FStar_TypeChecker_Env.curmodule  in
-         FStar_Options.debug_module uu____4530  in
-       if uu____4528
+         FStar_Options.debug_module uu____4495  in
+       if uu____4493
        then
-         let uu____4533 =
-           let uu____4535 =
+         let uu____4498 =
+           let uu____4500 =
              FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
                (FStar_List.map FStar_Ident.string_of_lid)
               in
-           FStar_All.pipe_right uu____4535 (FStar_String.concat ", ")  in
-         FStar_Util.print1 "Processing %s\n" uu____4533
+           FStar_All.pipe_right uu____4500 (FStar_String.concat ", ")  in
+         FStar_Util.print1 "Processing %s\n" uu____4498
        else ());
-      (let uu____4554 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
+      (let uu____4519 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low
           in
-       if uu____4554
+       if uu____4519
        then
-         let uu____4557 = FStar_Syntax_Print.sigelt_to_string se  in
-         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____4557
+         let uu____4522 = FStar_Syntax_Print.sigelt_to_string se  in
+         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____4522
        else ());
       if (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_admit
       then
@@ -3409,8 +3393,8 @@ let (tc_decl :
       else tc_decl' env1 se
   
 let for_export :
-  'uuuuuu4600 .
-    'uuuuuu4600 ->
+  'uuuuuu4565 .
+    'uuuuuu4565 ->
       FStar_Ident.lident Prims.list ->
         FStar_Syntax_Syntax.sigelt ->
           (FStar_Syntax_Syntax.sigelt Prims.list * FStar_Ident.lident
@@ -3422,158 +3406,158 @@ let for_export :
         let is_abstract quals =
           FStar_All.pipe_right quals
             (FStar_Util.for_some
-               (fun uu___2_4643  ->
-                  match uu___2_4643 with
+               (fun uu___2_4608  ->
+                  match uu___2_4608 with
                   | FStar_Syntax_Syntax.Abstract  -> true
-                  | uu____4646 -> false))
+                  | uu____4611 -> false))
            in
         let is_hidden_proj_or_disc q =
           match q with
-          | FStar_Syntax_Syntax.Projector (l,uu____4657) ->
+          | FStar_Syntax_Syntax.Projector (l,uu____4622) ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
           | FStar_Syntax_Syntax.Discriminator l ->
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Ident.lid_equals l))
-          | uu____4665 -> false  in
+          | uu____4630 -> false  in
         match se.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_pragma uu____4675 -> ([], hidden)
-        | FStar_Syntax_Syntax.Sig_fail uu____4680 ->
+        | FStar_Syntax_Syntax.Sig_pragma uu____4640 -> ([], hidden)
+        | FStar_Syntax_Syntax.Sig_fail uu____4645 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_splice uu____4702 ->
+        | FStar_Syntax_Syntax.Sig_splice uu____4667 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_inductive_typ uu____4718 ->
+        | FStar_Syntax_Syntax.Sig_inductive_typ uu____4683 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_datacon uu____4744 ->
+        | FStar_Syntax_Syntax.Sig_datacon uu____4709 ->
             failwith "Impossible (Already handled)"
-        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____4770) ->
-            let uu____4779 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____4779
+        | FStar_Syntax_Syntax.Sig_bundle (ses,uu____4735) ->
+            let uu____4744 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____4744
             then
-              let for_export_bundle se1 uu____4816 =
-                match uu____4816 with
+              let for_export_bundle se1 uu____4781 =
+                match uu____4781 with
                 | (out,hidden1) ->
                     (match se1.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l,us,bs,t,uu____4855,uu____4856) ->
+                         (l,us,bs,t,uu____4820,uu____4821) ->
                          let dec =
-                           let uu___848_4866 = se1  in
-                           let uu____4867 =
-                             let uu____4868 =
-                               let uu____4875 =
-                                 let uu____4876 =
+                           let uu___848_4831 = se1  in
+                           let uu____4832 =
+                             let uu____4833 =
+                               let uu____4840 =
+                                 let uu____4841 =
                                    FStar_Syntax_Syntax.mk_Total t  in
-                                 FStar_Syntax_Util.arrow bs uu____4876  in
-                               (l, us, uu____4875)  in
-                             FStar_Syntax_Syntax.Sig_declare_typ uu____4868
+                                 FStar_Syntax_Util.arrow bs uu____4841  in
+                               (l, us, uu____4840)  in
+                             FStar_Syntax_Syntax.Sig_declare_typ uu____4833
                               in
                            {
-                             FStar_Syntax_Syntax.sigel = uu____4867;
+                             FStar_Syntax_Syntax.sigel = uu____4832;
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___848_4866.FStar_Syntax_Syntax.sigrng);
+                               (uu___848_4831.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                (FStar_Syntax_Syntax.Assumption ::
                                FStar_Syntax_Syntax.New ::
                                (se1.FStar_Syntax_Syntax.sigquals));
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___848_4866.FStar_Syntax_Syntax.sigmeta);
+                               (uu___848_4831.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___848_4866.FStar_Syntax_Syntax.sigattrs);
+                               (uu___848_4831.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___848_4866.FStar_Syntax_Syntax.sigopts)
+                               (uu___848_4831.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ((dec :: out), hidden1)
                      | FStar_Syntax_Syntax.Sig_datacon
-                         (l,us,t,uu____4886,uu____4887,uu____4888) ->
+                         (l,us,t,uu____4851,uu____4852,uu____4853) ->
                          let dec =
-                           let uu___859_4896 = se1  in
+                           let uu___859_4861 = se1  in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_declare_typ
                                   (l, us, t));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___859_4896.FStar_Syntax_Syntax.sigrng);
+                               (uu___859_4861.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
                                [FStar_Syntax_Syntax.Assumption];
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___859_4896.FStar_Syntax_Syntax.sigmeta);
+                               (uu___859_4861.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___859_4896.FStar_Syntax_Syntax.sigattrs);
+                               (uu___859_4861.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___859_4896.FStar_Syntax_Syntax.sigopts)
+                               (uu___859_4861.FStar_Syntax_Syntax.sigopts)
                            }  in
                          ((dec :: out), (l :: hidden1))
-                     | uu____4901 -> (out, hidden1))
+                     | uu____4866 -> (out, hidden1))
                  in
               FStar_List.fold_right for_export_bundle ses ([], hidden)
             else ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_assume (uu____4924,uu____4925,uu____4926)
+        | FStar_Syntax_Syntax.Sig_assume (uu____4889,uu____4890,uu____4891)
             ->
-            let uu____4927 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____4927 then ([], hidden) else ([se], hidden)
+            let uu____4892 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____4892 then ([], hidden) else ([se], hidden)
         | FStar_Syntax_Syntax.Sig_declare_typ (l,us,t) ->
-            let uu____4951 =
+            let uu____4916 =
               FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                 (FStar_Util.for_some is_hidden_proj_or_disc)
                in
-            if uu____4951
+            if uu____4916
             then
-              ([(let uu___875_4970 = se  in
+              ([(let uu___875_4935 = se  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ (l, us, t));
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___875_4970.FStar_Syntax_Syntax.sigrng);
+                     (uu___875_4935.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___875_4970.FStar_Syntax_Syntax.sigmeta);
+                     (uu___875_4935.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___875_4970.FStar_Syntax_Syntax.sigattrs);
+                     (uu___875_4935.FStar_Syntax_Syntax.sigattrs);
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___875_4970.FStar_Syntax_Syntax.sigopts)
+                     (uu___875_4935.FStar_Syntax_Syntax.sigopts)
                  })], (l :: hidden))
             else
-              (let uu____4973 =
+              (let uu____4938 =
                  FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                    (FStar_Util.for_some
-                      (fun uu___3_4979  ->
-                         match uu___3_4979 with
+                      (fun uu___3_4944  ->
+                         match uu___3_4944 with
                          | FStar_Syntax_Syntax.Assumption  -> true
-                         | FStar_Syntax_Syntax.Projector uu____4982 -> true
-                         | FStar_Syntax_Syntax.Discriminator uu____4988 ->
+                         | FStar_Syntax_Syntax.Projector uu____4947 -> true
+                         | FStar_Syntax_Syntax.Discriminator uu____4953 ->
                              true
-                         | uu____4990 -> false))
+                         | uu____4955 -> false))
                   in
-               if uu____4973 then ([se], hidden) else ([], hidden))
-        | FStar_Syntax_Syntax.Sig_new_effect uu____5011 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_sub_effect uu____5016 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____5021 -> ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5038 ->
+               if uu____4938 then ([se], hidden) else ([], hidden))
+        | FStar_Syntax_Syntax.Sig_new_effect uu____4976 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_sub_effect uu____4981 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4986 -> ([se], hidden)
+        | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____5003 ->
             ([se], hidden)
-        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5054) when
+        | FStar_Syntax_Syntax.Sig_let ((false ,lb::[]),uu____5019) when
             FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
               (FStar_Util.for_some is_hidden_proj_or_disc)
             ->
             let fv = FStar_Util.right lb.FStar_Syntax_Syntax.lbname  in
             let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            let uu____5068 =
+            let uu____5033 =
               FStar_All.pipe_right hidden
                 (FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv))
                in
-            if uu____5068
+            if uu____5033
             then ([], hidden)
             else
               (let dec =
-                 let uu____5089 = FStar_Ident.range_of_lid lid  in
+                 let uu____5054 = FStar_Ident.range_of_lid lid  in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_declare_typ
                         (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
                           (lb.FStar_Syntax_Syntax.lbunivs),
                           (lb.FStar_Syntax_Syntax.lbtyp)));
-                   FStar_Syntax_Syntax.sigrng = uu____5089;
+                   FStar_Syntax_Syntax.sigrng = uu____5054;
                    FStar_Syntax_Syntax.sigquals =
                      [FStar_Syntax_Syntax.Assumption];
                    FStar_Syntax_Syntax.sigmeta =
@@ -3583,44 +3567,44 @@ let for_export :
                  }  in
                ([dec], (lid :: hidden)))
         | FStar_Syntax_Syntax.Sig_let (lbs,l) ->
-            let uu____5100 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
-            if uu____5100
+            let uu____5065 = is_abstract se.FStar_Syntax_Syntax.sigquals  in
+            if uu____5065
             then
-              let uu____5111 =
+              let uu____5076 =
                 FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                   (FStar_List.map
                      (fun lb  ->
-                        let uu___910_5125 = se  in
-                        let uu____5126 =
-                          let uu____5127 =
-                            let uu____5134 =
-                              let uu____5135 =
-                                let uu____5138 =
+                        let uu___910_5090 = se  in
+                        let uu____5091 =
+                          let uu____5092 =
+                            let uu____5099 =
+                              let uu____5100 =
+                                let uu____5103 =
                                   FStar_Util.right
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                uu____5138.FStar_Syntax_Syntax.fv_name  in
-                              uu____5135.FStar_Syntax_Syntax.v  in
-                            (uu____5134, (lb.FStar_Syntax_Syntax.lbunivs),
+                                uu____5103.FStar_Syntax_Syntax.fv_name  in
+                              uu____5100.FStar_Syntax_Syntax.v  in
+                            (uu____5099, (lb.FStar_Syntax_Syntax.lbunivs),
                               (lb.FStar_Syntax_Syntax.lbtyp))
                              in
-                          FStar_Syntax_Syntax.Sig_declare_typ uu____5127  in
+                          FStar_Syntax_Syntax.Sig_declare_typ uu____5092  in
                         {
-                          FStar_Syntax_Syntax.sigel = uu____5126;
+                          FStar_Syntax_Syntax.sigel = uu____5091;
                           FStar_Syntax_Syntax.sigrng =
-                            (uu___910_5125.FStar_Syntax_Syntax.sigrng);
+                            (uu___910_5090.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
                             (FStar_Syntax_Syntax.Assumption ::
                             (se.FStar_Syntax_Syntax.sigquals));
                           FStar_Syntax_Syntax.sigmeta =
-                            (uu___910_5125.FStar_Syntax_Syntax.sigmeta);
+                            (uu___910_5090.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (uu___910_5125.FStar_Syntax_Syntax.sigattrs);
+                            (uu___910_5090.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (uu___910_5125.FStar_Syntax_Syntax.sigopts)
+                            (uu___910_5090.FStar_Syntax_Syntax.sigopts)
                         }))
                  in
-              (uu____5111, hidden)
+              (uu____5076, hidden)
             else ([se], hidden)
   
 let (add_sigelt_to_env :
@@ -3630,458 +3614,458 @@ let (add_sigelt_to_env :
   fun env  ->
     fun se  ->
       fun from_cache  ->
-        (let uu____5168 = FStar_TypeChecker_Env.debug env FStar_Options.Low
+        (let uu____5133 = FStar_TypeChecker_Env.debug env FStar_Options.Low
             in
-         if uu____5168
+         if uu____5133
          then
-           let uu____5171 = FStar_Syntax_Print.sigelt_to_string se  in
-           let uu____5173 = FStar_Util.string_of_bool from_cache  in
+           let uu____5136 = FStar_Syntax_Print.sigelt_to_string se  in
+           let uu____5138 = FStar_Util.string_of_bool from_cache  in
            FStar_Util.print2
              ">>>>>>>>>>>>>>Adding top-level decl to environment: %s (from_cache:%s)\n"
-             uu____5171 uu____5173
+             uu____5136 uu____5138
          else ());
         (match se.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____5178 ->
-             let uu____5195 =
-               let uu____5201 =
-                 let uu____5203 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____5143 ->
+             let uu____5160 =
+               let uu____5166 =
+                 let uu____5168 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____5203
+                   uu____5168
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5201)  in
-             FStar_Errors.raise_error uu____5195
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5166)  in
+             FStar_Errors.raise_error uu____5160
                se.FStar_Syntax_Syntax.sigrng
-         | FStar_Syntax_Syntax.Sig_datacon uu____5207 ->
-             let uu____5223 =
-               let uu____5229 =
-                 let uu____5231 = FStar_Syntax_Print.sigelt_to_string se  in
+         | FStar_Syntax_Syntax.Sig_datacon uu____5172 ->
+             let uu____5188 =
+               let uu____5194 =
+                 let uu____5196 = FStar_Syntax_Print.sigelt_to_string se  in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____5231
+                   uu____5196
                   in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5229)  in
-             FStar_Errors.raise_error uu____5223
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____5194)  in
+             FStar_Errors.raise_error uu____5188
                se.FStar_Syntax_Syntax.sigrng
          | FStar_Syntax_Syntax.Sig_declare_typ
-             (uu____5235,uu____5236,uu____5237) when
+             (uu____5200,uu____5201,uu____5202) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___4_5242  ->
-                     match uu___4_5242 with
+                  (fun uu___4_5207  ->
+                     match uu___4_5207 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____5245 -> false))
+                     | uu____5210 -> false))
              -> env
-         | FStar_Syntax_Syntax.Sig_let (uu____5247,uu____5248) when
+         | FStar_Syntax_Syntax.Sig_let (uu____5212,uu____5213) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___4_5257  ->
-                     match uu___4_5257 with
+                  (fun uu___4_5222  ->
+                     match uu___4_5222 with
                      | FStar_Syntax_Syntax.OnlyName  -> true
-                     | uu____5260 -> false))
+                     | uu____5225 -> false))
              -> env
-         | uu____5262 ->
+         | uu____5227 ->
              let env1 = FStar_TypeChecker_Env.push_sigelt env se  in
              (match se.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.PushOptions uu____5264) ->
+                  (FStar_Syntax_Syntax.PushOptions uu____5229) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___947_5271 = env1  in
-                     let uu____5272 = FStar_Options.using_facts_from ()  in
+                    (let uu___947_5236 = env1  in
+                     let uu____5237 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___947_5271.FStar_TypeChecker_Env.solver);
+                         (uu___947_5236.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___947_5271.FStar_TypeChecker_Env.range);
+                         (uu___947_5236.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___947_5271.FStar_TypeChecker_Env.curmodule);
+                         (uu___947_5236.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___947_5271.FStar_TypeChecker_Env.gamma);
+                         (uu___947_5236.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___947_5271.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___947_5236.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___947_5271.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___947_5236.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___947_5271.FStar_TypeChecker_Env.modules);
+                         (uu___947_5236.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___947_5271.FStar_TypeChecker_Env.expected_typ);
+                         (uu___947_5236.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___947_5271.FStar_TypeChecker_Env.sigtab);
+                         (uu___947_5236.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___947_5271.FStar_TypeChecker_Env.attrtab);
+                         (uu___947_5236.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___947_5271.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___947_5236.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___947_5271.FStar_TypeChecker_Env.effects);
+                         (uu___947_5236.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___947_5271.FStar_TypeChecker_Env.generalize);
+                         (uu___947_5236.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___947_5271.FStar_TypeChecker_Env.letrecs);
+                         (uu___947_5236.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___947_5271.FStar_TypeChecker_Env.top_level);
+                         (uu___947_5236.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___947_5271.FStar_TypeChecker_Env.check_uvars);
+                         (uu___947_5236.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___947_5271.FStar_TypeChecker_Env.use_eq);
+                         (uu___947_5236.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___947_5271.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___947_5236.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___947_5271.FStar_TypeChecker_Env.is_iface);
+                         (uu___947_5236.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___947_5271.FStar_TypeChecker_Env.admit);
+                         (uu___947_5236.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___947_5271.FStar_TypeChecker_Env.lax);
+                         (uu___947_5236.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___947_5271.FStar_TypeChecker_Env.lax_universes);
+                         (uu___947_5236.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___947_5271.FStar_TypeChecker_Env.phase1);
+                         (uu___947_5236.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___947_5271.FStar_TypeChecker_Env.failhard);
+                         (uu___947_5236.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___947_5271.FStar_TypeChecker_Env.nosynth);
+                         (uu___947_5236.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___947_5271.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___947_5236.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___947_5271.FStar_TypeChecker_Env.tc_term);
+                         (uu___947_5236.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___947_5271.FStar_TypeChecker_Env.type_of);
+                         (uu___947_5236.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___947_5271.FStar_TypeChecker_Env.universe_of);
+                         (uu___947_5236.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___947_5271.FStar_TypeChecker_Env.check_type_of);
+                         (uu___947_5236.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___947_5271.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___947_5236.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___947_5271.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___947_5236.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___947_5271.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___947_5236.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___947_5271.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5272;
+                         (uu___947_5236.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5237;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___947_5271.FStar_TypeChecker_Env.synth_hook);
+                         (uu___947_5236.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___947_5271.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___947_5236.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___947_5271.FStar_TypeChecker_Env.splice);
+                         (uu___947_5236.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___947_5271.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___947_5236.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___947_5271.FStar_TypeChecker_Env.postprocess);
+                         (uu___947_5236.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___947_5271.FStar_TypeChecker_Env.identifier_info);
+                         (uu___947_5236.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___947_5271.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___947_5236.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___947_5271.FStar_TypeChecker_Env.dsenv);
+                         (uu___947_5236.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___947_5271.FStar_TypeChecker_Env.nbe);
+                         (uu___947_5236.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___947_5271.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___947_5236.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___947_5271.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___947_5236.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.PopOptions ) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___947_5276 = env1  in
-                     let uu____5277 = FStar_Options.using_facts_from ()  in
+                    (let uu___947_5241 = env1  in
+                     let uu____5242 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___947_5276.FStar_TypeChecker_Env.solver);
+                         (uu___947_5241.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___947_5276.FStar_TypeChecker_Env.range);
+                         (uu___947_5241.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___947_5276.FStar_TypeChecker_Env.curmodule);
+                         (uu___947_5241.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___947_5276.FStar_TypeChecker_Env.gamma);
+                         (uu___947_5241.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___947_5276.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___947_5241.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___947_5276.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___947_5241.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___947_5276.FStar_TypeChecker_Env.modules);
+                         (uu___947_5241.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___947_5276.FStar_TypeChecker_Env.expected_typ);
+                         (uu___947_5241.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___947_5276.FStar_TypeChecker_Env.sigtab);
+                         (uu___947_5241.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___947_5276.FStar_TypeChecker_Env.attrtab);
+                         (uu___947_5241.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___947_5276.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___947_5241.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___947_5276.FStar_TypeChecker_Env.effects);
+                         (uu___947_5241.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___947_5276.FStar_TypeChecker_Env.generalize);
+                         (uu___947_5241.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___947_5276.FStar_TypeChecker_Env.letrecs);
+                         (uu___947_5241.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___947_5276.FStar_TypeChecker_Env.top_level);
+                         (uu___947_5241.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___947_5276.FStar_TypeChecker_Env.check_uvars);
+                         (uu___947_5241.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___947_5276.FStar_TypeChecker_Env.use_eq);
+                         (uu___947_5241.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___947_5276.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___947_5241.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___947_5276.FStar_TypeChecker_Env.is_iface);
+                         (uu___947_5241.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___947_5276.FStar_TypeChecker_Env.admit);
+                         (uu___947_5241.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___947_5276.FStar_TypeChecker_Env.lax);
+                         (uu___947_5241.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___947_5276.FStar_TypeChecker_Env.lax_universes);
+                         (uu___947_5241.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___947_5276.FStar_TypeChecker_Env.phase1);
+                         (uu___947_5241.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___947_5276.FStar_TypeChecker_Env.failhard);
+                         (uu___947_5241.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___947_5276.FStar_TypeChecker_Env.nosynth);
+                         (uu___947_5241.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___947_5276.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___947_5241.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___947_5276.FStar_TypeChecker_Env.tc_term);
+                         (uu___947_5241.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___947_5276.FStar_TypeChecker_Env.type_of);
+                         (uu___947_5241.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___947_5276.FStar_TypeChecker_Env.universe_of);
+                         (uu___947_5241.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___947_5276.FStar_TypeChecker_Env.check_type_of);
+                         (uu___947_5241.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___947_5276.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___947_5241.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___947_5276.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___947_5241.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___947_5276.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___947_5241.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___947_5276.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5277;
+                         (uu___947_5241.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5242;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___947_5276.FStar_TypeChecker_Env.synth_hook);
+                         (uu___947_5241.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___947_5276.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___947_5241.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___947_5276.FStar_TypeChecker_Env.splice);
+                         (uu___947_5241.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___947_5276.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___947_5241.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___947_5276.FStar_TypeChecker_Env.postprocess);
+                         (uu___947_5241.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___947_5276.FStar_TypeChecker_Env.identifier_info);
+                         (uu___947_5241.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___947_5276.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___947_5241.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___947_5276.FStar_TypeChecker_Env.dsenv);
+                         (uu___947_5241.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___947_5276.FStar_TypeChecker_Env.nbe);
+                         (uu___947_5241.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___947_5276.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___947_5241.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___947_5276.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___947_5241.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.SetOptions uu____5278) ->
+                  (FStar_Syntax_Syntax.SetOptions uu____5243) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___947_5283 = env1  in
-                     let uu____5284 = FStar_Options.using_facts_from ()  in
+                    (let uu___947_5248 = env1  in
+                     let uu____5249 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___947_5283.FStar_TypeChecker_Env.solver);
+                         (uu___947_5248.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___947_5283.FStar_TypeChecker_Env.range);
+                         (uu___947_5248.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___947_5283.FStar_TypeChecker_Env.curmodule);
+                         (uu___947_5248.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___947_5283.FStar_TypeChecker_Env.gamma);
+                         (uu___947_5248.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___947_5283.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___947_5248.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___947_5283.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___947_5248.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___947_5283.FStar_TypeChecker_Env.modules);
+                         (uu___947_5248.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___947_5283.FStar_TypeChecker_Env.expected_typ);
+                         (uu___947_5248.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___947_5283.FStar_TypeChecker_Env.sigtab);
+                         (uu___947_5248.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___947_5283.FStar_TypeChecker_Env.attrtab);
+                         (uu___947_5248.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___947_5283.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___947_5248.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___947_5283.FStar_TypeChecker_Env.effects);
+                         (uu___947_5248.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___947_5283.FStar_TypeChecker_Env.generalize);
+                         (uu___947_5248.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___947_5283.FStar_TypeChecker_Env.letrecs);
+                         (uu___947_5248.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___947_5283.FStar_TypeChecker_Env.top_level);
+                         (uu___947_5248.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___947_5283.FStar_TypeChecker_Env.check_uvars);
+                         (uu___947_5248.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___947_5283.FStar_TypeChecker_Env.use_eq);
+                         (uu___947_5248.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___947_5283.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___947_5248.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___947_5283.FStar_TypeChecker_Env.is_iface);
+                         (uu___947_5248.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___947_5283.FStar_TypeChecker_Env.admit);
+                         (uu___947_5248.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___947_5283.FStar_TypeChecker_Env.lax);
+                         (uu___947_5248.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___947_5283.FStar_TypeChecker_Env.lax_universes);
+                         (uu___947_5248.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___947_5283.FStar_TypeChecker_Env.phase1);
+                         (uu___947_5248.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___947_5283.FStar_TypeChecker_Env.failhard);
+                         (uu___947_5248.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___947_5283.FStar_TypeChecker_Env.nosynth);
+                         (uu___947_5248.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___947_5283.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___947_5248.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___947_5283.FStar_TypeChecker_Env.tc_term);
+                         (uu___947_5248.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___947_5283.FStar_TypeChecker_Env.type_of);
+                         (uu___947_5248.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___947_5283.FStar_TypeChecker_Env.universe_of);
+                         (uu___947_5248.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___947_5283.FStar_TypeChecker_Env.check_type_of);
+                         (uu___947_5248.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___947_5283.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___947_5248.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___947_5283.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___947_5248.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___947_5283.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___947_5248.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___947_5283.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5284;
+                         (uu___947_5248.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5249;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___947_5283.FStar_TypeChecker_Env.synth_hook);
+                         (uu___947_5248.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___947_5283.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___947_5248.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___947_5283.FStar_TypeChecker_Env.splice);
+                         (uu___947_5248.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___947_5283.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___947_5248.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___947_5283.FStar_TypeChecker_Env.postprocess);
+                         (uu___947_5248.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___947_5283.FStar_TypeChecker_Env.identifier_info);
+                         (uu___947_5248.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___947_5283.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___947_5248.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___947_5283.FStar_TypeChecker_Env.dsenv);
+                         (uu___947_5248.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___947_5283.FStar_TypeChecker_Env.nbe);
+                         (uu___947_5248.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___947_5283.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___947_5248.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___947_5283.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___947_5248.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.ResetOptions uu____5285) ->
+                  (FStar_Syntax_Syntax.ResetOptions uu____5250) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___947_5292 = env1  in
-                     let uu____5293 = FStar_Options.using_facts_from ()  in
+                    (let uu___947_5257 = env1  in
+                     let uu____5258 = FStar_Options.using_facts_from ()  in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___947_5292.FStar_TypeChecker_Env.solver);
+                         (uu___947_5257.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___947_5292.FStar_TypeChecker_Env.range);
+                         (uu___947_5257.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___947_5292.FStar_TypeChecker_Env.curmodule);
+                         (uu___947_5257.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___947_5292.FStar_TypeChecker_Env.gamma);
+                         (uu___947_5257.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___947_5292.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___947_5257.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___947_5292.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___947_5257.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___947_5292.FStar_TypeChecker_Env.modules);
+                         (uu___947_5257.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___947_5292.FStar_TypeChecker_Env.expected_typ);
+                         (uu___947_5257.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___947_5292.FStar_TypeChecker_Env.sigtab);
+                         (uu___947_5257.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___947_5292.FStar_TypeChecker_Env.attrtab);
+                         (uu___947_5257.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___947_5292.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___947_5257.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___947_5292.FStar_TypeChecker_Env.effects);
+                         (uu___947_5257.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___947_5292.FStar_TypeChecker_Env.generalize);
+                         (uu___947_5257.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___947_5292.FStar_TypeChecker_Env.letrecs);
+                         (uu___947_5257.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___947_5292.FStar_TypeChecker_Env.top_level);
+                         (uu___947_5257.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___947_5292.FStar_TypeChecker_Env.check_uvars);
+                         (uu___947_5257.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___947_5292.FStar_TypeChecker_Env.use_eq);
+                         (uu___947_5257.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___947_5292.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___947_5257.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___947_5292.FStar_TypeChecker_Env.is_iface);
+                         (uu___947_5257.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___947_5292.FStar_TypeChecker_Env.admit);
+                         (uu___947_5257.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___947_5292.FStar_TypeChecker_Env.lax);
+                         (uu___947_5257.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___947_5292.FStar_TypeChecker_Env.lax_universes);
+                         (uu___947_5257.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___947_5292.FStar_TypeChecker_Env.phase1);
+                         (uu___947_5257.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___947_5292.FStar_TypeChecker_Env.failhard);
+                         (uu___947_5257.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___947_5292.FStar_TypeChecker_Env.nosynth);
+                         (uu___947_5257.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___947_5292.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___947_5257.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___947_5292.FStar_TypeChecker_Env.tc_term);
+                         (uu___947_5257.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___947_5292.FStar_TypeChecker_Env.type_of);
+                         (uu___947_5257.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___947_5292.FStar_TypeChecker_Env.universe_of);
+                         (uu___947_5257.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___947_5292.FStar_TypeChecker_Env.check_type_of);
+                         (uu___947_5257.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___947_5292.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___947_5257.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___947_5292.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___947_5257.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___947_5292.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___947_5257.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___947_5292.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____5293;
+                         (uu___947_5257.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____5258;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___947_5292.FStar_TypeChecker_Env.synth_hook);
+                         (uu___947_5257.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___947_5292.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___947_5257.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___947_5292.FStar_TypeChecker_Env.splice);
+                         (uu___947_5257.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___947_5292.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___947_5257.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___947_5292.FStar_TypeChecker_Env.postprocess);
+                         (uu___947_5257.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___947_5292.FStar_TypeChecker_Env.identifier_info);
+                         (uu___947_5257.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___947_5292.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___947_5257.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___947_5292.FStar_TypeChecker_Env.dsenv);
+                         (uu___947_5257.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___947_5292.FStar_TypeChecker_Env.nbe);
+                         (uu___947_5257.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___947_5292.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___947_5257.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___947_5292.FStar_TypeChecker_Env.erasable_types_tab)
+                         (uu___947_5257.FStar_TypeChecker_Env.erasable_types_tab)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.RestartSolver ) ->
@@ -4100,20 +4084,20 @@ let (add_sigelt_to_env :
                     (FStar_List.fold_left
                        (fun env3  ->
                           fun a  ->
-                            let uu____5309 =
+                            let uu____5274 =
                               FStar_Syntax_Util.action_as_lb
                                 ne.FStar_Syntax_Syntax.mname a
                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos
                                in
-                            FStar_TypeChecker_Env.push_sigelt env3 uu____5309)
+                            FStar_TypeChecker_Env.push_sigelt env3 uu____5274)
                        env2)
               | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                   FStar_TypeChecker_Util.update_env_sub_eff env1 sub
               | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                  (m,n,p,uu____5314,ty) ->
+                  (m,n,p,uu____5279,ty) ->
                   FStar_TypeChecker_Util.update_env_polymonadic_bind env1 m n
                     p ty
-              | uu____5316 -> env1))
+              | uu____5281 -> env1))
   
 let (tc_decls :
   FStar_TypeChecker_Env.env ->
@@ -4123,44 +4107,44 @@ let (tc_decls :
   =
   fun env  ->
     fun ses  ->
-      let rec process_one_decl uu____5385 se =
-        match uu____5385 with
+      let rec process_one_decl uu____5350 se =
+        match uu____5350 with
         | (ses1,exports,env1,hidden) ->
-            let uu____5437 =
+            let uu____5402 =
               env1.FStar_TypeChecker_Env.nosynth &&
                 (FStar_Options.debug_any ())
                in
-            if uu____5437
+            if uu____5402
             then ((ses1, exports, env1, hidden), [])
             else
-              ((let uu____5485 =
+              ((let uu____5450 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-                if uu____5485
+                if uu____5450
                 then
-                  let uu____5488 = FStar_Syntax_Print.tag_of_sigelt se  in
-                  let uu____5490 = FStar_Syntax_Print.sigelt_to_string se  in
+                  let uu____5453 = FStar_Syntax_Print.tag_of_sigelt se  in
+                  let uu____5455 = FStar_Syntax_Print.sigelt_to_string se  in
                   FStar_Util.print2
                     ">>>>>>>>>>>>>>Checking top-level %s decl %s\n"
-                    uu____5488 uu____5490
+                    uu____5453 uu____5455
                 else ());
-               (let uu____5495 = tc_decl env1 se  in
-                match uu____5495 with
+               (let uu____5460 = tc_decl env1 se  in
+                match uu____5460 with
                 | (ses',ses_elaborated,env2) ->
                     let ses'1 =
                       FStar_All.pipe_right ses'
                         (FStar_List.map
                            (fun se1  ->
-                              (let uu____5548 =
+                              (let uu____5513 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF")
                                   in
-                               if uu____5548
+                               if uu____5513
                                then
-                                 let uu____5552 =
+                                 let uu____5517 =
                                    FStar_Syntax_Print.sigelt_to_string se1
                                     in
                                  FStar_Util.print1
-                                   "About to elim vars from %s\n" uu____5552
+                                   "About to elim vars from %s\n" uu____5517
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                        in
@@ -4168,18 +4152,18 @@ let (tc_decls :
                       FStar_All.pipe_right ses_elaborated
                         (FStar_List.map
                            (fun se1  ->
-                              (let uu____5568 =
+                              (let uu____5533 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF")
                                   in
-                               if uu____5568
+                               if uu____5533
                                then
-                                 let uu____5572 =
+                                 let uu____5537 =
                                    FStar_Syntax_Print.sigelt_to_string se1
                                     in
                                  FStar_Util.print1
                                    "About to elim vars from (elaborated) %s\n"
-                                   uu____5572
+                                   uu____5537
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1))
                        in
@@ -4204,43 +4188,43 @@ let (tc_decls :
                              env2)
                          in
                       FStar_Syntax_Unionfind.reset ();
-                      (let uu____5590 =
+                      (let uu____5555 =
                          (FStar_Options.log_types ()) ||
                            (FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env3)
                               (FStar_Options.Other "LogTypes"))
                           in
-                       if uu____5590
+                       if uu____5555
                        then
-                         let uu____5595 =
+                         let uu____5560 =
                            FStar_List.fold_left
                              (fun s  ->
                                 fun se1  ->
-                                  let uu____5604 =
-                                    let uu____5606 =
+                                  let uu____5569 =
+                                    let uu____5571 =
                                       FStar_Syntax_Print.sigelt_to_string se1
                                        in
-                                    Prims.op_Hat uu____5606 "\n"  in
-                                  Prims.op_Hat s uu____5604) "" ses'1
+                                    Prims.op_Hat uu____5571 "\n"  in
+                                  Prims.op_Hat s uu____5569) "" ses'1
                             in
-                         FStar_Util.print1 "Checked: %s\n" uu____5595
+                         FStar_Util.print1 "Checked: %s\n" uu____5560
                        else ());
                       FStar_List.iter
                         (fun se1  ->
                            (env3.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.encode_sig
                              env3 se1) ses'1;
-                      (let uu____5616 =
-                         let uu____5625 =
+                      (let uu____5581 =
+                         let uu____5590 =
                            FStar_Options.use_extracted_interfaces ()  in
-                         if uu____5625
+                         if uu____5590
                          then ((FStar_List.rev_append ses'1 exports), [])
                          else
-                           (let accum_exports_hidden uu____5667 se1 =
-                              match uu____5667 with
+                           (let accum_exports_hidden uu____5632 se1 =
+                              match uu____5632 with
                               | (exports1,hidden1) ->
-                                  let uu____5695 =
+                                  let uu____5660 =
                                     for_export env3 hidden1 se1  in
-                                  (match uu____5695 with
+                                  (match uu____5660 with
                                    | (se_exported,hidden2) ->
                                        ((FStar_List.rev_append se_exported
                                            exports1), hidden2))
@@ -4248,33 +4232,33 @@ let (tc_decls :
                             FStar_List.fold_left accum_exports_hidden
                               (exports, hidden) ses'1)
                           in
-                       match uu____5616 with
+                       match uu____5581 with
                        | (exports1,hidden1) ->
                            (((FStar_List.rev_append ses'1 ses1), exports1,
                               env3, hidden1), ses_elaborated1))))))
          in
       let process_one_decl_timed acc se =
-        let uu____5849 = acc  in
-        match uu____5849 with
-        | (uu____5884,uu____5885,env1,uu____5887) ->
+        let uu____5814 = acc  in
+        match uu____5814 with
+        | (uu____5849,uu____5850,env1,uu____5852) ->
             let r =
-              let uu____5921 =
-                let uu____5925 =
-                  let uu____5927 = FStar_TypeChecker_Env.current_module env1
+              let uu____5886 =
+                let uu____5890 =
+                  let uu____5892 = FStar_TypeChecker_Env.current_module env1
                      in
-                  FStar_Ident.string_of_lid uu____5927  in
-                FStar_Pervasives_Native.Some uu____5925  in
+                  FStar_Ident.string_of_lid uu____5892  in
+                FStar_Pervasives_Native.Some uu____5890  in
               FStar_Profiling.profile
-                (fun uu____5950  -> process_one_decl acc se) uu____5921
+                (fun uu____5915  -> process_one_decl acc se) uu____5886
                 "FStar.TypeChecker.Tc.process_one_decl"
                in
-            ((let uu____5953 = FStar_Options.profile_group_by_decls ()  in
-              if uu____5953
+            ((let uu____5918 = FStar_Options.profile_group_by_decls ()  in
+              if uu____5918
               then
                 let tag =
                   match FStar_Syntax_Util.lids_of_sigelt se with
-                  | hd::uu____5960 -> FStar_Ident.string_of_lid hd
-                  | uu____5963 ->
+                  | hd::uu____5925 -> FStar_Ident.string_of_lid hd
+                  | uu____5928 ->
                       FStar_Range.string_of_range
                         (FStar_Syntax_Util.range_of_sigelt se)
                    in
@@ -4282,14 +4266,14 @@ let (tc_decls :
               else ());
              r)
          in
-      let uu____5968 =
+      let uu____5933 =
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____5998  ->
+          (fun uu____5963  ->
              FStar_Util.fold_flatten process_one_decl_timed ([], [], env, [])
                ses)
          in
-      match uu____5968 with
-      | (ses1,exports,env1,uu____6032) ->
+      match uu____5933 with
+      | (ses1,exports,env1,uu____5997) ->
           ((FStar_List.rev_append ses1 []),
             (FStar_List.rev_append exports []), env1)
   
@@ -4306,193 +4290,191 @@ let (check_exports :
     fun modul  ->
       fun exports  ->
         let env1 =
-          let uu___1043_6148 = env  in
+          let uu___1043_6113 = env  in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1043_6148.FStar_TypeChecker_Env.solver);
+              (uu___1043_6113.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1043_6148.FStar_TypeChecker_Env.range);
+              (uu___1043_6113.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1043_6148.FStar_TypeChecker_Env.curmodule);
+              (uu___1043_6113.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1043_6148.FStar_TypeChecker_Env.gamma);
+              (uu___1043_6113.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1043_6148.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1043_6113.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1043_6148.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1043_6113.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1043_6148.FStar_TypeChecker_Env.modules);
+              (uu___1043_6113.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1043_6148.FStar_TypeChecker_Env.expected_typ);
+              (uu___1043_6113.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1043_6148.FStar_TypeChecker_Env.sigtab);
+              (uu___1043_6113.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1043_6148.FStar_TypeChecker_Env.attrtab);
+              (uu___1043_6113.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1043_6148.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1043_6113.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1043_6148.FStar_TypeChecker_Env.effects);
+              (uu___1043_6113.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1043_6148.FStar_TypeChecker_Env.generalize);
+              (uu___1043_6113.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1043_6148.FStar_TypeChecker_Env.letrecs);
+              (uu___1043_6113.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level = true;
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1043_6148.FStar_TypeChecker_Env.check_uvars);
+              (uu___1043_6113.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1043_6148.FStar_TypeChecker_Env.use_eq);
+              (uu___1043_6113.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1043_6148.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1043_6113.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1043_6148.FStar_TypeChecker_Env.is_iface);
+              (uu___1043_6113.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1043_6148.FStar_TypeChecker_Env.admit);
+              (uu___1043_6113.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax = true;
             FStar_TypeChecker_Env.lax_universes = true;
             FStar_TypeChecker_Env.phase1 =
-              (uu___1043_6148.FStar_TypeChecker_Env.phase1);
+              (uu___1043_6113.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1043_6148.FStar_TypeChecker_Env.failhard);
+              (uu___1043_6113.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1043_6148.FStar_TypeChecker_Env.nosynth);
+              (uu___1043_6113.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1043_6148.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1043_6113.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1043_6148.FStar_TypeChecker_Env.tc_term);
+              (uu___1043_6113.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1043_6148.FStar_TypeChecker_Env.type_of);
+              (uu___1043_6113.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1043_6148.FStar_TypeChecker_Env.universe_of);
+              (uu___1043_6113.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1043_6148.FStar_TypeChecker_Env.check_type_of);
+              (uu___1043_6113.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1043_6148.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1043_6113.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1043_6148.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1043_6113.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1043_6148.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1043_6113.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1043_6148.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1043_6113.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1043_6148.FStar_TypeChecker_Env.proof_ns);
+              (uu___1043_6113.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1043_6148.FStar_TypeChecker_Env.synth_hook);
+              (uu___1043_6113.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1043_6148.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1043_6113.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1043_6148.FStar_TypeChecker_Env.splice);
+              (uu___1043_6113.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1043_6148.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1043_6113.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1043_6148.FStar_TypeChecker_Env.postprocess);
+              (uu___1043_6113.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1043_6148.FStar_TypeChecker_Env.identifier_info);
+              (uu___1043_6113.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1043_6148.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1043_6113.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1043_6148.FStar_TypeChecker_Env.dsenv);
+              (uu___1043_6113.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1043_6148.FStar_TypeChecker_Env.nbe);
+              (uu___1043_6113.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1043_6148.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1043_6113.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1043_6148.FStar_TypeChecker_Env.erasable_types_tab)
+              (uu___1043_6113.FStar_TypeChecker_Env.erasable_types_tab)
           }  in
         let check_term lid univs t =
-          let uu____6168 = FStar_Syntax_Subst.open_univ_vars univs t  in
-          match uu____6168 with
+          let uu____6133 = FStar_Syntax_Subst.open_univ_vars univs t  in
+          match uu____6133 with
           | (univs1,t1) ->
-              ((let uu____6176 =
-                  let uu____6178 =
-                    let uu____6184 =
+              ((let uu____6141 =
+                  let uu____6143 =
+                    let uu____6149 =
                       FStar_TypeChecker_Env.set_current_module env1
                         modul.FStar_Syntax_Syntax.name
                        in
-                    FStar_TypeChecker_Env.debug uu____6184  in
-                  FStar_All.pipe_left uu____6178
+                    FStar_TypeChecker_Env.debug uu____6149  in
+                  FStar_All.pipe_left uu____6143
                     (FStar_Options.Other "Exports")
                    in
-                if uu____6176
+                if uu____6141
                 then
-                  let uu____6188 = FStar_Syntax_Print.lid_to_string lid  in
-                  let uu____6190 =
-                    let uu____6192 =
+                  let uu____6153 = FStar_Syntax_Print.lid_to_string lid  in
+                  let uu____6155 =
+                    let uu____6157 =
                       FStar_All.pipe_right univs1
                         (FStar_List.map
                            (fun x  ->
                               FStar_Syntax_Print.univ_to_string
                                 (FStar_Syntax_Syntax.U_name x)))
                        in
-                    FStar_All.pipe_right uu____6192
+                    FStar_All.pipe_right uu____6157
                       (FStar_String.concat ", ")
                      in
-                  let uu____6209 = FStar_Syntax_Print.term_to_string t1  in
+                  let uu____6174 = FStar_Syntax_Print.term_to_string t1  in
                   FStar_Util.print3 "Checking for export %s <%s> : %s\n"
-                    uu____6188 uu____6190 uu____6209
+                    uu____6153 uu____6155 uu____6174
                 else ());
                (let env2 = FStar_TypeChecker_Env.push_univ_vars env1 univs1
                    in
-                let uu____6215 =
+                let uu____6180 =
                   FStar_TypeChecker_TcTerm.tc_trivial_guard env2 t1  in
-                FStar_All.pipe_right uu____6215 (fun uu____6224  -> ())))
+                FStar_All.pipe_right uu____6180 (fun uu____6189  -> ())))
            in
         let check_term1 lid univs t =
-          (let uu____6242 =
-             let uu____6244 =
+          (let uu____6207 =
+             let uu____6209 =
                FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
-             let uu____6246 = FStar_Ident.string_of_lid lid  in
+             let uu____6211 = FStar_Ident.string_of_lid lid  in
              FStar_Util.format2
                "Interface of %s violates its abstraction (add a 'private' qualifier to '%s'?)"
-               uu____6244 uu____6246
+               uu____6209 uu____6211
               in
-           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____6242);
+           FStar_Errors.message_prefix.FStar_Errors.set_prefix uu____6207);
           check_term lid univs t;
           FStar_Errors.message_prefix.FStar_Errors.clear_prefix ()  in
         let rec check_sigelt se =
           match se.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____6257) ->
-              let uu____6266 =
-                let uu____6268 =
+          | FStar_Syntax_Syntax.Sig_bundle (ses,uu____6222) ->
+              let uu____6231 =
+                let uu____6233 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6268  in
-              if uu____6266
+                Prims.op_Negation uu____6233  in
+              if uu____6231
               then FStar_All.pipe_right ses (FStar_List.iter check_sigelt)
               else ()
           | FStar_Syntax_Syntax.Sig_inductive_typ
-              (l,univs,binders,typ,uu____6282,uu____6283) ->
+              (l,univs,binders,typ,uu____6247,uu____6248) ->
               let t =
-                let uu____6295 =
-                  let uu____6302 =
-                    let uu____6303 =
-                      let uu____6318 = FStar_Syntax_Syntax.mk_Total typ  in
-                      (binders, uu____6318)  in
-                    FStar_Syntax_Syntax.Tm_arrow uu____6303  in
-                  FStar_Syntax_Syntax.mk uu____6302  in
-                uu____6295 FStar_Pervasives_Native.None
+                let uu____6260 =
+                  let uu____6261 =
+                    let uu____6276 = FStar_Syntax_Syntax.mk_Total typ  in
+                    (binders, uu____6276)  in
+                  FStar_Syntax_Syntax.Tm_arrow uu____6261  in
+                FStar_Syntax_Syntax.mk uu____6260
                   se.FStar_Syntax_Syntax.sigrng
                  in
               check_term1 l univs t
           | FStar_Syntax_Syntax.Sig_datacon
-              (l,univs,t,uu____6334,uu____6335,uu____6336) ->
+              (l,univs,t,uu____6292,uu____6293,uu____6294) ->
               check_term1 l univs t
           | FStar_Syntax_Syntax.Sig_declare_typ (l,univs,t) ->
-              let uu____6346 =
-                let uu____6348 =
+              let uu____6304 =
+                let uu____6306 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6348  in
-              if uu____6346 then check_term1 l univs t else ()
-          | FStar_Syntax_Syntax.Sig_let ((uu____6356,lbs),uu____6358) ->
-              let uu____6369 =
-                let uu____6371 =
+                Prims.op_Negation uu____6306  in
+              if uu____6304 then check_term1 l univs t else ()
+          | FStar_Syntax_Syntax.Sig_let ((uu____6314,lbs),uu____6316) ->
+              let uu____6327 =
+                let uu____6329 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6371  in
-              if uu____6369
+                Prims.op_Negation uu____6329  in
+              if uu____6327
               then
                 FStar_All.pipe_right lbs
                   (FStar_List.iter
@@ -4506,37 +4488,36 @@ let (check_exports :
               else ()
           | FStar_Syntax_Syntax.Sig_effect_abbrev
               (l,univs,binders,comp,flags) ->
-              let uu____6394 =
-                let uu____6396 =
+              let uu____6352 =
+                let uu____6354 =
                   FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                     (FStar_List.contains FStar_Syntax_Syntax.Private)
                    in
-                Prims.op_Negation uu____6396  in
-              if uu____6394
+                Prims.op_Negation uu____6354  in
+              if uu____6352
               then
                 let arrow =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_arrow (binders, comp))
-                    FStar_Pervasives_Native.None
                     se.FStar_Syntax_Syntax.sigrng
                    in
                 check_term1 l univs arrow
               else ()
-          | FStar_Syntax_Syntax.Sig_assume uu____6417 -> ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____6424 -> ()
-          | FStar_Syntax_Syntax.Sig_sub_effect uu____6425 -> ()
-          | FStar_Syntax_Syntax.Sig_pragma uu____6426 -> ()
-          | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6427 -> ()
-          | FStar_Syntax_Syntax.Sig_fail uu____6438 ->
+          | FStar_Syntax_Syntax.Sig_assume uu____6375 -> ()
+          | FStar_Syntax_Syntax.Sig_new_effect uu____6382 -> ()
+          | FStar_Syntax_Syntax.Sig_sub_effect uu____6383 -> ()
+          | FStar_Syntax_Syntax.Sig_pragma uu____6384 -> ()
+          | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6385 -> ()
+          | FStar_Syntax_Syntax.Sig_fail uu____6396 ->
               failwith "Impossible (Already handled)"
-          | FStar_Syntax_Syntax.Sig_splice uu____6452 ->
+          | FStar_Syntax_Syntax.Sig_splice uu____6410 ->
               failwith "Impossible (Already handled)"
            in
-        let uu____6460 =
+        let uu____6418 =
           FStar_Ident.lid_equals modul.FStar_Syntax_Syntax.name
             FStar_Parser_Const.prims_lid
            in
-        if uu____6460 then () else FStar_List.iter check_sigelt exports
+        if uu____6418 then () else FStar_List.iter check_sigelt exports
   
 let (extract_interface :
   FStar_TypeChecker_Env.env ->
@@ -4584,155 +4565,152 @@ let (extract_interface :
           (fun q  ->
              match q with
              | FStar_Syntax_Syntax.Discriminator l -> true
-             | FStar_Syntax_Syntax.Projector (l,uu____6566) -> true
-             | uu____6568 -> false) quals
+             | FStar_Syntax_Syntax.Projector (l,uu____6524) -> true
+             | uu____6526 -> false) quals
          in
       let vals_of_abstract_inductive s =
         let mk_typ_for_abstract_inductive bs t r =
           match bs with
           | [] -> t
-          | uu____6598 ->
+          | uu____6556 ->
               (match t.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_arrow (bs',c) ->
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_arrow
-                        ((FStar_List.append bs bs'), c))
-                     FStar_Pervasives_Native.None r
-               | uu____6637 ->
-                   let uu____6638 =
-                     let uu____6645 =
-                       let uu____6646 =
-                         let uu____6661 = FStar_Syntax_Syntax.mk_Total t  in
-                         (bs, uu____6661)  in
-                       FStar_Syntax_Syntax.Tm_arrow uu____6646  in
-                     FStar_Syntax_Syntax.mk uu____6645  in
-                   uu____6638 FStar_Pervasives_Native.None r)
+                        ((FStar_List.append bs bs'), c)) r
+               | uu____6595 ->
+                   let uu____6596 =
+                     let uu____6597 =
+                       let uu____6612 = FStar_Syntax_Syntax.mk_Total t  in
+                       (bs, uu____6612)  in
+                     FStar_Syntax_Syntax.Tm_arrow uu____6597  in
+                   FStar_Syntax_Syntax.mk uu____6596 r)
            in
         match s.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid,uvs,bs,t,uu____6678,uu____6679) ->
+            (lid,uvs,bs,t,uu____6629,uu____6630) ->
             let s1 =
-              let uu___1169_6689 = s  in
-              let uu____6690 =
-                let uu____6691 =
-                  let uu____6698 =
+              let uu___1169_6640 = s  in
+              let uu____6641 =
+                let uu____6642 =
+                  let uu____6649 =
                     mk_typ_for_abstract_inductive bs t
                       s.FStar_Syntax_Syntax.sigrng
                      in
-                  (lid, uvs, uu____6698)  in
-                FStar_Syntax_Syntax.Sig_declare_typ uu____6691  in
-              let uu____6699 =
-                let uu____6702 =
-                  let uu____6705 =
+                  (lid, uvs, uu____6649)  in
+                FStar_Syntax_Syntax.Sig_declare_typ uu____6642  in
+              let uu____6650 =
+                let uu____6653 =
+                  let uu____6656 =
                     filter_out_abstract_and_noeq
                       s.FStar_Syntax_Syntax.sigquals
                      in
-                  FStar_Syntax_Syntax.New :: uu____6705  in
-                FStar_Syntax_Syntax.Assumption :: uu____6702  in
+                  FStar_Syntax_Syntax.New :: uu____6656  in
+                FStar_Syntax_Syntax.Assumption :: uu____6653  in
               {
-                FStar_Syntax_Syntax.sigel = uu____6690;
+                FStar_Syntax_Syntax.sigel = uu____6641;
                 FStar_Syntax_Syntax.sigrng =
-                  (uu___1169_6689.FStar_Syntax_Syntax.sigrng);
-                FStar_Syntax_Syntax.sigquals = uu____6699;
+                  (uu___1169_6640.FStar_Syntax_Syntax.sigrng);
+                FStar_Syntax_Syntax.sigquals = uu____6650;
                 FStar_Syntax_Syntax.sigmeta =
-                  (uu___1169_6689.FStar_Syntax_Syntax.sigmeta);
+                  (uu___1169_6640.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs =
-                  (uu___1169_6689.FStar_Syntax_Syntax.sigattrs);
+                  (uu___1169_6640.FStar_Syntax_Syntax.sigattrs);
                 FStar_Syntax_Syntax.sigopts =
-                  (uu___1169_6689.FStar_Syntax_Syntax.sigopts)
+                  (uu___1169_6640.FStar_Syntax_Syntax.sigopts)
               }  in
             [s1]
-        | uu____6708 -> failwith "Impossible!"  in
-      let val_of_lb s lid uu____6733 lbdef =
-        match uu____6733 with
+        | uu____6659 -> failwith "Impossible!"  in
+      let val_of_lb s lid uu____6684 lbdef =
+        match uu____6684 with
         | (uvs,t) ->
             let attrs =
-              let uu____6744 =
+              let uu____6695 =
                 FStar_TypeChecker_Util.must_erase_for_extraction en lbdef  in
-              if uu____6744
+              if uu____6695
               then
-                let uu____6749 =
-                  let uu____6750 =
+                let uu____6700 =
+                  let uu____6701 =
                     FStar_Syntax_Syntax.lid_as_fv
                       FStar_Parser_Const.must_erase_for_extraction_attr
                       FStar_Syntax_Syntax.delta_constant
                       FStar_Pervasives_Native.None
                      in
-                  FStar_All.pipe_right uu____6750
+                  FStar_All.pipe_right uu____6701
                     FStar_Syntax_Syntax.fv_to_tm
                    in
-                uu____6749 :: (s.FStar_Syntax_Syntax.sigattrs)
+                uu____6700 :: (s.FStar_Syntax_Syntax.sigattrs)
               else s.FStar_Syntax_Syntax.sigattrs  in
-            let uu___1182_6753 = s  in
-            let uu____6754 =
-              let uu____6757 =
+            let uu___1182_6704 = s  in
+            let uu____6705 =
+              let uu____6708 =
                 filter_out_abstract_and_inline s.FStar_Syntax_Syntax.sigquals
                  in
-              FStar_Syntax_Syntax.Assumption :: uu____6757  in
+              FStar_Syntax_Syntax.Assumption :: uu____6708  in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t));
               FStar_Syntax_Syntax.sigrng =
-                (uu___1182_6753.FStar_Syntax_Syntax.sigrng);
-              FStar_Syntax_Syntax.sigquals = uu____6754;
+                (uu___1182_6704.FStar_Syntax_Syntax.sigrng);
+              FStar_Syntax_Syntax.sigquals = uu____6705;
               FStar_Syntax_Syntax.sigmeta =
-                (uu___1182_6753.FStar_Syntax_Syntax.sigmeta);
+                (uu___1182_6704.FStar_Syntax_Syntax.sigmeta);
               FStar_Syntax_Syntax.sigattrs = attrs;
               FStar_Syntax_Syntax.sigopts =
-                (uu___1182_6753.FStar_Syntax_Syntax.sigopts)
+                (uu___1182_6704.FStar_Syntax_Syntax.sigopts)
             }
          in
       let should_keep_lbdef t =
         let comp_effect_name c =
           match c.FStar_Syntax_Syntax.n with
           | FStar_Syntax_Syntax.Comp c1 -> c1.FStar_Syntax_Syntax.effect_name
-          | uu____6775 -> failwith "Impossible!"  in
+          | uu____6726 -> failwith "Impossible!"  in
         let c_opt =
-          let uu____6782 = FStar_Syntax_Util.is_unit t  in
-          if uu____6782
+          let uu____6733 = FStar_Syntax_Util.is_unit t  in
+          if uu____6733
           then
-            let uu____6789 = FStar_Syntax_Syntax.mk_Total t  in
-            FStar_Pervasives_Native.Some uu____6789
+            let uu____6740 = FStar_Syntax_Syntax.mk_Total t  in
+            FStar_Pervasives_Native.Some uu____6740
           else
-            (let uu____6796 =
-               let uu____6797 = FStar_Syntax_Subst.compress t  in
-               uu____6797.FStar_Syntax_Syntax.n  in
-             match uu____6796 with
-             | FStar_Syntax_Syntax.Tm_arrow (uu____6804,c) ->
+            (let uu____6747 =
+               let uu____6748 = FStar_Syntax_Subst.compress t  in
+               uu____6748.FStar_Syntax_Syntax.n  in
+             match uu____6747 with
+             | FStar_Syntax_Syntax.Tm_arrow (uu____6755,c) ->
                  FStar_Pervasives_Native.Some c
-             | uu____6828 -> FStar_Pervasives_Native.None)
+             | uu____6779 -> FStar_Pervasives_Native.None)
            in
         match c_opt with
         | FStar_Pervasives_Native.None  -> true
         | FStar_Pervasives_Native.Some c ->
-            let uu____6840 = FStar_Syntax_Util.is_lemma_comp c  in
-            if uu____6840
+            let uu____6791 = FStar_Syntax_Util.is_lemma_comp c  in
+            if uu____6791
             then false
             else
-              (let uu____6847 = FStar_Syntax_Util.is_pure_or_ghost_comp c  in
-               if uu____6847
+              (let uu____6798 = FStar_Syntax_Util.is_pure_or_ghost_comp c  in
+               if uu____6798
                then true
                else
-                 (let uu____6854 = comp_effect_name c  in
-                  FStar_TypeChecker_Env.is_reifiable_effect en uu____6854))
+                 (let uu____6805 = comp_effect_name c  in
+                  FStar_TypeChecker_Env.is_reifiable_effect en uu____6805))
          in
       let extract_sigelt s =
-        (let uu____6866 =
+        (let uu____6817 =
            FStar_TypeChecker_Env.debug en FStar_Options.Extreme  in
-         if uu____6866
+         if uu____6817
          then
-           let uu____6869 = FStar_Syntax_Print.sigelt_to_string s  in
-           FStar_Util.print1 "Extracting interface for %s\n" uu____6869
+           let uu____6820 = FStar_Syntax_Print.sigelt_to_string s  in
+           FStar_Util.print1 "Extracting interface for %s\n" uu____6820
          else ());
         (match s.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____6876 ->
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____6827 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_datacon uu____6896 ->
+         | FStar_Syntax_Syntax.Sig_datacon uu____6847 ->
              failwith "Impossible! extract_interface: bare data constructor"
-         | FStar_Syntax_Syntax.Sig_splice uu____6915 ->
+         | FStar_Syntax_Syntax.Sig_splice uu____6866 ->
              failwith
                "Impossible! extract_interface: trying to extract splice"
-         | FStar_Syntax_Syntax.Sig_fail uu____6925 ->
+         | FStar_Syntax_Syntax.Sig_fail uu____6876 ->
              failwith
                "Impossible! extract_interface: trying to extract Sig_fail"
          | FStar_Syntax_Syntax.Sig_bundle (sigelts,lidents) ->
@@ -4744,74 +4722,74 @@ let (extract_interface :
                        fun s1  ->
                          match s1.FStar_Syntax_Syntax.sigel with
                          | FStar_Syntax_Syntax.Sig_inductive_typ
-                             (lid,uu____6977,uu____6978,uu____6979,uu____6980,uu____6981)
+                             (lid,uu____6928,uu____6929,uu____6930,uu____6931,uu____6932)
                              ->
-                             ((let uu____6991 =
-                                 let uu____6994 =
+                             ((let uu____6942 =
+                                 let uu____6945 =
                                    FStar_ST.op_Bang abstract_inductive_tycons
                                     in
-                                 lid :: uu____6994  in
+                                 lid :: uu____6945  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_tycons uu____6991);
-                              (let uu____7043 = vals_of_abstract_inductive s1
+                                 abstract_inductive_tycons uu____6942);
+                              (let uu____6994 = vals_of_abstract_inductive s1
                                   in
-                               FStar_List.append uu____7043 sigelts1))
+                               FStar_List.append uu____6994 sigelts1))
                          | FStar_Syntax_Syntax.Sig_datacon
-                             (lid,uu____7047,uu____7048,uu____7049,uu____7050,uu____7051)
+                             (lid,uu____6998,uu____6999,uu____7000,uu____7001,uu____7002)
                              ->
-                             ((let uu____7059 =
-                                 let uu____7062 =
+                             ((let uu____7010 =
+                                 let uu____7013 =
                                    FStar_ST.op_Bang
                                      abstract_inductive_datacons
                                     in
-                                 lid :: uu____7062  in
+                                 lid :: uu____7013  in
                                FStar_ST.op_Colon_Equals
-                                 abstract_inductive_datacons uu____7059);
+                                 abstract_inductive_datacons uu____7010);
                               sigelts1)
-                         | uu____7111 ->
+                         | uu____7062 ->
                              failwith
                                "Impossible! extract_interface: Sig_bundle can't have anything other than Sig_inductive_typ and Sig_datacon")
                     [])
              else [s]
          | FStar_Syntax_Syntax.Sig_declare_typ (lid,uvs,t) ->
-             let uu____7120 =
+             let uu____7071 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____7120
+             if uu____7071
              then []
              else
                if is_assume s.FStar_Syntax_Syntax.sigquals
                then
-                 (let uu____7130 =
-                    let uu___1248_7131 = s  in
-                    let uu____7132 =
+                 (let uu____7081 =
+                    let uu___1248_7082 = s  in
+                    let uu____7083 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___1248_7131.FStar_Syntax_Syntax.sigel);
+                        (uu___1248_7082.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___1248_7131.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____7132;
+                        (uu___1248_7082.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____7083;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___1248_7131.FStar_Syntax_Syntax.sigmeta);
+                        (uu___1248_7082.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___1248_7131.FStar_Syntax_Syntax.sigattrs);
+                        (uu___1248_7082.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___1248_7131.FStar_Syntax_Syntax.sigopts)
+                        (uu___1248_7082.FStar_Syntax_Syntax.sigopts)
                     }  in
-                  [uu____7130])
+                  [uu____7081])
                else []
          | FStar_Syntax_Syntax.Sig_let (lbs,lids) ->
-             let uu____7143 =
+             let uu____7094 =
                is_projector_or_discriminator_of_an_abstract_inductive
                  s.FStar_Syntax_Syntax.sigquals
                 in
-             if uu____7143
+             if uu____7094
              then []
              else
-               (let uu____7150 = lbs  in
-                match uu____7150 with
+               (let uu____7101 = lbs  in
+                match uu____7101 with
                 | (flbs,slbs) ->
                     let typs_and_defs =
                       FStar_All.pipe_right slbs
@@ -4823,17 +4801,17 @@ let (extract_interface :
                        in
                     let is_lemma =
                       FStar_List.existsML
-                        (fun uu____7212  ->
-                           match uu____7212 with
-                           | (uu____7220,t,uu____7222) ->
+                        (fun uu____7163  ->
+                           match uu____7163 with
+                           | (uu____7171,t,uu____7173) ->
                                FStar_All.pipe_right t
                                  FStar_Syntax_Util.is_lemma) typs_and_defs
                        in
                     let vals =
                       FStar_List.map2
                         (fun lid  ->
-                           fun uu____7239  ->
-                             match uu____7239 with
+                           fun uu____7190  ->
+                             match uu____7190 with
                              | (u,t,d) -> val_of_lb s lid (u, t) d) lids
                         typs_and_defs
                        in
@@ -4845,86 +4823,86 @@ let (extract_interface :
                     else
                       (let should_keep_defs =
                          FStar_List.existsML
-                           (fun uu____7266  ->
-                              match uu____7266 with
-                              | (uu____7274,t,uu____7276) ->
+                           (fun uu____7217  ->
+                              match uu____7217 with
+                              | (uu____7225,t,uu____7227) ->
                                   FStar_All.pipe_right t should_keep_lbdef)
                            typs_and_defs
                           in
                        if should_keep_defs then [s] else vals))
-         | FStar_Syntax_Syntax.Sig_assume (lid,uu____7284,uu____7285) ->
+         | FStar_Syntax_Syntax.Sig_assume (lid,uu____7235,uu____7236) ->
              let is_haseq = FStar_TypeChecker_TcInductive.is_haseq_lid lid
                 in
              if is_haseq
              then
                let is_haseq_of_abstract_inductive =
-                 let uu____7293 = FStar_ST.op_Bang abstract_inductive_tycons
+                 let uu____7244 = FStar_ST.op_Bang abstract_inductive_tycons
                     in
                  FStar_List.existsML
                    (fun l  ->
-                      let uu____7322 =
+                      let uu____7273 =
                         FStar_TypeChecker_TcInductive.get_haseq_axiom_lid l
                          in
-                      FStar_Ident.lid_equals lid uu____7322) uu____7293
+                      FStar_Ident.lid_equals lid uu____7273) uu____7244
                   in
                (if is_haseq_of_abstract_inductive
                 then
-                  let uu____7326 =
-                    let uu___1288_7327 = s  in
-                    let uu____7328 =
+                  let uu____7277 =
+                    let uu___1288_7278 = s  in
+                    let uu____7279 =
                       filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                     {
                       FStar_Syntax_Syntax.sigel =
-                        (uu___1288_7327.FStar_Syntax_Syntax.sigel);
+                        (uu___1288_7278.FStar_Syntax_Syntax.sigel);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___1288_7327.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals = uu____7328;
+                        (uu___1288_7278.FStar_Syntax_Syntax.sigrng);
+                      FStar_Syntax_Syntax.sigquals = uu____7279;
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___1288_7327.FStar_Syntax_Syntax.sigmeta);
+                        (uu___1288_7278.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___1288_7327.FStar_Syntax_Syntax.sigattrs);
+                        (uu___1288_7278.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___1288_7327.FStar_Syntax_Syntax.sigopts)
+                        (uu___1288_7278.FStar_Syntax_Syntax.sigopts)
                     }  in
-                  [uu____7326]
+                  [uu____7277]
                 else [])
              else
-               (let uu____7335 =
-                  let uu___1290_7336 = s  in
-                  let uu____7337 =
+               (let uu____7286 =
+                  let uu___1290_7287 = s  in
+                  let uu____7288 =
                     filter_out_abstract s.FStar_Syntax_Syntax.sigquals  in
                   {
                     FStar_Syntax_Syntax.sigel =
-                      (uu___1290_7336.FStar_Syntax_Syntax.sigel);
+                      (uu___1290_7287.FStar_Syntax_Syntax.sigel);
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___1290_7336.FStar_Syntax_Syntax.sigrng);
-                    FStar_Syntax_Syntax.sigquals = uu____7337;
+                      (uu___1290_7287.FStar_Syntax_Syntax.sigrng);
+                    FStar_Syntax_Syntax.sigquals = uu____7288;
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___1290_7336.FStar_Syntax_Syntax.sigmeta);
+                      (uu___1290_7287.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___1290_7336.FStar_Syntax_Syntax.sigattrs);
+                      (uu___1290_7287.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___1290_7336.FStar_Syntax_Syntax.sigopts)
+                      (uu___1290_7287.FStar_Syntax_Syntax.sigopts)
                   }  in
-                [uu____7335])
-         | FStar_Syntax_Syntax.Sig_new_effect uu____7340 -> [s]
-         | FStar_Syntax_Syntax.Sig_sub_effect uu____7341 -> [s]
-         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____7342 -> [s]
-         | FStar_Syntax_Syntax.Sig_pragma uu____7355 -> [s]
-         | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____7356 -> [s])
+                [uu____7286])
+         | FStar_Syntax_Syntax.Sig_new_effect uu____7291 -> [s]
+         | FStar_Syntax_Syntax.Sig_sub_effect uu____7292 -> [s]
+         | FStar_Syntax_Syntax.Sig_effect_abbrev uu____7293 -> [s]
+         | FStar_Syntax_Syntax.Sig_pragma uu____7306 -> [s]
+         | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____7307 -> [s])
          in
-      let uu___1302_7367 = m  in
-      let uu____7368 =
-        let uu____7369 =
+      let uu___1302_7318 = m  in
+      let uu____7319 =
+        let uu____7320 =
           FStar_All.pipe_right m.FStar_Syntax_Syntax.declarations
             (FStar_List.map extract_sigelt)
            in
-        FStar_All.pipe_right uu____7369 FStar_List.flatten  in
+        FStar_All.pipe_right uu____7320 FStar_List.flatten  in
       {
-        FStar_Syntax_Syntax.name = (uu___1302_7367.FStar_Syntax_Syntax.name);
-        FStar_Syntax_Syntax.declarations = uu____7368;
+        FStar_Syntax_Syntax.name = (uu___1302_7318.FStar_Syntax_Syntax.name);
+        FStar_Syntax_Syntax.declarations = uu____7319;
         FStar_Syntax_Syntax.exports =
-          (uu___1302_7367.FStar_Syntax_Syntax.exports);
+          (uu___1302_7318.FStar_Syntax_Syntax.exports);
         FStar_Syntax_Syntax.is_interface = true
       }
   
@@ -4937,7 +4915,7 @@ let (snapshot_context :
   fun env  ->
     fun msg  ->
       FStar_Util.atomically
-        (fun uu____7420  -> FStar_TypeChecker_Env.snapshot env msg)
+        (fun uu____7371  -> FStar_TypeChecker_Env.snapshot env msg)
   
 let (rollback_context :
   FStar_TypeChecker_Env.solver_t ->
@@ -4950,7 +4928,7 @@ let (rollback_context :
     fun msg  ->
       fun depth  ->
         FStar_Util.atomically
-          (fun uu____7467  ->
+          (fun uu____7418  ->
              let env = FStar_TypeChecker_Env.rollback solver msg depth  in
              env)
   
@@ -4958,8 +4936,8 @@ let (push_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env  ->
     fun msg  ->
-      let uu____7482 = snapshot_context env msg  in
-      FStar_Pervasives_Native.snd uu____7482
+      let uu____7433 = snapshot_context env msg  in
+      FStar_Pervasives_Native.snd uu____7433
   
 let (pop_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
@@ -4977,141 +4955,141 @@ let (tc_partial_modul :
   fun env  ->
     fun modul  ->
       let verify =
-        let uu____7554 =
+        let uu____7505 =
           FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
-        FStar_Options.should_verify uu____7554  in
+        FStar_Options.should_verify uu____7505  in
       let action = if verify then "Verifying" else "Lax-checking"  in
       let label =
         if modul.FStar_Syntax_Syntax.is_interface
         then "interface"
         else "implementation"  in
-      (let uu____7573 = FStar_Options.debug_any ()  in
-       if uu____7573
+      (let uu____7524 = FStar_Options.debug_any ()  in
+       if uu____7524
        then
-         let uu____7576 =
+         let uu____7527 =
            FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
-         FStar_Util.print3 "%s %s of %s\n" action label uu____7576
+         FStar_Util.print3 "%s %s of %s\n" action label uu____7527
        else ());
       (let name =
-         let uu____7583 =
+         let uu____7534 =
            FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name  in
          FStar_Util.format2 "%s %s"
            (if modul.FStar_Syntax_Syntax.is_interface
             then "interface"
-            else "module") uu____7583
+            else "module") uu____7534
           in
        let env1 =
-         let uu___1327_7593 = env  in
+         let uu___1327_7544 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___1327_7593.FStar_TypeChecker_Env.solver);
+             (uu___1327_7544.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___1327_7593.FStar_TypeChecker_Env.range);
+             (uu___1327_7544.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___1327_7593.FStar_TypeChecker_Env.curmodule);
+             (uu___1327_7544.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___1327_7593.FStar_TypeChecker_Env.gamma);
+             (uu___1327_7544.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___1327_7593.FStar_TypeChecker_Env.gamma_sig);
+             (uu___1327_7544.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___1327_7593.FStar_TypeChecker_Env.gamma_cache);
+             (uu___1327_7544.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___1327_7593.FStar_TypeChecker_Env.modules);
+             (uu___1327_7544.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___1327_7593.FStar_TypeChecker_Env.expected_typ);
+             (uu___1327_7544.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___1327_7593.FStar_TypeChecker_Env.sigtab);
+             (uu___1327_7544.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___1327_7593.FStar_TypeChecker_Env.attrtab);
+             (uu___1327_7544.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___1327_7593.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___1327_7544.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___1327_7593.FStar_TypeChecker_Env.effects);
+             (uu___1327_7544.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___1327_7593.FStar_TypeChecker_Env.generalize);
+             (uu___1327_7544.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___1327_7593.FStar_TypeChecker_Env.letrecs);
+             (uu___1327_7544.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___1327_7593.FStar_TypeChecker_Env.top_level);
+             (uu___1327_7544.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___1327_7593.FStar_TypeChecker_Env.check_uvars);
+             (uu___1327_7544.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___1327_7593.FStar_TypeChecker_Env.use_eq);
+             (uu___1327_7544.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___1327_7593.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___1327_7544.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
              (modul.FStar_Syntax_Syntax.is_interface);
            FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
            FStar_TypeChecker_Env.lax =
-             (uu___1327_7593.FStar_TypeChecker_Env.lax);
+             (uu___1327_7544.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___1327_7593.FStar_TypeChecker_Env.lax_universes);
+             (uu___1327_7544.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___1327_7593.FStar_TypeChecker_Env.phase1);
+             (uu___1327_7544.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___1327_7593.FStar_TypeChecker_Env.failhard);
+             (uu___1327_7544.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___1327_7593.FStar_TypeChecker_Env.nosynth);
+             (uu___1327_7544.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___1327_7593.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___1327_7544.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___1327_7593.FStar_TypeChecker_Env.tc_term);
+             (uu___1327_7544.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___1327_7593.FStar_TypeChecker_Env.type_of);
+             (uu___1327_7544.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___1327_7593.FStar_TypeChecker_Env.universe_of);
+             (uu___1327_7544.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___1327_7593.FStar_TypeChecker_Env.check_type_of);
+             (uu___1327_7544.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___1327_7593.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___1327_7544.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___1327_7593.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___1327_7544.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___1327_7593.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___1327_7544.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___1327_7593.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___1327_7544.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___1327_7593.FStar_TypeChecker_Env.proof_ns);
+             (uu___1327_7544.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___1327_7593.FStar_TypeChecker_Env.synth_hook);
+             (uu___1327_7544.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___1327_7593.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___1327_7544.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___1327_7593.FStar_TypeChecker_Env.splice);
+             (uu___1327_7544.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___1327_7593.FStar_TypeChecker_Env.mpreprocess);
+             (uu___1327_7544.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___1327_7593.FStar_TypeChecker_Env.postprocess);
+             (uu___1327_7544.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___1327_7593.FStar_TypeChecker_Env.identifier_info);
+             (uu___1327_7544.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___1327_7593.FStar_TypeChecker_Env.tc_hooks);
+             (uu___1327_7544.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___1327_7593.FStar_TypeChecker_Env.dsenv);
+             (uu___1327_7544.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___1327_7593.FStar_TypeChecker_Env.nbe);
+             (uu___1327_7544.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___1327_7593.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___1327_7544.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___1327_7593.FStar_TypeChecker_Env.erasable_types_tab)
+             (uu___1327_7544.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
        let env2 =
          FStar_TypeChecker_Env.set_current_module env1
            modul.FStar_Syntax_Syntax.name
           in
-       let uu____7595 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
+       let uu____7546 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations
           in
-       match uu____7595 with
+       match uu____7546 with
        | (ses,exports,env3) ->
-           ((let uu___1335_7628 = modul  in
+           ((let uu___1335_7579 = modul  in
              {
                FStar_Syntax_Syntax.name =
-                 (uu___1335_7628.FStar_Syntax_Syntax.name);
+                 (uu___1335_7579.FStar_Syntax_Syntax.name);
                FStar_Syntax_Syntax.declarations = ses;
                FStar_Syntax_Syntax.exports =
-                 (uu___1335_7628.FStar_Syntax_Syntax.exports);
+                 (uu___1335_7579.FStar_Syntax_Syntax.exports);
                FStar_Syntax_Syntax.is_interface =
-                 (uu___1335_7628.FStar_Syntax_Syntax.is_interface)
+                 (uu___1335_7579.FStar_Syntax_Syntax.is_interface)
              }), exports, env3))
   
 let (tc_more_partial_modul :
@@ -5124,21 +5102,21 @@ let (tc_more_partial_modul :
   fun env  ->
     fun modul  ->
       fun decls  ->
-        let uu____7657 = tc_decls env decls  in
-        match uu____7657 with
+        let uu____7608 = tc_decls env decls  in
+        match uu____7608 with
         | (ses,exports,env1) ->
             let modul1 =
-              let uu___1344_7688 = modul  in
+              let uu___1344_7639 = modul  in
               {
                 FStar_Syntax_Syntax.name =
-                  (uu___1344_7688.FStar_Syntax_Syntax.name);
+                  (uu___1344_7639.FStar_Syntax_Syntax.name);
                 FStar_Syntax_Syntax.declarations =
                   (FStar_List.append modul.FStar_Syntax_Syntax.declarations
                      ses);
                 FStar_Syntax_Syntax.exports =
-                  (uu___1344_7688.FStar_Syntax_Syntax.exports);
+                  (uu___1344_7639.FStar_Syntax_Syntax.exports);
                 FStar_Syntax_Syntax.is_interface =
-                  (uu___1344_7688.FStar_Syntax_Syntax.is_interface)
+                  (uu___1344_7639.FStar_Syntax_Syntax.is_interface)
               }  in
             (modul1, exports, env1)
   
@@ -5151,12 +5129,12 @@ let rec (tc_modul :
     fun m  ->
       fun iface_exists  ->
         let msg =
-          let uu____7747 =
+          let uu____7698 =
             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-          Prims.op_Hat "Internals for " uu____7747  in
+          Prims.op_Hat "Internals for " uu____7698  in
         let env01 = push_context env0 msg  in
-        let uu____7751 = tc_partial_modul env01 m  in
-        match uu____7751 with
+        let uu____7702 = tc_partial_modul env01 m  in
+        match uu____7702 with
         | (modul,non_private_decls,env) ->
             finish_partial_modul false iface_exists env modul
               non_private_decls
@@ -5180,331 +5158,331 @@ and (finish_partial_modul :
                   && (FStar_Options.use_extracted_interfaces ()))
                  && (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface))
                 &&
-                (let uu____7788 = FStar_Errors.get_err_count ()  in
-                 uu____7788 = Prims.int_zero)
+                (let uu____7739 = FStar_Errors.get_err_count ()  in
+                 uu____7739 = Prims.int_zero)
                in
             if should_extract_interface
             then
               let modul_iface = extract_interface en m  in
-              ((let uu____7799 =
+              ((let uu____7750 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug en)
                     FStar_Options.Low
                    in
-                if uu____7799
+                if uu____7750
                 then
-                  let uu____7803 =
+                  let uu____7754 =
                     FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-                  let uu____7805 =
+                  let uu____7756 =
+                    let uu____7758 =
+                      let uu____7760 =
+                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                         in
+                      FStar_Options.should_verify uu____7760  in
+                    if uu____7758 then "" else " (in lax mode) "  in
+                  let uu____7768 =
+                    let uu____7770 =
+                      let uu____7772 =
+                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                         in
+                      FStar_Options.dump_module uu____7772  in
+                    if uu____7770
+                    then
+                      let uu____7776 =
+                        let uu____7778 = FStar_Syntax_Print.modul_to_string m
+                           in
+                        Prims.op_Hat uu____7778 "\n"  in
+                      Prims.op_Hat "\nfrom: " uu____7776
+                    else ""  in
+                  let uu____7785 =
+                    let uu____7787 =
+                      let uu____7789 =
+                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
+                         in
+                      FStar_Options.dump_module uu____7789  in
+                    if uu____7787
+                    then
+                      let uu____7793 =
+                        let uu____7795 =
+                          FStar_Syntax_Print.modul_to_string modul_iface  in
+                        Prims.op_Hat uu____7795 "\n"  in
+                      Prims.op_Hat "\nto: " uu____7793
+                    else ""  in
+                  FStar_Util.print4
+                    "Extracting and type checking module %s interface%s%s%s\n"
+                    uu____7754 uu____7756 uu____7768 uu____7785
+                else ());
+               (let en0 =
+                  let en0 =
                     let uu____7807 =
                       let uu____7809 =
                         FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
                          in
-                      FStar_Options.should_verify uu____7809  in
-                    if uu____7807 then "" else " (in lax mode) "  in
-                  let uu____7817 =
-                    let uu____7819 =
-                      let uu____7821 =
-                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
-                         in
-                      FStar_Options.dump_module uu____7821  in
-                    if uu____7819
-                    then
-                      let uu____7825 =
-                        let uu____7827 = FStar_Syntax_Print.modul_to_string m
-                           in
-                        Prims.op_Hat uu____7827 "\n"  in
-                      Prims.op_Hat "\nfrom: " uu____7825
-                    else ""  in
-                  let uu____7834 =
-                    let uu____7836 =
-                      let uu____7838 =
-                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
-                         in
-                      FStar_Options.dump_module uu____7838  in
-                    if uu____7836
-                    then
-                      let uu____7842 =
-                        let uu____7844 =
-                          FStar_Syntax_Print.modul_to_string modul_iface  in
-                        Prims.op_Hat uu____7844 "\n"  in
-                      Prims.op_Hat "\nto: " uu____7842
-                    else ""  in
-                  FStar_Util.print4
-                    "Extracting and type checking module %s interface%s%s%s\n"
-                    uu____7803 uu____7805 uu____7817 uu____7834
-                else ());
-               (let en0 =
-                  let en0 =
-                    let uu____7856 =
-                      let uu____7858 =
-                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name
-                         in
-                      Prims.op_Hat "Ending modul " uu____7858  in
-                    pop_context en uu____7856  in
+                      Prims.op_Hat "Ending modul " uu____7809  in
+                    pop_context en uu____7807  in
                   let en01 =
-                    let uu___1370_7862 = en0  in
+                    let uu___1370_7813 = en0  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___1370_7862.FStar_TypeChecker_Env.solver);
+                        (uu___1370_7813.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___1370_7862.FStar_TypeChecker_Env.range);
+                        (uu___1370_7813.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___1370_7862.FStar_TypeChecker_Env.curmodule);
+                        (uu___1370_7813.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___1370_7862.FStar_TypeChecker_Env.gamma);
+                        (uu___1370_7813.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___1370_7862.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___1370_7813.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___1370_7862.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___1370_7813.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___1370_7862.FStar_TypeChecker_Env.modules);
+                        (uu___1370_7813.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___1370_7862.FStar_TypeChecker_Env.expected_typ);
+                        (uu___1370_7813.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___1370_7862.FStar_TypeChecker_Env.sigtab);
+                        (uu___1370_7813.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___1370_7862.FStar_TypeChecker_Env.attrtab);
+                        (uu___1370_7813.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___1370_7862.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___1370_7813.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___1370_7862.FStar_TypeChecker_Env.effects);
+                        (uu___1370_7813.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___1370_7862.FStar_TypeChecker_Env.generalize);
+                        (uu___1370_7813.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___1370_7862.FStar_TypeChecker_Env.letrecs);
+                        (uu___1370_7813.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___1370_7862.FStar_TypeChecker_Env.top_level);
+                        (uu___1370_7813.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___1370_7862.FStar_TypeChecker_Env.check_uvars);
+                        (uu___1370_7813.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___1370_7862.FStar_TypeChecker_Env.use_eq);
+                        (uu___1370_7813.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.use_eq_strict =
-                        (uu___1370_7862.FStar_TypeChecker_Env.use_eq_strict);
+                        (uu___1370_7813.FStar_TypeChecker_Env.use_eq_strict);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___1370_7862.FStar_TypeChecker_Env.is_iface);
+                        (uu___1370_7813.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___1370_7862.FStar_TypeChecker_Env.admit);
+                        (uu___1370_7813.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___1370_7862.FStar_TypeChecker_Env.lax);
+                        (uu___1370_7813.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___1370_7862.FStar_TypeChecker_Env.lax_universes);
+                        (uu___1370_7813.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___1370_7862.FStar_TypeChecker_Env.phase1);
+                        (uu___1370_7813.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___1370_7862.FStar_TypeChecker_Env.failhard);
+                        (uu___1370_7813.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___1370_7862.FStar_TypeChecker_Env.nosynth);
+                        (uu___1370_7813.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___1370_7862.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___1370_7813.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___1370_7862.FStar_TypeChecker_Env.tc_term);
+                        (uu___1370_7813.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___1370_7862.FStar_TypeChecker_Env.type_of);
+                        (uu___1370_7813.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___1370_7862.FStar_TypeChecker_Env.universe_of);
+                        (uu___1370_7813.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___1370_7862.FStar_TypeChecker_Env.check_type_of);
+                        (uu___1370_7813.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___1370_7862.FStar_TypeChecker_Env.use_bv_sorts);
+                        (uu___1370_7813.FStar_TypeChecker_Env.use_bv_sorts);
                       FStar_TypeChecker_Env.qtbl_name_and_index =
-                        (uu___1370_7862.FStar_TypeChecker_Env.qtbl_name_and_index);
+                        (uu___1370_7813.FStar_TypeChecker_Env.qtbl_name_and_index);
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___1370_7862.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___1370_7813.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___1370_7862.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___1370_7813.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___1370_7862.FStar_TypeChecker_Env.proof_ns);
+                        (uu___1370_7813.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___1370_7862.FStar_TypeChecker_Env.synth_hook);
+                        (uu___1370_7813.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.try_solve_implicits_hook =
-                        (uu___1370_7862.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                        (uu___1370_7813.FStar_TypeChecker_Env.try_solve_implicits_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___1370_7862.FStar_TypeChecker_Env.splice);
+                        (uu___1370_7813.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.mpreprocess =
-                        (uu___1370_7862.FStar_TypeChecker_Env.mpreprocess);
+                        (uu___1370_7813.FStar_TypeChecker_Env.mpreprocess);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___1370_7862.FStar_TypeChecker_Env.postprocess);
+                        (uu___1370_7813.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___1370_7862.FStar_TypeChecker_Env.identifier_info);
+                        (uu___1370_7813.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___1370_7862.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___1370_7813.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
                         (en.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___1370_7862.FStar_TypeChecker_Env.nbe);
+                        (uu___1370_7813.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___1370_7862.FStar_TypeChecker_Env.strict_args_tab);
+                        (uu___1370_7813.FStar_TypeChecker_Env.strict_args_tab);
                       FStar_TypeChecker_Env.erasable_types_tab =
-                        (uu___1370_7862.FStar_TypeChecker_Env.erasable_types_tab)
+                        (uu___1370_7813.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
                   let en02 =
-                    let uu___1373_7864 = en01  in
-                    let uu____7865 =
-                      let uu____7880 =
+                    let uu___1373_7815 = en01  in
+                    let uu____7816 =
+                      let uu____7831 =
                         FStar_All.pipe_right
                           en.FStar_TypeChecker_Env.qtbl_name_and_index
                           FStar_Pervasives_Native.fst
                          in
-                      (uu____7880, FStar_Pervasives_Native.None)  in
+                      (uu____7831, FStar_Pervasives_Native.None)  in
                     {
                       FStar_TypeChecker_Env.solver =
-                        (uu___1373_7864.FStar_TypeChecker_Env.solver);
+                        (uu___1373_7815.FStar_TypeChecker_Env.solver);
                       FStar_TypeChecker_Env.range =
-                        (uu___1373_7864.FStar_TypeChecker_Env.range);
+                        (uu___1373_7815.FStar_TypeChecker_Env.range);
                       FStar_TypeChecker_Env.curmodule =
-                        (uu___1373_7864.FStar_TypeChecker_Env.curmodule);
+                        (uu___1373_7815.FStar_TypeChecker_Env.curmodule);
                       FStar_TypeChecker_Env.gamma =
-                        (uu___1373_7864.FStar_TypeChecker_Env.gamma);
+                        (uu___1373_7815.FStar_TypeChecker_Env.gamma);
                       FStar_TypeChecker_Env.gamma_sig =
-                        (uu___1373_7864.FStar_TypeChecker_Env.gamma_sig);
+                        (uu___1373_7815.FStar_TypeChecker_Env.gamma_sig);
                       FStar_TypeChecker_Env.gamma_cache =
-                        (uu___1373_7864.FStar_TypeChecker_Env.gamma_cache);
+                        (uu___1373_7815.FStar_TypeChecker_Env.gamma_cache);
                       FStar_TypeChecker_Env.modules =
-                        (uu___1373_7864.FStar_TypeChecker_Env.modules);
+                        (uu___1373_7815.FStar_TypeChecker_Env.modules);
                       FStar_TypeChecker_Env.expected_typ =
-                        (uu___1373_7864.FStar_TypeChecker_Env.expected_typ);
+                        (uu___1373_7815.FStar_TypeChecker_Env.expected_typ);
                       FStar_TypeChecker_Env.sigtab =
-                        (uu___1373_7864.FStar_TypeChecker_Env.sigtab);
+                        (uu___1373_7815.FStar_TypeChecker_Env.sigtab);
                       FStar_TypeChecker_Env.attrtab =
-                        (uu___1373_7864.FStar_TypeChecker_Env.attrtab);
+                        (uu___1373_7815.FStar_TypeChecker_Env.attrtab);
                       FStar_TypeChecker_Env.instantiate_imp =
-                        (uu___1373_7864.FStar_TypeChecker_Env.instantiate_imp);
+                        (uu___1373_7815.FStar_TypeChecker_Env.instantiate_imp);
                       FStar_TypeChecker_Env.effects =
-                        (uu___1373_7864.FStar_TypeChecker_Env.effects);
+                        (uu___1373_7815.FStar_TypeChecker_Env.effects);
                       FStar_TypeChecker_Env.generalize =
-                        (uu___1373_7864.FStar_TypeChecker_Env.generalize);
+                        (uu___1373_7815.FStar_TypeChecker_Env.generalize);
                       FStar_TypeChecker_Env.letrecs =
-                        (uu___1373_7864.FStar_TypeChecker_Env.letrecs);
+                        (uu___1373_7815.FStar_TypeChecker_Env.letrecs);
                       FStar_TypeChecker_Env.top_level =
-                        (uu___1373_7864.FStar_TypeChecker_Env.top_level);
+                        (uu___1373_7815.FStar_TypeChecker_Env.top_level);
                       FStar_TypeChecker_Env.check_uvars =
-                        (uu___1373_7864.FStar_TypeChecker_Env.check_uvars);
+                        (uu___1373_7815.FStar_TypeChecker_Env.check_uvars);
                       FStar_TypeChecker_Env.use_eq =
-                        (uu___1373_7864.FStar_TypeChecker_Env.use_eq);
+                        (uu___1373_7815.FStar_TypeChecker_Env.use_eq);
                       FStar_TypeChecker_Env.use_eq_strict =
-                        (uu___1373_7864.FStar_TypeChecker_Env.use_eq_strict);
+                        (uu___1373_7815.FStar_TypeChecker_Env.use_eq_strict);
                       FStar_TypeChecker_Env.is_iface =
-                        (uu___1373_7864.FStar_TypeChecker_Env.is_iface);
+                        (uu___1373_7815.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
-                        (uu___1373_7864.FStar_TypeChecker_Env.admit);
+                        (uu___1373_7815.FStar_TypeChecker_Env.admit);
                       FStar_TypeChecker_Env.lax =
-                        (uu___1373_7864.FStar_TypeChecker_Env.lax);
+                        (uu___1373_7815.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
-                        (uu___1373_7864.FStar_TypeChecker_Env.lax_universes);
+                        (uu___1373_7815.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
-                        (uu___1373_7864.FStar_TypeChecker_Env.phase1);
+                        (uu___1373_7815.FStar_TypeChecker_Env.phase1);
                       FStar_TypeChecker_Env.failhard =
-                        (uu___1373_7864.FStar_TypeChecker_Env.failhard);
+                        (uu___1373_7815.FStar_TypeChecker_Env.failhard);
                       FStar_TypeChecker_Env.nosynth =
-                        (uu___1373_7864.FStar_TypeChecker_Env.nosynth);
+                        (uu___1373_7815.FStar_TypeChecker_Env.nosynth);
                       FStar_TypeChecker_Env.uvar_subtyping =
-                        (uu___1373_7864.FStar_TypeChecker_Env.uvar_subtyping);
+                        (uu___1373_7815.FStar_TypeChecker_Env.uvar_subtyping);
                       FStar_TypeChecker_Env.tc_term =
-                        (uu___1373_7864.FStar_TypeChecker_Env.tc_term);
+                        (uu___1373_7815.FStar_TypeChecker_Env.tc_term);
                       FStar_TypeChecker_Env.type_of =
-                        (uu___1373_7864.FStar_TypeChecker_Env.type_of);
+                        (uu___1373_7815.FStar_TypeChecker_Env.type_of);
                       FStar_TypeChecker_Env.universe_of =
-                        (uu___1373_7864.FStar_TypeChecker_Env.universe_of);
+                        (uu___1373_7815.FStar_TypeChecker_Env.universe_of);
                       FStar_TypeChecker_Env.check_type_of =
-                        (uu___1373_7864.FStar_TypeChecker_Env.check_type_of);
+                        (uu___1373_7815.FStar_TypeChecker_Env.check_type_of);
                       FStar_TypeChecker_Env.use_bv_sorts =
-                        (uu___1373_7864.FStar_TypeChecker_Env.use_bv_sorts);
-                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____7865;
+                        (uu___1373_7815.FStar_TypeChecker_Env.use_bv_sorts);
+                      FStar_TypeChecker_Env.qtbl_name_and_index = uu____7816;
                       FStar_TypeChecker_Env.normalized_eff_names =
-                        (uu___1373_7864.FStar_TypeChecker_Env.normalized_eff_names);
+                        (uu___1373_7815.FStar_TypeChecker_Env.normalized_eff_names);
                       FStar_TypeChecker_Env.fv_delta_depths =
-                        (uu___1373_7864.FStar_TypeChecker_Env.fv_delta_depths);
+                        (uu___1373_7815.FStar_TypeChecker_Env.fv_delta_depths);
                       FStar_TypeChecker_Env.proof_ns =
-                        (uu___1373_7864.FStar_TypeChecker_Env.proof_ns);
+                        (uu___1373_7815.FStar_TypeChecker_Env.proof_ns);
                       FStar_TypeChecker_Env.synth_hook =
-                        (uu___1373_7864.FStar_TypeChecker_Env.synth_hook);
+                        (uu___1373_7815.FStar_TypeChecker_Env.synth_hook);
                       FStar_TypeChecker_Env.try_solve_implicits_hook =
-                        (uu___1373_7864.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                        (uu___1373_7815.FStar_TypeChecker_Env.try_solve_implicits_hook);
                       FStar_TypeChecker_Env.splice =
-                        (uu___1373_7864.FStar_TypeChecker_Env.splice);
+                        (uu___1373_7815.FStar_TypeChecker_Env.splice);
                       FStar_TypeChecker_Env.mpreprocess =
-                        (uu___1373_7864.FStar_TypeChecker_Env.mpreprocess);
+                        (uu___1373_7815.FStar_TypeChecker_Env.mpreprocess);
                       FStar_TypeChecker_Env.postprocess =
-                        (uu___1373_7864.FStar_TypeChecker_Env.postprocess);
+                        (uu___1373_7815.FStar_TypeChecker_Env.postprocess);
                       FStar_TypeChecker_Env.identifier_info =
-                        (uu___1373_7864.FStar_TypeChecker_Env.identifier_info);
+                        (uu___1373_7815.FStar_TypeChecker_Env.identifier_info);
                       FStar_TypeChecker_Env.tc_hooks =
-                        (uu___1373_7864.FStar_TypeChecker_Env.tc_hooks);
+                        (uu___1373_7815.FStar_TypeChecker_Env.tc_hooks);
                       FStar_TypeChecker_Env.dsenv =
-                        (uu___1373_7864.FStar_TypeChecker_Env.dsenv);
+                        (uu___1373_7815.FStar_TypeChecker_Env.dsenv);
                       FStar_TypeChecker_Env.nbe =
-                        (uu___1373_7864.FStar_TypeChecker_Env.nbe);
+                        (uu___1373_7815.FStar_TypeChecker_Env.nbe);
                       FStar_TypeChecker_Env.strict_args_tab =
-                        (uu___1373_7864.FStar_TypeChecker_Env.strict_args_tab);
+                        (uu___1373_7815.FStar_TypeChecker_Env.strict_args_tab);
                       FStar_TypeChecker_Env.erasable_types_tab =
-                        (uu___1373_7864.FStar_TypeChecker_Env.erasable_types_tab)
+                        (uu___1373_7815.FStar_TypeChecker_Env.erasable_types_tab)
                     }  in
-                  let uu____7926 =
-                    let uu____7928 = FStar_Options.interactive ()  in
-                    Prims.op_Negation uu____7928  in
-                  if uu____7926
+                  let uu____7877 =
+                    let uu____7879 = FStar_Options.interactive ()  in
+                    Prims.op_Negation uu____7879  in
+                  if uu____7877
                   then
-                    ((let uu____7932 =
+                    ((let uu____7883 =
                         FStar_Options.restore_cmd_line_options true  in
-                      FStar_All.pipe_right uu____7932 (fun uu____7934  -> ()));
+                      FStar_All.pipe_right uu____7883 (fun uu____7885  -> ()));
                      en02)
                   else en02  in
-                let uu____7937 = tc_modul en0 modul_iface true  in
-                match uu____7937 with
+                let uu____7888 = tc_modul en0 modul_iface true  in
+                match uu____7888 with
                 | (modul_iface1,env) ->
-                    ((let uu___1382_7950 = m  in
+                    ((let uu___1382_7901 = m  in
                       {
                         FStar_Syntax_Syntax.name =
-                          (uu___1382_7950.FStar_Syntax_Syntax.name);
+                          (uu___1382_7901.FStar_Syntax_Syntax.name);
                         FStar_Syntax_Syntax.declarations =
-                          (uu___1382_7950.FStar_Syntax_Syntax.declarations);
+                          (uu___1382_7901.FStar_Syntax_Syntax.declarations);
                         FStar_Syntax_Syntax.exports =
                           (modul_iface1.FStar_Syntax_Syntax.exports);
                         FStar_Syntax_Syntax.is_interface =
-                          (uu___1382_7950.FStar_Syntax_Syntax.is_interface)
+                          (uu___1382_7901.FStar_Syntax_Syntax.is_interface)
                       }), env)))
             else
               (let modul =
-                 let uu___1384_7954 = m  in
+                 let uu___1384_7905 = m  in
                  {
                    FStar_Syntax_Syntax.name =
-                     (uu___1384_7954.FStar_Syntax_Syntax.name);
+                     (uu___1384_7905.FStar_Syntax_Syntax.name);
                    FStar_Syntax_Syntax.declarations =
-                     (uu___1384_7954.FStar_Syntax_Syntax.declarations);
+                     (uu___1384_7905.FStar_Syntax_Syntax.declarations);
                    FStar_Syntax_Syntax.exports = exports;
                    FStar_Syntax_Syntax.is_interface =
-                     (uu___1384_7954.FStar_Syntax_Syntax.is_interface)
+                     (uu___1384_7905.FStar_Syntax_Syntax.is_interface)
                  }  in
                let env = FStar_TypeChecker_Env.finish_module en modul  in
-               (let uu____7957 =
+               (let uu____7908 =
                   FStar_All.pipe_right
                     env.FStar_TypeChecker_Env.qtbl_name_and_index
                     FStar_Pervasives_Native.fst
                    in
-                FStar_All.pipe_right uu____7957 FStar_Util.smap_clear);
-               (let uu____7993 =
-                  ((let uu____7997 = FStar_Options.lax ()  in
-                    Prims.op_Negation uu____7997) &&
+                FStar_All.pipe_right uu____7908 FStar_Util.smap_clear);
+               (let uu____7944 =
+                  ((let uu____7948 = FStar_Options.lax ()  in
+                    Prims.op_Negation uu____7948) &&
                      (Prims.op_Negation loading_from_cache))
                     &&
-                    (let uu____8000 =
+                    (let uu____7951 =
                        FStar_Options.use_extracted_interfaces ()  in
-                     Prims.op_Negation uu____8000)
+                     Prims.op_Negation uu____7951)
                    in
-                if uu____7993
+                if uu____7944
                 then
                   FStar_Syntax_Unionfind.with_uf_enabled
-                    (fun uu____8004  -> check_exports env modul exports)
+                    (fun uu____7955  -> check_exports env modul exports)
                 else ());
-               (let uu____8008 =
-                  let uu____8009 =
-                    let uu____8011 =
+               (let uu____7959 =
+                  let uu____7960 =
+                    let uu____7962 =
                       FStar_Ident.string_of_lid
                         modul.FStar_Syntax_Syntax.name
                        in
-                    Prims.op_Hat "Ending modul " uu____8011  in
-                  pop_context env uu____8009  in
-                FStar_All.pipe_right uu____8008 (fun uu____8014  -> ()));
+                    Prims.op_Hat "Ending modul " uu____7962  in
+                  pop_context env uu____7960  in
+                FStar_All.pipe_right uu____7959 (fun uu____7965  -> ()));
                (modul, env))
 
 let (load_checked_module :
@@ -5518,11 +5496,11 @@ let (load_checked_module :
           m.FStar_Syntax_Syntax.name
          in
       let env1 =
-        let uu____8028 =
-          let uu____8030 =
+        let uu____7979 =
+          let uu____7981 =
             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-          Prims.op_Hat "Internals for " uu____8030  in
-        push_context env uu____8028  in
+          Prims.op_Hat "Internals for " uu____7981  in
+        push_context env uu____7979  in
       let env2 =
         FStar_List.fold_left
           (fun env2  ->
@@ -5532,15 +5510,15 @@ let (load_checked_module :
                FStar_All.pipe_right lids
                  (FStar_List.iter
                     (fun lid  ->
-                       let uu____8052 =
+                       let uu____8003 =
                          FStar_TypeChecker_Env.lookup_sigelt env3 lid  in
                        ()));
                env3) env1 m.FStar_Syntax_Syntax.declarations
          in
-      let uu____8055 =
+      let uu____8006 =
         finish_partial_modul true true env2 m m.FStar_Syntax_Syntax.exports
          in
-      match uu____8055 with | (uu____8062,env3) -> env3
+      match uu____8006 with | (uu____8013,env3) -> env3
   
 let (check_module :
   FStar_TypeChecker_Env.env ->
@@ -5550,150 +5528,150 @@ let (check_module :
   fun env  ->
     fun m  ->
       fun b  ->
-        (let uu____8087 = FStar_Options.debug_any ()  in
-         if uu____8087
+        (let uu____8038 = FStar_Options.debug_any ()  in
+         if uu____8038
          then
-           let uu____8090 =
+           let uu____8041 =
              FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name  in
            FStar_Util.print2 "Checking %s: %s\n"
              (if m.FStar_Syntax_Syntax.is_interface
               then "i'face"
-              else "module") uu____8090
+              else "module") uu____8041
          else ());
-        (let uu____8102 =
-           let uu____8104 =
+        (let uu____8053 =
+           let uu____8055 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-           FStar_Options.dump_module uu____8104  in
-         if uu____8102
+           FStar_Options.dump_module uu____8055  in
+         if uu____8053
          then
-           let uu____8107 = FStar_Syntax_Print.modul_to_string m  in
-           FStar_Util.print1 "Module before type checking:\n%s\n" uu____8107
+           let uu____8058 = FStar_Syntax_Print.modul_to_string m  in
+           FStar_Util.print1 "Module before type checking:\n%s\n" uu____8058
          else ());
         (let env1 =
-           let uu___1415_8113 = env  in
-           let uu____8114 =
-             let uu____8116 =
-               let uu____8118 =
+           let uu___1415_8064 = env  in
+           let uu____8065 =
+             let uu____8067 =
+               let uu____8069 =
                  FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name  in
-               FStar_Options.should_verify uu____8118  in
-             Prims.op_Negation uu____8116  in
+               FStar_Options.should_verify uu____8069  in
+             Prims.op_Negation uu____8067  in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___1415_8113.FStar_TypeChecker_Env.solver);
+               (uu___1415_8064.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___1415_8113.FStar_TypeChecker_Env.range);
+               (uu___1415_8064.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___1415_8113.FStar_TypeChecker_Env.curmodule);
+               (uu___1415_8064.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___1415_8113.FStar_TypeChecker_Env.gamma);
+               (uu___1415_8064.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___1415_8113.FStar_TypeChecker_Env.gamma_sig);
+               (uu___1415_8064.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___1415_8113.FStar_TypeChecker_Env.gamma_cache);
+               (uu___1415_8064.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___1415_8113.FStar_TypeChecker_Env.modules);
+               (uu___1415_8064.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___1415_8113.FStar_TypeChecker_Env.expected_typ);
+               (uu___1415_8064.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___1415_8113.FStar_TypeChecker_Env.sigtab);
+               (uu___1415_8064.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___1415_8113.FStar_TypeChecker_Env.attrtab);
+               (uu___1415_8064.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___1415_8113.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___1415_8064.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___1415_8113.FStar_TypeChecker_Env.effects);
+               (uu___1415_8064.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___1415_8113.FStar_TypeChecker_Env.generalize);
+               (uu___1415_8064.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___1415_8113.FStar_TypeChecker_Env.letrecs);
+               (uu___1415_8064.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___1415_8113.FStar_TypeChecker_Env.top_level);
+               (uu___1415_8064.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___1415_8113.FStar_TypeChecker_Env.check_uvars);
+               (uu___1415_8064.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___1415_8113.FStar_TypeChecker_Env.use_eq);
+               (uu___1415_8064.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.use_eq_strict =
-               (uu___1415_8113.FStar_TypeChecker_Env.use_eq_strict);
+               (uu___1415_8064.FStar_TypeChecker_Env.use_eq_strict);
              FStar_TypeChecker_Env.is_iface =
-               (uu___1415_8113.FStar_TypeChecker_Env.is_iface);
+               (uu___1415_8064.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___1415_8113.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = uu____8114;
+               (uu___1415_8064.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = uu____8065;
              FStar_TypeChecker_Env.lax_universes =
-               (uu___1415_8113.FStar_TypeChecker_Env.lax_universes);
+               (uu___1415_8064.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___1415_8113.FStar_TypeChecker_Env.phase1);
+               (uu___1415_8064.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___1415_8113.FStar_TypeChecker_Env.failhard);
+               (uu___1415_8064.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___1415_8113.FStar_TypeChecker_Env.nosynth);
+               (uu___1415_8064.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___1415_8113.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___1415_8064.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___1415_8113.FStar_TypeChecker_Env.tc_term);
+               (uu___1415_8064.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___1415_8113.FStar_TypeChecker_Env.type_of);
+               (uu___1415_8064.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___1415_8113.FStar_TypeChecker_Env.universe_of);
+               (uu___1415_8064.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___1415_8113.FStar_TypeChecker_Env.check_type_of);
+               (uu___1415_8064.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___1415_8113.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___1415_8064.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___1415_8113.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___1415_8064.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___1415_8113.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___1415_8064.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___1415_8113.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___1415_8064.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___1415_8113.FStar_TypeChecker_Env.proof_ns);
+               (uu___1415_8064.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___1415_8113.FStar_TypeChecker_Env.synth_hook);
+               (uu___1415_8064.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (uu___1415_8113.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (uu___1415_8064.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___1415_8113.FStar_TypeChecker_Env.splice);
+               (uu___1415_8064.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (uu___1415_8113.FStar_TypeChecker_Env.mpreprocess);
+               (uu___1415_8064.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (uu___1415_8113.FStar_TypeChecker_Env.postprocess);
+               (uu___1415_8064.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___1415_8113.FStar_TypeChecker_Env.identifier_info);
+               (uu___1415_8064.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___1415_8113.FStar_TypeChecker_Env.tc_hooks);
+               (uu___1415_8064.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___1415_8113.FStar_TypeChecker_Env.dsenv);
+               (uu___1415_8064.FStar_TypeChecker_Env.dsenv);
              FStar_TypeChecker_Env.nbe =
-               (uu___1415_8113.FStar_TypeChecker_Env.nbe);
+               (uu___1415_8064.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___1415_8113.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___1415_8064.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___1415_8113.FStar_TypeChecker_Env.erasable_types_tab)
+               (uu___1415_8064.FStar_TypeChecker_Env.erasable_types_tab)
            }  in
-         let uu____8120 = tc_modul env1 m b  in
-         match uu____8120 with
+         let uu____8071 = tc_modul env1 m b  in
+         match uu____8071 with
          | (m1,env2) ->
-             ((let uu____8132 =
-                 let uu____8134 =
+             ((let uu____8083 =
+                 let uu____8085 =
                    FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name  in
-                 FStar_Options.dump_module uu____8134  in
-               if uu____8132
+                 FStar_Options.dump_module uu____8085  in
+               if uu____8083
                then
-                 let uu____8137 = FStar_Syntax_Print.modul_to_string m1  in
+                 let uu____8088 = FStar_Syntax_Print.modul_to_string m1  in
                  FStar_Util.print1 "Module after type checking:\n%s\n"
-                   uu____8137
+                   uu____8088
                else ());
-              (let uu____8143 =
-                 (let uu____8147 =
+              (let uu____8094 =
+                 (let uu____8098 =
                     FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name  in
-                  FStar_Options.dump_module uu____8147) &&
-                   (let uu____8150 =
+                  FStar_Options.dump_module uu____8098) &&
+                   (let uu____8101 =
                       FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name
                        in
-                    FStar_Options.debug_at_level uu____8150
+                    FStar_Options.debug_at_level uu____8101
                       (FStar_Options.Other "Normalize"))
                   in
-               if uu____8143
+               if uu____8094
                then
                  let normalize_toplevel_lets se =
                    match se.FStar_Syntax_Syntax.sigel with
@@ -5710,76 +5688,76 @@ let (check_module :
                            FStar_TypeChecker_Env.AllowUnboundUniverses]
                           in
                        let update lb =
-                         let uu____8188 =
+                         let uu____8139 =
                            FStar_Syntax_Subst.open_univ_vars
                              lb.FStar_Syntax_Syntax.lbunivs
                              lb.FStar_Syntax_Syntax.lbdef
                             in
-                         match uu____8188 with
+                         match uu____8139 with
                          | (univnames,e) ->
-                             let uu___1437_8195 = lb  in
-                             let uu____8196 =
-                               let uu____8199 =
+                             let uu___1437_8146 = lb  in
+                             let uu____8147 =
+                               let uu____8150 =
                                  FStar_TypeChecker_Env.push_univ_vars env2
                                    univnames
                                   in
-                               n uu____8199 e  in
+                               n uu____8150 e  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1437_8195.FStar_Syntax_Syntax.lbname);
+                                 (uu___1437_8146.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1437_8195.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___1437_8146.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___1437_8195.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___1437_8146.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1437_8195.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____8196;
+                                 (uu___1437_8146.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____8147;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1437_8195.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___1437_8146.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1437_8195.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1437_8146.FStar_Syntax_Syntax.lbpos)
                              }
                           in
-                       let uu___1439_8200 = se  in
-                       let uu____8201 =
-                         let uu____8202 =
-                           let uu____8209 =
-                             let uu____8210 = FStar_List.map update lbs  in
-                             (b1, uu____8210)  in
-                           (uu____8209, ids)  in
-                         FStar_Syntax_Syntax.Sig_let uu____8202  in
+                       let uu___1439_8151 = se  in
+                       let uu____8152 =
+                         let uu____8153 =
+                           let uu____8160 =
+                             let uu____8161 = FStar_List.map update lbs  in
+                             (b1, uu____8161)  in
+                           (uu____8160, ids)  in
+                         FStar_Syntax_Syntax.Sig_let uu____8153  in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____8201;
+                         FStar_Syntax_Syntax.sigel = uu____8152;
                          FStar_Syntax_Syntax.sigrng =
-                           (uu___1439_8200.FStar_Syntax_Syntax.sigrng);
+                           (uu___1439_8151.FStar_Syntax_Syntax.sigrng);
                          FStar_Syntax_Syntax.sigquals =
-                           (uu___1439_8200.FStar_Syntax_Syntax.sigquals);
+                           (uu___1439_8151.FStar_Syntax_Syntax.sigquals);
                          FStar_Syntax_Syntax.sigmeta =
-                           (uu___1439_8200.FStar_Syntax_Syntax.sigmeta);
+                           (uu___1439_8151.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
-                           (uu___1439_8200.FStar_Syntax_Syntax.sigattrs);
+                           (uu___1439_8151.FStar_Syntax_Syntax.sigattrs);
                          FStar_Syntax_Syntax.sigopts =
-                           (uu___1439_8200.FStar_Syntax_Syntax.sigopts)
+                           (uu___1439_8151.FStar_Syntax_Syntax.sigopts)
                        }
-                   | uu____8218 -> se  in
+                   | uu____8169 -> se  in
                  let normalized_module =
-                   let uu___1443_8220 = m1  in
-                   let uu____8221 =
+                   let uu___1443_8171 = m1  in
+                   let uu____8172 =
                      FStar_List.map normalize_toplevel_lets
                        m1.FStar_Syntax_Syntax.declarations
                       in
                    {
                      FStar_Syntax_Syntax.name =
-                       (uu___1443_8220.FStar_Syntax_Syntax.name);
-                     FStar_Syntax_Syntax.declarations = uu____8221;
+                       (uu___1443_8171.FStar_Syntax_Syntax.name);
+                     FStar_Syntax_Syntax.declarations = uu____8172;
                      FStar_Syntax_Syntax.exports =
-                       (uu___1443_8220.FStar_Syntax_Syntax.exports);
+                       (uu___1443_8171.FStar_Syntax_Syntax.exports);
                      FStar_Syntax_Syntax.is_interface =
-                       (uu___1443_8220.FStar_Syntax_Syntax.is_interface)
+                       (uu___1443_8171.FStar_Syntax_Syntax.is_interface)
                    }  in
-                 let uu____8222 =
+                 let uu____8173 =
                    FStar_Syntax_Print.modul_to_string normalized_module  in
-                 FStar_Util.print1 "%s\n" uu____8222
+                 FStar_Util.print1 "%s\n" uu____8173
                else ());
               (m1, env2)))
   

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -139,18 +139,16 @@ let (pure_wp_uvar :
             match uu____234 with
             | (uu____239,pure_wp_t) ->
                 let uu____241 =
-                  let uu____246 =
-                    let uu____247 =
-                      FStar_All.pipe_right t FStar_Syntax_Syntax.as_arg  in
-                    [uu____247]  in
-                  FStar_Syntax_Syntax.mk_Tm_app pure_wp_t uu____246  in
-                uu____241 FStar_Pervasives_Native.None r
+                  let uu____242 =
+                    FStar_All.pipe_right t FStar_Syntax_Syntax.as_arg  in
+                  [uu____242]  in
+                FStar_Syntax_Syntax.mk_Tm_app pure_wp_t uu____241 r
              in
-          let uu____280 =
+          let uu____275 =
             FStar_TypeChecker_Util.new_implicit_var reason r env pure_wp_t
              in
-          match uu____280 with
-          | (pure_wp_uvar,uu____298,guard_wp) -> (pure_wp_uvar, guard_wp)
+          match uu____275 with
+          | (pure_wp_uvar,uu____293,guard_wp) -> (pure_wp_uvar, guard_wp)
   
 let (check_no_subtyping_for_layered_combinator :
   FStar_TypeChecker_Env.env ->
@@ -160,14 +158,14 @@ let (check_no_subtyping_for_layered_combinator :
   fun env  ->
     fun t  ->
       fun k  ->
-        (let uu____333 =
+        (let uu____328 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "LayeredEffects")
             in
-         if uu____333
+         if uu____328
          then
-           let uu____338 = FStar_Syntax_Print.term_to_string t  in
-           let uu____340 =
+           let uu____333 = FStar_Syntax_Print.term_to_string t  in
+           let uu____335 =
              match k with
              | FStar_Pervasives_Native.None  -> "None"
              | FStar_Pervasives_Native.Some k1 ->
@@ -175,110 +173,110 @@ let (check_no_subtyping_for_layered_combinator :
               in
            FStar_Util.print2
              "Checking that %s is well typed with no subtyping (k:%s)\n"
-             uu____338 uu____340
+             uu____333 uu____335
          else ());
         (let env1 =
-           let uu___54_349 = env  in
+           let uu___54_344 = env  in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___54_349.FStar_TypeChecker_Env.solver);
+               (uu___54_344.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___54_349.FStar_TypeChecker_Env.range);
+               (uu___54_344.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___54_349.FStar_TypeChecker_Env.curmodule);
+               (uu___54_344.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___54_349.FStar_TypeChecker_Env.gamma);
+               (uu___54_344.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___54_349.FStar_TypeChecker_Env.gamma_sig);
+               (uu___54_344.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___54_349.FStar_TypeChecker_Env.gamma_cache);
+               (uu___54_344.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___54_349.FStar_TypeChecker_Env.modules);
+               (uu___54_344.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___54_349.FStar_TypeChecker_Env.expected_typ);
+               (uu___54_344.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___54_349.FStar_TypeChecker_Env.sigtab);
+               (uu___54_344.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___54_349.FStar_TypeChecker_Env.attrtab);
+               (uu___54_344.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___54_349.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___54_344.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___54_349.FStar_TypeChecker_Env.effects);
+               (uu___54_344.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___54_349.FStar_TypeChecker_Env.generalize);
+               (uu___54_344.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___54_349.FStar_TypeChecker_Env.letrecs);
+               (uu___54_344.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___54_349.FStar_TypeChecker_Env.top_level);
+               (uu___54_344.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___54_349.FStar_TypeChecker_Env.check_uvars);
+               (uu___54_344.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___54_349.FStar_TypeChecker_Env.use_eq);
+               (uu___54_344.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.use_eq_strict = true;
              FStar_TypeChecker_Env.is_iface =
-               (uu___54_349.FStar_TypeChecker_Env.is_iface);
+               (uu___54_344.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___54_349.FStar_TypeChecker_Env.admit);
+               (uu___54_344.FStar_TypeChecker_Env.admit);
              FStar_TypeChecker_Env.lax =
-               (uu___54_349.FStar_TypeChecker_Env.lax);
+               (uu___54_344.FStar_TypeChecker_Env.lax);
              FStar_TypeChecker_Env.lax_universes =
-               (uu___54_349.FStar_TypeChecker_Env.lax_universes);
+               (uu___54_344.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___54_349.FStar_TypeChecker_Env.phase1);
+               (uu___54_344.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___54_349.FStar_TypeChecker_Env.failhard);
+               (uu___54_344.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___54_349.FStar_TypeChecker_Env.nosynth);
+               (uu___54_344.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___54_349.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___54_344.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___54_349.FStar_TypeChecker_Env.tc_term);
+               (uu___54_344.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___54_349.FStar_TypeChecker_Env.type_of);
+               (uu___54_344.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___54_349.FStar_TypeChecker_Env.universe_of);
+               (uu___54_344.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___54_349.FStar_TypeChecker_Env.check_type_of);
+               (uu___54_344.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___54_349.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___54_344.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___54_349.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___54_344.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___54_349.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___54_344.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___54_349.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___54_344.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___54_349.FStar_TypeChecker_Env.proof_ns);
+               (uu___54_344.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___54_349.FStar_TypeChecker_Env.synth_hook);
+               (uu___54_344.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (uu___54_349.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (uu___54_344.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___54_349.FStar_TypeChecker_Env.splice);
+               (uu___54_344.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (uu___54_349.FStar_TypeChecker_Env.mpreprocess);
+               (uu___54_344.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (uu___54_349.FStar_TypeChecker_Env.postprocess);
+               (uu___54_344.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___54_349.FStar_TypeChecker_Env.identifier_info);
+               (uu___54_344.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___54_349.FStar_TypeChecker_Env.tc_hooks);
+               (uu___54_344.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___54_349.FStar_TypeChecker_Env.dsenv);
+               (uu___54_344.FStar_TypeChecker_Env.dsenv);
              FStar_TypeChecker_Env.nbe =
-               (uu___54_349.FStar_TypeChecker_Env.nbe);
+               (uu___54_344.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___54_349.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___54_344.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___54_349.FStar_TypeChecker_Env.erasable_types_tab)
+               (uu___54_344.FStar_TypeChecker_Env.erasable_types_tab)
            }  in
          match k with
          | FStar_Pervasives_Native.None  ->
-             let uu____351 = FStar_TypeChecker_TcTerm.tc_trivial_guard env1 t
+             let uu____346 = FStar_TypeChecker_TcTerm.tc_trivial_guard env1 t
                 in
              ()
          | FStar_Pervasives_Native.Some k1 ->
-             let uu____357 =
+             let uu____352 =
                FStar_TypeChecker_TcTerm.tc_check_trivial_guard env1 t k1  in
              ())
   
@@ -291,15 +289,15 @@ let (tc_layered_eff_decl :
   fun env0  ->
     fun ed  ->
       fun quals  ->
-        (let uu____379 =
+        (let uu____374 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
              (FStar_Options.Other "LayeredEffects")
             in
-         if uu____379
+         if uu____374
          then
-           let uu____384 = FStar_Syntax_Print.eff_decl_to_string false ed  in
+           let uu____379 = FStar_Syntax_Print.eff_decl_to_string false ed  in
            FStar_Util.print1 "Typechecking layered effect: \n\t%s\n"
-             uu____384
+             uu____379
          else ());
         if
           ((FStar_List.length ed.FStar_Syntax_Syntax.univs) <> Prims.int_zero)
@@ -307,132 +305,132 @@ let (tc_layered_eff_decl :
             ((FStar_List.length ed.FStar_Syntax_Syntax.binders) <>
                Prims.int_zero)
         then
-          (let uu____402 =
-             let uu____408 =
-               let uu____410 =
-                 let uu____412 =
+          (let uu____397 =
+             let uu____403 =
+               let uu____405 =
+                 let uu____407 =
                    FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname  in
-                 Prims.op_Hat uu____412 ")"  in
+                 Prims.op_Hat uu____407 ")"  in
                Prims.op_Hat "Binders are not supported for layered effects ("
-                 uu____410
+                 uu____405
                 in
-             (FStar_Errors.Fatal_UnexpectedEffect, uu____408)  in
-           let uu____417 =
+             (FStar_Errors.Fatal_UnexpectedEffect, uu____403)  in
+           let uu____412 =
              FStar_Ident.range_of_lid ed.FStar_Syntax_Syntax.mname  in
-           FStar_Errors.raise_error uu____402 uu____417)
+           FStar_Errors.raise_error uu____397 uu____412)
         else ();
-        (let log_combinator s uu____443 =
-           match uu____443 with
+        (let log_combinator s uu____438 =
+           match uu____438 with
            | (us,t,ty) ->
-               let uu____472 =
+               let uu____467 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                    (FStar_Options.Other "LayeredEffects")
                   in
-               if uu____472
+               if uu____467
                then
-                 let uu____477 =
+                 let uu____472 =
                    FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname  in
-                 let uu____479 = FStar_Syntax_Print.tscheme_to_string (us, t)
+                 let uu____474 = FStar_Syntax_Print.tscheme_to_string (us, t)
                     in
-                 let uu____485 =
+                 let uu____480 =
                    FStar_Syntax_Print.tscheme_to_string (us, ty)  in
-                 FStar_Util.print4 "Typechecked %s:%s = %s:%s\n" uu____477 s
-                   uu____479 uu____485
+                 FStar_Util.print4 "Typechecked %s:%s = %s:%s\n" uu____472 s
+                   uu____474 uu____480
                else ()
             in
          let fresh_a_and_u_a a =
-           let uu____510 = FStar_Syntax_Util.type_u ()  in
-           FStar_All.pipe_right uu____510
-             (fun uu____527  ->
-                match uu____527 with
+           let uu____505 = FStar_Syntax_Util.type_u ()  in
+           FStar_All.pipe_right uu____505
+             (fun uu____522  ->
+                match uu____522 with
                 | (t,u) ->
-                    let uu____538 =
-                      let uu____539 =
+                    let uu____533 =
+                      let uu____534 =
                         FStar_Syntax_Syntax.gen_bv a
                           FStar_Pervasives_Native.None t
                          in
-                      FStar_All.pipe_right uu____539
+                      FStar_All.pipe_right uu____534
                         FStar_Syntax_Syntax.mk_binder
                        in
-                    (uu____538, u))
+                    (uu____533, u))
             in
          let fresh_x_a x a =
-           let uu____553 =
-             let uu____554 =
-               let uu____555 =
+           let uu____548 =
+             let uu____549 =
+               let uu____550 =
                  FStar_All.pipe_right a FStar_Pervasives_Native.fst  in
-               FStar_All.pipe_right uu____555 FStar_Syntax_Syntax.bv_to_name
+               FStar_All.pipe_right uu____550 FStar_Syntax_Syntax.bv_to_name
                 in
              FStar_Syntax_Syntax.gen_bv x FStar_Pervasives_Native.None
-               uu____554
+               uu____549
               in
-           FStar_All.pipe_right uu____553 FStar_Syntax_Syntax.mk_binder  in
+           FStar_All.pipe_right uu____548 FStar_Syntax_Syntax.mk_binder  in
          let check_and_gen1 =
-           let uu____589 =
+           let uu____584 =
              FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname  in
-           check_and_gen env0 uu____589  in
+           check_and_gen env0 uu____584  in
          let signature =
            let r =
              (FStar_Pervasives_Native.snd ed.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos
               in
-           let uu____609 =
+           let uu____604 =
              check_and_gen1 "signature" Prims.int_one
                ed.FStar_Syntax_Syntax.signature
               in
-           match uu____609 with
+           match uu____604 with
            | (sig_us,sig_t,sig_ty) ->
-               let uu____633 = FStar_Syntax_Subst.open_univ_vars sig_us sig_t
+               let uu____628 = FStar_Syntax_Subst.open_univ_vars sig_us sig_t
                   in
-               (match uu____633 with
+               (match uu____628 with
                 | (us,t) ->
                     let env = FStar_TypeChecker_Env.push_univ_vars env0 us
                        in
-                    let uu____653 = fresh_a_and_u_a "a"  in
-                    (match uu____653 with
+                    let uu____648 = fresh_a_and_u_a "a"  in
+                    (match uu____648 with
                      | (a,u) ->
                          let rest_bs =
-                           let uu____674 =
-                             let uu____675 =
+                           let uu____669 =
+                             let uu____670 =
                                FStar_All.pipe_right a
                                  FStar_Pervasives_Native.fst
                                 in
-                             FStar_All.pipe_right uu____675
+                             FStar_All.pipe_right uu____670
                                FStar_Syntax_Syntax.bv_to_name
                               in
                            FStar_TypeChecker_Util.layered_effect_indices_as_binders
                              env r ed.FStar_Syntax_Syntax.mname
-                             (sig_us, sig_t) u uu____674
+                             (sig_us, sig_t) u uu____669
                             in
                          let bs = a :: rest_bs  in
                          let k =
-                           let uu____706 =
+                           let uu____701 =
                              FStar_Syntax_Syntax.mk_Total
                                FStar_Syntax_Syntax.teff
                               in
-                           FStar_Syntax_Util.arrow bs uu____706  in
+                           FStar_Syntax_Util.arrow bs uu____701  in
                          let g_eq = FStar_TypeChecker_Rel.teq env t k  in
                          (FStar_TypeChecker_Rel.force_trivial_guard env g_eq;
-                          (let uu____711 =
-                             let uu____714 =
+                          (let uu____706 =
+                             let uu____709 =
                                FStar_All.pipe_right k
                                  (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                     env)
                                 in
-                             FStar_Syntax_Subst.close_univ_vars us uu____714
+                             FStar_Syntax_Subst.close_univ_vars us uu____709
                               in
-                           (sig_us, uu____711, sig_ty)))))
+                           (sig_us, uu____706, sig_ty)))))
             in
          log_combinator "signature" signature;
-         (let uu____723 =
+         (let uu____718 =
             let repr_ts =
-              let uu____745 =
+              let uu____740 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr  in
-              FStar_All.pipe_right uu____745 FStar_Util.must  in
+              FStar_All.pipe_right uu____740 FStar_Util.must  in
             let r =
               (FStar_Pervasives_Native.snd repr_ts).FStar_Syntax_Syntax.pos
                in
-            let uu____773 = check_and_gen1 "repr" Prims.int_one repr_ts  in
-            match uu____773 with
+            let uu____768 = check_and_gen1 "repr" Prims.int_one repr_ts  in
+            match uu____768 with
             | (repr_us,repr_t,repr_ty) ->
                 let underlying_effect_lid =
                   let repr_t1 =
@@ -443,364 +441,364 @@ let (tc_layered_eff_decl :
                       FStar_TypeChecker_Env.AllowUnboundUniverses] env0
                       repr_t
                      in
-                  let uu____804 =
-                    let uu____805 = FStar_Syntax_Subst.compress repr_t1  in
-                    uu____805.FStar_Syntax_Syntax.n  in
-                  match uu____804 with
-                  | FStar_Syntax_Syntax.Tm_abs (uu____808,t,uu____810) ->
-                      let uu____835 =
-                        let uu____836 = FStar_Syntax_Subst.compress t  in
-                        uu____836.FStar_Syntax_Syntax.n  in
-                      (match uu____835 with
-                       | FStar_Syntax_Syntax.Tm_arrow (uu____839,c) ->
-                           let uu____861 =
+                  let uu____799 =
+                    let uu____800 = FStar_Syntax_Subst.compress repr_t1  in
+                    uu____800.FStar_Syntax_Syntax.n  in
+                  match uu____799 with
+                  | FStar_Syntax_Syntax.Tm_abs (uu____803,t,uu____805) ->
+                      let uu____830 =
+                        let uu____831 = FStar_Syntax_Subst.compress t  in
+                        uu____831.FStar_Syntax_Syntax.n  in
+                      (match uu____830 with
+                       | FStar_Syntax_Syntax.Tm_arrow (uu____834,c) ->
+                           let uu____856 =
                              FStar_All.pipe_right c
                                FStar_Syntax_Util.comp_effect_name
                               in
-                           FStar_All.pipe_right uu____861
+                           FStar_All.pipe_right uu____856
                              (FStar_TypeChecker_Env.norm_eff_name env0)
-                       | uu____864 ->
-                           let uu____865 =
-                             let uu____871 =
-                               let uu____873 =
+                       | uu____859 ->
+                           let uu____860 =
+                             let uu____866 =
+                               let uu____868 =
                                  FStar_All.pipe_right
                                    ed.FStar_Syntax_Syntax.mname
                                    FStar_Ident.string_of_lid
                                   in
-                               let uu____876 =
+                               let uu____871 =
                                  FStar_Syntax_Print.term_to_string t  in
                                FStar_Util.format2
                                  "repr body for %s is not an arrow (%s)"
-                                 uu____873 uu____876
+                                 uu____868 uu____871
                                 in
-                             (FStar_Errors.Fatal_UnexpectedEffect, uu____871)
+                             (FStar_Errors.Fatal_UnexpectedEffect, uu____866)
                               in
-                           FStar_Errors.raise_error uu____865 r)
-                  | uu____880 ->
-                      let uu____881 =
-                        let uu____887 =
-                          let uu____889 =
+                           FStar_Errors.raise_error uu____860 r)
+                  | uu____875 ->
+                      let uu____876 =
+                        let uu____882 =
+                          let uu____884 =
                             FStar_All.pipe_right ed.FStar_Syntax_Syntax.mname
                               FStar_Ident.string_of_lid
                              in
-                          let uu____892 =
+                          let uu____887 =
                             FStar_Syntax_Print.term_to_string repr_t1  in
                           FStar_Util.format2
                             "repr for %s is not an abstraction (%s)"
-                            uu____889 uu____892
+                            uu____884 uu____887
                            in
-                        (FStar_Errors.Fatal_UnexpectedEffect, uu____887)  in
-                      FStar_Errors.raise_error uu____881 r
+                        (FStar_Errors.Fatal_UnexpectedEffect, uu____882)  in
+                      FStar_Errors.raise_error uu____876 r
                    in
-                ((let uu____897 =
+                ((let uu____892 =
                     (FStar_All.pipe_right quals
                        (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
                       &&
-                      (let uu____903 =
+                      (let uu____898 =
                          FStar_TypeChecker_Env.is_total_effect env0
                            underlying_effect_lid
                           in
-                       Prims.op_Negation uu____903)
+                       Prims.op_Negation uu____898)
                      in
-                  if uu____897
+                  if uu____892
                   then
-                    let uu____906 =
-                      let uu____912 =
-                        let uu____914 =
+                    let uu____901 =
+                      let uu____907 =
+                        let uu____909 =
                           FStar_All.pipe_right ed.FStar_Syntax_Syntax.mname
                             FStar_Ident.string_of_lid
                            in
-                        let uu____917 =
+                        let uu____912 =
                           FStar_All.pipe_right underlying_effect_lid
                             FStar_Ident.string_of_lid
                            in
                         FStar_Util.format2
                           "Effect %s is marked total but its underlying effect %s is not total"
-                          uu____914 uu____917
+                          uu____909 uu____912
                          in
                       (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                        uu____912)
+                        uu____907)
                        in
-                    FStar_Errors.raise_error uu____906 r
+                    FStar_Errors.raise_error uu____901 r
                   else ());
-                 (let uu____924 =
+                 (let uu____919 =
                     FStar_Syntax_Subst.open_univ_vars repr_us repr_ty  in
-                  match uu____924 with
+                  match uu____919 with
                   | (us,ty) ->
                       let env = FStar_TypeChecker_Env.push_univ_vars env0 us
                          in
-                      let uu____948 = fresh_a_and_u_a "a"  in
-                      (match uu____948 with
+                      let uu____943 = fresh_a_and_u_a "a"  in
+                      (match uu____943 with
                        | (a,u) ->
                            let rest_bs =
                              let signature_ts =
-                               let uu____974 = signature  in
-                               match uu____974 with
-                               | (us1,t,uu____989) -> (us1, t)  in
-                             let uu____1006 =
-                               let uu____1007 =
+                               let uu____969 = signature  in
+                               match uu____969 with
+                               | (us1,t,uu____984) -> (us1, t)  in
+                             let uu____1001 =
+                               let uu____1002 =
                                  FStar_All.pipe_right a
                                    FStar_Pervasives_Native.fst
                                   in
-                               FStar_All.pipe_right uu____1007
+                               FStar_All.pipe_right uu____1002
                                  FStar_Syntax_Syntax.bv_to_name
                                 in
                              FStar_TypeChecker_Util.layered_effect_indices_as_binders
                                env r ed.FStar_Syntax_Syntax.mname
-                               signature_ts u uu____1006
+                               signature_ts u uu____1001
                               in
                            let bs = a :: rest_bs  in
                            let k =
-                             let uu____1034 =
-                               let uu____1037 = FStar_Syntax_Util.type_u ()
+                             let uu____1029 =
+                               let uu____1032 = FStar_Syntax_Util.type_u ()
                                   in
-                               FStar_All.pipe_right uu____1037
-                                 (fun uu____1050  ->
-                                    match uu____1050 with
+                               FStar_All.pipe_right uu____1032
+                                 (fun uu____1045  ->
+                                    match uu____1045 with
                                     | (t,u1) ->
-                                        let uu____1057 =
-                                          let uu____1060 =
+                                        let uu____1052 =
+                                          let uu____1055 =
                                             FStar_TypeChecker_Env.new_u_univ
                                               ()
                                              in
                                           FStar_Pervasives_Native.Some
-                                            uu____1060
+                                            uu____1055
                                            in
                                         FStar_Syntax_Syntax.mk_Total' t
-                                          uu____1057)
+                                          uu____1052)
                                 in
-                             FStar_Syntax_Util.arrow bs uu____1034  in
+                             FStar_Syntax_Util.arrow bs uu____1029  in
                            let g = FStar_TypeChecker_Rel.teq env ty k  in
                            (FStar_TypeChecker_Rel.force_trivial_guard env g;
-                            (let uu____1063 =
-                               let uu____1076 =
-                                 let uu____1079 =
+                            (let uu____1058 =
+                               let uu____1071 =
+                                 let uu____1074 =
                                    FStar_All.pipe_right k
                                      (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                         env)
                                     in
                                  FStar_Syntax_Subst.close_univ_vars us
-                                   uu____1079
+                                   uu____1074
                                   in
-                               (repr_us, repr_t, uu____1076)  in
-                             (uu____1063, underlying_effect_lid))))))
+                               (repr_us, repr_t, uu____1071)  in
+                             (uu____1058, underlying_effect_lid))))))
              in
-          match uu____723 with
+          match uu____718 with
           | (repr,underlying_effect_lid) ->
               (log_combinator "repr" repr;
                (let fresh_repr r env u a_tm =
                   let signature_ts =
-                    let uu____1152 = signature  in
-                    match uu____1152 with | (us,t,uu____1167) -> (us, t)  in
+                    let uu____1147 = signature  in
+                    match uu____1147 with | (us,t,uu____1162) -> (us, t)  in
                   let repr_ts =
-                    let uu____1185 = repr  in
-                    match uu____1185 with | (us,t,uu____1200) -> (us, t)  in
+                    let uu____1180 = repr  in
+                    match uu____1180 with | (us,t,uu____1195) -> (us, t)  in
                   FStar_TypeChecker_Util.fresh_effect_repr env r
                     ed.FStar_Syntax_Syntax.mname signature_ts
                     (FStar_Pervasives_Native.Some repr_ts) u a_tm
                    in
                 let not_an_arrow_error comb n t r =
-                  let uu____1250 =
-                    let uu____1256 =
-                      let uu____1258 =
+                  let uu____1245 =
+                    let uu____1251 =
+                      let uu____1253 =
                         FStar_Ident.string_of_lid
                           ed.FStar_Syntax_Syntax.mname
                          in
-                      let uu____1260 = FStar_Util.string_of_int n  in
-                      let uu____1262 = FStar_Syntax_Print.tag_of_term t  in
-                      let uu____1264 = FStar_Syntax_Print.term_to_string t
+                      let uu____1255 = FStar_Util.string_of_int n  in
+                      let uu____1257 = FStar_Syntax_Print.tag_of_term t  in
+                      let uu____1259 = FStar_Syntax_Print.term_to_string t
                          in
                       FStar_Util.format5
                         "Type of %s:%s is not an arrow with >= %s binders (%s::%s)"
-                        uu____1258 comb uu____1260 uu____1262 uu____1264
+                        uu____1253 comb uu____1255 uu____1257 uu____1259
                        in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu____1256)  in
-                  FStar_Errors.raise_error uu____1250 r  in
+                    (FStar_Errors.Fatal_UnexpectedEffect, uu____1251)  in
+                  FStar_Errors.raise_error uu____1245 r  in
                 let return_repr =
                   let return_repr_ts =
-                    let uu____1294 =
+                    let uu____1289 =
                       FStar_All.pipe_right ed
                         FStar_Syntax_Util.get_return_repr
                        in
-                    FStar_All.pipe_right uu____1294 FStar_Util.must  in
+                    FStar_All.pipe_right uu____1289 FStar_Util.must  in
                   let r =
                     (FStar_Pervasives_Native.snd return_repr_ts).FStar_Syntax_Syntax.pos
                      in
-                  let uu____1322 =
+                  let uu____1317 =
                     check_and_gen1 "return_repr" Prims.int_one return_repr_ts
                      in
-                  match uu____1322 with
+                  match uu____1317 with
                   | (ret_us,ret_t,ret_ty) ->
-                      let uu____1346 =
+                      let uu____1341 =
                         FStar_Syntax_Subst.open_univ_vars ret_us ret_ty  in
-                      (match uu____1346 with
+                      (match uu____1341 with
                        | (us,ty) ->
                            let env =
                              FStar_TypeChecker_Env.push_univ_vars env0 us  in
                            (check_no_subtyping_for_layered_combinator env ty
                               FStar_Pervasives_Native.None;
-                            (let uu____1367 = fresh_a_and_u_a "a"  in
-                             match uu____1367 with
+                            (let uu____1362 = fresh_a_and_u_a "a"  in
+                             match uu____1362 with
                              | (a,u_a) ->
                                  let x_a = fresh_x_a "x" a  in
                                  let rest_bs =
-                                   let uu____1398 =
-                                     let uu____1399 =
+                                   let uu____1393 =
+                                     let uu____1394 =
                                        FStar_Syntax_Subst.compress ty  in
-                                     uu____1399.FStar_Syntax_Syntax.n  in
-                                   match uu____1398 with
+                                     uu____1394.FStar_Syntax_Syntax.n  in
+                                   match uu____1393 with
                                    | FStar_Syntax_Syntax.Tm_arrow
-                                       (bs,uu____1411) when
+                                       (bs,uu____1406) when
                                        (FStar_List.length bs) >=
                                          (Prims.of_int (2))
                                        ->
-                                       let uu____1439 =
+                                       let uu____1434 =
                                          FStar_Syntax_Subst.open_binders bs
                                           in
-                                       (match uu____1439 with
-                                        | (a',uu____1449)::(x',uu____1451)::bs1
+                                       (match uu____1434 with
+                                        | (a',uu____1444)::(x',uu____1446)::bs1
                                             ->
-                                            let uu____1481 =
-                                              let uu____1482 =
-                                                let uu____1487 =
-                                                  let uu____1490 =
-                                                    let uu____1491 =
-                                                      let uu____1498 =
+                                            let uu____1476 =
+                                              let uu____1477 =
+                                                let uu____1482 =
+                                                  let uu____1485 =
+                                                    let uu____1486 =
+                                                      let uu____1493 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           (FStar_Pervasives_Native.fst
                                                              a)
                                                          in
-                                                      (a', uu____1498)  in
+                                                      (a', uu____1493)  in
                                                     FStar_Syntax_Syntax.NT
-                                                      uu____1491
+                                                      uu____1486
                                                      in
-                                                  [uu____1490]  in
+                                                  [uu____1485]  in
                                                 FStar_Syntax_Subst.subst_binders
-                                                  uu____1487
+                                                  uu____1482
                                                  in
                                               FStar_All.pipe_right bs1
-                                                uu____1482
+                                                uu____1477
                                                in
-                                            let uu____1505 =
-                                              let uu____1518 =
-                                                let uu____1521 =
-                                                  let uu____1522 =
-                                                    let uu____1529 =
+                                            let uu____1500 =
+                                              let uu____1513 =
+                                                let uu____1516 =
+                                                  let uu____1517 =
+                                                    let uu____1524 =
                                                       FStar_Syntax_Syntax.bv_to_name
                                                         (FStar_Pervasives_Native.fst
                                                            x_a)
                                                        in
-                                                    (x', uu____1529)  in
+                                                    (x', uu____1524)  in
                                                   FStar_Syntax_Syntax.NT
-                                                    uu____1522
+                                                    uu____1517
                                                    in
-                                                [uu____1521]  in
+                                                [uu____1516]  in
                                               FStar_Syntax_Subst.subst_binders
-                                                uu____1518
+                                                uu____1513
                                                in
-                                            FStar_All.pipe_right uu____1481
-                                              uu____1505)
-                                   | uu____1544 ->
+                                            FStar_All.pipe_right uu____1476
+                                              uu____1500)
+                                   | uu____1539 ->
                                        not_an_arrow_error "return"
                                          (Prims.of_int (2)) ty r
                                     in
                                  let bs = a :: x_a :: rest_bs  in
-                                 let uu____1568 =
-                                   let uu____1573 =
+                                 let uu____1563 =
+                                   let uu____1568 =
                                      FStar_TypeChecker_Env.push_binders env
                                        bs
                                       in
-                                   let uu____1574 =
+                                   let uu____1569 =
                                      FStar_All.pipe_right
                                        (FStar_Pervasives_Native.fst a)
                                        FStar_Syntax_Syntax.bv_to_name
                                       in
-                                   fresh_repr r uu____1573 u_a uu____1574  in
-                                 (match uu____1568 with
+                                   fresh_repr r uu____1568 u_a uu____1569  in
+                                 (match uu____1563 with
                                   | (repr1,g) ->
                                       let k =
-                                        let uu____1594 =
+                                        let uu____1589 =
                                           FStar_Syntax_Syntax.mk_Total' repr1
                                             (FStar_Pervasives_Native.Some u_a)
                                            in
-                                        FStar_Syntax_Util.arrow bs uu____1594
+                                        FStar_Syntax_Util.arrow bs uu____1589
                                          in
                                       let g_eq =
                                         FStar_TypeChecker_Rel.teq env ty k
                                          in
-                                      ((let uu____1599 =
+                                      ((let uu____1594 =
                                           FStar_TypeChecker_Env.conj_guard g
                                             g_eq
                                            in
                                         FStar_TypeChecker_Rel.force_trivial_guard
-                                          env uu____1599);
-                                       (let uu____1600 =
-                                          let uu____1603 =
+                                          env uu____1594);
+                                       (let uu____1595 =
+                                          let uu____1598 =
                                             FStar_All.pipe_right k
                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                  env)
                                              in
-                                          FStar_All.pipe_right uu____1603
+                                          FStar_All.pipe_right uu____1598
                                             (FStar_Syntax_Subst.close_univ_vars
                                                us)
                                            in
-                                        (ret_us, ret_t, uu____1600)))))))
+                                        (ret_us, ret_t, uu____1595)))))))
                    in
                 log_combinator "return_repr" return_repr;
                 (let bind_repr =
                    let bind_repr_ts =
-                     let uu____1632 =
+                     let uu____1627 =
                        FStar_All.pipe_right ed
                          FStar_Syntax_Util.get_bind_repr
                         in
-                     FStar_All.pipe_right uu____1632 FStar_Util.must  in
+                     FStar_All.pipe_right uu____1627 FStar_Util.must  in
                    let r =
                      (FStar_Pervasives_Native.snd bind_repr_ts).FStar_Syntax_Syntax.pos
                       in
-                   let uu____1660 =
+                   let uu____1655 =
                      check_and_gen1 "bind_repr" (Prims.of_int (2))
                        bind_repr_ts
                       in
-                   match uu____1660 with
+                   match uu____1655 with
                    | (bind_us,bind_t,bind_ty) ->
-                       let uu____1684 =
+                       let uu____1679 =
                          FStar_Syntax_Subst.open_univ_vars bind_us bind_ty
                           in
-                       (match uu____1684 with
+                       (match uu____1679 with
                         | (us,ty) ->
                             let env =
                               FStar_TypeChecker_Env.push_univ_vars env0 us
                                in
                             (check_no_subtyping_for_layered_combinator env ty
                                FStar_Pervasives_Native.None;
-                             (let uu____1705 = fresh_a_and_u_a "a"  in
-                              match uu____1705 with
+                             (let uu____1700 = fresh_a_and_u_a "a"  in
+                              match uu____1700 with
                               | (a,u_a) ->
-                                  let uu____1725 = fresh_a_and_u_a "b"  in
-                                  (match uu____1725 with
+                                  let uu____1720 = fresh_a_and_u_a "b"  in
+                                  (match uu____1720 with
                                    | (b,u_b) ->
                                        let rest_bs =
-                                         let uu____1754 =
-                                           let uu____1755 =
+                                         let uu____1749 =
+                                           let uu____1750 =
                                              FStar_Syntax_Subst.compress ty
                                               in
-                                           uu____1755.FStar_Syntax_Syntax.n
+                                           uu____1750.FStar_Syntax_Syntax.n
                                             in
-                                         match uu____1754 with
+                                         match uu____1749 with
                                          | FStar_Syntax_Syntax.Tm_arrow
-                                             (bs,uu____1767) when
+                                             (bs,uu____1762) when
                                              (FStar_List.length bs) >=
                                                (Prims.of_int (4))
                                              ->
-                                             let uu____1795 =
+                                             let uu____1790 =
                                                FStar_Syntax_Subst.open_binders
                                                  bs
                                                 in
-                                             (match uu____1795 with
-                                              | (a',uu____1805)::(b',uu____1807)::bs1
+                                             (match uu____1790 with
+                                              | (a',uu____1800)::(b',uu____1802)::bs1
                                                   ->
-                                                  let uu____1837 =
-                                                    let uu____1838 =
+                                                  let uu____1832 =
+                                                    let uu____1833 =
                                                       FStar_All.pipe_right
                                                         bs1
                                                         (FStar_List.splitAt
@@ -810,195 +808,195 @@ let (tc_layered_eff_decl :
                                                               (Prims.of_int (2))))
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____1838
+                                                      uu____1833
                                                       FStar_Pervasives_Native.fst
                                                      in
-                                                  let uu____1904 =
-                                                    let uu____1917 =
-                                                      let uu____1920 =
-                                                        let uu____1921 =
-                                                          let uu____1928 =
+                                                  let uu____1899 =
+                                                    let uu____1912 =
+                                                      let uu____1915 =
+                                                        let uu____1916 =
+                                                          let uu____1923 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               (FStar_Pervasives_Native.fst
                                                                  a)
                                                              in
-                                                          (a', uu____1928)
+                                                          (a', uu____1923)
                                                            in
                                                         FStar_Syntax_Syntax.NT
-                                                          uu____1921
+                                                          uu____1916
                                                          in
-                                                      let uu____1935 =
-                                                        let uu____1938 =
-                                                          let uu____1939 =
-                                                            let uu____1946 =
+                                                      let uu____1930 =
+                                                        let uu____1933 =
+                                                          let uu____1934 =
+                                                            let uu____1941 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 (FStar_Pervasives_Native.fst
                                                                    b)
                                                                in
-                                                            (b', uu____1946)
+                                                            (b', uu____1941)
                                                              in
                                                           FStar_Syntax_Syntax.NT
-                                                            uu____1939
+                                                            uu____1934
                                                            in
-                                                        [uu____1938]  in
-                                                      uu____1920 ::
-                                                        uu____1935
+                                                        [uu____1933]  in
+                                                      uu____1915 ::
+                                                        uu____1930
                                                        in
                                                     FStar_Syntax_Subst.subst_binders
-                                                      uu____1917
+                                                      uu____1912
                                                      in
                                                   FStar_All.pipe_right
-                                                    uu____1837 uu____1904)
-                                         | uu____1961 ->
+                                                    uu____1832 uu____1899)
+                                         | uu____1956 ->
                                              not_an_arrow_error "bind"
                                                (Prims.of_int (4)) ty r
                                           in
                                        let bs = a :: b :: rest_bs  in
-                                       let uu____1985 =
-                                         let uu____1996 =
-                                           let uu____2001 =
+                                       let uu____1980 =
+                                         let uu____1991 =
+                                           let uu____1996 =
                                              FStar_TypeChecker_Env.push_binders
                                                env bs
                                               in
-                                           let uu____2002 =
+                                           let uu____1997 =
                                              FStar_All.pipe_right
                                                (FStar_Pervasives_Native.fst a)
                                                FStar_Syntax_Syntax.bv_to_name
                                               in
-                                           fresh_repr r uu____2001 u_a
-                                             uu____2002
+                                           fresh_repr r uu____1996 u_a
+                                             uu____1997
                                             in
-                                         match uu____1996 with
+                                         match uu____1991 with
                                          | (repr1,g) ->
-                                             let uu____2017 =
-                                               let uu____2024 =
+                                             let uu____2012 =
+                                               let uu____2019 =
                                                  FStar_Syntax_Syntax.gen_bv
                                                    "f"
                                                    FStar_Pervasives_Native.None
                                                    repr1
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____2024
+                                                 uu____2019
                                                  FStar_Syntax_Syntax.mk_binder
                                                 in
-                                             (uu____2017, g)
+                                             (uu____2012, g)
                                           in
-                                       (match uu____1985 with
+                                       (match uu____1980 with
                                         | (f,guard_f) ->
-                                            let uu____2064 =
+                                            let uu____2059 =
                                               let x_a = fresh_x_a "x" a  in
-                                              let uu____2077 =
-                                                let uu____2082 =
+                                              let uu____2072 =
+                                                let uu____2077 =
                                                   FStar_TypeChecker_Env.push_binders
                                                     env
                                                     (FStar_List.append bs
                                                        [x_a])
                                                    in
-                                                let uu____2101 =
+                                                let uu____2096 =
                                                   FStar_All.pipe_right
                                                     (FStar_Pervasives_Native.fst
                                                        b)
                                                     FStar_Syntax_Syntax.bv_to_name
                                                    in
-                                                fresh_repr r uu____2082 u_b
-                                                  uu____2101
+                                                fresh_repr r uu____2077 u_b
+                                                  uu____2096
                                                  in
-                                              match uu____2077 with
+                                              match uu____2072 with
                                               | (repr1,g) ->
-                                                  let uu____2116 =
-                                                    let uu____2123 =
-                                                      let uu____2124 =
-                                                        let uu____2125 =
-                                                          let uu____2128 =
-                                                            let uu____2131 =
+                                                  let uu____2111 =
+                                                    let uu____2118 =
+                                                      let uu____2119 =
+                                                        let uu____2120 =
+                                                          let uu____2123 =
+                                                            let uu____2126 =
                                                               FStar_TypeChecker_Env.new_u_univ
                                                                 ()
                                                                in
                                                             FStar_Pervasives_Native.Some
-                                                              uu____2131
+                                                              uu____2126
                                                              in
                                                           FStar_Syntax_Syntax.mk_Total'
-                                                            repr1 uu____2128
+                                                            repr1 uu____2123
                                                            in
                                                         FStar_Syntax_Util.arrow
-                                                          [x_a] uu____2125
+                                                          [x_a] uu____2120
                                                          in
                                                       FStar_Syntax_Syntax.gen_bv
                                                         "g"
                                                         FStar_Pervasives_Native.None
-                                                        uu____2124
+                                                        uu____2119
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____2123
+                                                      uu____2118
                                                       FStar_Syntax_Syntax.mk_binder
                                                      in
-                                                  (uu____2116, g)
+                                                  (uu____2111, g)
                                                in
-                                            (match uu____2064 with
+                                            (match uu____2059 with
                                              | (g,guard_g) ->
-                                                 let uu____2183 =
-                                                   let uu____2188 =
+                                                 let uu____2178 =
+                                                   let uu____2183 =
                                                      FStar_TypeChecker_Env.push_binders
                                                        env bs
                                                       in
-                                                   let uu____2189 =
+                                                   let uu____2184 =
                                                      FStar_All.pipe_right
                                                        (FStar_Pervasives_Native.fst
                                                           b)
                                                        FStar_Syntax_Syntax.bv_to_name
                                                       in
-                                                   fresh_repr r uu____2188
-                                                     u_b uu____2189
+                                                   fresh_repr r uu____2183
+                                                     u_b uu____2184
                                                     in
-                                                 (match uu____2183 with
+                                                 (match uu____2178 with
                                                   | (repr1,guard_repr) ->
-                                                      let uu____2206 =
-                                                        let uu____2211 =
+                                                      let uu____2201 =
+                                                        let uu____2206 =
                                                           FStar_TypeChecker_Env.push_binders
                                                             env bs
                                                            in
-                                                        let uu____2212 =
-                                                          let uu____2214 =
+                                                        let uu____2207 =
+                                                          let uu____2209 =
                                                             FStar_Ident.string_of_lid
                                                               ed.FStar_Syntax_Syntax.mname
                                                              in
                                                           FStar_Util.format1
                                                             "implicit for pure_wp in checking bind for %s"
-                                                            uu____2214
+                                                            uu____2209
                                                            in
                                                         pure_wp_uvar
-                                                          uu____2211 repr1
-                                                          uu____2212 r
+                                                          uu____2206 repr1
+                                                          uu____2207 r
                                                          in
-                                                      (match uu____2206 with
+                                                      (match uu____2201 with
                                                        | (pure_wp_uvar1,g_pure_wp_uvar)
                                                            ->
                                                            let k =
-                                                             let uu____2234 =
-                                                               let uu____2237
+                                                             let uu____2229 =
+                                                               let uu____2232
                                                                  =
-                                                                 let uu____2238
+                                                                 let uu____2233
                                                                    =
-                                                                   let uu____2239
+                                                                   let uu____2234
                                                                     =
                                                                     FStar_TypeChecker_Env.new_u_univ
                                                                     ()  in
-                                                                   [uu____2239]
+                                                                   [uu____2234]
                                                                     in
-                                                                 let uu____2240
+                                                                 let uu____2235
                                                                    =
-                                                                   let uu____2251
+                                                                   let uu____2246
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     pure_wp_uvar1
                                                                     FStar_Syntax_Syntax.as_arg
                                                                      in
-                                                                   [uu____2251]
+                                                                   [uu____2246]
                                                                     in
                                                                  {
                                                                    FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____2238;
+                                                                    uu____2233;
                                                                    FStar_Syntax_Syntax.effect_name
                                                                     =
                                                                     FStar_Parser_Const.effect_PURE_lid;
@@ -1006,18 +1004,18 @@ let (tc_layered_eff_decl :
                                                                     = repr1;
                                                                    FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____2240;
+                                                                    uu____2235;
                                                                    FStar_Syntax_Syntax.flags
                                                                     = []
                                                                  }  in
                                                                FStar_Syntax_Syntax.mk_Comp
-                                                                 uu____2237
+                                                                 uu____2232
                                                                 in
                                                              FStar_Syntax_Util.arrow
                                                                (FStar_List.append
                                                                   bs 
                                                                   [f; g])
-                                                               uu____2234
+                                                               uu____2229
                                                               in
                                                            let guard_eq =
                                                              FStar_TypeChecker_Rel.teq
@@ -1031,8 +1029,8 @@ let (tc_layered_eff_decl :
                                                               guard_repr;
                                                               g_pure_wp_uvar;
                                                               guard_eq];
-                                                            (let uu____2310 =
-                                                               let uu____2313
+                                                            (let uu____2305 =
+                                                               let uu____2308
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    k
@@ -1040,83 +1038,83 @@ let (tc_layered_eff_decl :
                                                                     env)
                                                                   in
                                                                FStar_All.pipe_right
-                                                                 uu____2313
+                                                                 uu____2308
                                                                  (FStar_Syntax_Subst.close_univ_vars
                                                                     bind_us)
                                                                 in
                                                              (bind_us,
                                                                bind_t,
-                                                               uu____2310)))))))))))
+                                                               uu____2305)))))))))))
                     in
                  log_combinator "bind_repr" bind_repr;
                  (let stronger_repr =
                     let stronger_repr =
-                      let uu____2342 =
+                      let uu____2337 =
                         FStar_All.pipe_right ed
                           FStar_Syntax_Util.get_stronger_repr
                          in
-                      FStar_All.pipe_right uu____2342 FStar_Util.must  in
+                      FStar_All.pipe_right uu____2337 FStar_Util.must  in
                     let r =
                       (FStar_Pervasives_Native.snd stronger_repr).FStar_Syntax_Syntax.pos
                        in
-                    let uu____2370 =
+                    let uu____2365 =
                       check_and_gen1 "stronger_repr" Prims.int_one
                         stronger_repr
                        in
-                    match uu____2370 with
+                    match uu____2365 with
                     | (stronger_us,stronger_t,stronger_ty) ->
-                        ((let uu____2395 =
+                        ((let uu____2390 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "LayeredEffects")
                              in
-                          if uu____2395
+                          if uu____2390
                           then
-                            let uu____2400 =
+                            let uu____2395 =
                               FStar_Syntax_Print.tscheme_to_string
                                 (stronger_us, stronger_t)
                                in
-                            let uu____2406 =
+                            let uu____2401 =
                               FStar_Syntax_Print.tscheme_to_string
                                 (stronger_us, stronger_ty)
                                in
                             FStar_Util.print2
                               "stronger combinator typechecked with term: %s and type: %s\n"
-                              uu____2400 uu____2406
+                              uu____2395 uu____2401
                           else ());
-                         (let uu____2415 =
+                         (let uu____2410 =
                             FStar_Syntax_Subst.open_univ_vars stronger_us
                               stronger_ty
                              in
-                          match uu____2415 with
+                          match uu____2410 with
                           | (us,ty) ->
                               let env =
                                 FStar_TypeChecker_Env.push_univ_vars env0 us
                                  in
                               (check_no_subtyping_for_layered_combinator env
                                  ty FStar_Pervasives_Native.None;
-                               (let uu____2436 = fresh_a_and_u_a "a"  in
-                                match uu____2436 with
+                               (let uu____2431 = fresh_a_and_u_a "a"  in
+                                match uu____2431 with
                                 | (a,u) ->
                                     let rest_bs =
-                                      let uu____2465 =
-                                        let uu____2466 =
+                                      let uu____2460 =
+                                        let uu____2461 =
                                           FStar_Syntax_Subst.compress ty  in
-                                        uu____2466.FStar_Syntax_Syntax.n  in
-                                      match uu____2465 with
+                                        uu____2461.FStar_Syntax_Syntax.n  in
+                                      match uu____2460 with
                                       | FStar_Syntax_Syntax.Tm_arrow
-                                          (bs,uu____2478) when
+                                          (bs,uu____2473) when
                                           (FStar_List.length bs) >=
                                             (Prims.of_int (2))
                                           ->
-                                          let uu____2506 =
+                                          let uu____2501 =
                                             FStar_Syntax_Subst.open_binders
                                               bs
                                              in
-                                          (match uu____2506 with
-                                           | (a',uu____2516)::bs1 ->
-                                               let uu____2536 =
-                                                 let uu____2537 =
+                                          (match uu____2501 with
+                                           | (a',uu____2511)::bs1 ->
+                                               let uu____2531 =
+                                                 let uu____2532 =
                                                    FStar_All.pipe_right bs1
                                                      (FStar_List.splitAt
                                                         ((FStar_List.length
@@ -1124,147 +1122,147 @@ let (tc_layered_eff_decl :
                                                            - Prims.int_one))
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____2537
+                                                   uu____2532
                                                    FStar_Pervasives_Native.fst
                                                   in
-                                               let uu____2635 =
-                                                 let uu____2648 =
-                                                   let uu____2651 =
-                                                     let uu____2652 =
-                                                       let uu____2659 =
+                                               let uu____2630 =
+                                                 let uu____2643 =
+                                                   let uu____2646 =
+                                                     let uu____2647 =
+                                                       let uu____2654 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            (FStar_Pervasives_Native.fst
                                                               a)
                                                           in
-                                                       (a', uu____2659)  in
+                                                       (a', uu____2654)  in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____2652
+                                                       uu____2647
                                                       in
-                                                   [uu____2651]  in
+                                                   [uu____2646]  in
                                                  FStar_Syntax_Subst.subst_binders
-                                                   uu____2648
+                                                   uu____2643
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____2536 uu____2635)
-                                      | uu____2674 ->
+                                                 uu____2531 uu____2630)
+                                      | uu____2669 ->
                                           not_an_arrow_error "stronger"
                                             (Prims.of_int (2)) ty r
                                        in
                                     let bs = a :: rest_bs  in
-                                    let uu____2692 =
-                                      let uu____2703 =
-                                        let uu____2708 =
+                                    let uu____2687 =
+                                      let uu____2698 =
+                                        let uu____2703 =
                                           FStar_TypeChecker_Env.push_binders
                                             env bs
                                            in
-                                        let uu____2709 =
+                                        let uu____2704 =
                                           FStar_All.pipe_right
                                             (FStar_Pervasives_Native.fst a)
                                             FStar_Syntax_Syntax.bv_to_name
                                            in
-                                        fresh_repr r uu____2708 u uu____2709
+                                        fresh_repr r uu____2703 u uu____2704
                                          in
-                                      match uu____2703 with
+                                      match uu____2698 with
                                       | (repr1,g) ->
-                                          let uu____2724 =
-                                            let uu____2731 =
+                                          let uu____2719 =
+                                            let uu____2726 =
                                               FStar_Syntax_Syntax.gen_bv "f"
                                                 FStar_Pervasives_Native.None
                                                 repr1
                                                in
-                                            FStar_All.pipe_right uu____2731
+                                            FStar_All.pipe_right uu____2726
                                               FStar_Syntax_Syntax.mk_binder
                                              in
-                                          (uu____2724, g)
+                                          (uu____2719, g)
                                        in
-                                    (match uu____2692 with
+                                    (match uu____2687 with
                                      | (f,guard_f) ->
-                                         let uu____2771 =
-                                           let uu____2776 =
+                                         let uu____2766 =
+                                           let uu____2771 =
                                              FStar_TypeChecker_Env.push_binders
                                                env bs
                                               in
-                                           let uu____2777 =
+                                           let uu____2772 =
                                              FStar_All.pipe_right
                                                (FStar_Pervasives_Native.fst a)
                                                FStar_Syntax_Syntax.bv_to_name
                                               in
-                                           fresh_repr r uu____2776 u
-                                             uu____2777
+                                           fresh_repr r uu____2771 u
+                                             uu____2772
                                             in
-                                         (match uu____2771 with
+                                         (match uu____2766 with
                                           | (ret_t,guard_ret_t) ->
-                                              let uu____2794 =
-                                                let uu____2799 =
+                                              let uu____2789 =
+                                                let uu____2794 =
                                                   FStar_TypeChecker_Env.push_binders
                                                     env bs
                                                    in
-                                                let uu____2800 =
-                                                  let uu____2802 =
+                                                let uu____2795 =
+                                                  let uu____2797 =
                                                     FStar_Ident.string_of_lid
                                                       ed.FStar_Syntax_Syntax.mname
                                                      in
                                                   FStar_Util.format1
                                                     "implicit for pure_wp in checking stronger for %s"
-                                                    uu____2802
+                                                    uu____2797
                                                    in
-                                                pure_wp_uvar uu____2799 ret_t
-                                                  uu____2800 r
+                                                pure_wp_uvar uu____2794 ret_t
+                                                  uu____2795 r
                                                  in
-                                              (match uu____2794 with
+                                              (match uu____2789 with
                                                | (pure_wp_uvar1,guard_wp) ->
                                                    let c =
-                                                     let uu____2820 =
-                                                       let uu____2821 =
-                                                         let uu____2822 =
+                                                     let uu____2815 =
+                                                       let uu____2816 =
+                                                         let uu____2817 =
                                                            FStar_TypeChecker_Env.new_u_univ
                                                              ()
                                                             in
-                                                         [uu____2822]  in
-                                                       let uu____2823 =
-                                                         let uu____2834 =
+                                                         [uu____2817]  in
+                                                       let uu____2818 =
+                                                         let uu____2829 =
                                                            FStar_All.pipe_right
                                                              pure_wp_uvar1
                                                              FStar_Syntax_Syntax.as_arg
                                                             in
-                                                         [uu____2834]  in
+                                                         [uu____2829]  in
                                                        {
                                                          FStar_Syntax_Syntax.comp_univs
-                                                           = uu____2821;
+                                                           = uu____2816;
                                                          FStar_Syntax_Syntax.effect_name
                                                            =
                                                            FStar_Parser_Const.effect_PURE_lid;
                                                          FStar_Syntax_Syntax.result_typ
                                                            = ret_t;
                                                          FStar_Syntax_Syntax.effect_args
-                                                           = uu____2823;
+                                                           = uu____2818;
                                                          FStar_Syntax_Syntax.flags
                                                            = []
                                                        }  in
                                                      FStar_Syntax_Syntax.mk_Comp
-                                                       uu____2820
+                                                       uu____2815
                                                       in
                                                    let k =
                                                      FStar_Syntax_Util.arrow
                                                        (FStar_List.append bs
                                                           [f]) c
                                                       in
-                                                   ((let uu____2889 =
+                                                   ((let uu____2884 =
                                                        FStar_All.pipe_left
                                                          (FStar_TypeChecker_Env.debug
                                                             env)
                                                          (FStar_Options.Other
                                                             "LayeredEffects")
                                                         in
-                                                     if uu____2889
+                                                     if uu____2884
                                                      then
-                                                       let uu____2894 =
+                                                       let uu____2889 =
                                                          FStar_Syntax_Print.term_to_string
                                                            k
                                                           in
                                                        FStar_Util.print1
                                                          "Expected type before unification: %s\n"
-                                                         uu____2894
+                                                         uu____2889
                                                      else ());
                                                     (let guard_eq =
                                                        FStar_TypeChecker_Rel.teq
@@ -1277,89 +1275,89 @@ let (tc_layered_eff_decl :
                                                        guard_ret_t;
                                                        guard_wp;
                                                        guard_eq];
-                                                     (let uu____2901 =
-                                                        let uu____2904 =
-                                                          let uu____2905 =
+                                                     (let uu____2896 =
+                                                        let uu____2899 =
+                                                          let uu____2900 =
                                                             FStar_All.pipe_right
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env)
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____2905
+                                                            uu____2900
                                                             (FStar_TypeChecker_Normalize.normalize
                                                                [FStar_TypeChecker_Env.Beta;
                                                                FStar_TypeChecker_Env.Eager_unfolding]
                                                                env)
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____2904
+                                                          uu____2899
                                                           (FStar_Syntax_Subst.close_univ_vars
                                                              stronger_us)
                                                          in
                                                       (stronger_us,
                                                         stronger_t,
-                                                        uu____2901)))))))))))
+                                                        uu____2896)))))))))))
                      in
                   log_combinator "stronger_repr" stronger_repr;
                   (let if_then_else =
                      let if_then_else_ts =
-                       let uu____2936 =
+                       let uu____2931 =
                          FStar_All.pipe_right ed
                            FStar_Syntax_Util.get_layered_if_then_else_combinator
                           in
-                       FStar_All.pipe_right uu____2936 FStar_Util.must  in
+                       FStar_All.pipe_right uu____2931 FStar_Util.must  in
                      let r =
                        (FStar_Pervasives_Native.snd if_then_else_ts).FStar_Syntax_Syntax.pos
                         in
-                     let uu____2976 =
+                     let uu____2971 =
                        check_and_gen1 "if_then_else" Prims.int_one
                          if_then_else_ts
                         in
-                     match uu____2976 with
+                     match uu____2971 with
                      | (if_then_else_us,if_then_else_t,if_then_else_ty) ->
-                         let uu____3000 =
+                         let uu____2995 =
                            FStar_Syntax_Subst.open_univ_vars if_then_else_us
                              if_then_else_t
                             in
-                         (match uu____3000 with
+                         (match uu____2995 with
                           | (us,t) ->
-                              let uu____3019 =
+                              let uu____3014 =
                                 FStar_Syntax_Subst.open_univ_vars
                                   if_then_else_us if_then_else_ty
                                  in
-                              (match uu____3019 with
-                               | (uu____3036,ty) ->
+                              (match uu____3014 with
+                               | (uu____3031,ty) ->
                                    let env =
                                      FStar_TypeChecker_Env.push_univ_vars
                                        env0 us
                                       in
                                    (check_no_subtyping_for_layered_combinator
                                       env t (FStar_Pervasives_Native.Some ty);
-                                    (let uu____3040 = fresh_a_and_u_a "a"  in
-                                     match uu____3040 with
+                                    (let uu____3035 = fresh_a_and_u_a "a"  in
+                                     match uu____3035 with
                                      | (a,u_a) ->
                                          let rest_bs =
-                                           let uu____3069 =
-                                             let uu____3070 =
+                                           let uu____3064 =
+                                             let uu____3065 =
                                                FStar_Syntax_Subst.compress ty
                                                 in
-                                             uu____3070.FStar_Syntax_Syntax.n
+                                             uu____3065.FStar_Syntax_Syntax.n
                                               in
-                                           match uu____3069 with
+                                           match uu____3064 with
                                            | FStar_Syntax_Syntax.Tm_arrow
-                                               (bs,uu____3082) when
+                                               (bs,uu____3077) when
                                                (FStar_List.length bs) >=
                                                  (Prims.of_int (4))
                                                ->
-                                               let uu____3110 =
+                                               let uu____3105 =
                                                  FStar_Syntax_Subst.open_binders
                                                    bs
                                                   in
-                                               (match uu____3110 with
-                                                | (a',uu____3120)::bs1 ->
-                                                    let uu____3140 =
-                                                      let uu____3141 =
+                                               (match uu____3105 with
+                                                | (a',uu____3115)::bs1 ->
+                                                    let uu____3135 =
+                                                      let uu____3136 =
                                                         FStar_All.pipe_right
                                                           bs1
                                                           (FStar_List.splitAt
@@ -1369,143 +1367,143 @@ let (tc_layered_eff_decl :
                                                                 (Prims.of_int (3))))
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____3141
+                                                        uu____3136
                                                         FStar_Pervasives_Native.fst
                                                        in
-                                                    let uu____3239 =
-                                                      let uu____3252 =
-                                                        let uu____3255 =
-                                                          let uu____3256 =
-                                                            let uu____3263 =
-                                                              let uu____3266
+                                                    let uu____3234 =
+                                                      let uu____3247 =
+                                                        let uu____3250 =
+                                                          let uu____3251 =
+                                                            let uu____3258 =
+                                                              let uu____3261
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   a
                                                                   FStar_Pervasives_Native.fst
                                                                  in
                                                               FStar_All.pipe_right
-                                                                uu____3266
+                                                                uu____3261
                                                                 FStar_Syntax_Syntax.bv_to_name
                                                                in
-                                                            (a', uu____3263)
+                                                            (a', uu____3258)
                                                              in
                                                           FStar_Syntax_Syntax.NT
-                                                            uu____3256
+                                                            uu____3251
                                                            in
-                                                        [uu____3255]  in
+                                                        [uu____3250]  in
                                                       FStar_Syntax_Subst.subst_binders
-                                                        uu____3252
+                                                        uu____3247
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____3140 uu____3239)
-                                           | uu____3287 ->
+                                                      uu____3135 uu____3234)
+                                           | uu____3282 ->
                                                not_an_arrow_error
                                                  "if_then_else"
                                                  (Prims.of_int (4)) ty r
                                             in
                                          let bs = a :: rest_bs  in
-                                         let uu____3305 =
-                                           let uu____3316 =
-                                             let uu____3321 =
+                                         let uu____3300 =
+                                           let uu____3311 =
+                                             let uu____3316 =
                                                FStar_TypeChecker_Env.push_binders
                                                  env bs
                                                 in
-                                             let uu____3322 =
-                                               let uu____3323 =
+                                             let uu____3317 =
+                                               let uu____3318 =
                                                  FStar_All.pipe_right a
                                                    FStar_Pervasives_Native.fst
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____3323
+                                                 uu____3318
                                                  FStar_Syntax_Syntax.bv_to_name
                                                 in
-                                             fresh_repr r uu____3321 u_a
-                                               uu____3322
+                                             fresh_repr r uu____3316 u_a
+                                               uu____3317
                                               in
-                                           match uu____3316 with
+                                           match uu____3311 with
                                            | (repr1,g) ->
-                                               let uu____3344 =
-                                                 let uu____3351 =
+                                               let uu____3339 =
+                                                 let uu____3346 =
                                                    FStar_Syntax_Syntax.gen_bv
                                                      "f"
                                                      FStar_Pervasives_Native.None
                                                      repr1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____3351
+                                                   uu____3346
                                                    FStar_Syntax_Syntax.mk_binder
                                                   in
-                                               (uu____3344, g)
+                                               (uu____3339, g)
                                             in
-                                         (match uu____3305 with
+                                         (match uu____3300 with
                                           | (f_bs,guard_f) ->
-                                              let uu____3391 =
-                                                let uu____3402 =
-                                                  let uu____3407 =
+                                              let uu____3386 =
+                                                let uu____3397 =
+                                                  let uu____3402 =
                                                     FStar_TypeChecker_Env.push_binders
                                                       env bs
                                                      in
-                                                  let uu____3408 =
-                                                    let uu____3409 =
+                                                  let uu____3403 =
+                                                    let uu____3404 =
                                                       FStar_All.pipe_right a
                                                         FStar_Pervasives_Native.fst
                                                        in
                                                     FStar_All.pipe_right
-                                                      uu____3409
+                                                      uu____3404
                                                       FStar_Syntax_Syntax.bv_to_name
                                                      in
-                                                  fresh_repr r uu____3407 u_a
-                                                    uu____3408
+                                                  fresh_repr r uu____3402 u_a
+                                                    uu____3403
                                                    in
-                                                match uu____3402 with
+                                                match uu____3397 with
                                                 | (repr1,g) ->
-                                                    let uu____3430 =
-                                                      let uu____3437 =
+                                                    let uu____3425 =
+                                                      let uu____3432 =
                                                         FStar_Syntax_Syntax.gen_bv
                                                           "g"
                                                           FStar_Pervasives_Native.None
                                                           repr1
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____3437
+                                                        uu____3432
                                                         FStar_Syntax_Syntax.mk_binder
                                                        in
-                                                    (uu____3430, g)
+                                                    (uu____3425, g)
                                                  in
-                                              (match uu____3391 with
+                                              (match uu____3386 with
                                                | (g_bs,guard_g) ->
                                                    let p_b =
-                                                     let uu____3484 =
+                                                     let uu____3479 =
                                                        FStar_Syntax_Syntax.gen_bv
                                                          "p"
                                                          FStar_Pervasives_Native.None
                                                          FStar_Syntax_Util.ktype0
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____3484
+                                                       uu____3479
                                                        FStar_Syntax_Syntax.mk_binder
                                                       in
-                                                   let uu____3492 =
-                                                     let uu____3497 =
+                                                   let uu____3487 =
+                                                     let uu____3492 =
                                                        FStar_TypeChecker_Env.push_binders
                                                          env
                                                          (FStar_List.append
                                                             bs [p_b])
                                                         in
-                                                     let uu____3516 =
-                                                       let uu____3517 =
+                                                     let uu____3511 =
+                                                       let uu____3512 =
                                                          FStar_All.pipe_right
                                                            a
                                                            FStar_Pervasives_Native.fst
                                                           in
                                                        FStar_All.pipe_right
-                                                         uu____3517
+                                                         uu____3512
                                                          FStar_Syntax_Syntax.bv_to_name
                                                         in
-                                                     fresh_repr r uu____3497
-                                                       u_a uu____3516
+                                                     fresh_repr r uu____3492
+                                                       u_a uu____3511
                                                       in
-                                                   (match uu____3492 with
+                                                   (match uu____3487 with
                                                     | (t_body,guard_body) ->
                                                         let k =
                                                           FStar_Syntax_Util.abs
@@ -1528,148 +1526,143 @@ let (tc_layered_eff_decl :
                                                            (FStar_List.iter
                                                               (FStar_TypeChecker_Rel.force_trivial_guard
                                                                  env));
-                                                         (let uu____3577 =
-                                                            let uu____3580 =
+                                                         (let uu____3572 =
+                                                            let uu____3575 =
                                                               FStar_All.pipe_right
                                                                 k
                                                                 (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                    env)
                                                                in
                                                             FStar_All.pipe_right
-                                                              uu____3580
+                                                              uu____3575
                                                               (FStar_Syntax_Subst.close_univ_vars
                                                                  if_then_else_us)
                                                              in
                                                           (if_then_else_us,
-                                                            uu____3577,
+                                                            uu____3572,
                                                             if_then_else_ty))))))))))
                       in
                    log_combinator "if_then_else" if_then_else;
                    (let r =
-                      let uu____3593 =
-                        let uu____3596 =
-                          let uu____3605 =
+                      let uu____3588 =
+                        let uu____3591 =
+                          let uu____3600 =
                             FStar_All.pipe_right ed
                               FStar_Syntax_Util.get_layered_if_then_else_combinator
                              in
-                          FStar_All.pipe_right uu____3605 FStar_Util.must  in
-                        FStar_All.pipe_right uu____3596
+                          FStar_All.pipe_right uu____3600 FStar_Util.must  in
+                        FStar_All.pipe_right uu____3591
                           FStar_Pervasives_Native.snd
                          in
-                      uu____3593.FStar_Syntax_Syntax.pos  in
-                    let uu____3666 = if_then_else  in
-                    match uu____3666 with
-                    | (ite_us,ite_t,uu____3681) ->
-                        let uu____3694 =
+                      uu____3588.FStar_Syntax_Syntax.pos  in
+                    let uu____3661 = if_then_else  in
+                    match uu____3661 with
+                    | (ite_us,ite_t,uu____3676) ->
+                        let uu____3689 =
                           FStar_Syntax_Subst.open_univ_vars ite_us ite_t  in
-                        (match uu____3694 with
+                        (match uu____3689 with
                          | (us,ite_t1) ->
-                             let uu____3701 =
-                               let uu____3716 =
-                                 let uu____3717 =
+                             let uu____3696 =
+                               let uu____3711 =
+                                 let uu____3712 =
                                    FStar_Syntax_Subst.compress ite_t1  in
-                                 uu____3717.FStar_Syntax_Syntax.n  in
-                               match uu____3716 with
+                                 uu____3712.FStar_Syntax_Syntax.n  in
+                               match uu____3711 with
                                | FStar_Syntax_Syntax.Tm_abs
-                                   (bs,uu____3735,uu____3736) ->
+                                   (bs,uu____3730,uu____3731) ->
                                    let bs1 =
                                      FStar_Syntax_Subst.open_binders bs  in
-                                   let uu____3762 =
-                                     let uu____3775 =
-                                       let uu____3780 =
-                                         let uu____3783 =
-                                           let uu____3792 =
+                                   let uu____3757 =
+                                     let uu____3770 =
+                                       let uu____3775 =
+                                         let uu____3778 =
+                                           let uu____3787 =
                                              FStar_All.pipe_right bs1
                                                (FStar_List.splitAt
                                                   ((FStar_List.length bs1) -
                                                      (Prims.of_int (3))))
                                               in
-                                           FStar_All.pipe_right uu____3792
+                                           FStar_All.pipe_right uu____3787
                                              FStar_Pervasives_Native.snd
                                             in
-                                         FStar_All.pipe_right uu____3783
+                                         FStar_All.pipe_right uu____3778
                                            (FStar_List.map
                                               FStar_Pervasives_Native.fst)
                                           in
-                                       FStar_All.pipe_right uu____3780
+                                       FStar_All.pipe_right uu____3775
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.bv_to_name)
                                         in
-                                     FStar_All.pipe_right uu____3775
+                                     FStar_All.pipe_right uu____3770
                                        (fun l  ->
-                                          let uu____3948 = l  in
-                                          match uu____3948 with
+                                          let uu____3943 = l  in
+                                          match uu____3943 with
                                           | f::g::p::[] -> (f, g, p))
                                       in
-                                   (match uu____3762 with
+                                   (match uu____3757 with
                                     | (f,g,p) ->
-                                        let uu____4017 =
-                                          let uu____4018 =
+                                        let uu____4012 =
+                                          let uu____4013 =
                                             FStar_TypeChecker_Env.push_univ_vars
                                               env0 us
                                              in
                                           FStar_TypeChecker_Env.push_binders
-                                            uu____4018 bs1
+                                            uu____4013 bs1
                                            in
-                                        let uu____4019 =
-                                          let uu____4020 =
-                                            let uu____4025 =
-                                              let uu____4026 =
-                                                let uu____4029 =
-                                                  FStar_All.pipe_right bs1
-                                                    (FStar_List.map
-                                                       FStar_Pervasives_Native.fst)
-                                                   in
-                                                FStar_All.pipe_right
-                                                  uu____4029
+                                        let uu____4014 =
+                                          let uu____4015 =
+                                            let uu____4016 =
+                                              let uu____4019 =
+                                                FStar_All.pipe_right bs1
                                                   (FStar_List.map
-                                                     FStar_Syntax_Syntax.bv_to_name)
+                                                     FStar_Pervasives_Native.fst)
                                                  in
-                                              FStar_All.pipe_right uu____4026
+                                              FStar_All.pipe_right uu____4019
                                                 (FStar_List.map
-                                                   FStar_Syntax_Syntax.as_arg)
+                                                   FStar_Syntax_Syntax.bv_to_name)
                                                in
-                                            FStar_Syntax_Syntax.mk_Tm_app
-                                              ite_t1 uu____4025
+                                            FStar_All.pipe_right uu____4016
+                                              (FStar_List.map
+                                                 FStar_Syntax_Syntax.as_arg)
                                              in
-                                          uu____4020
-                                            FStar_Pervasives_Native.None r
+                                          FStar_Syntax_Syntax.mk_Tm_app
+                                            ite_t1 uu____4015 r
                                            in
-                                        (uu____4017, uu____4019, f, g, p))
-                               | uu____4060 ->
+                                        (uu____4012, uu____4014, f, g, p))
+                               | uu____4050 ->
                                    failwith
                                      "Impossible! ite_t must have been an abstraction with at least 3 binders"
                                 in
-                             (match uu____3701 with
+                             (match uu____3696 with
                               | (env,ite_t_applied,f_t,g_t,p_t) ->
-                                  let uu____4089 =
-                                    let uu____4098 = stronger_repr  in
-                                    match uu____4098 with
-                                    | (uu____4119,subcomp_t,subcomp_ty) ->
-                                        let uu____4134 =
+                                  let uu____4079 =
+                                    let uu____4088 = stronger_repr  in
+                                    match uu____4088 with
+                                    | (uu____4109,subcomp_t,subcomp_ty) ->
+                                        let uu____4124 =
                                           FStar_Syntax_Subst.open_univ_vars
                                             us subcomp_t
                                            in
-                                        (match uu____4134 with
-                                         | (uu____4147,subcomp_t1) ->
-                                             let uu____4149 =
-                                               let uu____4160 =
+                                        (match uu____4124 with
+                                         | (uu____4137,subcomp_t1) ->
+                                             let uu____4139 =
+                                               let uu____4150 =
                                                  FStar_Syntax_Subst.open_univ_vars
                                                    us subcomp_ty
                                                   in
-                                               match uu____4160 with
-                                               | (uu____4175,subcomp_ty1) ->
-                                                   let uu____4177 =
-                                                     let uu____4178 =
+                                               match uu____4150 with
+                                               | (uu____4165,subcomp_ty1) ->
+                                                   let uu____4167 =
+                                                     let uu____4168 =
                                                        FStar_Syntax_Subst.compress
                                                          subcomp_ty1
                                                         in
-                                                     uu____4178.FStar_Syntax_Syntax.n
+                                                     uu____4168.FStar_Syntax_Syntax.n
                                                       in
-                                                   (match uu____4177 with
+                                                   (match uu____4167 with
                                                     | FStar_Syntax_Syntax.Tm_arrow
-                                                        (bs,uu____4192) ->
-                                                        let uu____4213 =
+                                                        (bs,uu____4182) ->
+                                                        let uu____4203 =
                                                           FStar_All.pipe_right
                                                             bs
                                                             (FStar_List.splitAt
@@ -1678,34 +1671,34 @@ let (tc_layered_eff_decl :
                                                                   -
                                                                   Prims.int_one))
                                                            in
-                                                        (match uu____4213
+                                                        (match uu____4203
                                                          with
                                                          | (bs_except_last,last_b)
                                                              ->
-                                                             let uu____4319 =
+                                                             let uu____4309 =
                                                                FStar_All.pipe_right
                                                                  bs_except_last
                                                                  (FStar_List.map
                                                                     FStar_Pervasives_Native.snd)
                                                                 in
-                                                             let uu____4346 =
-                                                               let uu____4349
+                                                             let uu____4336 =
+                                                               let uu____4339
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    last_b
                                                                    FStar_List.hd
                                                                   in
                                                                FStar_All.pipe_right
-                                                                 uu____4349
+                                                                 uu____4339
                                                                  FStar_Pervasives_Native.snd
                                                                 in
-                                                             (uu____4319,
-                                                               uu____4346))
-                                                    | uu____4392 ->
+                                                             (uu____4309,
+                                                               uu____4336))
+                                                    | uu____4382 ->
                                                         failwith
                                                           "Impossible! subcomp_ty must have been an arrow with at lease 1 binder")
                                                 in
-                                             (match uu____4149 with
+                                             (match uu____4139 with
                                               | (aqs_except_last,last_aq) ->
                                                   let aux t =
                                                     let tun_args =
@@ -1720,141 +1713,127 @@ let (tc_layered_eff_decl :
                                                       subcomp_t1
                                                       (FStar_List.append
                                                          tun_args
-                                                         [(t, last_aq)])
-                                                      FStar_Pervasives_Native.None
-                                                      r
+                                                         [(t, last_aq)]) r
                                                      in
-                                                  let uu____4505 = aux f_t
+                                                  let uu____4493 = aux f_t
                                                      in
-                                                  let uu____4508 = aux g_t
+                                                  let uu____4496 = aux g_t
                                                      in
-                                                  (uu____4505, uu____4508)))
+                                                  (uu____4493, uu____4496)))
                                      in
-                                  (match uu____4089 with
+                                  (match uu____4079 with
                                    | (subcomp_f,subcomp_g) ->
-                                       let uu____4525 =
+                                       let uu____4513 =
                                          let aux t =
-                                           let uu____4542 =
-                                             let uu____4549 =
-                                               let uu____4550 =
-                                                 let uu____4577 =
-                                                   let uu____4594 =
-                                                     let uu____4603 =
-                                                       FStar_Syntax_Syntax.mk_Total
-                                                         ite_t_applied
-                                                        in
-                                                     FStar_Util.Inr
-                                                       uu____4603
+                                           let uu____4530 =
+                                             let uu____4531 =
+                                               let uu____4558 =
+                                                 let uu____4575 =
+                                                   let uu____4584 =
+                                                     FStar_Syntax_Syntax.mk_Total
+                                                       ite_t_applied
                                                       in
-                                                   (uu____4594,
-                                                     FStar_Pervasives_Native.None)
+                                                   FStar_Util.Inr uu____4584
                                                     in
-                                                 (t, uu____4577,
+                                                 (uu____4575,
                                                    FStar_Pervasives_Native.None)
                                                   in
-                                               FStar_Syntax_Syntax.Tm_ascribed
-                                                 uu____4550
+                                               (t, uu____4558,
+                                                 FStar_Pervasives_Native.None)
                                                 in
-                                             FStar_Syntax_Syntax.mk
-                                               uu____4549
+                                             FStar_Syntax_Syntax.Tm_ascribed
+                                               uu____4531
                                               in
-                                           uu____4542
-                                             FStar_Pervasives_Native.None r
+                                           FStar_Syntax_Syntax.mk uu____4530
+                                             r
                                             in
-                                         let uu____4644 = aux subcomp_f  in
-                                         let uu____4645 = aux subcomp_g  in
-                                         (uu____4644, uu____4645)  in
-                                       (match uu____4525 with
+                                         let uu____4625 = aux subcomp_f  in
+                                         let uu____4626 = aux subcomp_g  in
+                                         (uu____4625, uu____4626)  in
+                                       (match uu____4513 with
                                         | (tm_subcomp_ascribed_f,tm_subcomp_ascribed_g)
                                             ->
-                                            ((let uu____4649 =
+                                            ((let uu____4630 =
                                                 FStar_All.pipe_left
                                                   (FStar_TypeChecker_Env.debug
                                                      env)
                                                   (FStar_Options.Other
                                                      "LayeredEffects")
                                                  in
-                                              if uu____4649
+                                              if uu____4630
                                               then
-                                                let uu____4654 =
+                                                let uu____4635 =
                                                   FStar_Syntax_Print.term_to_string
                                                     tm_subcomp_ascribed_f
                                                    in
-                                                let uu____4656 =
+                                                let uu____4637 =
                                                   FStar_Syntax_Print.term_to_string
                                                     tm_subcomp_ascribed_g
                                                    in
                                                 FStar_Util.print2
                                                   "Checking the soundness of the if_then_else combinators, f: %s, g: %s\n"
-                                                  uu____4654 uu____4656
+                                                  uu____4635 uu____4637
                                               else ());
-                                             (let uu____4661 =
+                                             (let uu____4642 =
                                                 FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                   env tm_subcomp_ascribed_f
                                                  in
-                                              match uu____4661 with
-                                              | (uu____4668,uu____4669,g_f)
+                                              match uu____4642 with
+                                              | (uu____4649,uu____4650,g_f)
                                                   ->
                                                   let g_f1 =
-                                                    let uu____4672 =
+                                                    let uu____4653 =
                                                       FStar_TypeChecker_Env.guard_of_guard_formula
                                                         (FStar_TypeChecker_Common.NonTrivial
                                                            p_t)
                                                        in
                                                     FStar_TypeChecker_Env.imp_guard
-                                                      uu____4672 g_f
+                                                      uu____4653 g_f
                                                      in
                                                   (FStar_TypeChecker_Rel.force_trivial_guard
                                                      env g_f1;
-                                                   (let uu____4674 =
+                                                   (let uu____4655 =
                                                       FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                         env
                                                         tm_subcomp_ascribed_g
                                                        in
-                                                    match uu____4674 with
-                                                    | (uu____4681,uu____4682,g_g)
+                                                    match uu____4655 with
+                                                    | (uu____4662,uu____4663,g_g)
                                                         ->
                                                         let g_g1 =
                                                           let not_p =
-                                                            let uu____4688 =
-                                                              let uu____4693
+                                                            let uu____4667 =
+                                                              let uu____4668
                                                                 =
-                                                                let uu____4694
-                                                                  =
-                                                                  FStar_Syntax_Syntax.lid_as_fv
-                                                                    FStar_Parser_Const.not_lid
-                                                                    FStar_Syntax_Syntax.delta_constant
-                                                                    FStar_Pervasives_Native.None
-                                                                   in
-                                                                FStar_All.pipe_right
-                                                                  uu____4694
-                                                                  FStar_Syntax_Syntax.fv_to_tm
+                                                                FStar_Syntax_Syntax.lid_as_fv
+                                                                  FStar_Parser_Const.not_lid
+                                                                  FStar_Syntax_Syntax.delta_constant
+                                                                  FStar_Pervasives_Native.None
                                                                  in
-                                                              let uu____4695
-                                                                =
-                                                                let uu____4696
-                                                                  =
-                                                                  FStar_All.pipe_right
-                                                                    p_t
-                                                                    FStar_Syntax_Syntax.as_arg
-                                                                   in
-                                                                [uu____4696]
-                                                                 in
-                                                              FStar_Syntax_Syntax.mk_Tm_app
-                                                                uu____4693
-                                                                uu____4695
+                                                              FStar_All.pipe_right
+                                                                uu____4668
+                                                                FStar_Syntax_Syntax.fv_to_tm
                                                                in
-                                                            uu____4688
-                                                              FStar_Pervasives_Native.None
-                                                              r
+                                                            let uu____4669 =
+                                                              let uu____4670
+                                                                =
+                                                                FStar_All.pipe_right
+                                                                  p_t
+                                                                  FStar_Syntax_Syntax.as_arg
+                                                                 in
+                                                              [uu____4670]
+                                                               in
+                                                            FStar_Syntax_Syntax.mk_Tm_app
+                                                              uu____4667
+                                                              uu____4669 r
                                                              in
-                                                          let uu____4729 =
+                                                          let uu____4703 =
                                                             FStar_TypeChecker_Env.guard_of_guard_formula
                                                               (FStar_TypeChecker_Common.NonTrivial
                                                                  not_p)
                                                              in
                                                           FStar_TypeChecker_Env.imp_guard
-                                                            uu____4729 g_g
+                                                            uu____4703 g_g
                                                            in
                                                         FStar_TypeChecker_Rel.force_trivial_guard
                                                           env g_g1)))))))));
@@ -1868,280 +1847,276 @@ let (tc_layered_eff_decl :
                            act.FStar_Syntax_Syntax.action_params)
                           <> Prims.int_zero
                       then
-                        (let uu____4753 =
-                           let uu____4759 =
-                             let uu____4761 =
+                        (let uu____4727 =
+                           let uu____4733 =
+                             let uu____4735 =
                                FStar_Ident.string_of_lid
                                  ed.FStar_Syntax_Syntax.mname
                                 in
-                             let uu____4763 =
+                             let uu____4737 =
                                FStar_Ident.string_of_lid
                                  act.FStar_Syntax_Syntax.action_name
                                 in
-                             let uu____4765 =
+                             let uu____4739 =
                                FStar_Syntax_Print.binders_to_string "; "
                                  act.FStar_Syntax_Syntax.action_params
                                 in
                              FStar_Util.format3
                                "Action %s:%s has non-empty action params (%s)"
-                               uu____4761 uu____4763 uu____4765
+                               uu____4735 uu____4737 uu____4739
                               in
                            (FStar_Errors.Fatal_MalformedActionDeclaration,
-                             uu____4759)
+                             uu____4733)
                             in
-                         FStar_Errors.raise_error uu____4753 r)
+                         FStar_Errors.raise_error uu____4727 r)
                       else ();
-                      (let uu____4772 =
-                         let uu____4777 =
+                      (let uu____4746 =
+                         let uu____4751 =
                            FStar_Syntax_Subst.univ_var_opening
                              act.FStar_Syntax_Syntax.action_univs
                             in
-                         match uu____4777 with
+                         match uu____4751 with
                          | (usubst,us) ->
-                             let uu____4800 =
+                             let uu____4774 =
                                FStar_TypeChecker_Env.push_univ_vars env us
                                 in
-                             let uu____4801 =
-                               let uu___452_4802 = act  in
-                               let uu____4803 =
+                             let uu____4775 =
+                               let uu___452_4776 = act  in
+                               let uu____4777 =
                                  FStar_Syntax_Subst.subst usubst
                                    act.FStar_Syntax_Syntax.action_defn
                                   in
-                               let uu____4804 =
+                               let uu____4778 =
                                  FStar_Syntax_Subst.subst usubst
                                    act.FStar_Syntax_Syntax.action_typ
                                   in
                                {
                                  FStar_Syntax_Syntax.action_name =
-                                   (uu___452_4802.FStar_Syntax_Syntax.action_name);
+                                   (uu___452_4776.FStar_Syntax_Syntax.action_name);
                                  FStar_Syntax_Syntax.action_unqualified_name
                                    =
-                                   (uu___452_4802.FStar_Syntax_Syntax.action_unqualified_name);
+                                   (uu___452_4776.FStar_Syntax_Syntax.action_unqualified_name);
                                  FStar_Syntax_Syntax.action_univs = us;
                                  FStar_Syntax_Syntax.action_params =
-                                   (uu___452_4802.FStar_Syntax_Syntax.action_params);
-                                 FStar_Syntax_Syntax.action_defn = uu____4803;
-                                 FStar_Syntax_Syntax.action_typ = uu____4804
+                                   (uu___452_4776.FStar_Syntax_Syntax.action_params);
+                                 FStar_Syntax_Syntax.action_defn = uu____4777;
+                                 FStar_Syntax_Syntax.action_typ = uu____4778
                                }  in
-                             (uu____4800, uu____4801)
+                             (uu____4774, uu____4775)
                           in
-                       match uu____4772 with
+                       match uu____4746 with
                        | (env1,act1) ->
                            let act_typ =
-                             let uu____4808 =
-                               let uu____4809 =
+                             let uu____4782 =
+                               let uu____4783 =
                                  FStar_Syntax_Subst.compress
                                    act1.FStar_Syntax_Syntax.action_typ
                                   in
-                               uu____4809.FStar_Syntax_Syntax.n  in
-                             match uu____4808 with
+                               uu____4783.FStar_Syntax_Syntax.n  in
+                             match uu____4782 with
                              | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                                  let ct =
                                    FStar_Syntax_Util.comp_to_comp_typ c  in
-                                 let uu____4835 =
+                                 let uu____4809 =
                                    FStar_Ident.lid_equals
                                      ct.FStar_Syntax_Syntax.effect_name
                                      ed.FStar_Syntax_Syntax.mname
                                     in
-                                 if uu____4835
+                                 if uu____4809
                                  then
                                    let repr_ts =
-                                     let uu____4839 = repr  in
-                                     match uu____4839 with
-                                     | (us,t,uu____4854) -> (us, t)  in
+                                     let uu____4813 = repr  in
+                                     match uu____4813 with
+                                     | (us,t,uu____4828) -> (us, t)  in
                                    let repr1 =
-                                     let uu____4872 =
+                                     let uu____4846 =
                                        FStar_TypeChecker_Env.inst_tscheme_with
                                          repr_ts
                                          ct.FStar_Syntax_Syntax.comp_univs
                                         in
-                                     FStar_All.pipe_right uu____4872
+                                     FStar_All.pipe_right uu____4846
                                        FStar_Pervasives_Native.snd
                                       in
                                    let repr2 =
-                                     let uu____4884 =
-                                       let uu____4889 =
-                                         let uu____4890 =
-                                           FStar_Syntax_Syntax.as_arg
-                                             ct.FStar_Syntax_Syntax.result_typ
-                                            in
-                                         uu____4890 ::
-                                           (ct.FStar_Syntax_Syntax.effect_args)
+                                     let uu____4856 =
+                                       let uu____4857 =
+                                         FStar_Syntax_Syntax.as_arg
+                                           ct.FStar_Syntax_Syntax.result_typ
                                           in
-                                       FStar_Syntax_Syntax.mk_Tm_app repr1
-                                         uu____4889
+                                       uu____4857 ::
+                                         (ct.FStar_Syntax_Syntax.effect_args)
                                         in
-                                     uu____4884 FStar_Pervasives_Native.None
-                                       r
+                                     FStar_Syntax_Syntax.mk_Tm_app repr1
+                                       uu____4856 r
                                       in
                                    let c1 =
-                                     let uu____4908 =
-                                       let uu____4911 =
+                                     let uu____4875 =
+                                       let uu____4878 =
                                          FStar_TypeChecker_Env.new_u_univ ()
                                           in
                                        FStar_Pervasives_Native.Some
-                                         uu____4911
+                                         uu____4878
                                         in
                                      FStar_Syntax_Syntax.mk_Total' repr2
-                                       uu____4908
+                                       uu____4875
                                       in
                                    FStar_Syntax_Util.arrow bs c1
                                  else act1.FStar_Syntax_Syntax.action_typ
-                             | uu____4914 ->
+                             | uu____4881 ->
                                  act1.FStar_Syntax_Syntax.action_typ
                               in
-                           let uu____4915 =
+                           let uu____4882 =
                              FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                env1 act_typ
                               in
-                           (match uu____4915 with
-                            | (act_typ1,uu____4923,g_t) ->
-                                let uu____4925 =
-                                  let uu____4932 =
-                                    let uu___477_4933 =
+                           (match uu____4882 with
+                            | (act_typ1,uu____4890,g_t) ->
+                                let uu____4892 =
+                                  let uu____4899 =
+                                    let uu___477_4900 =
                                       FStar_TypeChecker_Env.set_expected_typ
                                         env1 act_typ1
                                        in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___477_4933.FStar_TypeChecker_Env.solver);
+                                        (uu___477_4900.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___477_4933.FStar_TypeChecker_Env.range);
+                                        (uu___477_4900.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___477_4933.FStar_TypeChecker_Env.curmodule);
+                                        (uu___477_4900.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___477_4933.FStar_TypeChecker_Env.gamma);
+                                        (uu___477_4900.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___477_4933.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___477_4900.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___477_4933.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___477_4900.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___477_4933.FStar_TypeChecker_Env.modules);
+                                        (uu___477_4900.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___477_4933.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___477_4900.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___477_4933.FStar_TypeChecker_Env.sigtab);
+                                        (uu___477_4900.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___477_4933.FStar_TypeChecker_Env.attrtab);
+                                        (uu___477_4900.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
                                         false;
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___477_4933.FStar_TypeChecker_Env.effects);
+                                        (uu___477_4900.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___477_4933.FStar_TypeChecker_Env.generalize);
+                                        (uu___477_4900.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___477_4933.FStar_TypeChecker_Env.letrecs);
+                                        (uu___477_4900.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___477_4933.FStar_TypeChecker_Env.top_level);
+                                        (uu___477_4900.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
-                                        (uu___477_4933.FStar_TypeChecker_Env.check_uvars);
+                                        (uu___477_4900.FStar_TypeChecker_Env.check_uvars);
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___477_4933.FStar_TypeChecker_Env.use_eq);
+                                        (uu___477_4900.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___477_4933.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___477_4900.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___477_4933.FStar_TypeChecker_Env.is_iface);
+                                        (uu___477_4900.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___477_4933.FStar_TypeChecker_Env.admit);
+                                        (uu___477_4900.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___477_4933.FStar_TypeChecker_Env.lax);
+                                        (uu___477_4900.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___477_4933.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___477_4900.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___477_4933.FStar_TypeChecker_Env.phase1);
+                                        (uu___477_4900.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___477_4933.FStar_TypeChecker_Env.failhard);
+                                        (uu___477_4900.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___477_4933.FStar_TypeChecker_Env.nosynth);
+                                        (uu___477_4900.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___477_4933.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___477_4900.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___477_4933.FStar_TypeChecker_Env.tc_term);
+                                        (uu___477_4900.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___477_4933.FStar_TypeChecker_Env.type_of);
+                                        (uu___477_4900.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___477_4933.FStar_TypeChecker_Env.universe_of);
+                                        (uu___477_4900.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___477_4933.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___477_4900.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___477_4933.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___477_4900.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___477_4933.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___477_4900.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___477_4933.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___477_4900.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___477_4933.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___477_4900.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___477_4933.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___477_4900.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___477_4933.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___477_4900.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___477_4933.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___477_4900.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___477_4933.FStar_TypeChecker_Env.splice);
+                                        (uu___477_4900.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___477_4933.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___477_4900.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___477_4933.FStar_TypeChecker_Env.postprocess);
+                                        (uu___477_4900.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___477_4933.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___477_4900.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___477_4933.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___477_4900.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___477_4933.FStar_TypeChecker_Env.dsenv);
+                                        (uu___477_4900.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___477_4933.FStar_TypeChecker_Env.nbe);
+                                        (uu___477_4900.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___477_4933.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___477_4900.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___477_4933.FStar_TypeChecker_Env.erasable_types_tab)
+                                        (uu___477_4900.FStar_TypeChecker_Env.erasable_types_tab)
                                     }  in
                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                    uu____4932
+                                    uu____4899
                                     act1.FStar_Syntax_Syntax.action_defn
                                    in
-                                (match uu____4925 with
-                                 | (act_defn,uu____4936,g_d) ->
-                                     ((let uu____4939 =
+                                (match uu____4892 with
+                                 | (act_defn,uu____4903,g_d) ->
+                                     ((let uu____4906 =
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.debug env1)
                                            (FStar_Options.Other
                                               "LayeredEffects")
                                           in
-                                       if uu____4939
+                                       if uu____4906
                                        then
-                                         let uu____4944 =
+                                         let uu____4911 =
                                            FStar_Syntax_Print.term_to_string
                                              act_defn
                                             in
-                                         let uu____4946 =
+                                         let uu____4913 =
                                            FStar_Syntax_Print.term_to_string
                                              act_typ1
                                             in
                                          FStar_Util.print2
                                            "Typechecked action definition: %s and action type: %s\n"
-                                           uu____4944 uu____4946
+                                           uu____4911 uu____4913
                                        else ());
-                                      (let uu____4951 =
+                                      (let uu____4918 =
                                          let act_typ2 =
                                            FStar_TypeChecker_Normalize.normalize
                                              [FStar_TypeChecker_Env.Beta]
                                              env1 act_typ1
                                             in
-                                         let uu____4959 =
-                                           let uu____4960 =
+                                         let uu____4926 =
+                                           let uu____4927 =
                                              FStar_Syntax_Subst.compress
                                                act_typ2
                                               in
-                                           uu____4960.FStar_Syntax_Syntax.n
+                                           uu____4927.FStar_Syntax_Syntax.n
                                             in
-                                         match uu____4959 with
+                                         match uu____4926 with
                                          | FStar_Syntax_Syntax.Tm_arrow
-                                             (bs,uu____4970) ->
+                                             (bs,uu____4937) ->
                                              let bs1 =
                                                FStar_Syntax_Subst.open_binders
                                                  bs
@@ -2150,113 +2125,113 @@ let (tc_layered_eff_decl :
                                                FStar_TypeChecker_Env.push_binders
                                                  env1 bs1
                                                 in
-                                             let uu____4993 =
+                                             let uu____4960 =
                                                FStar_Syntax_Util.type_u ()
                                                 in
-                                             (match uu____4993 with
+                                             (match uu____4960 with
                                               | (t,u) ->
                                                   let reason =
-                                                    let uu____5008 =
+                                                    let uu____4975 =
                                                       FStar_Ident.string_of_lid
                                                         ed.FStar_Syntax_Syntax.mname
                                                        in
-                                                    let uu____5010 =
+                                                    let uu____4977 =
                                                       FStar_Ident.string_of_lid
                                                         act1.FStar_Syntax_Syntax.action_name
                                                        in
                                                     FStar_Util.format2
                                                       "implicit for return type of action %s:%s"
-                                                      uu____5008 uu____5010
+                                                      uu____4975 uu____4977
                                                      in
-                                                  let uu____5013 =
+                                                  let uu____4980 =
                                                     FStar_TypeChecker_Util.new_implicit_var
                                                       reason r env2 t
                                                      in
-                                                  (match uu____5013 with
-                                                   | (a_tm,uu____5033,g_tm)
+                                                  (match uu____4980 with
+                                                   | (a_tm,uu____5000,g_tm)
                                                        ->
-                                                       let uu____5047 =
+                                                       let uu____5014 =
                                                          fresh_repr r env2 u
                                                            a_tm
                                                           in
-                                                       (match uu____5047 with
+                                                       (match uu____5014 with
                                                         | (repr1,g) ->
-                                                            let uu____5060 =
-                                                              let uu____5063
+                                                            let uu____5027 =
+                                                              let uu____5030
                                                                 =
-                                                                let uu____5066
+                                                                let uu____5033
                                                                   =
-                                                                  let uu____5069
+                                                                  let uu____5036
                                                                     =
                                                                     FStar_TypeChecker_Env.new_u_univ
                                                                     ()  in
                                                                   FStar_All.pipe_right
-                                                                    uu____5069
+                                                                    uu____5036
                                                                     (
                                                                     fun
-                                                                    uu____5072
+                                                                    uu____5039
                                                                      ->
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____5072)
+                                                                    uu____5039)
                                                                    in
                                                                 FStar_Syntax_Syntax.mk_Total'
                                                                   repr1
-                                                                  uu____5066
+                                                                  uu____5033
                                                                  in
                                                               FStar_Syntax_Util.arrow
                                                                 bs1
-                                                                uu____5063
+                                                                uu____5030
                                                                in
-                                                            let uu____5073 =
+                                                            let uu____5040 =
                                                               FStar_TypeChecker_Env.conj_guard
                                                                 g g_tm
                                                                in
-                                                            (uu____5060,
-                                                              uu____5073))))
-                                         | uu____5076 ->
-                                             let uu____5077 =
-                                               let uu____5083 =
-                                                 let uu____5085 =
+                                                            (uu____5027,
+                                                              uu____5040))))
+                                         | uu____5043 ->
+                                             let uu____5044 =
+                                               let uu____5050 =
+                                                 let uu____5052 =
                                                    FStar_Ident.string_of_lid
                                                      ed.FStar_Syntax_Syntax.mname
                                                     in
-                                                 let uu____5087 =
+                                                 let uu____5054 =
                                                    FStar_Ident.string_of_lid
                                                      act1.FStar_Syntax_Syntax.action_name
                                                     in
-                                                 let uu____5089 =
+                                                 let uu____5056 =
                                                    FStar_Syntax_Print.term_to_string
                                                      act_typ2
                                                     in
                                                  FStar_Util.format3
                                                    "Unexpected non-function type for action %s:%s (%s)"
-                                                   uu____5085 uu____5087
-                                                   uu____5089
+                                                   uu____5052 uu____5054
+                                                   uu____5056
                                                   in
                                                (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                 uu____5083)
+                                                 uu____5050)
                                                 in
                                              FStar_Errors.raise_error
-                                               uu____5077 r
+                                               uu____5044 r
                                           in
-                                       match uu____4951 with
+                                       match uu____4918 with
                                        | (k,g_k) ->
-                                           ((let uu____5106 =
+                                           ((let uu____5073 =
                                                FStar_All.pipe_left
                                                  (FStar_TypeChecker_Env.debug
                                                     env1)
                                                  (FStar_Options.Other
                                                     "LayeredEffects")
                                                 in
-                                             if uu____5106
+                                             if uu____5073
                                              then
-                                               let uu____5111 =
+                                               let uu____5078 =
                                                  FStar_Syntax_Print.term_to_string
                                                    k
                                                   in
                                                FStar_Util.print1
                                                  "Expected action type: %s\n"
-                                                 uu____5111
+                                                 uu____5078
                                              else ());
                                             (let g =
                                                FStar_TypeChecker_Rel.teq env1
@@ -2265,112 +2240,112 @@ let (tc_layered_eff_decl :
                                              FStar_List.iter
                                                (FStar_TypeChecker_Rel.force_trivial_guard
                                                   env1) [g_t; g_d; g_k; g];
-                                             (let uu____5119 =
+                                             (let uu____5086 =
                                                 FStar_All.pipe_left
                                                   (FStar_TypeChecker_Env.debug
                                                      env1)
                                                   (FStar_Options.Other
                                                      "LayeredEffects")
                                                  in
-                                              if uu____5119
+                                              if uu____5086
                                               then
-                                                let uu____5124 =
+                                                let uu____5091 =
                                                   FStar_Syntax_Print.term_to_string
                                                     k
                                                    in
                                                 FStar_Util.print1
                                                   "Expected action type after unification: %s\n"
-                                                  uu____5124
+                                                  uu____5091
                                               else ());
                                              (let act_typ2 =
                                                 let err_msg t =
-                                                  let uu____5137 =
+                                                  let uu____5104 =
                                                     FStar_Ident.string_of_lid
                                                       ed.FStar_Syntax_Syntax.mname
                                                      in
-                                                  let uu____5139 =
+                                                  let uu____5106 =
                                                     FStar_Ident.string_of_lid
                                                       act1.FStar_Syntax_Syntax.action_name
                                                      in
-                                                  let uu____5141 =
+                                                  let uu____5108 =
                                                     FStar_Syntax_Print.term_to_string
                                                       t
                                                      in
                                                   FStar_Util.format3
                                                     "Unexpected (k-)type of action %s:%s, expected bs -> repr<u> i_1 ... i_n, found: %s"
-                                                    uu____5137 uu____5139
-                                                    uu____5141
+                                                    uu____5104 uu____5106
+                                                    uu____5108
                                                    in
                                                 let repr_args t =
-                                                  let uu____5162 =
-                                                    let uu____5163 =
+                                                  let uu____5129 =
+                                                    let uu____5130 =
                                                       FStar_Syntax_Subst.compress
                                                         t
                                                        in
-                                                    uu____5163.FStar_Syntax_Syntax.n
+                                                    uu____5130.FStar_Syntax_Syntax.n
                                                      in
-                                                  match uu____5162 with
+                                                  match uu____5129 with
                                                   | FStar_Syntax_Syntax.Tm_app
                                                       (head,a::is) ->
-                                                      let uu____5215 =
-                                                        let uu____5216 =
+                                                      let uu____5182 =
+                                                        let uu____5183 =
                                                           FStar_Syntax_Subst.compress
                                                             head
                                                            in
-                                                        uu____5216.FStar_Syntax_Syntax.n
+                                                        uu____5183.FStar_Syntax_Syntax.n
                                                          in
-                                                      (match uu____5215 with
+                                                      (match uu____5182 with
                                                        | FStar_Syntax_Syntax.Tm_uinst
-                                                           (uu____5225,us) ->
+                                                           (uu____5192,us) ->
                                                            (us,
                                                              (FStar_Pervasives_Native.fst
                                                                 a), is)
-                                                       | uu____5235 ->
-                                                           let uu____5236 =
-                                                             let uu____5242 =
+                                                       | uu____5202 ->
+                                                           let uu____5203 =
+                                                             let uu____5209 =
                                                                err_msg t  in
                                                              (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                               uu____5242)
+                                                               uu____5209)
                                                               in
                                                            FStar_Errors.raise_error
-                                                             uu____5236 r)
-                                                  | uu____5251 ->
-                                                      let uu____5252 =
-                                                        let uu____5258 =
+                                                             uu____5203 r)
+                                                  | uu____5218 ->
+                                                      let uu____5219 =
+                                                        let uu____5225 =
                                                           err_msg t  in
                                                         (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                          uu____5258)
+                                                          uu____5225)
                                                          in
                                                       FStar_Errors.raise_error
-                                                        uu____5252 r
+                                                        uu____5219 r
                                                    in
                                                 let k1 =
                                                   FStar_TypeChecker_Normalize.normalize
                                                     [FStar_TypeChecker_Env.Beta]
                                                     env1 k
                                                    in
-                                                let uu____5268 =
-                                                  let uu____5269 =
+                                                let uu____5235 =
+                                                  let uu____5236 =
                                                     FStar_Syntax_Subst.compress
                                                       k1
                                                      in
-                                                  uu____5269.FStar_Syntax_Syntax.n
+                                                  uu____5236.FStar_Syntax_Syntax.n
                                                    in
-                                                match uu____5268 with
+                                                match uu____5235 with
                                                 | FStar_Syntax_Syntax.Tm_arrow
                                                     (bs,c) ->
-                                                    let uu____5294 =
+                                                    let uu____5261 =
                                                       FStar_Syntax_Subst.open_comp
                                                         bs c
                                                        in
-                                                    (match uu____5294 with
+                                                    (match uu____5261 with
                                                      | (bs1,c1) ->
-                                                         let uu____5301 =
+                                                         let uu____5268 =
                                                            repr_args
                                                              (FStar_Syntax_Util.comp_result
                                                                 c1)
                                                             in
-                                                         (match uu____5301
+                                                         (match uu____5268
                                                           with
                                                           | (us,a,is) ->
                                                               let ct =
@@ -2388,77 +2363,77 @@ let (tc_layered_eff_decl :
                                                                   FStar_Syntax_Syntax.flags
                                                                     = []
                                                                 }  in
-                                                              let uu____5312
+                                                              let uu____5279
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_Comp
                                                                   ct
                                                                  in
                                                               FStar_Syntax_Util.arrow
                                                                 bs1
-                                                                uu____5312))
-                                                | uu____5315 ->
-                                                    let uu____5316 =
-                                                      let uu____5322 =
+                                                                uu____5279))
+                                                | uu____5282 ->
+                                                    let uu____5283 =
+                                                      let uu____5289 =
                                                         err_msg k1  in
                                                       (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                        uu____5322)
+                                                        uu____5289)
                                                        in
                                                     FStar_Errors.raise_error
-                                                      uu____5316 r
+                                                      uu____5283 r
                                                  in
-                                              (let uu____5326 =
+                                              (let uu____5293 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env1)
                                                    (FStar_Options.Other
                                                       "LayeredEffects")
                                                   in
-                                               if uu____5326
+                                               if uu____5293
                                                then
-                                                 let uu____5331 =
+                                                 let uu____5298 =
                                                    FStar_Syntax_Print.term_to_string
                                                      act_typ2
                                                     in
                                                  FStar_Util.print1
                                                    "Action type after injecting it into the monad: %s\n"
-                                                   uu____5331
+                                                   uu____5298
                                                else ());
                                               (let act2 =
-                                                 let uu____5337 =
+                                                 let uu____5304 =
                                                    FStar_TypeChecker_Util.generalize_universes
                                                      env1 act_defn
                                                     in
-                                                 match uu____5337 with
+                                                 match uu____5304 with
                                                  | (us,act_defn1) ->
                                                      if
                                                        act1.FStar_Syntax_Syntax.action_univs
                                                          = []
                                                      then
-                                                       let uu___550_5351 =
+                                                       let uu___550_5318 =
                                                          act1  in
-                                                       let uu____5352 =
+                                                       let uu____5319 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            us act_typ2
                                                           in
                                                        {
                                                          FStar_Syntax_Syntax.action_name
                                                            =
-                                                           (uu___550_5351.FStar_Syntax_Syntax.action_name);
+                                                           (uu___550_5318.FStar_Syntax_Syntax.action_name);
                                                          FStar_Syntax_Syntax.action_unqualified_name
                                                            =
-                                                           (uu___550_5351.FStar_Syntax_Syntax.action_unqualified_name);
+                                                           (uu___550_5318.FStar_Syntax_Syntax.action_unqualified_name);
                                                          FStar_Syntax_Syntax.action_univs
                                                            = us;
                                                          FStar_Syntax_Syntax.action_params
                                                            =
-                                                           (uu___550_5351.FStar_Syntax_Syntax.action_params);
+                                                           (uu___550_5318.FStar_Syntax_Syntax.action_params);
                                                          FStar_Syntax_Syntax.action_defn
                                                            = act_defn1;
                                                          FStar_Syntax_Syntax.action_typ
-                                                           = uu____5352
+                                                           = uu____5319
                                                        }
                                                      else
-                                                       (let uu____5355 =
+                                                       (let uu____5322 =
                                                           ((FStar_List.length
                                                               us)
                                                              =
@@ -2468,21 +2443,21 @@ let (tc_layered_eff_decl :
                                                             (FStar_List.forall2
                                                                (fun u1  ->
                                                                   fun u2  ->
-                                                                    let uu____5362
+                                                                    let uu____5329
                                                                     =
                                                                     FStar_Syntax_Syntax.order_univ_name
                                                                     u1 u2  in
-                                                                    uu____5362
+                                                                    uu____5329
                                                                     =
                                                                     Prims.int_zero)
                                                                us
                                                                act1.FStar_Syntax_Syntax.action_univs)
                                                            in
-                                                        if uu____5355
+                                                        if uu____5322
                                                         then
-                                                          let uu___555_5367 =
+                                                          let uu___555_5334 =
                                                             act1  in
-                                                          let uu____5368 =
+                                                          let uu____5335 =
                                                             FStar_Syntax_Subst.close_univ_vars
                                                               act1.FStar_Syntax_Syntax.action_univs
                                                               act_typ2
@@ -2490,100 +2465,100 @@ let (tc_layered_eff_decl :
                                                           {
                                                             FStar_Syntax_Syntax.action_name
                                                               =
-                                                              (uu___555_5367.FStar_Syntax_Syntax.action_name);
+                                                              (uu___555_5334.FStar_Syntax_Syntax.action_name);
                                                             FStar_Syntax_Syntax.action_unqualified_name
                                                               =
-                                                              (uu___555_5367.FStar_Syntax_Syntax.action_unqualified_name);
+                                                              (uu___555_5334.FStar_Syntax_Syntax.action_unqualified_name);
                                                             FStar_Syntax_Syntax.action_univs
                                                               =
-                                                              (uu___555_5367.FStar_Syntax_Syntax.action_univs);
+                                                              (uu___555_5334.FStar_Syntax_Syntax.action_univs);
                                                             FStar_Syntax_Syntax.action_params
                                                               =
-                                                              (uu___555_5367.FStar_Syntax_Syntax.action_params);
+                                                              (uu___555_5334.FStar_Syntax_Syntax.action_params);
                                                             FStar_Syntax_Syntax.action_defn
                                                               = act_defn1;
                                                             FStar_Syntax_Syntax.action_typ
-                                                              = uu____5368
+                                                              = uu____5335
                                                           }
                                                         else
-                                                          (let uu____5371 =
-                                                             let uu____5377 =
-                                                               let uu____5379
+                                                          (let uu____5338 =
+                                                             let uu____5344 =
+                                                               let uu____5346
                                                                  =
                                                                  FStar_Ident.string_of_lid
                                                                    ed.FStar_Syntax_Syntax.mname
                                                                   in
-                                                               let uu____5381
+                                                               let uu____5348
                                                                  =
                                                                  FStar_Ident.string_of_lid
                                                                    act1.FStar_Syntax_Syntax.action_name
                                                                   in
-                                                               let uu____5383
+                                                               let uu____5350
                                                                  =
                                                                  FStar_Syntax_Print.univ_names_to_string
                                                                    us
                                                                   in
-                                                               let uu____5385
+                                                               let uu____5352
                                                                  =
                                                                  FStar_Syntax_Print.univ_names_to_string
                                                                    act1.FStar_Syntax_Syntax.action_univs
                                                                   in
                                                                FStar_Util.format4
                                                                  "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
-                                                                 uu____5379
-                                                                 uu____5381
-                                                                 uu____5383
-                                                                 uu____5385
+                                                                 uu____5346
+                                                                 uu____5348
+                                                                 uu____5350
+                                                                 uu____5352
                                                                 in
                                                              (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                               uu____5377)
+                                                               uu____5344)
                                                               in
                                                            FStar_Errors.raise_error
-                                                             uu____5371 r))
+                                                             uu____5338 r))
                                                   in
                                                act2)))))))))
                        in
-                    let tschemes_of uu____5410 =
-                      match uu____5410 with
+                    let tschemes_of uu____5377 =
+                      match uu____5377 with
                       | (us,t,ty) -> ((us, t), (us, ty))  in
                     let combinators =
-                      let uu____5455 =
-                        let uu____5456 = tschemes_of repr  in
-                        let uu____5461 = tschemes_of return_repr  in
-                        let uu____5466 = tschemes_of bind_repr  in
-                        let uu____5471 = tschemes_of stronger_repr  in
-                        let uu____5476 = tschemes_of if_then_else  in
+                      let uu____5422 =
+                        let uu____5423 = tschemes_of repr  in
+                        let uu____5428 = tschemes_of return_repr  in
+                        let uu____5433 = tschemes_of bind_repr  in
+                        let uu____5438 = tschemes_of stronger_repr  in
+                        let uu____5443 = tschemes_of if_then_else  in
                         {
                           FStar_Syntax_Syntax.l_base_effect =
                             underlying_effect_lid;
-                          FStar_Syntax_Syntax.l_repr = uu____5456;
-                          FStar_Syntax_Syntax.l_return = uu____5461;
-                          FStar_Syntax_Syntax.l_bind = uu____5466;
-                          FStar_Syntax_Syntax.l_subcomp = uu____5471;
-                          FStar_Syntax_Syntax.l_if_then_else = uu____5476
+                          FStar_Syntax_Syntax.l_repr = uu____5423;
+                          FStar_Syntax_Syntax.l_return = uu____5428;
+                          FStar_Syntax_Syntax.l_bind = uu____5433;
+                          FStar_Syntax_Syntax.l_subcomp = uu____5438;
+                          FStar_Syntax_Syntax.l_if_then_else = uu____5443
                         }  in
-                      FStar_Syntax_Syntax.Layered_eff uu____5455  in
-                    let uu___564_5481 = ed  in
-                    let uu____5482 =
+                      FStar_Syntax_Syntax.Layered_eff uu____5422  in
+                    let uu___564_5448 = ed  in
+                    let uu____5449 =
                       FStar_List.map (tc_action env0)
                         ed.FStar_Syntax_Syntax.actions
                        in
                     {
                       FStar_Syntax_Syntax.mname =
-                        (uu___564_5481.FStar_Syntax_Syntax.mname);
+                        (uu___564_5448.FStar_Syntax_Syntax.mname);
                       FStar_Syntax_Syntax.cattributes =
-                        (uu___564_5481.FStar_Syntax_Syntax.cattributes);
+                        (uu___564_5448.FStar_Syntax_Syntax.cattributes);
                       FStar_Syntax_Syntax.univs =
-                        (uu___564_5481.FStar_Syntax_Syntax.univs);
+                        (uu___564_5448.FStar_Syntax_Syntax.univs);
                       FStar_Syntax_Syntax.binders =
-                        (uu___564_5481.FStar_Syntax_Syntax.binders);
+                        (uu___564_5448.FStar_Syntax_Syntax.binders);
                       FStar_Syntax_Syntax.signature =
-                        (let uu____5489 = signature  in
-                         match uu____5489 with | (us,t,uu____5504) -> (us, t));
+                        (let uu____5456 = signature  in
+                         match uu____5456 with | (us,t,uu____5471) -> (us, t));
                       FStar_Syntax_Syntax.combinators = combinators;
-                      FStar_Syntax_Syntax.actions = uu____5482;
+                      FStar_Syntax_Syntax.actions = uu____5449;
                       FStar_Syntax_Syntax.eff_attrs =
-                        (uu___564_5481.FStar_Syntax_Syntax.eff_attrs)
+                        (uu___564_5448.FStar_Syntax_Syntax.eff_attrs)
                     }))))))))
   
 let (tc_non_layered_eff_decl :
@@ -2595,244 +2570,244 @@ let (tc_non_layered_eff_decl :
   fun env0  ->
     fun ed  ->
       fun _quals  ->
-        (let uu____5542 =
+        (let uu____5509 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
              (FStar_Options.Other "ED")
             in
-         if uu____5542
+         if uu____5509
          then
-           let uu____5547 = FStar_Syntax_Print.eff_decl_to_string false ed
+           let uu____5514 = FStar_Syntax_Print.eff_decl_to_string false ed
               in
-           FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____5547
+           FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____5514
          else ());
-        (let uu____5553 =
-           let uu____5558 =
+        (let uu____5520 =
+           let uu____5525 =
              FStar_Syntax_Subst.univ_var_opening ed.FStar_Syntax_Syntax.univs
               in
-           match uu____5558 with
+           match uu____5525 with
            | (ed_univs_subst,ed_univs) ->
                let bs =
-                 let uu____5582 =
+                 let uu____5549 =
                    FStar_Syntax_Subst.subst_binders ed_univs_subst
                      ed.FStar_Syntax_Syntax.binders
                     in
-                 FStar_Syntax_Subst.open_binders uu____5582  in
-               let uu____5583 =
-                 let uu____5590 =
+                 FStar_Syntax_Subst.open_binders uu____5549  in
+               let uu____5550 =
+                 let uu____5557 =
                    FStar_TypeChecker_Env.push_univ_vars env0 ed_univs  in
-                 FStar_TypeChecker_TcTerm.tc_tparams uu____5590 bs  in
-               (match uu____5583 with
-                | (bs1,uu____5596,uu____5597) ->
-                    let uu____5598 =
+                 FStar_TypeChecker_TcTerm.tc_tparams uu____5557 bs  in
+               (match uu____5550 with
+                | (bs1,uu____5563,uu____5564) ->
+                    let uu____5565 =
                       let tmp_t =
-                        let uu____5608 =
-                          let uu____5611 =
+                        let uu____5575 =
+                          let uu____5578 =
                             FStar_All.pipe_right FStar_Syntax_Syntax.U_zero
-                              (fun uu____5616  ->
-                                 FStar_Pervasives_Native.Some uu____5616)
+                              (fun uu____5583  ->
+                                 FStar_Pervasives_Native.Some uu____5583)
                              in
                           FStar_Syntax_Syntax.mk_Total'
-                            FStar_Syntax_Syntax.t_unit uu____5611
+                            FStar_Syntax_Syntax.t_unit uu____5578
                            in
-                        FStar_Syntax_Util.arrow bs1 uu____5608  in
-                      let uu____5617 =
+                        FStar_Syntax_Util.arrow bs1 uu____5575  in
+                      let uu____5584 =
                         FStar_TypeChecker_Util.generalize_universes env0
                           tmp_t
                          in
-                      match uu____5617 with
+                      match uu____5584 with
                       | (us,tmp_t1) ->
-                          let uu____5634 =
-                            let uu____5635 =
-                              let uu____5636 =
+                          let uu____5601 =
+                            let uu____5602 =
+                              let uu____5603 =
                                 FStar_All.pipe_right tmp_t1
                                   FStar_Syntax_Util.arrow_formals
                                  in
-                              FStar_All.pipe_right uu____5636
+                              FStar_All.pipe_right uu____5603
                                 FStar_Pervasives_Native.fst
                                in
-                            FStar_All.pipe_right uu____5635
+                            FStar_All.pipe_right uu____5602
                               FStar_Syntax_Subst.close_binders
                              in
-                          (us, uu____5634)
+                          (us, uu____5601)
                        in
-                    (match uu____5598 with
+                    (match uu____5565 with
                      | (us,bs2) ->
                          (match ed_univs with
                           | [] -> (us, bs2)
-                          | uu____5673 ->
-                              let uu____5676 =
+                          | uu____5640 ->
+                              let uu____5643 =
                                 ((FStar_List.length ed_univs) =
                                    (FStar_List.length us))
                                   &&
                                   (FStar_List.forall2
                                      (fun u1  ->
                                         fun u2  ->
-                                          let uu____5683 =
+                                          let uu____5650 =
                                             FStar_Syntax_Syntax.order_univ_name
                                               u1 u2
                                              in
-                                          uu____5683 = Prims.int_zero)
+                                          uu____5650 = Prims.int_zero)
                                      ed_univs us)
                                  in
-                              if uu____5676
+                              if uu____5643
                               then (us, bs2)
                               else
-                                (let uu____5694 =
-                                   let uu____5700 =
-                                     let uu____5702 =
+                                (let uu____5661 =
+                                   let uu____5667 =
+                                     let uu____5669 =
                                        FStar_Ident.string_of_lid
                                          ed.FStar_Syntax_Syntax.mname
                                         in
-                                     let uu____5704 =
+                                     let uu____5671 =
                                        FStar_Util.string_of_int
                                          (FStar_List.length ed_univs)
                                         in
-                                     let uu____5706 =
+                                     let uu____5673 =
                                        FStar_Util.string_of_int
                                          (FStar_List.length us)
                                         in
                                      FStar_Util.format3
                                        "Expected and generalized universes in effect declaration for %s are different, expected: %s, but found %s"
-                                       uu____5702 uu____5704 uu____5706
+                                       uu____5669 uu____5671 uu____5673
                                       in
                                    (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                     uu____5700)
+                                     uu____5667)
                                     in
-                                 let uu____5710 =
+                                 let uu____5677 =
                                    FStar_Ident.range_of_lid
                                      ed.FStar_Syntax_Syntax.mname
                                     in
-                                 FStar_Errors.raise_error uu____5694
-                                   uu____5710))))
+                                 FStar_Errors.raise_error uu____5661
+                                   uu____5677))))
             in
-         match uu____5553 with
+         match uu____5520 with
          | (us,bs) ->
              let ed1 =
-               let uu___598_5718 = ed  in
+               let uu___598_5685 = ed  in
                {
                  FStar_Syntax_Syntax.mname =
-                   (uu___598_5718.FStar_Syntax_Syntax.mname);
+                   (uu___598_5685.FStar_Syntax_Syntax.mname);
                  FStar_Syntax_Syntax.cattributes =
-                   (uu___598_5718.FStar_Syntax_Syntax.cattributes);
+                   (uu___598_5685.FStar_Syntax_Syntax.cattributes);
                  FStar_Syntax_Syntax.univs = us;
                  FStar_Syntax_Syntax.binders = bs;
                  FStar_Syntax_Syntax.signature =
-                   (uu___598_5718.FStar_Syntax_Syntax.signature);
+                   (uu___598_5685.FStar_Syntax_Syntax.signature);
                  FStar_Syntax_Syntax.combinators =
-                   (uu___598_5718.FStar_Syntax_Syntax.combinators);
+                   (uu___598_5685.FStar_Syntax_Syntax.combinators);
                  FStar_Syntax_Syntax.actions =
-                   (uu___598_5718.FStar_Syntax_Syntax.actions);
+                   (uu___598_5685.FStar_Syntax_Syntax.actions);
                  FStar_Syntax_Syntax.eff_attrs =
-                   (uu___598_5718.FStar_Syntax_Syntax.eff_attrs)
+                   (uu___598_5685.FStar_Syntax_Syntax.eff_attrs)
                }  in
-             let uu____5719 = FStar_Syntax_Subst.univ_var_opening us  in
-             (match uu____5719 with
+             let uu____5686 = FStar_Syntax_Subst.univ_var_opening us  in
+             (match uu____5686 with
               | (ed_univs_subst,ed_univs) ->
-                  let uu____5738 =
-                    let uu____5743 =
+                  let uu____5705 =
+                    let uu____5710 =
                       FStar_Syntax_Subst.subst_binders ed_univs_subst bs  in
-                    FStar_Syntax_Subst.open_binders' uu____5743  in
-                  (match uu____5738 with
+                    FStar_Syntax_Subst.open_binders' uu____5710  in
+                  (match uu____5705 with
                    | (ed_bs,ed_bs_subst) ->
                        let ed2 =
-                         let op uu____5764 =
-                           match uu____5764 with
+                         let op uu____5731 =
+                           match uu____5731 with
                            | (us1,t) ->
                                let t1 =
-                                 let uu____5784 =
+                                 let uu____5751 =
                                    FStar_Syntax_Subst.shift_subst
                                      ((FStar_List.length ed_bs) +
                                         (FStar_List.length us1))
                                      ed_univs_subst
                                     in
-                                 FStar_Syntax_Subst.subst uu____5784 t  in
-                               let uu____5793 =
-                                 let uu____5794 =
+                                 FStar_Syntax_Subst.subst uu____5751 t  in
+                               let uu____5760 =
+                                 let uu____5761 =
                                    FStar_Syntax_Subst.shift_subst
                                      (FStar_List.length us1) ed_bs_subst
                                     in
-                                 FStar_Syntax_Subst.subst uu____5794 t1  in
-                               (us1, uu____5793)
+                                 FStar_Syntax_Subst.subst uu____5761 t1  in
+                               (us1, uu____5760)
                             in
-                         let uu___612_5799 = ed1  in
-                         let uu____5800 =
+                         let uu___612_5766 = ed1  in
+                         let uu____5767 =
                            op ed1.FStar_Syntax_Syntax.signature  in
-                         let uu____5801 =
+                         let uu____5768 =
                            FStar_Syntax_Util.apply_eff_combinators op
                              ed1.FStar_Syntax_Syntax.combinators
                             in
-                         let uu____5802 =
+                         let uu____5769 =
                            FStar_List.map
                              (fun a  ->
-                                let uu___615_5810 = a  in
-                                let uu____5811 =
-                                  let uu____5812 =
+                                let uu___615_5777 = a  in
+                                let uu____5778 =
+                                  let uu____5779 =
                                     op
                                       ((a.FStar_Syntax_Syntax.action_univs),
                                         (a.FStar_Syntax_Syntax.action_defn))
                                      in
-                                  FStar_Pervasives_Native.snd uu____5812  in
-                                let uu____5823 =
-                                  let uu____5824 =
+                                  FStar_Pervasives_Native.snd uu____5779  in
+                                let uu____5790 =
+                                  let uu____5791 =
                                     op
                                       ((a.FStar_Syntax_Syntax.action_univs),
                                         (a.FStar_Syntax_Syntax.action_typ))
                                      in
-                                  FStar_Pervasives_Native.snd uu____5824  in
+                                  FStar_Pervasives_Native.snd uu____5791  in
                                 {
                                   FStar_Syntax_Syntax.action_name =
-                                    (uu___615_5810.FStar_Syntax_Syntax.action_name);
+                                    (uu___615_5777.FStar_Syntax_Syntax.action_name);
                                   FStar_Syntax_Syntax.action_unqualified_name
                                     =
-                                    (uu___615_5810.FStar_Syntax_Syntax.action_unqualified_name);
+                                    (uu___615_5777.FStar_Syntax_Syntax.action_unqualified_name);
                                   FStar_Syntax_Syntax.action_univs =
-                                    (uu___615_5810.FStar_Syntax_Syntax.action_univs);
+                                    (uu___615_5777.FStar_Syntax_Syntax.action_univs);
                                   FStar_Syntax_Syntax.action_params =
-                                    (uu___615_5810.FStar_Syntax_Syntax.action_params);
+                                    (uu___615_5777.FStar_Syntax_Syntax.action_params);
                                   FStar_Syntax_Syntax.action_defn =
-                                    uu____5811;
-                                  FStar_Syntax_Syntax.action_typ = uu____5823
+                                    uu____5778;
+                                  FStar_Syntax_Syntax.action_typ = uu____5790
                                 }) ed1.FStar_Syntax_Syntax.actions
                             in
                          {
                            FStar_Syntax_Syntax.mname =
-                             (uu___612_5799.FStar_Syntax_Syntax.mname);
+                             (uu___612_5766.FStar_Syntax_Syntax.mname);
                            FStar_Syntax_Syntax.cattributes =
-                             (uu___612_5799.FStar_Syntax_Syntax.cattributes);
+                             (uu___612_5766.FStar_Syntax_Syntax.cattributes);
                            FStar_Syntax_Syntax.univs =
-                             (uu___612_5799.FStar_Syntax_Syntax.univs);
+                             (uu___612_5766.FStar_Syntax_Syntax.univs);
                            FStar_Syntax_Syntax.binders =
-                             (uu___612_5799.FStar_Syntax_Syntax.binders);
-                           FStar_Syntax_Syntax.signature = uu____5800;
-                           FStar_Syntax_Syntax.combinators = uu____5801;
-                           FStar_Syntax_Syntax.actions = uu____5802;
+                             (uu___612_5766.FStar_Syntax_Syntax.binders);
+                           FStar_Syntax_Syntax.signature = uu____5767;
+                           FStar_Syntax_Syntax.combinators = uu____5768;
+                           FStar_Syntax_Syntax.actions = uu____5769;
                            FStar_Syntax_Syntax.eff_attrs =
-                             (uu___612_5799.FStar_Syntax_Syntax.eff_attrs)
+                             (uu___612_5766.FStar_Syntax_Syntax.eff_attrs)
                          }  in
-                       ((let uu____5836 =
+                       ((let uu____5803 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env0)
                              (FStar_Options.Other "ED")
                             in
-                         if uu____5836
+                         if uu____5803
                          then
-                           let uu____5841 =
+                           let uu____5808 =
                              FStar_Syntax_Print.eff_decl_to_string false ed2
                               in
                            FStar_Util.print1
                              "After typechecking binders eff_decl: \n\t%s\n"
-                             uu____5841
+                             uu____5808
                          else ());
                         (let env =
-                           let uu____5848 =
+                           let uu____5815 =
                              FStar_TypeChecker_Env.push_univ_vars env0
                                ed_univs
                               in
-                           FStar_TypeChecker_Env.push_binders uu____5848
+                           FStar_TypeChecker_Env.push_binders uu____5815
                              ed_bs
                             in
-                         let check_and_gen' comb n env_opt uu____5883 k =
-                           match uu____5883 with
+                         let check_and_gen' comb n env_opt uu____5850 k =
+                           match uu____5850 with
                            | (us1,t) ->
                                let env1 =
                                  if FStar_Util.is_some env_opt
@@ -2840,63 +2815,63 @@ let (tc_non_layered_eff_decl :
                                    FStar_All.pipe_right env_opt
                                      FStar_Util.must
                                  else env  in
-                               let uu____5903 =
+                               let uu____5870 =
                                  FStar_Syntax_Subst.open_univ_vars us1 t  in
-                               (match uu____5903 with
+                               (match uu____5870 with
                                 | (us2,t1) ->
                                     let t2 =
                                       match k with
                                       | FStar_Pervasives_Native.Some k1 ->
-                                          let uu____5912 =
+                                          let uu____5879 =
                                             FStar_TypeChecker_Env.push_univ_vars
                                               env1 us2
                                              in
                                           FStar_TypeChecker_TcTerm.tc_check_trivial_guard
-                                            uu____5912 t1 k1
+                                            uu____5879 t1 k1
                                       | FStar_Pervasives_Native.None  ->
-                                          let uu____5913 =
-                                            let uu____5920 =
+                                          let uu____5880 =
+                                            let uu____5887 =
                                               FStar_TypeChecker_Env.push_univ_vars
                                                 env1 us2
                                                in
                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                              uu____5920 t1
+                                              uu____5887 t1
                                              in
-                                          (match uu____5913 with
-                                           | (t2,uu____5922,g) ->
+                                          (match uu____5880 with
+                                           | (t2,uu____5889,g) ->
                                                (FStar_TypeChecker_Rel.force_trivial_guard
                                                   env1 g;
                                                 t2))
                                        in
-                                    let uu____5925 =
+                                    let uu____5892 =
                                       FStar_TypeChecker_Util.generalize_universes
                                         env1 t2
                                        in
-                                    (match uu____5925 with
+                                    (match uu____5892 with
                                      | (g_us,t3) ->
                                          (if (FStar_List.length g_us) <> n
                                           then
                                             (let error =
-                                               let uu____5941 =
+                                               let uu____5908 =
                                                  FStar_Ident.string_of_lid
                                                    ed2.FStar_Syntax_Syntax.mname
                                                   in
-                                               let uu____5943 =
+                                               let uu____5910 =
                                                  FStar_Util.string_of_int n
                                                   in
-                                               let uu____5945 =
-                                                 let uu____5947 =
+                                               let uu____5912 =
+                                                 let uu____5914 =
                                                    FStar_All.pipe_right g_us
                                                      FStar_List.length
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____5947
+                                                   uu____5914
                                                    FStar_Util.string_of_int
                                                   in
                                                FStar_Util.format4
                                                  "Expected %s:%s to be universe-polymorphic in %s universes, found %s"
-                                                 uu____5941 comb uu____5943
-                                                 uu____5945
+                                                 uu____5908 comb uu____5910
+                                                 uu____5912
                                                 in
                                              FStar_Errors.raise_error
                                                (FStar_Errors.Fatal_MismatchUniversePolymorphic,
@@ -2905,51 +2880,51 @@ let (tc_non_layered_eff_decl :
                                           else ();
                                           (match us2 with
                                            | [] -> (g_us, t3)
-                                           | uu____5962 ->
-                                               let uu____5963 =
+                                           | uu____5929 ->
+                                               let uu____5930 =
                                                  ((FStar_List.length us2) =
                                                     (FStar_List.length g_us))
                                                    &&
                                                    (FStar_List.forall2
                                                       (fun u1  ->
                                                          fun u2  ->
-                                                           let uu____5970 =
+                                                           let uu____5937 =
                                                              FStar_Syntax_Syntax.order_univ_name
                                                                u1 u2
                                                               in
-                                                           uu____5970 =
+                                                           uu____5937 =
                                                              Prims.int_zero)
                                                       us2 g_us)
                                                   in
-                                               if uu____5963
+                                               if uu____5930
                                                then (g_us, t3)
                                                else
-                                                 (let uu____5981 =
-                                                    let uu____5987 =
-                                                      let uu____5989 =
+                                                 (let uu____5948 =
+                                                    let uu____5954 =
+                                                      let uu____5956 =
                                                         FStar_Ident.string_of_lid
                                                           ed2.FStar_Syntax_Syntax.mname
                                                          in
-                                                      let uu____5991 =
+                                                      let uu____5958 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
                                                              us2)
                                                          in
-                                                      let uu____5993 =
+                                                      let uu____5960 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
                                                              g_us)
                                                          in
                                                       FStar_Util.format4
                                                         "Expected and generalized universes in the declaration for %s:%s are different, expected: %s, but found %s"
-                                                        uu____5989 comb
-                                                        uu____5991 uu____5993
+                                                        uu____5956 comb
+                                                        uu____5958 uu____5960
                                                        in
                                                     (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                      uu____5987)
+                                                      uu____5954)
                                                      in
                                                   FStar_Errors.raise_error
-                                                    uu____5981
+                                                    uu____5948
                                                     t3.FStar_Syntax_Syntax.pos)))))
                             in
                          let signature =
@@ -2958,666 +2933,655 @@ let (tc_non_layered_eff_decl :
                              ed2.FStar_Syntax_Syntax.signature
                              FStar_Pervasives_Native.None
                             in
-                         (let uu____6001 =
+                         (let uu____5968 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "ED")
                              in
-                          if uu____6001
+                          if uu____5968
                           then
-                            let uu____6006 =
+                            let uu____5973 =
                               FStar_Syntax_Print.tscheme_to_string signature
                                in
                             FStar_Util.print1 "Typechecked signature: %s\n"
-                              uu____6006
+                              uu____5973
                           else ());
-                         (let fresh_a_and_wp uu____6022 =
+                         (let fresh_a_and_wp uu____5989 =
                             let fail t =
-                              let uu____6035 =
+                              let uu____6002 =
                                 FStar_TypeChecker_Err.unexpected_signature_for_monad
                                   env ed2.FStar_Syntax_Syntax.mname t
                                  in
-                              FStar_Errors.raise_error uu____6035
+                              FStar_Errors.raise_error uu____6002
                                 (FStar_Pervasives_Native.snd
                                    ed2.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos
                                in
-                            let uu____6051 =
+                            let uu____6018 =
                               FStar_TypeChecker_Env.inst_tscheme signature
                                in
-                            match uu____6051 with
-                            | (uu____6062,signature1) ->
-                                let uu____6064 =
-                                  let uu____6065 =
+                            match uu____6018 with
+                            | (uu____6029,signature1) ->
+                                let uu____6031 =
+                                  let uu____6032 =
                                     FStar_Syntax_Subst.compress signature1
                                      in
-                                  uu____6065.FStar_Syntax_Syntax.n  in
-                                (match uu____6064 with
+                                  uu____6032.FStar_Syntax_Syntax.n  in
+                                (match uu____6031 with
                                  | FStar_Syntax_Syntax.Tm_arrow
-                                     (bs1,uu____6075) ->
+                                     (bs1,uu____6042) ->
                                      let bs2 =
                                        FStar_Syntax_Subst.open_binders bs1
                                         in
                                      (match bs2 with
-                                      | (a,uu____6104)::(wp,uu____6106)::[]
+                                      | (a,uu____6071)::(wp,uu____6073)::[]
                                           ->
                                           (a, (wp.FStar_Syntax_Syntax.sort))
-                                      | uu____6135 -> fail signature1)
-                                 | uu____6136 -> fail signature1)
+                                      | uu____6102 -> fail signature1)
+                                 | uu____6103 -> fail signature1)
                              in
                           let log_combinator s ts =
-                            let uu____6150 =
+                            let uu____6117 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "ED")
                                in
-                            if uu____6150
+                            if uu____6117
                             then
-                              let uu____6155 =
+                              let uu____6122 =
                                 FStar_Ident.string_of_lid
                                   ed2.FStar_Syntax_Syntax.mname
                                  in
-                              let uu____6157 =
+                              let uu____6124 =
                                 FStar_Syntax_Print.tscheme_to_string ts  in
                               FStar_Util.print3 "Typechecked %s:%s = %s\n"
-                                uu____6155 s uu____6157
+                                uu____6122 s uu____6124
                             else ()  in
                           let ret_wp =
-                            let uu____6163 = fresh_a_and_wp ()  in
-                            match uu____6163 with
+                            let uu____6130 = fresh_a_and_wp ()  in
+                            match uu____6130 with
                             | (a,wp_sort) ->
                                 let k =
-                                  let uu____6179 =
-                                    let uu____6188 =
+                                  let uu____6146 =
+                                    let uu____6155 =
                                       FStar_Syntax_Syntax.mk_binder a  in
-                                    let uu____6195 =
-                                      let uu____6204 =
-                                        let uu____6211 =
+                                    let uu____6162 =
+                                      let uu____6171 =
+                                        let uu____6178 =
                                           FStar_Syntax_Syntax.bv_to_name a
                                            in
                                         FStar_Syntax_Syntax.null_binder
-                                          uu____6211
+                                          uu____6178
                                          in
-                                      [uu____6204]  in
-                                    uu____6188 :: uu____6195  in
-                                  let uu____6230 =
+                                      [uu____6171]  in
+                                    uu____6155 :: uu____6162  in
+                                  let uu____6197 =
                                     FStar_Syntax_Syntax.mk_GTotal wp_sort  in
-                                  FStar_Syntax_Util.arrow uu____6179
-                                    uu____6230
+                                  FStar_Syntax_Util.arrow uu____6146
+                                    uu____6197
                                    in
-                                let uu____6233 =
+                                let uu____6200 =
                                   FStar_All.pipe_right ed2
                                     FStar_Syntax_Util.get_return_vc_combinator
                                    in
                                 check_and_gen' "ret_wp" Prims.int_one
-                                  FStar_Pervasives_Native.None uu____6233
+                                  FStar_Pervasives_Native.None uu____6200
                                   (FStar_Pervasives_Native.Some k)
                              in
                           log_combinator "ret_wp" ret_wp;
                           (let bind_wp =
-                             let uu____6247 = fresh_a_and_wp ()  in
-                             match uu____6247 with
+                             let uu____6214 = fresh_a_and_wp ()  in
+                             match uu____6214 with
                              | (a,wp_sort_a) ->
-                                 let uu____6260 = fresh_a_and_wp ()  in
-                                 (match uu____6260 with
+                                 let uu____6227 = fresh_a_and_wp ()  in
+                                 (match uu____6227 with
                                   | (b,wp_sort_b) ->
                                       let wp_sort_a_b =
-                                        let uu____6276 =
-                                          let uu____6285 =
-                                            let uu____6292 =
+                                        let uu____6243 =
+                                          let uu____6252 =
+                                            let uu____6259 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a
                                                in
                                             FStar_Syntax_Syntax.null_binder
-                                              uu____6292
+                                              uu____6259
                                              in
-                                          [uu____6285]  in
-                                        let uu____6305 =
+                                          [uu____6252]  in
+                                        let uu____6272 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_b
                                            in
-                                        FStar_Syntax_Util.arrow uu____6276
-                                          uu____6305
+                                        FStar_Syntax_Util.arrow uu____6243
+                                          uu____6272
                                          in
                                       let k =
-                                        let uu____6311 =
-                                          let uu____6320 =
+                                        let uu____6278 =
+                                          let uu____6287 =
                                             FStar_Syntax_Syntax.null_binder
                                               FStar_Syntax_Syntax.t_range
                                              in
-                                          let uu____6327 =
-                                            let uu____6336 =
+                                          let uu____6294 =
+                                            let uu____6303 =
                                               FStar_Syntax_Syntax.mk_binder a
                                                in
-                                            let uu____6343 =
-                                              let uu____6352 =
+                                            let uu____6310 =
+                                              let uu____6319 =
                                                 FStar_Syntax_Syntax.mk_binder
                                                   b
                                                  in
-                                              let uu____6359 =
-                                                let uu____6368 =
+                                              let uu____6326 =
+                                                let uu____6335 =
                                                   FStar_Syntax_Syntax.null_binder
                                                     wp_sort_a
                                                    in
-                                                let uu____6375 =
-                                                  let uu____6384 =
+                                                let uu____6342 =
+                                                  let uu____6351 =
                                                     FStar_Syntax_Syntax.null_binder
                                                       wp_sort_a_b
                                                      in
-                                                  [uu____6384]  in
-                                                uu____6368 :: uu____6375  in
-                                              uu____6352 :: uu____6359  in
-                                            uu____6336 :: uu____6343  in
-                                          uu____6320 :: uu____6327  in
-                                        let uu____6427 =
+                                                  [uu____6351]  in
+                                                uu____6335 :: uu____6342  in
+                                              uu____6319 :: uu____6326  in
+                                            uu____6303 :: uu____6310  in
+                                          uu____6287 :: uu____6294  in
+                                        let uu____6394 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_b
                                            in
-                                        FStar_Syntax_Util.arrow uu____6311
-                                          uu____6427
+                                        FStar_Syntax_Util.arrow uu____6278
+                                          uu____6394
                                          in
-                                      let uu____6430 =
+                                      let uu____6397 =
                                         FStar_All.pipe_right ed2
                                           FStar_Syntax_Util.get_bind_vc_combinator
                                          in
                                       check_and_gen' "bind_wp"
                                         (Prims.of_int (2))
                                         FStar_Pervasives_Native.None
-                                        uu____6430
+                                        uu____6397
                                         (FStar_Pervasives_Native.Some k))
                               in
                            log_combinator "bind_wp" bind_wp;
                            (let stronger =
-                              let uu____6444 = fresh_a_and_wp ()  in
-                              match uu____6444 with
+                              let uu____6411 = fresh_a_and_wp ()  in
+                              match uu____6411 with
                               | (a,wp_sort_a) ->
-                                  let uu____6457 =
+                                  let uu____6424 =
                                     FStar_Syntax_Util.type_u ()  in
-                                  (match uu____6457 with
-                                   | (t,uu____6463) ->
+                                  (match uu____6424 with
+                                   | (t,uu____6430) ->
                                        let k =
-                                         let uu____6467 =
-                                           let uu____6476 =
+                                         let uu____6434 =
+                                           let uu____6443 =
                                              FStar_Syntax_Syntax.mk_binder a
                                               in
-                                           let uu____6483 =
-                                             let uu____6492 =
+                                           let uu____6450 =
+                                             let uu____6459 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a
                                                 in
-                                             let uu____6499 =
-                                               let uu____6508 =
+                                             let uu____6466 =
+                                               let uu____6475 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_a
                                                   in
-                                               [uu____6508]  in
-                                             uu____6492 :: uu____6499  in
-                                           uu____6476 :: uu____6483  in
-                                         let uu____6539 =
+                                               [uu____6475]  in
+                                             uu____6459 :: uu____6466  in
+                                           uu____6443 :: uu____6450  in
+                                         let uu____6506 =
                                            FStar_Syntax_Syntax.mk_Total t  in
-                                         FStar_Syntax_Util.arrow uu____6467
-                                           uu____6539
+                                         FStar_Syntax_Util.arrow uu____6434
+                                           uu____6506
                                           in
-                                       let uu____6542 =
+                                       let uu____6509 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_stronger_vc_combinator
                                           in
                                        check_and_gen' "stronger"
                                          Prims.int_one
                                          FStar_Pervasives_Native.None
-                                         uu____6542
+                                         uu____6509
                                          (FStar_Pervasives_Native.Some k))
                                in
                             log_combinator "stronger" stronger;
                             (let if_then_else =
-                               let uu____6556 = fresh_a_and_wp ()  in
-                               match uu____6556 with
+                               let uu____6523 = fresh_a_and_wp ()  in
+                               match uu____6523 with
                                | (a,wp_sort_a) ->
                                    let p =
-                                     let uu____6570 =
-                                       let uu____6573 =
+                                     let uu____6537 =
+                                       let uu____6540 =
                                          FStar_Ident.range_of_lid
                                            ed2.FStar_Syntax_Syntax.mname
                                           in
                                        FStar_Pervasives_Native.Some
-                                         uu____6573
+                                         uu____6540
                                         in
-                                     let uu____6574 =
-                                       let uu____6575 =
+                                     let uu____6541 =
+                                       let uu____6542 =
                                          FStar_Syntax_Util.type_u ()  in
-                                       FStar_All.pipe_right uu____6575
+                                       FStar_All.pipe_right uu____6542
                                          FStar_Pervasives_Native.fst
                                         in
-                                     FStar_Syntax_Syntax.new_bv uu____6570
-                                       uu____6574
+                                     FStar_Syntax_Syntax.new_bv uu____6537
+                                       uu____6541
                                       in
                                    let k =
-                                     let uu____6587 =
-                                       let uu____6596 =
+                                     let uu____6554 =
+                                       let uu____6563 =
                                          FStar_Syntax_Syntax.mk_binder a  in
-                                       let uu____6603 =
-                                         let uu____6612 =
+                                       let uu____6570 =
+                                         let uu____6579 =
                                            FStar_Syntax_Syntax.mk_binder p
                                             in
-                                         let uu____6619 =
-                                           let uu____6628 =
+                                         let uu____6586 =
+                                           let uu____6595 =
                                              FStar_Syntax_Syntax.null_binder
                                                wp_sort_a
                                               in
-                                           let uu____6635 =
-                                             let uu____6644 =
+                                           let uu____6602 =
+                                             let uu____6611 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a
                                                 in
-                                             [uu____6644]  in
-                                           uu____6628 :: uu____6635  in
-                                         uu____6612 :: uu____6619  in
-                                       uu____6596 :: uu____6603  in
-                                     let uu____6681 =
+                                             [uu____6611]  in
+                                           uu____6595 :: uu____6602  in
+                                         uu____6579 :: uu____6586  in
+                                       uu____6563 :: uu____6570  in
+                                     let uu____6648 =
                                        FStar_Syntax_Syntax.mk_Total wp_sort_a
                                         in
-                                     FStar_Syntax_Util.arrow uu____6587
-                                       uu____6681
+                                     FStar_Syntax_Util.arrow uu____6554
+                                       uu____6648
                                       in
-                                   let uu____6684 =
-                                     let uu____6689 =
+                                   let uu____6651 =
+                                     let uu____6656 =
                                        FStar_All.pipe_right ed2
                                          FStar_Syntax_Util.get_wp_if_then_else_combinator
                                         in
-                                     FStar_All.pipe_right uu____6689
+                                     FStar_All.pipe_right uu____6656
                                        FStar_Util.must
                                       in
                                    check_and_gen' "if_then_else"
                                      Prims.int_one
-                                     FStar_Pervasives_Native.None uu____6684
+                                     FStar_Pervasives_Native.None uu____6651
                                      (FStar_Pervasives_Native.Some k)
                                 in
                              log_combinator "if_then_else" if_then_else;
                              (let ite_wp =
-                                let uu____6721 = fresh_a_and_wp ()  in
-                                match uu____6721 with
+                                let uu____6688 = fresh_a_and_wp ()  in
+                                match uu____6688 with
                                 | (a,wp_sort_a) ->
                                     let k =
-                                      let uu____6737 =
-                                        let uu____6746 =
+                                      let uu____6704 =
+                                        let uu____6713 =
                                           FStar_Syntax_Syntax.mk_binder a  in
-                                        let uu____6753 =
-                                          let uu____6762 =
+                                        let uu____6720 =
+                                          let uu____6729 =
                                             FStar_Syntax_Syntax.null_binder
                                               wp_sort_a
                                              in
-                                          [uu____6762]  in
-                                        uu____6746 :: uu____6753  in
-                                      let uu____6787 =
+                                          [uu____6729]  in
+                                        uu____6713 :: uu____6720  in
+                                      let uu____6754 =
                                         FStar_Syntax_Syntax.mk_Total
                                           wp_sort_a
                                          in
-                                      FStar_Syntax_Util.arrow uu____6737
-                                        uu____6787
+                                      FStar_Syntax_Util.arrow uu____6704
+                                        uu____6754
                                        in
-                                    let uu____6790 =
-                                      let uu____6795 =
+                                    let uu____6757 =
+                                      let uu____6762 =
                                         FStar_All.pipe_right ed2
                                           FStar_Syntax_Util.get_wp_ite_combinator
                                          in
-                                      FStar_All.pipe_right uu____6795
+                                      FStar_All.pipe_right uu____6762
                                         FStar_Util.must
                                        in
                                     check_and_gen' "ite_wp" Prims.int_one
-                                      FStar_Pervasives_Native.None uu____6790
+                                      FStar_Pervasives_Native.None uu____6757
                                       (FStar_Pervasives_Native.Some k)
                                  in
                               log_combinator "ite_wp" ite_wp;
                               (let close_wp =
-                                 let uu____6811 = fresh_a_and_wp ()  in
-                                 match uu____6811 with
+                                 let uu____6778 = fresh_a_and_wp ()  in
+                                 match uu____6778 with
                                  | (a,wp_sort_a) ->
                                      let b =
-                                       let uu____6825 =
-                                         let uu____6828 =
+                                       let uu____6792 =
+                                         let uu____6795 =
                                            FStar_Ident.range_of_lid
                                              ed2.FStar_Syntax_Syntax.mname
                                             in
                                          FStar_Pervasives_Native.Some
-                                           uu____6828
+                                           uu____6795
                                           in
-                                       let uu____6829 =
-                                         let uu____6830 =
+                                       let uu____6796 =
+                                         let uu____6797 =
                                            FStar_Syntax_Util.type_u ()  in
-                                         FStar_All.pipe_right uu____6830
+                                         FStar_All.pipe_right uu____6797
                                            FStar_Pervasives_Native.fst
                                           in
-                                       FStar_Syntax_Syntax.new_bv uu____6825
-                                         uu____6829
+                                       FStar_Syntax_Syntax.new_bv uu____6792
+                                         uu____6796
                                         in
                                      let wp_sort_b_a =
-                                       let uu____6842 =
-                                         let uu____6851 =
-                                           let uu____6858 =
+                                       let uu____6809 =
+                                         let uu____6818 =
+                                           let uu____6825 =
                                              FStar_Syntax_Syntax.bv_to_name b
                                               in
                                            FStar_Syntax_Syntax.null_binder
-                                             uu____6858
+                                             uu____6825
                                             in
-                                         [uu____6851]  in
-                                       let uu____6871 =
+                                         [uu____6818]  in
+                                       let uu____6838 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a
                                           in
-                                       FStar_Syntax_Util.arrow uu____6842
-                                         uu____6871
+                                       FStar_Syntax_Util.arrow uu____6809
+                                         uu____6838
                                         in
                                      let k =
-                                       let uu____6877 =
-                                         let uu____6886 =
+                                       let uu____6844 =
+                                         let uu____6853 =
                                            FStar_Syntax_Syntax.mk_binder a
                                             in
-                                         let uu____6893 =
-                                           let uu____6902 =
+                                         let uu____6860 =
+                                           let uu____6869 =
                                              FStar_Syntax_Syntax.mk_binder b
                                               in
-                                           let uu____6909 =
-                                             let uu____6918 =
+                                           let uu____6876 =
+                                             let uu____6885 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_b_a
                                                 in
-                                             [uu____6918]  in
-                                           uu____6902 :: uu____6909  in
-                                         uu____6886 :: uu____6893  in
-                                       let uu____6949 =
+                                             [uu____6885]  in
+                                           uu____6869 :: uu____6876  in
+                                         uu____6853 :: uu____6860  in
+                                       let uu____6916 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a
                                           in
-                                       FStar_Syntax_Util.arrow uu____6877
-                                         uu____6949
+                                       FStar_Syntax_Util.arrow uu____6844
+                                         uu____6916
                                         in
-                                     let uu____6952 =
-                                       let uu____6957 =
+                                     let uu____6919 =
+                                       let uu____6924 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_wp_close_combinator
                                           in
-                                       FStar_All.pipe_right uu____6957
+                                       FStar_All.pipe_right uu____6924
                                          FStar_Util.must
                                         in
                                      check_and_gen' "close_wp"
                                        (Prims.of_int (2))
                                        FStar_Pervasives_Native.None
-                                       uu____6952
+                                       uu____6919
                                        (FStar_Pervasives_Native.Some k)
                                   in
                                log_combinator "close_wp" close_wp;
                                (let trivial =
-                                  let uu____6973 = fresh_a_and_wp ()  in
-                                  match uu____6973 with
+                                  let uu____6940 = fresh_a_and_wp ()  in
+                                  match uu____6940 with
                                   | (a,wp_sort_a) ->
-                                      let uu____6986 =
+                                      let uu____6953 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      (match uu____6986 with
-                                       | (t,uu____6992) ->
+                                      (match uu____6953 with
+                                       | (t,uu____6959) ->
                                            let k =
-                                             let uu____6996 =
-                                               let uu____7005 =
+                                             let uu____6963 =
+                                               let uu____6972 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    a
                                                   in
-                                               let uu____7012 =
-                                                 let uu____7021 =
+                                               let uu____6979 =
+                                                 let uu____6988 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      wp_sort_a
                                                     in
-                                                 [uu____7021]  in
-                                               uu____7005 :: uu____7012  in
-                                             let uu____7046 =
+                                                 [uu____6988]  in
+                                               uu____6972 :: uu____6979  in
+                                             let uu____7013 =
                                                FStar_Syntax_Syntax.mk_GTotal
                                                  t
                                                 in
                                              FStar_Syntax_Util.arrow
-                                               uu____6996 uu____7046
+                                               uu____6963 uu____7013
                                               in
                                            let trivial =
-                                             let uu____7050 =
-                                               let uu____7055 =
+                                             let uu____7017 =
+                                               let uu____7022 =
                                                  FStar_All.pipe_right ed2
                                                    FStar_Syntax_Util.get_wp_trivial_combinator
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____7055 FStar_Util.must
+                                                 uu____7022 FStar_Util.must
                                                 in
                                              check_and_gen' "trivial"
                                                Prims.int_one
                                                FStar_Pervasives_Native.None
-                                               uu____7050
+                                               uu____7017
                                                (FStar_Pervasives_Native.Some
                                                   k)
                                               in
                                            (log_combinator "trivial" trivial;
                                             trivial))
                                    in
-                                let uu____7070 =
-                                  let uu____7087 =
+                                let uu____7037 =
+                                  let uu____7054 =
                                     FStar_All.pipe_right ed2
                                       FStar_Syntax_Util.get_eff_repr
                                      in
-                                  match uu____7087 with
+                                  match uu____7054 with
                                   | FStar_Pervasives_Native.None  ->
                                       (FStar_Pervasives_Native.None,
                                         FStar_Pervasives_Native.None,
                                         FStar_Pervasives_Native.None,
                                         (ed2.FStar_Syntax_Syntax.actions))
-                                  | uu____7116 ->
+                                  | uu____7083 ->
                                       let repr =
-                                        let uu____7120 = fresh_a_and_wp ()
+                                        let uu____7087 = fresh_a_and_wp ()
                                            in
-                                        match uu____7120 with
+                                        match uu____7087 with
                                         | (a,wp_sort_a) ->
-                                            let uu____7133 =
+                                            let uu____7100 =
                                               FStar_Syntax_Util.type_u ()  in
-                                            (match uu____7133 with
-                                             | (t,uu____7139) ->
+                                            (match uu____7100 with
+                                             | (t,uu____7106) ->
                                                  let k =
-                                                   let uu____7143 =
-                                                     let uu____7152 =
+                                                   let uu____7110 =
+                                                     let uu____7119 =
                                                        FStar_Syntax_Syntax.mk_binder
                                                          a
                                                         in
-                                                     let uu____7159 =
-                                                       let uu____7168 =
+                                                     let uu____7126 =
+                                                       let uu____7135 =
                                                          FStar_Syntax_Syntax.null_binder
                                                            wp_sort_a
                                                           in
-                                                       [uu____7168]  in
-                                                     uu____7152 :: uu____7159
+                                                       [uu____7135]  in
+                                                     uu____7119 :: uu____7126
                                                       in
-                                                   let uu____7193 =
+                                                   let uu____7160 =
                                                      FStar_Syntax_Syntax.mk_GTotal
                                                        t
                                                       in
                                                    FStar_Syntax_Util.arrow
-                                                     uu____7143 uu____7193
+                                                     uu____7110 uu____7160
                                                     in
-                                                 let uu____7196 =
-                                                   let uu____7201 =
+                                                 let uu____7163 =
+                                                   let uu____7168 =
                                                      FStar_All.pipe_right ed2
                                                        FStar_Syntax_Util.get_eff_repr
                                                       in
                                                    FStar_All.pipe_right
-                                                     uu____7201
+                                                     uu____7168
                                                      FStar_Util.must
                                                     in
                                                  check_and_gen' "repr"
                                                    Prims.int_one
                                                    FStar_Pervasives_Native.None
-                                                   uu____7196
+                                                   uu____7163
                                                    (FStar_Pervasives_Native.Some
                                                       k))
                                          in
                                       (log_combinator "repr" repr;
                                        (let mk_repr' t wp =
-                                          let uu____7245 =
+                                          let uu____7212 =
                                             FStar_TypeChecker_Env.inst_tscheme
                                               repr
                                              in
-                                          match uu____7245 with
-                                          | (uu____7252,repr1) ->
+                                          match uu____7212 with
+                                          | (uu____7219,repr1) ->
                                               let repr2 =
                                                 FStar_TypeChecker_Normalize.normalize
                                                   [FStar_TypeChecker_Env.EraseUniverses;
                                                   FStar_TypeChecker_Env.AllowUnboundUniverses]
                                                   env repr1
                                                  in
-                                              let uu____7255 =
-                                                let uu____7262 =
-                                                  let uu____7263 =
-                                                    let uu____7280 =
-                                                      let uu____7291 =
+                                              let uu____7222 =
+                                                let uu____7223 =
+                                                  let uu____7240 =
+                                                    let uu____7251 =
+                                                      FStar_All.pipe_right t
+                                                        FStar_Syntax_Syntax.as_arg
+                                                       in
+                                                    let uu____7268 =
+                                                      let uu____7279 =
                                                         FStar_All.pipe_right
-                                                          t
+                                                          wp
                                                           FStar_Syntax_Syntax.as_arg
                                                          in
-                                                      let uu____7308 =
-                                                        let uu____7319 =
-                                                          FStar_All.pipe_right
-                                                            wp
-                                                            FStar_Syntax_Syntax.as_arg
-                                                           in
-                                                        [uu____7319]  in
-                                                      uu____7291 ::
-                                                        uu____7308
-                                                       in
-                                                    (repr2, uu____7280)  in
-                                                  FStar_Syntax_Syntax.Tm_app
-                                                    uu____7263
-                                                   in
-                                                FStar_Syntax_Syntax.mk
-                                                  uu____7262
+                                                      [uu____7279]  in
+                                                    uu____7251 :: uu____7268
+                                                     in
+                                                  (repr2, uu____7240)  in
+                                                FStar_Syntax_Syntax.Tm_app
+                                                  uu____7223
                                                  in
-                                              uu____7255
-                                                FStar_Pervasives_Native.None
+                                              FStar_Syntax_Syntax.mk
+                                                uu____7222
                                                 FStar_Range.dummyRange
                                            in
                                         let mk_repr a wp =
-                                          let uu____7385 =
+                                          let uu____7345 =
                                             FStar_Syntax_Syntax.bv_to_name a
                                              in
-                                          mk_repr' uu____7385 wp  in
+                                          mk_repr' uu____7345 wp  in
                                         let destruct_repr t =
-                                          let uu____7400 =
-                                            let uu____7401 =
+                                          let uu____7360 =
+                                            let uu____7361 =
                                               FStar_Syntax_Subst.compress t
                                                in
-                                            uu____7401.FStar_Syntax_Syntax.n
+                                            uu____7361.FStar_Syntax_Syntax.n
                                              in
-                                          match uu____7400 with
+                                          match uu____7360 with
                                           | FStar_Syntax_Syntax.Tm_app
-                                              (uu____7412,(t1,uu____7414)::
-                                               (wp,uu____7416)::[])
+                                              (uu____7372,(t1,uu____7374)::
+                                               (wp,uu____7376)::[])
                                               -> (t1, wp)
-                                          | uu____7475 ->
+                                          | uu____7435 ->
                                               failwith "Unexpected repr type"
                                            in
                                         let return_repr =
                                           let return_repr_ts =
-                                            let uu____7491 =
+                                            let uu____7451 =
                                               FStar_All.pipe_right ed2
                                                 FStar_Syntax_Util.get_return_repr
                                                in
-                                            FStar_All.pipe_right uu____7491
+                                            FStar_All.pipe_right uu____7451
                                               FStar_Util.must
                                              in
-                                          let uu____7518 = fresh_a_and_wp ()
+                                          let uu____7478 = fresh_a_and_wp ()
                                              in
-                                          match uu____7518 with
-                                          | (a,uu____7526) ->
+                                          match uu____7478 with
+                                          | (a,uu____7486) ->
                                               let x_a =
-                                                let uu____7532 =
+                                                let uu____7492 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     a
                                                    in
                                                 FStar_Syntax_Syntax.gen_bv
                                                   "x_a"
                                                   FStar_Pervasives_Native.None
-                                                  uu____7532
+                                                  uu____7492
                                                  in
                                               let res =
                                                 let wp =
-                                                  let uu____7540 =
-                                                    let uu____7545 =
-                                                      let uu____7546 =
-                                                        FStar_TypeChecker_Env.inst_tscheme
-                                                          ret_wp
+                                                  let uu____7498 =
+                                                    let uu____7499 =
+                                                      FStar_TypeChecker_Env.inst_tscheme
+                                                        ret_wp
+                                                       in
+                                                    FStar_All.pipe_right
+                                                      uu____7499
+                                                      FStar_Pervasives_Native.snd
+                                                     in
+                                                  let uu____7508 =
+                                                    let uu____7509 =
+                                                      let uu____7518 =
+                                                        FStar_Syntax_Syntax.bv_to_name
+                                                          a
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____7546
-                                                        FStar_Pervasives_Native.snd
+                                                        uu____7518
+                                                        FStar_Syntax_Syntax.as_arg
                                                        in
-                                                    let uu____7555 =
-                                                      let uu____7556 =
-                                                        let uu____7565 =
+                                                    let uu____7527 =
+                                                      let uu____7538 =
+                                                        let uu____7547 =
                                                           FStar_Syntax_Syntax.bv_to_name
-                                                            a
+                                                            x_a
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____7565
+                                                          uu____7547
                                                           FStar_Syntax_Syntax.as_arg
                                                          in
-                                                      let uu____7574 =
-                                                        let uu____7585 =
-                                                          let uu____7594 =
-                                                            FStar_Syntax_Syntax.bv_to_name
-                                                              x_a
-                                                             in
-                                                          FStar_All.pipe_right
-                                                            uu____7594
-                                                            FStar_Syntax_Syntax.as_arg
-                                                           in
-                                                        [uu____7585]  in
-                                                      uu____7556 ::
-                                                        uu____7574
-                                                       in
-                                                    FStar_Syntax_Syntax.mk_Tm_app
-                                                      uu____7545 uu____7555
+                                                      [uu____7538]  in
+                                                    uu____7509 :: uu____7527
                                                      in
-                                                  uu____7540
-                                                    FStar_Pervasives_Native.None
+                                                  FStar_Syntax_Syntax.mk_Tm_app
+                                                    uu____7498 uu____7508
                                                     FStar_Range.dummyRange
                                                    in
                                                 mk_repr a wp  in
                                               let k =
-                                                let uu____7630 =
-                                                  let uu____7639 =
+                                                let uu____7583 =
+                                                  let uu____7592 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       a
                                                      in
-                                                  let uu____7646 =
-                                                    let uu____7655 =
+                                                  let uu____7599 =
+                                                    let uu____7608 =
                                                       FStar_Syntax_Syntax.mk_binder
                                                         x_a
                                                        in
-                                                    [uu____7655]  in
-                                                  uu____7639 :: uu____7646
+                                                    [uu____7608]  in
+                                                  uu____7592 :: uu____7599
                                                    in
-                                                let uu____7680 =
+                                                let uu____7633 =
                                                   FStar_Syntax_Syntax.mk_Total
                                                     res
                                                    in
                                                 FStar_Syntax_Util.arrow
-                                                  uu____7630 uu____7680
+                                                  uu____7583 uu____7633
                                                  in
-                                              let uu____7683 =
+                                              let uu____7636 =
                                                 FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                   env k
                                                  in
-                                              (match uu____7683 with
-                                               | (k1,uu____7691,uu____7692)
+                                              (match uu____7636 with
+                                               | (k1,uu____7644,uu____7645)
                                                    ->
                                                    let env1 =
-                                                     let uu____7696 =
+                                                     let uu____7649 =
                                                        FStar_TypeChecker_Env.set_range
                                                          env
                                                          (FStar_Pervasives_Native.snd
                                                             return_repr_ts).FStar_Syntax_Syntax.pos
                                                         in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____7696
+                                                       uu____7649
                                                       in
                                                    check_and_gen'
                                                      "return_repr"
@@ -3630,48 +3594,48 @@ let (tc_non_layered_eff_decl :
                                           return_repr;
                                         (let bind_repr =
                                            let bind_repr_ts =
-                                             let uu____7709 =
+                                             let uu____7662 =
                                                FStar_All.pipe_right ed2
                                                  FStar_Syntax_Util.get_bind_repr
                                                 in
-                                             FStar_All.pipe_right uu____7709
+                                             FStar_All.pipe_right uu____7662
                                                FStar_Util.must
                                               in
                                            let r =
-                                             let uu____7747 =
+                                             let uu____7700 =
                                                FStar_Syntax_Syntax.lid_as_fv
                                                  FStar_Parser_Const.range_0
                                                  FStar_Syntax_Syntax.delta_constant
                                                  FStar_Pervasives_Native.None
                                                 in
-                                             FStar_All.pipe_right uu____7747
+                                             FStar_All.pipe_right uu____7700
                                                FStar_Syntax_Syntax.fv_to_tm
                                               in
-                                           let uu____7748 = fresh_a_and_wp ()
+                                           let uu____7701 = fresh_a_and_wp ()
                                               in
-                                           match uu____7748 with
+                                           match uu____7701 with
                                            | (a,wp_sort_a) ->
-                                               let uu____7761 =
+                                               let uu____7714 =
                                                  fresh_a_and_wp ()  in
-                                               (match uu____7761 with
+                                               (match uu____7714 with
                                                 | (b,wp_sort_b) ->
                                                     let wp_sort_a_b =
-                                                      let uu____7777 =
-                                                        let uu____7786 =
-                                                          let uu____7793 =
+                                                      let uu____7730 =
+                                                        let uu____7739 =
+                                                          let uu____7746 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               a
                                                              in
                                                           FStar_Syntax_Syntax.null_binder
-                                                            uu____7793
+                                                            uu____7746
                                                            in
-                                                        [uu____7786]  in
-                                                      let uu____7806 =
+                                                        [uu____7739]  in
+                                                      let uu____7759 =
                                                         FStar_Syntax_Syntax.mk_Total
                                                           wp_sort_b
                                                          in
                                                       FStar_Syntax_Util.arrow
-                                                        uu____7777 uu____7806
+                                                        uu____7730 uu____7759
                                                        in
                                                     let wp_f =
                                                       FStar_Syntax_Syntax.gen_bv
@@ -3686,237 +3650,227 @@ let (tc_non_layered_eff_decl :
                                                         wp_sort_a_b
                                                        in
                                                     let x_a =
-                                                      let uu____7814 =
+                                                      let uu____7767 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           a
                                                          in
                                                       FStar_Syntax_Syntax.gen_bv
                                                         "x_a"
                                                         FStar_Pervasives_Native.None
-                                                        uu____7814
+                                                        uu____7767
                                                        in
                                                     let wp_g_x =
-                                                      let uu____7819 =
-                                                        let uu____7824 =
-                                                          FStar_Syntax_Syntax.bv_to_name
-                                                            wp_g
-                                                           in
-                                                        let uu____7825 =
-                                                          let uu____7826 =
-                                                            let uu____7835 =
-                                                              FStar_Syntax_Syntax.bv_to_name
-                                                                x_a
-                                                               in
-                                                            FStar_All.pipe_right
-                                                              uu____7835
-                                                              FStar_Syntax_Syntax.as_arg
-                                                             in
-                                                          [uu____7826]  in
-                                                        FStar_Syntax_Syntax.mk_Tm_app
-                                                          uu____7824
-                                                          uu____7825
+                                                      let uu____7770 =
+                                                        FStar_Syntax_Syntax.bv_to_name
+                                                          wp_g
                                                          in
-                                                      uu____7819
-                                                        FStar_Pervasives_Native.None
+                                                      let uu____7771 =
+                                                        let uu____7772 =
+                                                          let uu____7781 =
+                                                            FStar_Syntax_Syntax.bv_to_name
+                                                              x_a
+                                                             in
+                                                          FStar_All.pipe_right
+                                                            uu____7781
+                                                            FStar_Syntax_Syntax.as_arg
+                                                           in
+                                                        [uu____7772]  in
+                                                      FStar_Syntax_Syntax.mk_Tm_app
+                                                        uu____7770 uu____7771
                                                         FStar_Range.dummyRange
                                                        in
                                                     let res =
                                                       let wp =
-                                                        let uu____7866 =
-                                                          let uu____7871 =
-                                                            let uu____7872 =
-                                                              FStar_TypeChecker_Env.inst_tscheme
-                                                                bind_wp
-                                                               in
-                                                            FStar_All.pipe_right
-                                                              uu____7872
-                                                              FStar_Pervasives_Native.snd
+                                                        let uu____7810 =
+                                                          let uu____7811 =
+                                                            FStar_TypeChecker_Env.inst_tscheme
+                                                              bind_wp
                                                              in
-                                                          let uu____7881 =
-                                                            let uu____7882 =
-                                                              let uu____7885
+                                                          FStar_All.pipe_right
+                                                            uu____7811
+                                                            FStar_Pervasives_Native.snd
+                                                           in
+                                                        let uu____7820 =
+                                                          let uu____7821 =
+                                                            let uu____7824 =
+                                                              let uu____7827
                                                                 =
-                                                                let uu____7888
+                                                                FStar_Syntax_Syntax.bv_to_name
+                                                                  a
+                                                                 in
+                                                              let uu____7828
+                                                                =
+                                                                let uu____7831
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
-                                                                    a
+                                                                    b
                                                                    in
-                                                                let uu____7889
+                                                                let uu____7832
                                                                   =
-                                                                  let uu____7892
-                                                                    =
-                                                                    FStar_Syntax_Syntax.bv_to_name
-                                                                    b  in
-                                                                  let uu____7893
-                                                                    =
-                                                                    let uu____7896
+                                                                  let uu____7835
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f  in
-                                                                    let uu____7897
+                                                                  let uu____7836
                                                                     =
-                                                                    let uu____7900
+                                                                    let uu____7839
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_g  in
-                                                                    [uu____7900]
+                                                                    [uu____7839]
                                                                      in
-                                                                    uu____7896
+                                                                  uu____7835
                                                                     ::
-                                                                    uu____7897
-                                                                     in
-                                                                  uu____7892
-                                                                    ::
-                                                                    uu____7893
+                                                                    uu____7836
                                                                    in
-                                                                uu____7888 ::
-                                                                  uu____7889
+                                                                uu____7831 ::
+                                                                  uu____7832
                                                                  in
-                                                              r :: uu____7885
+                                                              uu____7827 ::
+                                                                uu____7828
                                                                in
-                                                            FStar_List.map
-                                                              FStar_Syntax_Syntax.as_arg
-                                                              uu____7882
+                                                            r :: uu____7824
                                                              in
-                                                          FStar_Syntax_Syntax.mk_Tm_app
-                                                            uu____7871
-                                                            uu____7881
+                                                          FStar_List.map
+                                                            FStar_Syntax_Syntax.as_arg
+                                                            uu____7821
                                                            in
-                                                        uu____7866
-                                                          FStar_Pervasives_Native.None
+                                                        FStar_Syntax_Syntax.mk_Tm_app
+                                                          uu____7810
+                                                          uu____7820
                                                           FStar_Range.dummyRange
                                                          in
                                                       mk_repr b wp  in
                                                     let maybe_range_arg =
-                                                      let uu____7918 =
+                                                      let uu____7857 =
                                                         FStar_Util.for_some
                                                           (FStar_Syntax_Util.attr_eq
                                                              FStar_Syntax_Util.dm4f_bind_range_attr)
                                                           ed2.FStar_Syntax_Syntax.eff_attrs
                                                          in
-                                                      if uu____7918
+                                                      if uu____7857
                                                       then
-                                                        let uu____7929 =
+                                                        let uu____7868 =
                                                           FStar_Syntax_Syntax.null_binder
                                                             FStar_Syntax_Syntax.t_range
                                                            in
-                                                        let uu____7936 =
-                                                          let uu____7945 =
+                                                        let uu____7875 =
+                                                          let uu____7884 =
                                                             FStar_Syntax_Syntax.null_binder
                                                               FStar_Syntax_Syntax.t_range
                                                              in
-                                                          [uu____7945]  in
-                                                        uu____7929 ::
-                                                          uu____7936
+                                                          [uu____7884]  in
+                                                        uu____7868 ::
+                                                          uu____7875
                                                       else []  in
                                                     let k =
-                                                      let uu____7981 =
-                                                        let uu____7990 =
-                                                          let uu____7999 =
+                                                      let uu____7920 =
+                                                        let uu____7929 =
+                                                          let uu____7938 =
                                                             FStar_Syntax_Syntax.mk_binder
                                                               a
                                                              in
-                                                          let uu____8006 =
-                                                            let uu____8015 =
+                                                          let uu____7945 =
+                                                            let uu____7954 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 b
                                                                in
-                                                            [uu____8015]  in
-                                                          uu____7999 ::
-                                                            uu____8006
+                                                            [uu____7954]  in
+                                                          uu____7938 ::
+                                                            uu____7945
                                                            in
-                                                        let uu____8040 =
-                                                          let uu____8049 =
-                                                            let uu____8058 =
+                                                        let uu____7979 =
+                                                          let uu____7988 =
+                                                            let uu____7997 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 wp_f
                                                                in
-                                                            let uu____8065 =
-                                                              let uu____8074
+                                                            let uu____8004 =
+                                                              let uu____8013
                                                                 =
-                                                                let uu____8081
+                                                                let uu____8020
                                                                   =
-                                                                  let uu____8082
+                                                                  let uu____8021
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f  in
                                                                   mk_repr a
-                                                                    uu____8082
+                                                                    uu____8021
                                                                    in
                                                                 FStar_Syntax_Syntax.null_binder
-                                                                  uu____8081
+                                                                  uu____8020
                                                                  in
-                                                              let uu____8083
+                                                              let uu____8022
                                                                 =
-                                                                let uu____8092
+                                                                let uu____8031
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     wp_g
                                                                    in
-                                                                let uu____8099
+                                                                let uu____8038
                                                                   =
-                                                                  let uu____8108
+                                                                  let uu____8047
                                                                     =
-                                                                    let uu____8115
+                                                                    let uu____8054
                                                                     =
-                                                                    let uu____8116
+                                                                    let uu____8055
                                                                     =
-                                                                    let uu____8125
+                                                                    let uu____8064
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x_a  in
-                                                                    [uu____8125]
+                                                                    [uu____8064]
                                                                      in
-                                                                    let uu____8144
+                                                                    let uu____8083
                                                                     =
-                                                                    let uu____8147
+                                                                    let uu____8086
                                                                     =
                                                                     mk_repr b
                                                                     wp_g_x
                                                                      in
                                                                     FStar_All.pipe_left
                                                                     FStar_Syntax_Syntax.mk_Total
-                                                                    uu____8147
+                                                                    uu____8086
                                                                      in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____8116
-                                                                    uu____8144
+                                                                    uu____8055
+                                                                    uu____8083
                                                                      in
                                                                     FStar_Syntax_Syntax.null_binder
-                                                                    uu____8115
+                                                                    uu____8054
                                                                      in
-                                                                  [uu____8108]
+                                                                  [uu____8047]
                                                                    in
-                                                                uu____8092 ::
-                                                                  uu____8099
+                                                                uu____8031 ::
+                                                                  uu____8038
                                                                  in
-                                                              uu____8074 ::
-                                                                uu____8083
+                                                              uu____8013 ::
+                                                                uu____8022
                                                                in
-                                                            uu____8058 ::
-                                                              uu____8065
+                                                            uu____7997 ::
+                                                              uu____8004
                                                              in
                                                           FStar_List.append
                                                             maybe_range_arg
-                                                            uu____8049
+                                                            uu____7988
                                                            in
                                                         FStar_List.append
-                                                          uu____7990
-                                                          uu____8040
+                                                          uu____7929
+                                                          uu____7979
                                                          in
-                                                      let uu____8192 =
+                                                      let uu____8131 =
                                                         FStar_Syntax_Syntax.mk_Total
                                                           res
                                                          in
                                                       FStar_Syntax_Util.arrow
-                                                        uu____7981 uu____8192
+                                                        uu____7920 uu____8131
                                                        in
-                                                    let uu____8195 =
+                                                    let uu____8134 =
                                                       FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                         env k
                                                        in
-                                                    (match uu____8195 with
-                                                     | (k1,uu____8203,uu____8204)
+                                                    (match uu____8134 with
+                                                     | (k1,uu____8142,uu____8143)
                                                          ->
                                                          let env1 =
                                                            FStar_TypeChecker_Env.set_range
@@ -3926,151 +3880,151 @@ let (tc_non_layered_eff_decl :
                                                             in
                                                          let env2 =
                                                            FStar_All.pipe_right
-                                                             (let uu___810_8214
+                                                             (let uu___810_8153
                                                                 = env1  in
                                                               {
                                                                 FStar_TypeChecker_Env.solver
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.solver);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.solver);
                                                                 FStar_TypeChecker_Env.range
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.range);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.range);
                                                                 FStar_TypeChecker_Env.curmodule
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.curmodule);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.curmodule);
                                                                 FStar_TypeChecker_Env.gamma
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.gamma);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.gamma);
                                                                 FStar_TypeChecker_Env.gamma_sig
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.gamma_sig);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.gamma_sig);
                                                                 FStar_TypeChecker_Env.gamma_cache
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.gamma_cache);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.gamma_cache);
                                                                 FStar_TypeChecker_Env.modules
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.modules);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.modules);
                                                                 FStar_TypeChecker_Env.expected_typ
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.expected_typ);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.expected_typ);
                                                                 FStar_TypeChecker_Env.sigtab
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.sigtab);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.sigtab);
                                                                 FStar_TypeChecker_Env.attrtab
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.attrtab);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.attrtab);
                                                                 FStar_TypeChecker_Env.instantiate_imp
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.instantiate_imp);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.instantiate_imp);
                                                                 FStar_TypeChecker_Env.effects
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.effects);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.effects);
                                                                 FStar_TypeChecker_Env.generalize
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.generalize);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.generalize);
                                                                 FStar_TypeChecker_Env.letrecs
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.letrecs);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.letrecs);
                                                                 FStar_TypeChecker_Env.top_level
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.top_level);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.top_level);
                                                                 FStar_TypeChecker_Env.check_uvars
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.check_uvars);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.check_uvars);
                                                                 FStar_TypeChecker_Env.use_eq
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.use_eq);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.use_eq);
                                                                 FStar_TypeChecker_Env.use_eq_strict
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.use_eq_strict);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.use_eq_strict);
                                                                 FStar_TypeChecker_Env.is_iface
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.is_iface);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.is_iface);
                                                                 FStar_TypeChecker_Env.admit
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.admit);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.admit);
                                                                 FStar_TypeChecker_Env.lax
                                                                   = true;
                                                                 FStar_TypeChecker_Env.lax_universes
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.lax_universes);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.lax_universes);
                                                                 FStar_TypeChecker_Env.phase1
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.phase1);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.phase1);
                                                                 FStar_TypeChecker_Env.failhard
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.failhard);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.failhard);
                                                                 FStar_TypeChecker_Env.nosynth
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.nosynth);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.nosynth);
                                                                 FStar_TypeChecker_Env.uvar_subtyping
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.uvar_subtyping);
                                                                 FStar_TypeChecker_Env.tc_term
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.tc_term);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.tc_term);
                                                                 FStar_TypeChecker_Env.type_of
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.type_of);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.type_of);
                                                                 FStar_TypeChecker_Env.universe_of
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.universe_of);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.universe_of);
                                                                 FStar_TypeChecker_Env.check_type_of
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.check_type_of);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.check_type_of);
                                                                 FStar_TypeChecker_Env.use_bv_sorts
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.use_bv_sorts);
                                                                 FStar_TypeChecker_Env.qtbl_name_and_index
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                 FStar_TypeChecker_Env.normalized_eff_names
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.normalized_eff_names);
                                                                 FStar_TypeChecker_Env.fv_delta_depths
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.fv_delta_depths);
                                                                 FStar_TypeChecker_Env.proof_ns
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.proof_ns);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.proof_ns);
                                                                 FStar_TypeChecker_Env.synth_hook
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.synth_hook);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.synth_hook);
                                                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                 FStar_TypeChecker_Env.splice
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.splice);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.splice);
                                                                 FStar_TypeChecker_Env.mpreprocess
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.mpreprocess);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.mpreprocess);
                                                                 FStar_TypeChecker_Env.postprocess
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.postprocess);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.postprocess);
                                                                 FStar_TypeChecker_Env.identifier_info
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.identifier_info);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.identifier_info);
                                                                 FStar_TypeChecker_Env.tc_hooks
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.tc_hooks);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.tc_hooks);
                                                                 FStar_TypeChecker_Env.dsenv
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.dsenv);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.dsenv);
                                                                 FStar_TypeChecker_Env.nbe
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.nbe);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.nbe);
                                                                 FStar_TypeChecker_Env.strict_args_tab
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.strict_args_tab);
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.strict_args_tab);
                                                                 FStar_TypeChecker_Env.erasable_types_tab
                                                                   =
-                                                                  (uu___810_8214.FStar_TypeChecker_Env.erasable_types_tab)
+                                                                  (uu___810_8153.FStar_TypeChecker_Env.erasable_types_tab)
                                                               })
-                                                             (fun uu____8216 
+                                                             (fun uu____8155 
                                                                 ->
                                                                 FStar_Pervasives_Native.Some
-                                                                  uu____8216)
+                                                                  uu____8155)
                                                             in
                                                          check_and_gen'
                                                            "bind_repr"
@@ -4090,31 +4044,31 @@ let (tc_non_layered_eff_decl :
                                                 failwith
                                                   "tc_eff_decl: expected action_params to be empty"
                                               else ();
-                                              (let uu____8243 =
+                                              (let uu____8182 =
                                                  if
                                                    act.FStar_Syntax_Syntax.action_univs
                                                      = []
                                                  then (env, act)
                                                  else
-                                                   (let uu____8257 =
+                                                   (let uu____8196 =
                                                       FStar_Syntax_Subst.univ_var_opening
                                                         act.FStar_Syntax_Syntax.action_univs
                                                        in
-                                                    match uu____8257 with
+                                                    match uu____8196 with
                                                     | (usubst,uvs) ->
-                                                        let uu____8280 =
+                                                        let uu____8219 =
                                                           FStar_TypeChecker_Env.push_univ_vars
                                                             env uvs
                                                            in
-                                                        let uu____8281 =
-                                                          let uu___823_8282 =
+                                                        let uu____8220 =
+                                                          let uu___823_8221 =
                                                             act  in
-                                                          let uu____8283 =
+                                                          let uu____8222 =
                                                             FStar_Syntax_Subst.subst
                                                               usubst
                                                               act.FStar_Syntax_Syntax.action_defn
                                                              in
-                                                          let uu____8284 =
+                                                          let uu____8223 =
                                                             FStar_Syntax_Subst.subst
                                                               usubst
                                                               act.FStar_Syntax_Syntax.action_typ
@@ -4122,258 +4076,258 @@ let (tc_non_layered_eff_decl :
                                                           {
                                                             FStar_Syntax_Syntax.action_name
                                                               =
-                                                              (uu___823_8282.FStar_Syntax_Syntax.action_name);
+                                                              (uu___823_8221.FStar_Syntax_Syntax.action_name);
                                                             FStar_Syntax_Syntax.action_unqualified_name
                                                               =
-                                                              (uu___823_8282.FStar_Syntax_Syntax.action_unqualified_name);
+                                                              (uu___823_8221.FStar_Syntax_Syntax.action_unqualified_name);
                                                             FStar_Syntax_Syntax.action_univs
                                                               = uvs;
                                                             FStar_Syntax_Syntax.action_params
                                                               =
-                                                              (uu___823_8282.FStar_Syntax_Syntax.action_params);
+                                                              (uu___823_8221.FStar_Syntax_Syntax.action_params);
                                                             FStar_Syntax_Syntax.action_defn
-                                                              = uu____8283;
+                                                              = uu____8222;
                                                             FStar_Syntax_Syntax.action_typ
-                                                              = uu____8284
+                                                              = uu____8223
                                                           }  in
-                                                        (uu____8280,
-                                                          uu____8281))
+                                                        (uu____8219,
+                                                          uu____8220))
                                                   in
-                                               match uu____8243 with
+                                               match uu____8182 with
                                                | (env1,act1) ->
                                                    let act_typ =
-                                                     let uu____8288 =
-                                                       let uu____8289 =
+                                                     let uu____8227 =
+                                                       let uu____8228 =
                                                          FStar_Syntax_Subst.compress
                                                            act1.FStar_Syntax_Syntax.action_typ
                                                           in
-                                                       uu____8289.FStar_Syntax_Syntax.n
+                                                       uu____8228.FStar_Syntax_Syntax.n
                                                         in
-                                                     match uu____8288 with
+                                                     match uu____8227 with
                                                      | FStar_Syntax_Syntax.Tm_arrow
                                                          (bs1,c) ->
                                                          let c1 =
                                                            FStar_Syntax_Util.comp_to_comp_typ
                                                              c
                                                             in
-                                                         let uu____8315 =
+                                                         let uu____8254 =
                                                            FStar_Ident.lid_equals
                                                              c1.FStar_Syntax_Syntax.effect_name
                                                              ed2.FStar_Syntax_Syntax.mname
                                                             in
-                                                         if uu____8315
+                                                         if uu____8254
                                                          then
-                                                           let uu____8318 =
-                                                             let uu____8321 =
-                                                               let uu____8322
+                                                           let uu____8257 =
+                                                             let uu____8260 =
+                                                               let uu____8261
                                                                  =
-                                                                 let uu____8323
+                                                                 let uu____8262
                                                                    =
                                                                    FStar_List.hd
                                                                     c1.FStar_Syntax_Syntax.effect_args
                                                                     in
                                                                  FStar_Pervasives_Native.fst
-                                                                   uu____8323
+                                                                   uu____8262
                                                                   in
                                                                mk_repr'
                                                                  c1.FStar_Syntax_Syntax.result_typ
-                                                                 uu____8322
+                                                                 uu____8261
                                                                 in
                                                              FStar_Syntax_Syntax.mk_Total
-                                                               uu____8321
+                                                               uu____8260
                                                               in
                                                            FStar_Syntax_Util.arrow
-                                                             bs1 uu____8318
+                                                             bs1 uu____8257
                                                          else
                                                            act1.FStar_Syntax_Syntax.action_typ
-                                                     | uu____8346 ->
+                                                     | uu____8285 ->
                                                          act1.FStar_Syntax_Syntax.action_typ
                                                       in
-                                                   let uu____8347 =
+                                                   let uu____8286 =
                                                      FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                        env1 act_typ
                                                       in
-                                                   (match uu____8347 with
-                                                    | (act_typ1,uu____8355,g_t)
+                                                   (match uu____8286 with
+                                                    | (act_typ1,uu____8294,g_t)
                                                         ->
                                                         let env' =
-                                                          let uu___840_8358 =
+                                                          let uu___840_8297 =
                                                             FStar_TypeChecker_Env.set_expected_typ
                                                               env1 act_typ1
                                                              in
                                                           {
                                                             FStar_TypeChecker_Env.solver
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.solver);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.solver);
                                                             FStar_TypeChecker_Env.range
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.range);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.range);
                                                             FStar_TypeChecker_Env.curmodule
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.curmodule);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.curmodule);
                                                             FStar_TypeChecker_Env.gamma
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.gamma);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.gamma);
                                                             FStar_TypeChecker_Env.gamma_sig
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.gamma_sig);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.gamma_sig);
                                                             FStar_TypeChecker_Env.gamma_cache
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.gamma_cache);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.gamma_cache);
                                                             FStar_TypeChecker_Env.modules
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.modules);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.modules);
                                                             FStar_TypeChecker_Env.expected_typ
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.expected_typ);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.expected_typ);
                                                             FStar_TypeChecker_Env.sigtab
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.sigtab);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.sigtab);
                                                             FStar_TypeChecker_Env.attrtab
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.attrtab);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.attrtab);
                                                             FStar_TypeChecker_Env.instantiate_imp
                                                               = false;
                                                             FStar_TypeChecker_Env.effects
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.effects);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.effects);
                                                             FStar_TypeChecker_Env.generalize
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.generalize);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.generalize);
                                                             FStar_TypeChecker_Env.letrecs
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.letrecs);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.letrecs);
                                                             FStar_TypeChecker_Env.top_level
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.top_level);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.top_level);
                                                             FStar_TypeChecker_Env.check_uvars
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.check_uvars);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.check_uvars);
                                                             FStar_TypeChecker_Env.use_eq
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.use_eq);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.use_eq);
                                                             FStar_TypeChecker_Env.use_eq_strict
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.use_eq_strict);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.use_eq_strict);
                                                             FStar_TypeChecker_Env.is_iface
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.is_iface);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.is_iface);
                                                             FStar_TypeChecker_Env.admit
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.admit);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.admit);
                                                             FStar_TypeChecker_Env.lax
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.lax);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.lax);
                                                             FStar_TypeChecker_Env.lax_universes
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.lax_universes);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.lax_universes);
                                                             FStar_TypeChecker_Env.phase1
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.phase1);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.phase1);
                                                             FStar_TypeChecker_Env.failhard
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.failhard);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.failhard);
                                                             FStar_TypeChecker_Env.nosynth
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.nosynth);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.nosynth);
                                                             FStar_TypeChecker_Env.uvar_subtyping
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.uvar_subtyping);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.uvar_subtyping);
                                                             FStar_TypeChecker_Env.tc_term
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.tc_term);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.tc_term);
                                                             FStar_TypeChecker_Env.type_of
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.type_of);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.type_of);
                                                             FStar_TypeChecker_Env.universe_of
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.universe_of);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.universe_of);
                                                             FStar_TypeChecker_Env.check_type_of
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.check_type_of);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.check_type_of);
                                                             FStar_TypeChecker_Env.use_bv_sorts
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.use_bv_sorts);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.use_bv_sorts);
                                                             FStar_TypeChecker_Env.qtbl_name_and_index
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                             FStar_TypeChecker_Env.normalized_eff_names
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.normalized_eff_names);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.normalized_eff_names);
                                                             FStar_TypeChecker_Env.fv_delta_depths
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.fv_delta_depths);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.fv_delta_depths);
                                                             FStar_TypeChecker_Env.proof_ns
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.proof_ns);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.proof_ns);
                                                             FStar_TypeChecker_Env.synth_hook
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.synth_hook);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.synth_hook);
                                                             FStar_TypeChecker_Env.try_solve_implicits_hook
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                             FStar_TypeChecker_Env.splice
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.splice);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.splice);
                                                             FStar_TypeChecker_Env.mpreprocess
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.mpreprocess);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.mpreprocess);
                                                             FStar_TypeChecker_Env.postprocess
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.postprocess);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.postprocess);
                                                             FStar_TypeChecker_Env.identifier_info
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.identifier_info);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.identifier_info);
                                                             FStar_TypeChecker_Env.tc_hooks
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.tc_hooks);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.tc_hooks);
                                                             FStar_TypeChecker_Env.dsenv
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.dsenv);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.dsenv);
                                                             FStar_TypeChecker_Env.nbe
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.nbe);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.nbe);
                                                             FStar_TypeChecker_Env.strict_args_tab
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.strict_args_tab);
+                                                              (uu___840_8297.FStar_TypeChecker_Env.strict_args_tab);
                                                             FStar_TypeChecker_Env.erasable_types_tab
                                                               =
-                                                              (uu___840_8358.FStar_TypeChecker_Env.erasable_types_tab)
+                                                              (uu___840_8297.FStar_TypeChecker_Env.erasable_types_tab)
                                                           }  in
-                                                        ((let uu____8361 =
+                                                        ((let uu____8300 =
                                                             FStar_TypeChecker_Env.debug
                                                               env1
                                                               (FStar_Options.Other
                                                                  "ED")
                                                              in
-                                                          if uu____8361
+                                                          if uu____8300
                                                           then
-                                                            let uu____8365 =
+                                                            let uu____8304 =
                                                               FStar_Ident.string_of_lid
                                                                 act1.FStar_Syntax_Syntax.action_name
                                                                in
-                                                            let uu____8367 =
+                                                            let uu____8306 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 act1.FStar_Syntax_Syntax.action_defn
                                                                in
-                                                            let uu____8369 =
+                                                            let uu____8308 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 act_typ1
                                                                in
                                                             FStar_Util.print3
                                                               "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
-                                                              uu____8365
-                                                              uu____8367
-                                                              uu____8369
+                                                              uu____8304
+                                                              uu____8306
+                                                              uu____8308
                                                           else ());
-                                                         (let uu____8374 =
+                                                         (let uu____8313 =
                                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                               env'
                                                               act1.FStar_Syntax_Syntax.action_defn
                                                              in
-                                                          match uu____8374
+                                                          match uu____8313
                                                           with
-                                                          | (act_defn,uu____8382,g_a)
+                                                          | (act_defn,uu____8321,g_a)
                                                               ->
                                                               let act_defn1 =
                                                                 FStar_TypeChecker_Normalize.normalize
@@ -4391,7 +4345,7 @@ let (tc_non_layered_eff_decl :
                                                                   env1
                                                                   act_typ1
                                                                  in
-                                                              let uu____8386
+                                                              let uu____8325
                                                                 =
                                                                 let act_typ3
                                                                   =
@@ -4404,14 +4358,14 @@ let (tc_non_layered_eff_decl :
                                                                 | FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1,c)
                                                                     ->
-                                                                    let uu____8422
+                                                                    let uu____8361
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c  in
-                                                                    (match uu____8422
+                                                                    (match uu____8361
                                                                     with
                                                                     | 
-                                                                    (bs2,uu____8434)
+                                                                    (bs2,uu____8373)
                                                                     ->
                                                                     let res =
                                                                     mk_repr'
@@ -4419,54 +4373,54 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
                                                                     let k =
-                                                                    let uu____8441
+                                                                    let uu____8380
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     res  in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____8441
+                                                                    uu____8380
                                                                      in
-                                                                    let uu____8444
+                                                                    let uu____8383
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                                     env1 k
                                                                      in
-                                                                    (match uu____8444
+                                                                    (match uu____8383
                                                                     with
                                                                     | 
-                                                                    (k1,uu____8458,g)
+                                                                    (k1,uu____8397,g)
                                                                     ->
                                                                     (k1, g)))
-                                                                | uu____8462
+                                                                | uu____8401
                                                                     ->
-                                                                    let uu____8463
+                                                                    let uu____8402
                                                                     =
-                                                                    let uu____8469
+                                                                    let uu____8408
                                                                     =
-                                                                    let uu____8471
+                                                                    let uu____8410
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     act_typ3
                                                                      in
-                                                                    let uu____8473
+                                                                    let uu____8412
                                                                     =
                                                                     FStar_Syntax_Print.tag_of_term
                                                                     act_typ3
                                                                      in
                                                                     FStar_Util.format2
                                                                     "Actions must have function types (not: %s, a.k.a. %s)"
-                                                                    uu____8471
-                                                                    uu____8473
+                                                                    uu____8410
+                                                                    uu____8412
                                                                      in
                                                                     (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                                    uu____8469)
+                                                                    uu____8408)
                                                                      in
                                                                     FStar_Errors.raise_error
-                                                                    uu____8463
+                                                                    uu____8402
                                                                     act_defn1.FStar_Syntax_Syntax.pos
                                                                  in
-                                                              (match uu____8386
+                                                              (match uu____8325
                                                                with
                                                                | (expected_k,g_k)
                                                                    ->
@@ -4477,83 +4431,83 @@ let (tc_non_layered_eff_decl :
                                                                     expected_k
                                                                      in
                                                                    ((
-                                                                    let uu____8491
+                                                                    let uu____8430
                                                                     =
-                                                                    let uu____8492
+                                                                    let uu____8431
                                                                     =
-                                                                    let uu____8493
+                                                                    let uu____8432
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_t g  in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_k
-                                                                    uu____8493
+                                                                    uu____8432
                                                                      in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_a
-                                                                    uu____8492
+                                                                    uu____8431
                                                                      in
                                                                     FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env1
-                                                                    uu____8491);
+                                                                    uu____8430);
                                                                     (
                                                                     let act_typ3
                                                                     =
-                                                                    let uu____8495
+                                                                    let uu____8434
                                                                     =
-                                                                    let uu____8496
+                                                                    let uu____8435
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     expected_k
                                                                      in
-                                                                    uu____8496.FStar_Syntax_Syntax.n
+                                                                    uu____8435.FStar_Syntax_Syntax.n
                                                                      in
-                                                                    match uu____8495
+                                                                    match uu____8434
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1,c)
                                                                     ->
-                                                                    let uu____8521
+                                                                    let uu____8460
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c  in
-                                                                    (match uu____8521
+                                                                    (match uu____8460
                                                                     with
                                                                     | 
                                                                     (bs2,c1)
                                                                     ->
-                                                                    let uu____8528
+                                                                    let uu____8467
                                                                     =
                                                                     destruct_repr
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c1)  in
-                                                                    (match uu____8528
+                                                                    (match uu____8467
                                                                     with
                                                                     | 
                                                                     (a,wp) ->
                                                                     let c2 =
-                                                                    let uu____8548
+                                                                    let uu____8487
                                                                     =
-                                                                    let uu____8549
+                                                                    let uu____8488
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 a
                                                                      in
-                                                                    [uu____8549]
+                                                                    [uu____8488]
                                                                      in
-                                                                    let uu____8550
+                                                                    let uu____8489
                                                                     =
-                                                                    let uu____8561
+                                                                    let uu____8500
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     wp  in
-                                                                    [uu____8561]
+                                                                    [uu____8500]
                                                                      in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____8548;
+                                                                    uu____8487;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     =
                                                                     (ed2.FStar_Syntax_Syntax.mname);
@@ -4561,24 +4515,24 @@ let (tc_non_layered_eff_decl :
                                                                     = a;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____8550;
+                                                                    uu____8489;
                                                                     FStar_Syntax_Syntax.flags
                                                                     = []
                                                                     }  in
-                                                                    let uu____8586
+                                                                    let uu____8525
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Comp
                                                                     c2  in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____8586))
+                                                                    uu____8525))
                                                                     | 
-                                                                    uu____8589
+                                                                    uu____8528
                                                                     ->
                                                                     failwith
                                                                     "Impossible (expected_k is an arrow)"
                                                                      in
-                                                                    let uu____8591
+                                                                    let uu____8530
                                                                     =
                                                                     if
                                                                     act1.FStar_Syntax_Syntax.action_univs
@@ -4588,16 +4542,16 @@ let (tc_non_layered_eff_decl :
                                                                     env1
                                                                     act_defn1
                                                                     else
-                                                                    (let uu____8613
+                                                                    (let uu____8552
                                                                     =
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     act1.FStar_Syntax_Syntax.action_univs
                                                                     act_defn1
                                                                      in
                                                                     ((act1.FStar_Syntax_Syntax.action_univs),
-                                                                    uu____8613))
+                                                                    uu____8552))
                                                                      in
-                                                                    match uu____8591
+                                                                    match uu____8530
                                                                     with
                                                                     | 
                                                                     (univs,act_defn2)
@@ -4615,21 +4569,21 @@ let (tc_non_layered_eff_decl :
                                                                     univs
                                                                     act_typ4
                                                                      in
-                                                                    let uu___890_8632
+                                                                    let uu___890_8571
                                                                     = act1
                                                                      in
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___890_8632.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___890_8571.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___890_8632.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___890_8571.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     = univs;
                                                                     FStar_Syntax_Syntax.action_params
                                                                     =
-                                                                    (uu___890_8632.FStar_Syntax_Syntax.action_params);
+                                                                    (uu___890_8571.FStar_Syntax_Syntax.action_params);
                                                                     FStar_Syntax_Syntax.action_defn
                                                                     =
                                                                     act_defn2;
@@ -4648,7 +4602,7 @@ let (tc_non_layered_eff_decl :
                                             (FStar_Pervasives_Native.Some
                                                bind_repr), actions)))))
                                    in
-                                match uu____7070 with
+                                match uu____7037 with
                                 | (repr,return_repr,bind_repr,actions) ->
                                     let cl ts =
                                       let ts1 =
@@ -4659,13 +4613,13 @@ let (tc_non_layered_eff_decl :
                                         FStar_Syntax_Subst.univ_var_closing
                                           ed_univs
                                          in
-                                      let uu____8675 =
+                                      let uu____8614 =
                                         FStar_Syntax_Subst.shift_subst
                                           (FStar_List.length ed_bs)
                                           ed_univs_closing
                                          in
                                       FStar_Syntax_Subst.subst_tscheme
-                                        uu____8675 ts1
+                                        uu____8614 ts1
                                        in
                                     let combinators =
                                       {
@@ -4693,95 +4647,95 @@ let (tc_non_layered_eff_decl :
                                       match ed2.FStar_Syntax_Syntax.combinators
                                       with
                                       | FStar_Syntax_Syntax.Primitive_eff
-                                          uu____8687 ->
+                                          uu____8626 ->
                                           FStar_Syntax_Syntax.Primitive_eff
                                             combinators1
                                       | FStar_Syntax_Syntax.DM4F_eff
-                                          uu____8688 ->
+                                          uu____8627 ->
                                           FStar_Syntax_Syntax.DM4F_eff
                                             combinators1
-                                      | uu____8689 ->
+                                      | uu____8628 ->
                                           failwith
                                             "Impossible! tc_eff_decl on a layered effect is not expected"
                                        in
                                     let ed3 =
-                                      let uu___910_8692 = ed2  in
-                                      let uu____8693 = cl signature  in
-                                      let uu____8694 =
+                                      let uu___910_8631 = ed2  in
+                                      let uu____8632 = cl signature  in
+                                      let uu____8633 =
                                         FStar_List.map
                                           (fun a  ->
-                                             let uu___913_8702 = a  in
-                                             let uu____8703 =
-                                               let uu____8704 =
+                                             let uu___913_8641 = a  in
+                                             let uu____8642 =
+                                               let uu____8643 =
                                                  cl
                                                    ((a.FStar_Syntax_Syntax.action_univs),
                                                      (a.FStar_Syntax_Syntax.action_defn))
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____8704
+                                                 uu____8643
                                                  FStar_Pervasives_Native.snd
                                                 in
-                                             let uu____8729 =
-                                               let uu____8730 =
+                                             let uu____8668 =
+                                               let uu____8669 =
                                                  cl
                                                    ((a.FStar_Syntax_Syntax.action_univs),
                                                      (a.FStar_Syntax_Syntax.action_typ))
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____8730
+                                                 uu____8669
                                                  FStar_Pervasives_Native.snd
                                                 in
                                              {
                                                FStar_Syntax_Syntax.action_name
                                                  =
-                                                 (uu___913_8702.FStar_Syntax_Syntax.action_name);
+                                                 (uu___913_8641.FStar_Syntax_Syntax.action_name);
                                                FStar_Syntax_Syntax.action_unqualified_name
                                                  =
-                                                 (uu___913_8702.FStar_Syntax_Syntax.action_unqualified_name);
+                                                 (uu___913_8641.FStar_Syntax_Syntax.action_unqualified_name);
                                                FStar_Syntax_Syntax.action_univs
                                                  =
-                                                 (uu___913_8702.FStar_Syntax_Syntax.action_univs);
+                                                 (uu___913_8641.FStar_Syntax_Syntax.action_univs);
                                                FStar_Syntax_Syntax.action_params
                                                  =
-                                                 (uu___913_8702.FStar_Syntax_Syntax.action_params);
+                                                 (uu___913_8641.FStar_Syntax_Syntax.action_params);
                                                FStar_Syntax_Syntax.action_defn
-                                                 = uu____8703;
+                                                 = uu____8642;
                                                FStar_Syntax_Syntax.action_typ
-                                                 = uu____8729
+                                                 = uu____8668
                                              }) actions
                                          in
                                       {
                                         FStar_Syntax_Syntax.mname =
-                                          (uu___910_8692.FStar_Syntax_Syntax.mname);
+                                          (uu___910_8631.FStar_Syntax_Syntax.mname);
                                         FStar_Syntax_Syntax.cattributes =
-                                          (uu___910_8692.FStar_Syntax_Syntax.cattributes);
+                                          (uu___910_8631.FStar_Syntax_Syntax.cattributes);
                                         FStar_Syntax_Syntax.univs =
-                                          (uu___910_8692.FStar_Syntax_Syntax.univs);
+                                          (uu___910_8631.FStar_Syntax_Syntax.univs);
                                         FStar_Syntax_Syntax.binders =
-                                          (uu___910_8692.FStar_Syntax_Syntax.binders);
+                                          (uu___910_8631.FStar_Syntax_Syntax.binders);
                                         FStar_Syntax_Syntax.signature =
-                                          uu____8693;
+                                          uu____8632;
                                         FStar_Syntax_Syntax.combinators =
                                           combinators2;
                                         FStar_Syntax_Syntax.actions =
-                                          uu____8694;
+                                          uu____8633;
                                         FStar_Syntax_Syntax.eff_attrs =
-                                          (uu___910_8692.FStar_Syntax_Syntax.eff_attrs)
+                                          (uu___910_8631.FStar_Syntax_Syntax.eff_attrs)
                                       }  in
-                                    ((let uu____8756 =
+                                    ((let uu____8695 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env)
                                           (FStar_Options.Other "ED")
                                          in
-                                      if uu____8756
+                                      if uu____8695
                                       then
-                                        let uu____8761 =
+                                        let uu____8700 =
                                           FStar_Syntax_Print.eff_decl_to_string
                                             false ed3
                                            in
                                         FStar_Util.print1
                                           "Typechecked effect declaration:\n\t%s\n"
-                                          uu____8761
+                                          uu____8700
                                       else ());
                                      ed3)))))))))))))
   
@@ -4794,12 +4748,12 @@ let (tc_eff_decl :
   fun env  ->
     fun ed  ->
       fun quals  ->
-        let uu____8787 =
-          let uu____8802 =
+        let uu____8726 =
+          let uu____8741 =
             FStar_All.pipe_right ed FStar_Syntax_Util.is_layered  in
-          if uu____8802 then tc_layered_eff_decl else tc_non_layered_eff_decl
+          if uu____8741 then tc_layered_eff_decl else tc_non_layered_eff_decl
            in
-        uu____8787 env ed quals
+        uu____8726 env ed quals
   
 let (monad_signature :
   FStar_TypeChecker_Env.env ->
@@ -4811,20 +4765,20 @@ let (monad_signature :
   fun env  ->
     fun m  ->
       fun s  ->
-        let fail uu____8852 =
-          let uu____8853 =
+        let fail uu____8791 =
+          let uu____8792 =
             FStar_TypeChecker_Err.unexpected_signature_for_monad env m s  in
-          let uu____8859 = FStar_Ident.range_of_lid m  in
-          FStar_Errors.raise_error uu____8853 uu____8859  in
+          let uu____8798 = FStar_Ident.range_of_lid m  in
+          FStar_Errors.raise_error uu____8792 uu____8798  in
         let s1 = FStar_Syntax_Subst.compress s  in
         match s1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
             let bs1 = FStar_Syntax_Subst.open_binders bs  in
             (match bs1 with
-             | (a,uu____8903)::(wp,uu____8905)::[] ->
+             | (a,uu____8842)::(wp,uu____8844)::[] ->
                  (a, (wp.FStar_Syntax_Syntax.sort))
-             | uu____8934 -> fail ())
-        | uu____8935 -> fail ()
+             | uu____8873 -> fail ())
+        | uu____8874 -> fail ()
   
 let (tc_layered_lift :
   FStar_TypeChecker_Env.env ->
@@ -4832,22 +4786,22 @@ let (tc_layered_lift :
   =
   fun env0  ->
     fun sub  ->
-      (let uu____8948 =
+      (let uu____8887 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
            (FStar_Options.Other "LayeredEffects")
           in
-       if uu____8948
+       if uu____8887
        then
-         let uu____8953 = FStar_Syntax_Print.sub_eff_to_string sub  in
-         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____8953
+         let uu____8892 = FStar_Syntax_Print.sub_eff_to_string sub  in
+         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____8892
        else ());
       (let lift_ts =
          FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift FStar_Util.must
           in
        let r =
-         let uu____8970 =
+         let uu____8909 =
            FStar_All.pipe_right lift_ts FStar_Pervasives_Native.snd  in
-         uu____8970.FStar_Syntax_Syntax.pos  in
+         uu____8909.FStar_Syntax_Syntax.pos  in
        (let src_ed =
           FStar_TypeChecker_Env.get_effect_decl env0
             sub.FStar_Syntax_Syntax.source
@@ -4856,347 +4810,347 @@ let (tc_layered_lift :
           FStar_TypeChecker_Env.get_effect_decl env0
             sub.FStar_Syntax_Syntax.target
            in
-        let uu____8982 =
+        let uu____8921 =
           ((FStar_All.pipe_right src_ed FStar_Syntax_Util.is_layered) &&
-             (let uu____8986 =
-                let uu____8987 =
+             (let uu____8925 =
+                let uu____8926 =
                   FStar_All.pipe_right src_ed
                     FStar_Syntax_Util.get_layered_effect_base
                    in
-                FStar_All.pipe_right uu____8987 FStar_Util.must  in
-              FStar_Ident.lid_equals uu____8986
+                FStar_All.pipe_right uu____8926 FStar_Util.must  in
+              FStar_Ident.lid_equals uu____8925
                 tgt_ed.FStar_Syntax_Syntax.mname))
             ||
             (((FStar_All.pipe_right tgt_ed FStar_Syntax_Util.is_layered) &&
-                (let uu____8996 =
-                   let uu____8997 =
+                (let uu____8935 =
+                   let uu____8936 =
                      FStar_All.pipe_right tgt_ed
                        FStar_Syntax_Util.get_layered_effect_base
                       in
-                   FStar_All.pipe_right uu____8997 FStar_Util.must  in
-                 FStar_Ident.lid_equals uu____8996
+                   FStar_All.pipe_right uu____8936 FStar_Util.must  in
+                 FStar_Ident.lid_equals uu____8935
                    src_ed.FStar_Syntax_Syntax.mname))
                &&
-               (let uu____9005 =
+               (let uu____8944 =
                   FStar_Ident.lid_equals src_ed.FStar_Syntax_Syntax.mname
                     FStar_Parser_Const.effect_PURE_lid
                    in
-                Prims.op_Negation uu____9005))
+                Prims.op_Negation uu____8944))
            in
-        if uu____8982
+        if uu____8921
         then
-          let uu____9008 =
-            let uu____9014 =
-              let uu____9016 =
+          let uu____8947 =
+            let uu____8953 =
+              let uu____8955 =
                 FStar_All.pipe_right src_ed.FStar_Syntax_Syntax.mname
                   FStar_Ident.string_of_lid
                  in
-              let uu____9019 =
+              let uu____8958 =
                 FStar_All.pipe_right tgt_ed.FStar_Syntax_Syntax.mname
                   FStar_Ident.string_of_lid
                  in
               FStar_Util.format2
                 "Lifts cannot be defined from a layered effect to its repr or vice versa (%s and %s here)"
-                uu____9016 uu____9019
+                uu____8955 uu____8958
                in
-            (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____9014)  in
-          FStar_Errors.raise_error uu____9008 r
+            (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____8953)  in
+          FStar_Errors.raise_error uu____8947 r
         else ());
-       (let uu____9026 = check_and_gen env0 "" "lift" Prims.int_one lift_ts
+       (let uu____8965 = check_and_gen env0 "" "lift" Prims.int_one lift_ts
            in
-        match uu____9026 with
+        match uu____8965 with
         | (us,lift,lift_ty) ->
-            ((let uu____9040 =
+            ((let uu____8979 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                   (FStar_Options.Other "LayeredEffects")
                  in
-              if uu____9040
+              if uu____8979
               then
-                let uu____9045 =
+                let uu____8984 =
                   FStar_Syntax_Print.tscheme_to_string (us, lift)  in
-                let uu____9051 =
+                let uu____8990 =
                   FStar_Syntax_Print.tscheme_to_string (us, lift_ty)  in
                 FStar_Util.print2 "Typechecked lift: %s and lift_ty: %s\n"
-                  uu____9045 uu____9051
+                  uu____8984 uu____8990
               else ());
-             (let uu____9060 = FStar_Syntax_Subst.open_univ_vars us lift_ty
+             (let uu____8999 = FStar_Syntax_Subst.open_univ_vars us lift_ty
                  in
-              match uu____9060 with
+              match uu____8999 with
               | (us1,lift_ty1) ->
                   let env = FStar_TypeChecker_Env.push_univ_vars env0 us1  in
                   (check_no_subtyping_for_layered_combinator env lift_ty1
                      FStar_Pervasives_Native.None;
                    (let lift_t_shape_error s =
-                      let uu____9078 =
+                      let uu____9017 =
                         FStar_Ident.string_of_lid
                           sub.FStar_Syntax_Syntax.source
                          in
-                      let uu____9080 =
+                      let uu____9019 =
                         FStar_Ident.string_of_lid
                           sub.FStar_Syntax_Syntax.target
                          in
-                      let uu____9082 =
+                      let uu____9021 =
                         FStar_Syntax_Print.term_to_string lift_ty1  in
                       FStar_Util.format4
                         "Unexpected shape of lift %s~>%s, reason:%s (t:%s)"
-                        uu____9078 uu____9080 s uu____9082
+                        uu____9017 uu____9019 s uu____9021
                        in
-                    let uu____9085 =
-                      let uu____9092 =
-                        let uu____9097 = FStar_Syntax_Util.type_u ()  in
-                        FStar_All.pipe_right uu____9097
-                          (fun uu____9114  ->
-                             match uu____9114 with
+                    let uu____9024 =
+                      let uu____9031 =
+                        let uu____9036 = FStar_Syntax_Util.type_u ()  in
+                        FStar_All.pipe_right uu____9036
+                          (fun uu____9053  ->
+                             match uu____9053 with
                              | (t,u) ->
-                                 let uu____9125 =
-                                   let uu____9126 =
+                                 let uu____9064 =
+                                   let uu____9065 =
                                      FStar_Syntax_Syntax.gen_bv "a"
                                        FStar_Pervasives_Native.None t
                                       in
-                                   FStar_All.pipe_right uu____9126
+                                   FStar_All.pipe_right uu____9065
                                      FStar_Syntax_Syntax.mk_binder
                                     in
-                                 (uu____9125, u))
+                                 (uu____9064, u))
                          in
-                      match uu____9092 with
+                      match uu____9031 with
                       | (a,u_a) ->
                           let rest_bs =
-                            let uu____9145 =
-                              let uu____9146 =
+                            let uu____9084 =
+                              let uu____9085 =
                                 FStar_Syntax_Subst.compress lift_ty1  in
-                              uu____9146.FStar_Syntax_Syntax.n  in
-                            match uu____9145 with
-                            | FStar_Syntax_Syntax.Tm_arrow (bs,uu____9158)
+                              uu____9085.FStar_Syntax_Syntax.n  in
+                            match uu____9084 with
+                            | FStar_Syntax_Syntax.Tm_arrow (bs,uu____9097)
                                 when
                                 (FStar_List.length bs) >= (Prims.of_int (2))
                                 ->
-                                let uu____9186 =
+                                let uu____9125 =
                                   FStar_Syntax_Subst.open_binders bs  in
-                                (match uu____9186 with
-                                 | (a',uu____9196)::bs1 ->
-                                     let uu____9216 =
-                                       let uu____9217 =
+                                (match uu____9125 with
+                                 | (a',uu____9135)::bs1 ->
+                                     let uu____9155 =
+                                       let uu____9156 =
                                          FStar_All.pipe_right bs1
                                            (FStar_List.splitAt
                                               ((FStar_List.length bs1) -
                                                  Prims.int_one))
                                           in
-                                       FStar_All.pipe_right uu____9217
+                                       FStar_All.pipe_right uu____9156
                                          FStar_Pervasives_Native.fst
                                         in
-                                     let uu____9283 =
-                                       let uu____9296 =
-                                         let uu____9299 =
-                                           let uu____9300 =
-                                             let uu____9307 =
+                                     let uu____9222 =
+                                       let uu____9235 =
+                                         let uu____9238 =
+                                           let uu____9239 =
+                                             let uu____9246 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  (FStar_Pervasives_Native.fst
                                                     a)
                                                 in
-                                             (a', uu____9307)  in
-                                           FStar_Syntax_Syntax.NT uu____9300
+                                             (a', uu____9246)  in
+                                           FStar_Syntax_Syntax.NT uu____9239
                                             in
-                                         [uu____9299]  in
+                                         [uu____9238]  in
                                        FStar_Syntax_Subst.subst_binders
-                                         uu____9296
+                                         uu____9235
                                         in
-                                     FStar_All.pipe_right uu____9216
-                                       uu____9283)
-                            | uu____9322 ->
-                                let uu____9323 =
-                                  let uu____9329 =
+                                     FStar_All.pipe_right uu____9155
+                                       uu____9222)
+                            | uu____9261 ->
+                                let uu____9262 =
+                                  let uu____9268 =
                                     lift_t_shape_error
                                       "either not an arrow, or not enough binders"
                                      in
                                   (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                    uu____9329)
+                                    uu____9268)
                                    in
-                                FStar_Errors.raise_error uu____9323 r
+                                FStar_Errors.raise_error uu____9262 r
                              in
-                          let uu____9341 =
-                            let uu____9352 =
-                              let uu____9357 =
+                          let uu____9280 =
+                            let uu____9291 =
+                              let uu____9296 =
                                 FStar_TypeChecker_Env.push_binders env (a ::
                                   rest_bs)
                                  in
-                              let uu____9364 =
-                                let uu____9365 =
+                              let uu____9303 =
+                                let uu____9304 =
                                   FStar_All.pipe_right a
                                     FStar_Pervasives_Native.fst
                                    in
-                                FStar_All.pipe_right uu____9365
+                                FStar_All.pipe_right uu____9304
                                   FStar_Syntax_Syntax.bv_to_name
                                  in
                               FStar_TypeChecker_Util.fresh_effect_repr_en
-                                uu____9357 r sub.FStar_Syntax_Syntax.source
-                                u_a uu____9364
+                                uu____9296 r sub.FStar_Syntax_Syntax.source
+                                u_a uu____9303
                                in
-                            match uu____9352 with
+                            match uu____9291 with
                             | (f_sort,g) ->
-                                let uu____9386 =
-                                  let uu____9393 =
+                                let uu____9325 =
+                                  let uu____9332 =
                                     FStar_Syntax_Syntax.gen_bv "f"
                                       FStar_Pervasives_Native.None f_sort
                                      in
-                                  FStar_All.pipe_right uu____9393
+                                  FStar_All.pipe_right uu____9332
                                     FStar_Syntax_Syntax.mk_binder
                                    in
-                                (uu____9386, g)
+                                (uu____9325, g)
                              in
-                          (match uu____9341 with
+                          (match uu____9280 with
                            | (f_b,g_f_b) ->
                                let bs = a ::
                                  (FStar_List.append rest_bs [f_b])  in
-                               let uu____9460 =
-                                 let uu____9465 =
+                               let uu____9399 =
+                                 let uu____9404 =
                                    FStar_TypeChecker_Env.push_binders env bs
                                     in
-                                 let uu____9466 =
-                                   let uu____9467 =
+                                 let uu____9405 =
+                                   let uu____9406 =
                                      FStar_All.pipe_right a
                                        FStar_Pervasives_Native.fst
                                       in
-                                   FStar_All.pipe_right uu____9467
+                                   FStar_All.pipe_right uu____9406
                                      FStar_Syntax_Syntax.bv_to_name
                                     in
                                  FStar_TypeChecker_Util.fresh_effect_repr_en
-                                   uu____9465 r
+                                   uu____9404 r
                                    sub.FStar_Syntax_Syntax.target u_a
-                                   uu____9466
+                                   uu____9405
                                   in
-                               (match uu____9460 with
+                               (match uu____9399 with
                                 | (repr,g_repr) ->
-                                    let uu____9484 =
-                                      let uu____9489 =
+                                    let uu____9423 =
+                                      let uu____9428 =
                                         FStar_TypeChecker_Env.push_binders
                                           env bs
                                          in
-                                      let uu____9490 =
-                                        let uu____9492 =
+                                      let uu____9429 =
+                                        let uu____9431 =
                                           FStar_Ident.string_of_lid
                                             sub.FStar_Syntax_Syntax.source
                                            in
-                                        let uu____9494 =
+                                        let uu____9433 =
                                           FStar_Ident.string_of_lid
                                             sub.FStar_Syntax_Syntax.target
                                            in
                                         FStar_Util.format2
                                           "implicit for pure_wp in typechecking lift %s~>%s"
-                                          uu____9492 uu____9494
+                                          uu____9431 uu____9433
                                          in
-                                      pure_wp_uvar uu____9489 repr uu____9490
+                                      pure_wp_uvar uu____9428 repr uu____9429
                                         r
                                        in
-                                    (match uu____9484 with
+                                    (match uu____9423 with
                                      | (pure_wp_uvar1,guard_wp) ->
                                          let c =
-                                           let uu____9506 =
-                                             let uu____9507 =
-                                               let uu____9508 =
+                                           let uu____9445 =
+                                             let uu____9446 =
+                                               let uu____9447 =
                                                  FStar_TypeChecker_Env.new_u_univ
                                                    ()
                                                   in
-                                               [uu____9508]  in
-                                             let uu____9509 =
-                                               let uu____9520 =
+                                               [uu____9447]  in
+                                             let uu____9448 =
+                                               let uu____9459 =
                                                  FStar_All.pipe_right
                                                    pure_wp_uvar1
                                                    FStar_Syntax_Syntax.as_arg
                                                   in
-                                               [uu____9520]  in
+                                               [uu____9459]  in
                                              {
                                                FStar_Syntax_Syntax.comp_univs
-                                                 = uu____9507;
+                                                 = uu____9446;
                                                FStar_Syntax_Syntax.effect_name
                                                  =
                                                  FStar_Parser_Const.effect_PURE_lid;
                                                FStar_Syntax_Syntax.result_typ
                                                  = repr;
                                                FStar_Syntax_Syntax.effect_args
-                                                 = uu____9509;
+                                                 = uu____9448;
                                                FStar_Syntax_Syntax.flags = []
                                              }  in
                                            FStar_Syntax_Syntax.mk_Comp
-                                             uu____9506
+                                             uu____9445
                                             in
-                                         let uu____9553 =
+                                         let uu____9492 =
                                            FStar_Syntax_Util.arrow bs c  in
-                                         let uu____9556 =
-                                           let uu____9557 =
+                                         let uu____9495 =
+                                           let uu____9496 =
                                              FStar_TypeChecker_Env.conj_guard
                                                g_f_b g_repr
                                               in
                                            FStar_TypeChecker_Env.conj_guard
-                                             uu____9557 guard_wp
+                                             uu____9496 guard_wp
                                             in
-                                         (uu____9553, uu____9556))))
+                                         (uu____9492, uu____9495))))
                        in
-                    match uu____9085 with
+                    match uu____9024 with
                     | (k,g_k) ->
-                        ((let uu____9567 =
+                        ((let uu____9506 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "LayeredEffects")
                              in
-                          if uu____9567
+                          if uu____9506
                           then
-                            let uu____9572 =
+                            let uu____9511 =
                               FStar_Syntax_Print.term_to_string k  in
                             FStar_Util.print1
                               "tc_layered_lift: before unification k: %s\n"
-                              uu____9572
+                              uu____9511
                           else ());
                          (let g = FStar_TypeChecker_Rel.teq env lift_ty1 k
                              in
                           FStar_TypeChecker_Rel.force_trivial_guard env g_k;
                           FStar_TypeChecker_Rel.force_trivial_guard env g;
-                          (let uu____9581 =
+                          (let uu____9520 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env0)
                                (FStar_Options.Other "LayeredEffects")
                               in
-                           if uu____9581
+                           if uu____9520
                            then
-                             let uu____9586 =
+                             let uu____9525 =
                                FStar_Syntax_Print.term_to_string k  in
                              FStar_Util.print1 "After unification k: %s\n"
-                               uu____9586
+                               uu____9525
                            else ());
                           (let sub1 =
-                             let uu___1006_9592 = sub  in
-                             let uu____9593 =
-                               let uu____9596 =
-                                 let uu____9597 =
-                                   let uu____9600 =
+                             let uu___1006_9531 = sub  in
+                             let uu____9532 =
+                               let uu____9535 =
+                                 let uu____9536 =
+                                   let uu____9539 =
                                      FStar_All.pipe_right k
                                        (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                           env)
                                       in
-                                   FStar_All.pipe_right uu____9600
+                                   FStar_All.pipe_right uu____9539
                                      (FStar_Syntax_Subst.close_univ_vars us1)
                                     in
-                                 (us1, uu____9597)  in
-                               FStar_Pervasives_Native.Some uu____9596  in
+                                 (us1, uu____9536)  in
+                               FStar_Pervasives_Native.Some uu____9535  in
                              {
                                FStar_Syntax_Syntax.source =
-                                 (uu___1006_9592.FStar_Syntax_Syntax.source);
+                                 (uu___1006_9531.FStar_Syntax_Syntax.source);
                                FStar_Syntax_Syntax.target =
-                                 (uu___1006_9592.FStar_Syntax_Syntax.target);
-                               FStar_Syntax_Syntax.lift_wp = uu____9593;
+                                 (uu___1006_9531.FStar_Syntax_Syntax.target);
+                               FStar_Syntax_Syntax.lift_wp = uu____9532;
                                FStar_Syntax_Syntax.lift =
                                  (FStar_Pervasives_Native.Some (us1, lift))
                              }  in
-                           (let uu____9612 =
+                           (let uu____9551 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "LayeredEffects")
                                in
-                            if uu____9612
+                            if uu____9551
                             then
-                              let uu____9617 =
+                              let uu____9556 =
                                 FStar_Syntax_Print.sub_eff_to_string sub1  in
                               FStar_Util.print1 "Final sub_effect: %s\n"
-                                uu____9617
+                                uu____9556
                             else ());
                            sub1)))))))))
   
@@ -5209,9 +5163,9 @@ let (tc_lift :
     fun sub  ->
       fun r  ->
         let check_and_gen1 env1 t k =
-          let uu____9654 =
+          let uu____9593 =
             FStar_TypeChecker_TcTerm.tc_check_trivial_guard env1 t k  in
-          FStar_TypeChecker_Util.generalize_universes env1 uu____9654  in
+          FStar_TypeChecker_Util.generalize_universes env1 uu____9593  in
         let ed_src =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.source
@@ -5220,116 +5174,114 @@ let (tc_lift :
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.target
            in
-        let uu____9657 =
+        let uu____9596 =
           (FStar_All.pipe_right ed_src FStar_Syntax_Util.is_layered) ||
             (FStar_All.pipe_right ed_tgt FStar_Syntax_Util.is_layered)
            in
-        if uu____9657
+        if uu____9596
         then tc_layered_lift env sub
         else
-          (let uu____9664 =
-             let uu____9671 =
+          (let uu____9603 =
+             let uu____9610 =
                FStar_TypeChecker_Env.lookup_effect_lid env
                  sub.FStar_Syntax_Syntax.source
                 in
-             monad_signature env sub.FStar_Syntax_Syntax.source uu____9671
+             monad_signature env sub.FStar_Syntax_Syntax.source uu____9610
               in
-           match uu____9664 with
+           match uu____9603 with
            | (a,wp_a_src) ->
-               let uu____9678 =
-                 let uu____9685 =
+               let uu____9617 =
+                 let uu____9624 =
                    FStar_TypeChecker_Env.lookup_effect_lid env
                      sub.FStar_Syntax_Syntax.target
                     in
                  monad_signature env sub.FStar_Syntax_Syntax.target
-                   uu____9685
+                   uu____9624
                   in
-               (match uu____9678 with
+               (match uu____9617 with
                 | (b,wp_b_tgt) ->
                     let wp_a_tgt =
-                      let uu____9693 =
-                        let uu____9696 =
-                          let uu____9697 =
-                            let uu____9704 = FStar_Syntax_Syntax.bv_to_name a
+                      let uu____9632 =
+                        let uu____9635 =
+                          let uu____9636 =
+                            let uu____9643 = FStar_Syntax_Syntax.bv_to_name a
                                in
-                            (b, uu____9704)  in
-                          FStar_Syntax_Syntax.NT uu____9697  in
-                        [uu____9696]  in
-                      FStar_Syntax_Subst.subst uu____9693 wp_b_tgt  in
+                            (b, uu____9643)  in
+                          FStar_Syntax_Syntax.NT uu____9636  in
+                        [uu____9635]  in
+                      FStar_Syntax_Subst.subst uu____9632 wp_b_tgt  in
                     let expected_k =
-                      let uu____9712 =
-                        let uu____9721 = FStar_Syntax_Syntax.mk_binder a  in
-                        let uu____9728 =
-                          let uu____9737 =
+                      let uu____9651 =
+                        let uu____9660 = FStar_Syntax_Syntax.mk_binder a  in
+                        let uu____9667 =
+                          let uu____9676 =
                             FStar_Syntax_Syntax.null_binder wp_a_src  in
-                          [uu____9737]  in
-                        uu____9721 :: uu____9728  in
-                      let uu____9762 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
+                          [uu____9676]  in
+                        uu____9660 :: uu____9667  in
+                      let uu____9701 = FStar_Syntax_Syntax.mk_Total wp_a_tgt
                          in
-                      FStar_Syntax_Util.arrow uu____9712 uu____9762  in
+                      FStar_Syntax_Util.arrow uu____9651 uu____9701  in
                     let repr_type eff_name a1 wp =
-                      (let uu____9784 =
-                         let uu____9786 =
+                      (let uu____9723 =
+                         let uu____9725 =
                            FStar_TypeChecker_Env.is_reifiable_effect env
                              eff_name
                             in
-                         Prims.op_Negation uu____9786  in
-                       if uu____9784
+                         Prims.op_Negation uu____9725  in
+                       if uu____9723
                        then
-                         let uu____9789 =
-                           let uu____9795 =
-                             let uu____9797 =
+                         let uu____9728 =
+                           let uu____9734 =
+                             let uu____9736 =
                                FStar_Ident.string_of_lid eff_name  in
                              FStar_Util.format1 "Effect %s cannot be reified"
-                               uu____9797
+                               uu____9736
                               in
                            (FStar_Errors.Fatal_EffectCannotBeReified,
-                             uu____9795)
+                             uu____9734)
                             in
-                         let uu____9801 = FStar_TypeChecker_Env.get_range env
+                         let uu____9740 = FStar_TypeChecker_Env.get_range env
                             in
-                         FStar_Errors.raise_error uu____9789 uu____9801
+                         FStar_Errors.raise_error uu____9728 uu____9740
                        else ());
-                      (let uu____9804 =
+                      (let uu____9743 =
                          FStar_TypeChecker_Env.effect_decl_opt env eff_name
                           in
-                       match uu____9804 with
+                       match uu____9743 with
                        | FStar_Pervasives_Native.None  ->
                            failwith
                              "internal error: reifiable effect has no decl?"
                        | FStar_Pervasives_Native.Some (ed,qualifiers) ->
                            let repr =
-                             let uu____9837 =
-                               let uu____9838 =
+                             let uu____9776 =
+                               let uu____9777 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr
                                   in
-                               FStar_All.pipe_right uu____9838
+                               FStar_All.pipe_right uu____9777
                                  FStar_Util.must
                                 in
                              FStar_TypeChecker_Env.inst_effect_fun_with
                                [FStar_Syntax_Syntax.U_unknown] env ed
-                               uu____9837
+                               uu____9776
                               in
-                           let uu____9845 =
+                           let uu____9784 =
+                             let uu____9785 =
+                               let uu____9802 =
+                                 let uu____9813 =
+                                   FStar_Syntax_Syntax.as_arg a1  in
+                                 let uu____9822 =
+                                   let uu____9833 =
+                                     FStar_Syntax_Syntax.as_arg wp  in
+                                   [uu____9833]  in
+                                 uu____9813 :: uu____9822  in
+                               (repr, uu____9802)  in
+                             FStar_Syntax_Syntax.Tm_app uu____9785  in
+                           let uu____9878 =
                              FStar_TypeChecker_Env.get_range env  in
-                           let uu____9846 =
-                             let uu____9853 =
-                               let uu____9854 =
-                                 let uu____9871 =
-                                   let uu____9882 =
-                                     FStar_Syntax_Syntax.as_arg a1  in
-                                   let uu____9891 =
-                                     let uu____9902 =
-                                       FStar_Syntax_Syntax.as_arg wp  in
-                                     [uu____9902]  in
-                                   uu____9882 :: uu____9891  in
-                                 (repr, uu____9871)  in
-                               FStar_Syntax_Syntax.Tm_app uu____9854  in
-                             FStar_Syntax_Syntax.mk uu____9853  in
-                           uu____9846 FStar_Pervasives_Native.None uu____9845)
+                           FStar_Syntax_Syntax.mk uu____9784 uu____9878)
                        in
-                    let uu____9947 =
+                    let uu____9879 =
                       match ((sub.FStar_Syntax_Syntax.lift),
                               (sub.FStar_Syntax_Syntax.lift_wp))
                       with
@@ -5337,23 +5289,23 @@ let (tc_lift :
                          ,FStar_Pervasives_Native.None ) ->
                           failwith "Impossible (parser)"
                       | (lift,FStar_Pervasives_Native.Some (uvs,lift_wp)) ->
-                          let uu____10120 =
+                          let uu____10052 =
                             if (FStar_List.length uvs) > Prims.int_zero
                             then
-                              let uu____10131 =
+                              let uu____10063 =
                                 FStar_Syntax_Subst.univ_var_opening uvs  in
-                              match uu____10131 with
+                              match uu____10063 with
                               | (usubst,uvs1) ->
-                                  let uu____10154 =
+                                  let uu____10086 =
                                     FStar_TypeChecker_Env.push_univ_vars env
                                       uvs1
                                      in
-                                  let uu____10155 =
+                                  let uu____10087 =
                                     FStar_Syntax_Subst.subst usubst lift_wp
                                      in
-                                  (uu____10154, uu____10155)
+                                  (uu____10086, uu____10087)
                             else (env, lift_wp)  in
-                          (match uu____10120 with
+                          (match uu____10052 with
                            | (env1,lift_wp1) ->
                                let lift_wp2 =
                                  if (FStar_List.length uvs) = Prims.int_zero
@@ -5363,61 +5315,61 @@ let (tc_lift :
                                       FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                         env1 lift_wp1 expected_k
                                        in
-                                    let uu____10205 =
+                                    let uu____10137 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
                                         lift_wp2
                                        in
-                                    (uvs, uu____10205))
+                                    (uvs, uu____10137))
                                   in
                                (lift, lift_wp2))
                       | (FStar_Pervasives_Native.Some
                          (what,lift),FStar_Pervasives_Native.None ) ->
-                          let uu____10276 =
+                          let uu____10208 =
                             if (FStar_List.length what) > Prims.int_zero
                             then
-                              let uu____10291 =
+                              let uu____10223 =
                                 FStar_Syntax_Subst.univ_var_opening what  in
-                              match uu____10291 with
+                              match uu____10223 with
                               | (usubst,uvs) ->
-                                  let uu____10316 =
+                                  let uu____10248 =
                                     FStar_Syntax_Subst.subst usubst lift  in
-                                  (uvs, uu____10316)
+                                  (uvs, uu____10248)
                             else ([], lift)  in
-                          (match uu____10276 with
+                          (match uu____10208 with
                            | (uvs,lift1) ->
-                               ((let uu____10352 =
+                               ((let uu____10284 =
                                    FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other "ED")
                                     in
-                                 if uu____10352
+                                 if uu____10284
                                  then
-                                   let uu____10356 =
+                                   let uu____10288 =
                                      FStar_Syntax_Print.term_to_string lift1
                                       in
                                    FStar_Util.print1 "Lift for free : %s\n"
-                                     uu____10356
+                                     uu____10288
                                  else ());
                                 (let dmff_env =
                                    FStar_TypeChecker_DMFF.empty env
                                      (FStar_TypeChecker_TcTerm.tc_constant
                                         env FStar_Range.dummyRange)
                                     in
-                                 let uu____10362 =
-                                   let uu____10369 =
+                                 let uu____10294 =
+                                   let uu____10301 =
                                      FStar_TypeChecker_Env.push_univ_vars env
                                        uvs
                                       in
                                    FStar_TypeChecker_TcTerm.tc_term
-                                     uu____10369 lift1
+                                     uu____10301 lift1
                                     in
-                                 match uu____10362 with
-                                 | (lift2,comp,uu____10394) ->
-                                     let uu____10395 =
+                                 match uu____10294 with
+                                 | (lift2,comp,uu____10326) ->
+                                     let uu____10327 =
                                        FStar_TypeChecker_DMFF.star_expr
                                          dmff_env lift2
                                         in
-                                     (match uu____10395 with
-                                      | (uu____10424,lift_wp,lift_elab) ->
+                                     (match uu____10327 with
+                                      | (uu____10356,lift_wp,lift_elab) ->
                                           let lift_wp1 =
                                             FStar_TypeChecker_DMFF.recheck_debug
                                               "lift-wp" env lift_wp
@@ -5430,167 +5382,167 @@ let (tc_lift :
                                             (FStar_List.length uvs) =
                                               Prims.int_zero
                                           then
-                                            let uu____10456 =
-                                              let uu____10467 =
+                                            let uu____10388 =
+                                              let uu____10399 =
                                                 FStar_TypeChecker_Util.generalize_universes
                                                   env lift_elab1
                                                  in
                                               FStar_Pervasives_Native.Some
-                                                uu____10467
+                                                uu____10399
                                                in
-                                            let uu____10484 =
+                                            let uu____10416 =
                                               FStar_TypeChecker_Util.generalize_universes
                                                 env lift_wp1
                                                in
-                                            (uu____10456, uu____10484)
+                                            (uu____10388, uu____10416)
                                           else
-                                            (let uu____10513 =
-                                               let uu____10524 =
-                                                 let uu____10533 =
+                                            (let uu____10445 =
+                                               let uu____10456 =
+                                                 let uu____10465 =
                                                    FStar_Syntax_Subst.close_univ_vars
                                                      uvs lift_elab1
                                                     in
-                                                 (uvs, uu____10533)  in
+                                                 (uvs, uu____10465)  in
                                                FStar_Pervasives_Native.Some
-                                                 uu____10524
+                                                 uu____10456
                                                 in
-                                             let uu____10548 =
-                                               let uu____10557 =
+                                             let uu____10480 =
+                                               let uu____10489 =
                                                  FStar_Syntax_Subst.close_univ_vars
                                                    uvs lift_wp1
                                                   in
-                                               (uvs, uu____10557)  in
-                                             (uu____10513, uu____10548))))))
+                                               (uvs, uu____10489)  in
+                                             (uu____10445, uu____10480))))))
                        in
-                    (match uu____9947 with
+                    (match uu____9879 with
                      | (lift,lift_wp) ->
                          let env1 =
-                           let uu___1090_10621 = env  in
+                           let uu___1090_10553 = env  in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___1090_10621.FStar_TypeChecker_Env.solver);
+                               (uu___1090_10553.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___1090_10621.FStar_TypeChecker_Env.range);
+                               (uu___1090_10553.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___1090_10621.FStar_TypeChecker_Env.curmodule);
+                               (uu___1090_10553.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___1090_10621.FStar_TypeChecker_Env.gamma);
+                               (uu___1090_10553.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___1090_10621.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___1090_10553.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___1090_10621.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___1090_10553.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___1090_10621.FStar_TypeChecker_Env.modules);
+                               (uu___1090_10553.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___1090_10621.FStar_TypeChecker_Env.expected_typ);
+                               (uu___1090_10553.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___1090_10621.FStar_TypeChecker_Env.sigtab);
+                               (uu___1090_10553.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___1090_10621.FStar_TypeChecker_Env.attrtab);
+                               (uu___1090_10553.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___1090_10621.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___1090_10553.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___1090_10621.FStar_TypeChecker_Env.effects);
+                               (uu___1090_10553.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___1090_10621.FStar_TypeChecker_Env.generalize);
+                               (uu___1090_10553.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___1090_10621.FStar_TypeChecker_Env.letrecs);
+                               (uu___1090_10553.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level =
-                               (uu___1090_10621.FStar_TypeChecker_Env.top_level);
+                               (uu___1090_10553.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___1090_10621.FStar_TypeChecker_Env.check_uvars);
+                               (uu___1090_10553.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___1090_10621.FStar_TypeChecker_Env.use_eq);
+                               (uu___1090_10553.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___1090_10621.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___1090_10553.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___1090_10621.FStar_TypeChecker_Env.is_iface);
+                               (uu___1090_10553.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___1090_10621.FStar_TypeChecker_Env.admit);
+                               (uu___1090_10553.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax = true;
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___1090_10621.FStar_TypeChecker_Env.lax_universes);
+                               (uu___1090_10553.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___1090_10621.FStar_TypeChecker_Env.phase1);
+                               (uu___1090_10553.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___1090_10621.FStar_TypeChecker_Env.failhard);
+                               (uu___1090_10553.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___1090_10621.FStar_TypeChecker_Env.nosynth);
+                               (uu___1090_10553.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___1090_10621.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___1090_10553.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___1090_10621.FStar_TypeChecker_Env.tc_term);
+                               (uu___1090_10553.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___1090_10621.FStar_TypeChecker_Env.type_of);
+                               (uu___1090_10553.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___1090_10621.FStar_TypeChecker_Env.universe_of);
+                               (uu___1090_10553.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___1090_10621.FStar_TypeChecker_Env.check_type_of);
+                               (uu___1090_10553.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___1090_10621.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___1090_10553.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___1090_10621.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___1090_10553.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___1090_10621.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___1090_10553.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___1090_10621.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___1090_10553.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___1090_10621.FStar_TypeChecker_Env.proof_ns);
+                               (uu___1090_10553.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___1090_10621.FStar_TypeChecker_Env.synth_hook);
+                               (uu___1090_10553.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___1090_10621.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___1090_10553.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___1090_10621.FStar_TypeChecker_Env.splice);
+                               (uu___1090_10553.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___1090_10621.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___1090_10553.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___1090_10621.FStar_TypeChecker_Env.postprocess);
+                               (uu___1090_10553.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___1090_10621.FStar_TypeChecker_Env.identifier_info);
+                               (uu___1090_10553.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___1090_10621.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___1090_10553.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___1090_10621.FStar_TypeChecker_Env.dsenv);
+                               (uu___1090_10553.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___1090_10621.FStar_TypeChecker_Env.nbe);
+                               (uu___1090_10553.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___1090_10621.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___1090_10553.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___1090_10621.FStar_TypeChecker_Env.erasable_types_tab)
+                               (uu___1090_10553.FStar_TypeChecker_Env.erasable_types_tab)
                            }  in
                          let lift1 =
                            match lift with
                            | FStar_Pervasives_Native.None  ->
                                FStar_Pervasives_Native.None
                            | FStar_Pervasives_Native.Some (uvs,lift1) ->
-                               let uu____10654 =
-                                 let uu____10659 =
+                               let uu____10586 =
+                                 let uu____10591 =
                                    FStar_Syntax_Subst.univ_var_opening uvs
                                     in
-                                 match uu____10659 with
+                                 match uu____10591 with
                                  | (usubst,uvs1) ->
-                                     let uu____10682 =
+                                     let uu____10614 =
                                        FStar_TypeChecker_Env.push_univ_vars
                                          env1 uvs1
                                         in
-                                     let uu____10683 =
+                                     let uu____10615 =
                                        FStar_Syntax_Subst.subst usubst lift1
                                         in
-                                     (uu____10682, uu____10683)
+                                     (uu____10614, uu____10615)
                                   in
-                               (match uu____10654 with
+                               (match uu____10586 with
                                 | (env2,lift2) ->
-                                    let uu____10688 =
-                                      let uu____10695 =
+                                    let uu____10620 =
+                                      let uu____10627 =
                                         FStar_TypeChecker_Env.lookup_effect_lid
                                           env2 sub.FStar_Syntax_Syntax.source
                                          in
                                       monad_signature env2
                                         sub.FStar_Syntax_Syntax.source
-                                        uu____10695
+                                        uu____10627
                                        in
-                                    (match uu____10688 with
+                                    (match uu____10620 with
                                      | (a1,wp_a_src1) ->
                                          let wp_a =
                                            FStar_Syntax_Syntax.new_bv
@@ -5619,75 +5571,68 @@ let (tc_lift :
                                                   lift_wp)
                                               in
                                            let lift_wp_a =
-                                             let uu____10721 =
+                                             let uu____10653 =
+                                               let uu____10654 =
+                                                 let uu____10671 =
+                                                   let uu____10682 =
+                                                     FStar_Syntax_Syntax.as_arg
+                                                       a_typ
+                                                      in
+                                                   let uu____10691 =
+                                                     let uu____10702 =
+                                                       FStar_Syntax_Syntax.as_arg
+                                                         wp_a_typ
+                                                        in
+                                                     [uu____10702]  in
+                                                   uu____10682 :: uu____10691
+                                                    in
+                                                 (lift_wp1, uu____10671)  in
+                                               FStar_Syntax_Syntax.Tm_app
+                                                 uu____10654
+                                                in
+                                             let uu____10747 =
                                                FStar_TypeChecker_Env.get_range
                                                  env2
                                                 in
-                                             let uu____10722 =
-                                               let uu____10729 =
-                                                 let uu____10730 =
-                                                   let uu____10747 =
-                                                     let uu____10758 =
-                                                       FStar_Syntax_Syntax.as_arg
-                                                         a_typ
-                                                        in
-                                                     let uu____10767 =
-                                                       let uu____10778 =
-                                                         FStar_Syntax_Syntax.as_arg
-                                                           wp_a_typ
-                                                          in
-                                                       [uu____10778]  in
-                                                     uu____10758 ::
-                                                       uu____10767
-                                                      in
-                                                   (lift_wp1, uu____10747)
-                                                    in
-                                                 FStar_Syntax_Syntax.Tm_app
-                                                   uu____10730
-                                                  in
-                                               FStar_Syntax_Syntax.mk
-                                                 uu____10729
-                                                in
-                                             uu____10722
-                                               FStar_Pervasives_Native.None
-                                               uu____10721
+                                             FStar_Syntax_Syntax.mk
+                                               uu____10653 uu____10747
                                               in
                                            repr_type
                                              sub.FStar_Syntax_Syntax.target
                                              a_typ lift_wp_a
                                             in
                                          let expected_k1 =
-                                           let uu____10826 =
-                                             let uu____10835 =
+                                           let uu____10751 =
+                                             let uu____10760 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  a1
                                                 in
-                                             let uu____10842 =
-                                               let uu____10851 =
+                                             let uu____10767 =
+                                               let uu____10776 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    wp_a
                                                   in
-                                               let uu____10858 =
-                                                 let uu____10867 =
+                                               let uu____10783 =
+                                                 let uu____10792 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      repr_f
                                                     in
-                                                 [uu____10867]  in
-                                               uu____10851 :: uu____10858  in
-                                             uu____10835 :: uu____10842  in
-                                           let uu____10898 =
+                                                 [uu____10792]  in
+                                               uu____10776 :: uu____10783  in
+                                             uu____10760 :: uu____10767  in
+                                           let uu____10823 =
                                              FStar_Syntax_Syntax.mk_Total
                                                repr_result
                                               in
                                            FStar_Syntax_Util.arrow
-                                             uu____10826 uu____10898
+                                             uu____10751 uu____10823
                                             in
-                                         let uu____10901 =
+                                         let uu____10826 =
                                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                              env2 expected_k1
                                             in
-                                         (match uu____10901 with
-                                          | (expected_k2,uu____10911,uu____10912)
+                                         (match uu____10826 with
+                                          | (expected_k2,uu____10836,uu____10837)
                                               ->
                                               let lift3 =
                                                 if
@@ -5701,117 +5646,117 @@ let (tc_lift :
                                                      FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                                        env2 lift2 expected_k2
                                                       in
-                                                   let uu____10920 =
+                                                   let uu____10845 =
                                                      FStar_Syntax_Subst.close_univ_vars
                                                        uvs lift3
                                                       in
-                                                   (uvs, uu____10920))
+                                                   (uvs, uu____10845))
                                                  in
                                               FStar_Pervasives_Native.Some
                                                 lift3)))
                             in
-                         ((let uu____10928 =
-                             let uu____10930 =
-                               let uu____10932 =
+                         ((let uu____10853 =
+                             let uu____10855 =
+                               let uu____10857 =
                                  FStar_All.pipe_right lift_wp
                                    FStar_Pervasives_Native.fst
                                   in
-                               FStar_All.pipe_right uu____10932
+                               FStar_All.pipe_right uu____10857
                                  FStar_List.length
                                 in
-                             uu____10930 <> Prims.int_one  in
-                           if uu____10928
+                             uu____10855 <> Prims.int_one  in
+                           if uu____10853
                            then
-                             let uu____10955 =
-                               let uu____10961 =
-                                 let uu____10963 =
+                             let uu____10880 =
+                               let uu____10886 =
+                                 let uu____10888 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source
                                     in
-                                 let uu____10965 =
+                                 let uu____10890 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target
                                     in
-                                 let uu____10967 =
-                                   let uu____10969 =
-                                     let uu____10971 =
+                                 let uu____10892 =
+                                   let uu____10894 =
+                                     let uu____10896 =
                                        FStar_All.pipe_right lift_wp
                                          FStar_Pervasives_Native.fst
                                         in
-                                     FStar_All.pipe_right uu____10971
+                                     FStar_All.pipe_right uu____10896
                                        FStar_List.length
                                       in
-                                   FStar_All.pipe_right uu____10969
+                                   FStar_All.pipe_right uu____10894
                                      FStar_Util.string_of_int
                                     in
                                  FStar_Util.format3
                                    "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____10963 uu____10965 uu____10967
+                                   uu____10888 uu____10890 uu____10892
                                   in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____10961)
+                                 uu____10886)
                                 in
-                             FStar_Errors.raise_error uu____10955 r
+                             FStar_Errors.raise_error uu____10880 r
                            else ());
-                          (let uu____10998 =
+                          (let uu____10923 =
                              (FStar_Util.is_some lift1) &&
-                               (let uu____11001 =
-                                  let uu____11003 =
-                                    let uu____11006 =
+                               (let uu____10926 =
+                                  let uu____10928 =
+                                    let uu____10931 =
                                       FStar_All.pipe_right lift1
                                         FStar_Util.must
                                        in
-                                    FStar_All.pipe_right uu____11006
+                                    FStar_All.pipe_right uu____10931
                                       FStar_Pervasives_Native.fst
                                      in
-                                  FStar_All.pipe_right uu____11003
+                                  FStar_All.pipe_right uu____10928
                                     FStar_List.length
                                    in
-                                uu____11001 <> Prims.int_one)
+                                uu____10926 <> Prims.int_one)
                               in
-                           if uu____10998
+                           if uu____10923
                            then
-                             let uu____11045 =
-                               let uu____11051 =
-                                 let uu____11053 =
+                             let uu____10970 =
+                               let uu____10976 =
+                                 let uu____10978 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source
                                     in
-                                 let uu____11055 =
+                                 let uu____10980 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target
                                     in
-                                 let uu____11057 =
-                                   let uu____11059 =
-                                     let uu____11061 =
-                                       let uu____11064 =
+                                 let uu____10982 =
+                                   let uu____10984 =
+                                     let uu____10986 =
+                                       let uu____10989 =
                                          FStar_All.pipe_right lift1
                                            FStar_Util.must
                                           in
-                                       FStar_All.pipe_right uu____11064
+                                       FStar_All.pipe_right uu____10989
                                          FStar_Pervasives_Native.fst
                                         in
-                                     FStar_All.pipe_right uu____11061
+                                     FStar_All.pipe_right uu____10986
                                        FStar_List.length
                                       in
-                                   FStar_All.pipe_right uu____11059
+                                   FStar_All.pipe_right uu____10984
                                      FStar_Util.string_of_int
                                     in
                                  FStar_Util.format3
                                    "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____11053 uu____11055 uu____11057
+                                   uu____10978 uu____10980 uu____10982
                                   in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____11051)
+                                 uu____10976)
                                 in
-                             FStar_Errors.raise_error uu____11045 r
+                             FStar_Errors.raise_error uu____10970 r
                            else ());
-                          (let uu___1127_11106 = sub  in
+                          (let uu___1127_11031 = sub  in
                            {
                              FStar_Syntax_Syntax.source =
-                               (uu___1127_11106.FStar_Syntax_Syntax.source);
+                               (uu___1127_11031.FStar_Syntax_Syntax.source);
                              FStar_Syntax_Syntax.target =
-                               (uu___1127_11106.FStar_Syntax_Syntax.target);
+                               (uu___1127_11031.FStar_Syntax_Syntax.target);
                              FStar_Syntax_Syntax.lift_wp =
                                (FStar_Pervasives_Native.Some lift_wp);
                              FStar_Syntax_Syntax.lift = lift1
@@ -5826,52 +5771,52 @@ let (tc_effect_abbrev :
           FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun env  ->
-    fun uu____11137  ->
+    fun uu____11062  ->
       fun r  ->
-        match uu____11137 with
+        match uu____11062 with
         | (lid,uvs,tps,c) ->
             let env0 = env  in
-            let uu____11160 =
+            let uu____11085 =
               if (FStar_List.length uvs) = Prims.int_zero
               then (env, uvs, tps, c)
               else
-                (let uu____11188 = FStar_Syntax_Subst.univ_var_opening uvs
+                (let uu____11113 = FStar_Syntax_Subst.univ_var_opening uvs
                     in
-                 match uu____11188 with
+                 match uu____11113 with
                  | (usubst,uvs1) ->
                      let tps1 = FStar_Syntax_Subst.subst_binders usubst tps
                         in
                      let c1 =
-                       let uu____11219 =
+                       let uu____11144 =
                          FStar_Syntax_Subst.shift_subst
                            (FStar_List.length tps1) usubst
                           in
-                       FStar_Syntax_Subst.subst_comp uu____11219 c  in
-                     let uu____11228 =
+                       FStar_Syntax_Subst.subst_comp uu____11144 c  in
+                     let uu____11153 =
                        FStar_TypeChecker_Env.push_univ_vars env uvs1  in
-                     (uu____11228, uvs1, tps1, c1))
+                     (uu____11153, uvs1, tps1, c1))
                in
-            (match uu____11160 with
+            (match uu____11085 with
              | (env1,uvs1,tps1,c1) ->
                  let env2 = FStar_TypeChecker_Env.set_range env1 r  in
-                 let uu____11248 = FStar_Syntax_Subst.open_comp tps1 c1  in
-                 (match uu____11248 with
+                 let uu____11173 = FStar_Syntax_Subst.open_comp tps1 c1  in
+                 (match uu____11173 with
                   | (tps2,c2) ->
-                      let uu____11263 =
+                      let uu____11188 =
                         FStar_TypeChecker_TcTerm.tc_tparams env2 tps2  in
-                      (match uu____11263 with
+                      (match uu____11188 with
                        | (tps3,env3,us) ->
-                           let uu____11281 =
+                           let uu____11206 =
                              FStar_TypeChecker_TcTerm.tc_comp env3 c2  in
-                           (match uu____11281 with
+                           (match uu____11206 with
                             | (c3,u,g) ->
                                 (FStar_TypeChecker_Rel.force_trivial_guard
                                    env3 g;
                                  (let expected_result_typ =
                                     match tps3 with
-                                    | (x,uu____11307)::uu____11308 ->
+                                    | (x,uu____11232)::uu____11233 ->
                                         FStar_Syntax_Syntax.bv_to_name x
-                                    | uu____11327 ->
+                                    | uu____11252 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
                                             "Effect abbreviations must bind at least the result type")
@@ -5879,107 +5824,106 @@ let (tc_effect_abbrev :
                                      in
                                   let def_result_typ =
                                     FStar_Syntax_Util.comp_result c3  in
-                                  let uu____11335 =
-                                    let uu____11337 =
+                                  let uu____11260 =
+                                    let uu____11262 =
                                       FStar_TypeChecker_Rel.teq_nosmt_force
                                         env3 expected_result_typ
                                         def_result_typ
                                        in
-                                    Prims.op_Negation uu____11337  in
-                                  if uu____11335
+                                    Prims.op_Negation uu____11262  in
+                                  if uu____11260
                                   then
-                                    let uu____11340 =
-                                      let uu____11346 =
-                                        let uu____11348 =
+                                    let uu____11265 =
+                                      let uu____11271 =
+                                        let uu____11273 =
                                           FStar_Syntax_Print.term_to_string
                                             expected_result_typ
                                            in
-                                        let uu____11350 =
+                                        let uu____11275 =
                                           FStar_Syntax_Print.term_to_string
                                             def_result_typ
                                            in
                                         FStar_Util.format2
                                           "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
-                                          uu____11348 uu____11350
+                                          uu____11273 uu____11275
                                          in
                                       (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
-                                        uu____11346)
+                                        uu____11271)
                                        in
-                                    FStar_Errors.raise_error uu____11340 r
+                                    FStar_Errors.raise_error uu____11265 r
                                   else ());
                                  (let tps4 =
                                     FStar_Syntax_Subst.close_binders tps3  in
                                   let c4 =
                                     FStar_Syntax_Subst.close_comp tps4 c3  in
-                                  let uu____11358 =
-                                    let uu____11359 =
+                                  let uu____11283 =
+                                    let uu____11284 =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_arrow
-                                           (tps4, c4))
-                                        FStar_Pervasives_Native.None r
+                                           (tps4, c4)) r
                                        in
                                     FStar_TypeChecker_Util.generalize_universes
-                                      env0 uu____11359
+                                      env0 uu____11284
                                      in
-                                  match uu____11358 with
+                                  match uu____11283 with
                                   | (uvs2,t) ->
-                                      let uu____11388 =
-                                        let uu____11393 =
-                                          let uu____11406 =
-                                            let uu____11407 =
+                                      let uu____11313 =
+                                        let uu____11318 =
+                                          let uu____11331 =
+                                            let uu____11332 =
                                               FStar_Syntax_Subst.compress t
                                                in
-                                            uu____11407.FStar_Syntax_Syntax.n
+                                            uu____11332.FStar_Syntax_Syntax.n
                                              in
-                                          (tps4, uu____11406)  in
-                                        match uu____11393 with
+                                          (tps4, uu____11331)  in
+                                        match uu____11318 with
                                         | ([],FStar_Syntax_Syntax.Tm_arrow
-                                           (uu____11422,c5)) -> ([], c5)
-                                        | (uu____11464,FStar_Syntax_Syntax.Tm_arrow
+                                           (uu____11347,c5)) -> ([], c5)
+                                        | (uu____11389,FStar_Syntax_Syntax.Tm_arrow
                                            (tps5,c5)) -> (tps5, c5)
-                                        | uu____11503 ->
+                                        | uu____11428 ->
                                             failwith
                                               "Impossible (t is an arrow)"
                                          in
-                                      (match uu____11388 with
+                                      (match uu____11313 with
                                        | (tps5,c5) ->
                                            (if
                                               (FStar_List.length uvs2) <>
                                                 Prims.int_one
                                             then
-                                              (let uu____11535 =
+                                              (let uu____11460 =
                                                  FStar_Syntax_Subst.open_univ_vars
                                                    uvs2 t
                                                   in
-                                               match uu____11535 with
-                                               | (uu____11540,t1) ->
-                                                   let uu____11542 =
-                                                     let uu____11548 =
-                                                       let uu____11550 =
+                                               match uu____11460 with
+                                               | (uu____11465,t1) ->
+                                                   let uu____11467 =
+                                                     let uu____11473 =
+                                                       let uu____11475 =
                                                          FStar_Syntax_Print.lid_to_string
                                                            lid
                                                           in
-                                                       let uu____11552 =
+                                                       let uu____11477 =
                                                          FStar_All.pipe_right
                                                            (FStar_List.length
                                                               uvs2)
                                                            FStar_Util.string_of_int
                                                           in
-                                                       let uu____11556 =
+                                                       let uu____11481 =
                                                          FStar_Syntax_Print.term_to_string
                                                            t1
                                                           in
                                                        FStar_Util.format3
                                                          "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                         uu____11550
-                                                         uu____11552
-                                                         uu____11556
+                                                         uu____11475
+                                                         uu____11477
+                                                         uu____11481
                                                         in
                                                      (FStar_Errors.Fatal_TooManyUniverse,
-                                                       uu____11548)
+                                                       uu____11473)
                                                       in
                                                    FStar_Errors.raise_error
-                                                     uu____11542 r)
+                                                     uu____11467 r)
                                             else ();
                                             (lid, uvs2, tps5, c5)))))))))
   
@@ -5997,321 +5941,321 @@ let (tc_polymonadic_bind :
         fun p  ->
           fun ts  ->
             let eff_name =
-              let uu____11598 = FStar_Ident.string_of_lid m  in
-              let uu____11600 = FStar_Ident.string_of_lid n  in
-              let uu____11602 = FStar_Ident.string_of_lid p  in
-              FStar_Util.format3 "(%s, %s) |> %s)" uu____11598 uu____11600
-                uu____11602
+              let uu____11523 = FStar_Ident.string_of_lid m  in
+              let uu____11525 = FStar_Ident.string_of_lid n  in
+              let uu____11527 = FStar_Ident.string_of_lid p  in
+              FStar_Util.format3 "(%s, %s) |> %s)" uu____11523 uu____11525
+                uu____11527
                in
             let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos
                in
-            let uu____11610 =
+            let uu____11535 =
               check_and_gen env eff_name "polymonadic_bind"
                 (Prims.of_int (2)) ts
                in
-            match uu____11610 with
+            match uu____11535 with
             | (us,t,ty) ->
-                let uu____11626 = FStar_Syntax_Subst.open_univ_vars us ty  in
-                (match uu____11626 with
+                let uu____11551 = FStar_Syntax_Subst.open_univ_vars us ty  in
+                (match uu____11551 with
                  | (us1,ty1) ->
                      let env1 = FStar_TypeChecker_Env.push_univ_vars env us1
                         in
                      (check_no_subtyping_for_layered_combinator env1 ty1
                         FStar_Pervasives_Native.None;
-                      (let uu____11639 =
-                         let uu____11644 = FStar_Syntax_Util.type_u ()  in
-                         FStar_All.pipe_right uu____11644
-                           (fun uu____11661  ->
-                              match uu____11661 with
+                      (let uu____11564 =
+                         let uu____11569 = FStar_Syntax_Util.type_u ()  in
+                         FStar_All.pipe_right uu____11569
+                           (fun uu____11586  ->
+                              match uu____11586 with
                               | (t1,u) ->
-                                  let uu____11672 =
-                                    let uu____11673 =
+                                  let uu____11597 =
+                                    let uu____11598 =
                                       FStar_Syntax_Syntax.gen_bv "a"
                                         FStar_Pervasives_Native.None t1
                                        in
-                                    FStar_All.pipe_right uu____11673
+                                    FStar_All.pipe_right uu____11598
                                       FStar_Syntax_Syntax.mk_binder
                                      in
-                                  (uu____11672, u))
+                                  (uu____11597, u))
                           in
-                       match uu____11639 with
+                       match uu____11564 with
                        | (a,u_a) ->
-                           let uu____11681 =
-                             let uu____11686 = FStar_Syntax_Util.type_u ()
+                           let uu____11606 =
+                             let uu____11611 = FStar_Syntax_Util.type_u ()
                                 in
-                             FStar_All.pipe_right uu____11686
-                               (fun uu____11703  ->
-                                  match uu____11703 with
+                             FStar_All.pipe_right uu____11611
+                               (fun uu____11628  ->
+                                  match uu____11628 with
                                   | (t1,u) ->
-                                      let uu____11714 =
-                                        let uu____11715 =
+                                      let uu____11639 =
+                                        let uu____11640 =
                                           FStar_Syntax_Syntax.gen_bv "b"
                                             FStar_Pervasives_Native.None t1
                                            in
-                                        FStar_All.pipe_right uu____11715
+                                        FStar_All.pipe_right uu____11640
                                           FStar_Syntax_Syntax.mk_binder
                                          in
-                                      (uu____11714, u))
+                                      (uu____11639, u))
                               in
-                           (match uu____11681 with
+                           (match uu____11606 with
                             | (b,u_b) ->
                                 let rest_bs =
-                                  let uu____11732 =
-                                    let uu____11733 =
+                                  let uu____11657 =
+                                    let uu____11658 =
                                       FStar_Syntax_Subst.compress ty1  in
-                                    uu____11733.FStar_Syntax_Syntax.n  in
-                                  match uu____11732 with
+                                    uu____11658.FStar_Syntax_Syntax.n  in
+                                  match uu____11657 with
                                   | FStar_Syntax_Syntax.Tm_arrow
-                                      (bs,uu____11745) when
+                                      (bs,uu____11670) when
                                       (FStar_List.length bs) >=
                                         (Prims.of_int (4))
                                       ->
-                                      let uu____11773 =
+                                      let uu____11698 =
                                         FStar_Syntax_Subst.open_binders bs
                                          in
-                                      (match uu____11773 with
-                                       | (a',uu____11783)::(b',uu____11785)::bs1
+                                      (match uu____11698 with
+                                       | (a',uu____11708)::(b',uu____11710)::bs1
                                            ->
-                                           let uu____11815 =
-                                             let uu____11816 =
+                                           let uu____11740 =
+                                             let uu____11741 =
                                                FStar_All.pipe_right bs1
                                                  (FStar_List.splitAt
                                                     ((FStar_List.length bs1)
                                                        - (Prims.of_int (2))))
                                                 in
-                                             FStar_All.pipe_right uu____11816
+                                             FStar_All.pipe_right uu____11741
                                                FStar_Pervasives_Native.fst
                                               in
-                                           let uu____11882 =
-                                             let uu____11895 =
-                                               let uu____11898 =
-                                                 let uu____11899 =
-                                                   let uu____11906 =
-                                                     let uu____11909 =
+                                           let uu____11807 =
+                                             let uu____11820 =
+                                               let uu____11823 =
+                                                 let uu____11824 =
+                                                   let uu____11831 =
+                                                     let uu____11834 =
                                                        FStar_All.pipe_right a
                                                          FStar_Pervasives_Native.fst
                                                         in
                                                      FStar_All.pipe_right
-                                                       uu____11909
+                                                       uu____11834
                                                        FStar_Syntax_Syntax.bv_to_name
                                                       in
-                                                   (a', uu____11906)  in
+                                                   (a', uu____11831)  in
                                                  FStar_Syntax_Syntax.NT
-                                                   uu____11899
+                                                   uu____11824
                                                   in
-                                               let uu____11922 =
-                                                 let uu____11925 =
-                                                   let uu____11926 =
-                                                     let uu____11933 =
-                                                       let uu____11936 =
+                                               let uu____11847 =
+                                                 let uu____11850 =
+                                                   let uu____11851 =
+                                                     let uu____11858 =
+                                                       let uu____11861 =
                                                          FStar_All.pipe_right
                                                            b
                                                            FStar_Pervasives_Native.fst
                                                           in
                                                        FStar_All.pipe_right
-                                                         uu____11936
+                                                         uu____11861
                                                          FStar_Syntax_Syntax.bv_to_name
                                                         in
-                                                     (b', uu____11933)  in
+                                                     (b', uu____11858)  in
                                                    FStar_Syntax_Syntax.NT
-                                                     uu____11926
+                                                     uu____11851
                                                     in
-                                                 [uu____11925]  in
-                                               uu____11898 :: uu____11922  in
+                                                 [uu____11850]  in
+                                               uu____11823 :: uu____11847  in
                                              FStar_Syntax_Subst.subst_binders
-                                               uu____11895
+                                               uu____11820
                                               in
-                                           FStar_All.pipe_right uu____11815
-                                             uu____11882)
-                                  | uu____11957 ->
-                                      let uu____11958 =
-                                        let uu____11964 =
-                                          let uu____11966 =
+                                           FStar_All.pipe_right uu____11740
+                                             uu____11807)
+                                  | uu____11882 ->
+                                      let uu____11883 =
+                                        let uu____11889 =
+                                          let uu____11891 =
                                             FStar_Syntax_Print.tag_of_term
                                               ty1
                                              in
-                                          let uu____11968 =
+                                          let uu____11893 =
                                             FStar_Syntax_Print.term_to_string
                                               ty1
                                              in
                                           FStar_Util.format3
                                             "Type of %s is not an arrow with >= 4 binders (%s::%s)"
-                                            eff_name uu____11966 uu____11968
+                                            eff_name uu____11891 uu____11893
                                            in
                                         (FStar_Errors.Fatal_UnexpectedEffect,
-                                          uu____11964)
+                                          uu____11889)
                                          in
-                                      FStar_Errors.raise_error uu____11958 r
+                                      FStar_Errors.raise_error uu____11883 r
                                    in
                                 let bs = a :: b :: rest_bs  in
-                                let uu____12001 =
-                                  let uu____12012 =
-                                    let uu____12017 =
+                                let uu____11926 =
+                                  let uu____11937 =
+                                    let uu____11942 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         bs
                                        in
-                                    let uu____12018 =
-                                      let uu____12019 =
+                                    let uu____11943 =
+                                      let uu____11944 =
                                         FStar_All.pipe_right a
                                           FStar_Pervasives_Native.fst
                                          in
-                                      FStar_All.pipe_right uu____12019
+                                      FStar_All.pipe_right uu____11944
                                         FStar_Syntax_Syntax.bv_to_name
                                        in
                                     FStar_TypeChecker_Util.fresh_effect_repr_en
-                                      uu____12017 r m u_a uu____12018
+                                      uu____11942 r m u_a uu____11943
                                      in
-                                  match uu____12012 with
+                                  match uu____11937 with
                                   | (repr,g) ->
-                                      let uu____12040 =
-                                        let uu____12047 =
+                                      let uu____11965 =
+                                        let uu____11972 =
                                           FStar_Syntax_Syntax.gen_bv "f"
                                             FStar_Pervasives_Native.None repr
                                            in
-                                        FStar_All.pipe_right uu____12047
+                                        FStar_All.pipe_right uu____11972
                                           FStar_Syntax_Syntax.mk_binder
                                          in
-                                      (uu____12040, g)
+                                      (uu____11965, g)
                                    in
-                                (match uu____12001 with
+                                (match uu____11926 with
                                  | (f,guard_f) ->
-                                     let uu____12079 =
+                                     let uu____12004 =
                                        let x_a =
-                                         let uu____12097 =
-                                           let uu____12098 =
-                                             let uu____12099 =
+                                         let uu____12022 =
+                                           let uu____12023 =
+                                             let uu____12024 =
                                                FStar_All.pipe_right a
                                                  FStar_Pervasives_Native.fst
                                                 in
-                                             FStar_All.pipe_right uu____12099
+                                             FStar_All.pipe_right uu____12024
                                                FStar_Syntax_Syntax.bv_to_name
                                               in
                                            FStar_Syntax_Syntax.gen_bv "x"
                                              FStar_Pervasives_Native.None
-                                             uu____12098
+                                             uu____12023
                                             in
-                                         FStar_All.pipe_right uu____12097
+                                         FStar_All.pipe_right uu____12022
                                            FStar_Syntax_Syntax.mk_binder
                                           in
-                                       let uu____12115 =
-                                         let uu____12120 =
+                                       let uu____12040 =
+                                         let uu____12045 =
                                            FStar_TypeChecker_Env.push_binders
                                              env1
                                              (FStar_List.append bs [x_a])
                                             in
-                                         let uu____12139 =
-                                           let uu____12140 =
+                                         let uu____12064 =
+                                           let uu____12065 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst
                                               in
-                                           FStar_All.pipe_right uu____12140
+                                           FStar_All.pipe_right uu____12065
                                              FStar_Syntax_Syntax.bv_to_name
                                             in
                                          FStar_TypeChecker_Util.fresh_effect_repr_en
-                                           uu____12120 r n u_b uu____12139
+                                           uu____12045 r n u_b uu____12064
                                           in
-                                       match uu____12115 with
+                                       match uu____12040 with
                                        | (repr,g) ->
-                                           let uu____12161 =
-                                             let uu____12168 =
-                                               let uu____12169 =
-                                                 let uu____12170 =
-                                                   let uu____12173 =
-                                                     let uu____12176 =
+                                           let uu____12086 =
+                                             let uu____12093 =
+                                               let uu____12094 =
+                                                 let uu____12095 =
+                                                   let uu____12098 =
+                                                     let uu____12101 =
                                                        FStar_TypeChecker_Env.new_u_univ
                                                          ()
                                                         in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____12176
+                                                       uu____12101
                                                       in
                                                    FStar_Syntax_Syntax.mk_Total'
-                                                     repr uu____12173
+                                                     repr uu____12098
                                                     in
                                                  FStar_Syntax_Util.arrow
-                                                   [x_a] uu____12170
+                                                   [x_a] uu____12095
                                                   in
                                                FStar_Syntax_Syntax.gen_bv "g"
                                                  FStar_Pervasives_Native.None
-                                                 uu____12169
+                                                 uu____12094
                                                 in
-                                             FStar_All.pipe_right uu____12168
+                                             FStar_All.pipe_right uu____12093
                                                FStar_Syntax_Syntax.mk_binder
                                               in
-                                           (uu____12161, g)
+                                           (uu____12086, g)
                                         in
-                                     (match uu____12079 with
+                                     (match uu____12004 with
                                       | (g,guard_g) ->
-                                          let uu____12220 =
-                                            let uu____12225 =
+                                          let uu____12145 =
+                                            let uu____12150 =
                                               FStar_TypeChecker_Env.push_binders
                                                 env1 bs
                                                in
-                                            let uu____12226 =
-                                              let uu____12227 =
+                                            let uu____12151 =
+                                              let uu____12152 =
                                                 FStar_All.pipe_right b
                                                   FStar_Pervasives_Native.fst
                                                  in
                                               FStar_All.pipe_right
-                                                uu____12227
+                                                uu____12152
                                                 FStar_Syntax_Syntax.bv_to_name
                                                in
                                             FStar_TypeChecker_Util.fresh_effect_repr_en
-                                              uu____12225 r p u_b uu____12226
+                                              uu____12150 r p u_b uu____12151
                                              in
-                                          (match uu____12220 with
+                                          (match uu____12145 with
                                            | (repr,guard_repr) ->
-                                               let uu____12242 =
-                                                 let uu____12247 =
+                                               let uu____12167 =
+                                                 let uu____12172 =
                                                    FStar_TypeChecker_Env.push_binders
                                                      env1 bs
                                                     in
-                                                 let uu____12248 =
+                                                 let uu____12173 =
                                                    FStar_Util.format1
                                                      "implicit for pure_wp in checking %s"
                                                      eff_name
                                                     in
-                                                 pure_wp_uvar uu____12247
-                                                   repr uu____12248 r
+                                                 pure_wp_uvar uu____12172
+                                                   repr uu____12173 r
                                                   in
-                                               (match uu____12242 with
+                                               (match uu____12167 with
                                                 | (pure_wp_uvar1,g_pure_wp_uvar)
                                                     ->
                                                     let k =
-                                                      let uu____12260 =
-                                                        let uu____12263 =
-                                                          let uu____12264 =
-                                                            let uu____12265 =
+                                                      let uu____12185 =
+                                                        let uu____12188 =
+                                                          let uu____12189 =
+                                                            let uu____12190 =
                                                               FStar_TypeChecker_Env.new_u_univ
                                                                 ()
                                                                in
-                                                            [uu____12265]  in
-                                                          let uu____12266 =
-                                                            let uu____12277 =
+                                                            [uu____12190]  in
+                                                          let uu____12191 =
+                                                            let uu____12202 =
                                                               FStar_All.pipe_right
                                                                 pure_wp_uvar1
                                                                 FStar_Syntax_Syntax.as_arg
                                                                in
-                                                            [uu____12277]  in
+                                                            [uu____12202]  in
                                                           {
                                                             FStar_Syntax_Syntax.comp_univs
-                                                              = uu____12264;
+                                                              = uu____12189;
                                                             FStar_Syntax_Syntax.effect_name
                                                               =
                                                               FStar_Parser_Const.effect_PURE_lid;
                                                             FStar_Syntax_Syntax.result_typ
                                                               = repr;
                                                             FStar_Syntax_Syntax.effect_args
-                                                              = uu____12266;
+                                                              = uu____12191;
                                                             FStar_Syntax_Syntax.flags
                                                               = []
                                                           }  in
                                                         FStar_Syntax_Syntax.mk_Comp
-                                                          uu____12263
+                                                          uu____12188
                                                          in
                                                       FStar_Syntax_Util.arrow
                                                         (FStar_List.append bs
                                                            [f; g])
-                                                        uu____12260
+                                                        uu____12185
                                                        in
                                                     let guard_eq =
                                                       FStar_TypeChecker_Rel.teq
@@ -6325,53 +6269,53 @@ let (tc_polymonadic_bind :
                                                        guard_repr;
                                                        g_pure_wp_uvar;
                                                        guard_eq];
-                                                     (let uu____12337 =
+                                                     (let uu____12262 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env1)
                                                           FStar_Options.Extreme
                                                          in
-                                                      if uu____12337
+                                                      if uu____12262
                                                       then
-                                                        let uu____12341 =
+                                                        let uu____12266 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, t)
                                                            in
-                                                        let uu____12347 =
+                                                        let uu____12272 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, k)
                                                            in
                                                         FStar_Util.print3
                                                           "Polymonadic bind %s after typechecking (%s::%s)\n"
                                                           eff_name
-                                                          uu____12341
-                                                          uu____12347
+                                                          uu____12266
+                                                          uu____12272
                                                       else ());
-                                                     (let uu____12357 =
-                                                        let uu____12363 =
+                                                     (let uu____12282 =
+                                                        let uu____12288 =
                                                           FStar_Util.format1
                                                             "Polymonadic binds (%s in this case) is a bleeding edge F* feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                                             eff_name
                                                            in
                                                         (FStar_Errors.Warning_BleedingEdge_Feature,
-                                                          uu____12363)
+                                                          uu____12288)
                                                          in
                                                       FStar_Errors.log_issue
-                                                        r uu____12357);
-                                                     (let uu____12367 =
-                                                        let uu____12368 =
-                                                          let uu____12371 =
+                                                        r uu____12282);
+                                                     (let uu____12292 =
+                                                        let uu____12293 =
+                                                          let uu____12296 =
                                                             FStar_All.pipe_right
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env1)
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____12371
+                                                            uu____12296
                                                             (FStar_Syntax_Subst.close_univ_vars
                                                                us1)
                                                            in
-                                                        (us1, uu____12368)
+                                                        (us1, uu____12293)
                                                          in
-                                                      ((us1, t), uu____12367)))))))))))
+                                                      ((us1, t), uu____12292)))))))))))
   

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -349,7 +349,6 @@ let (tc_data :
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_arrow
                                              (bs', res))
-                                          FStar_Pervasives_Native.None
                                           t2.FStar_Syntax_Syntax.pos
                                          in
                                       let subst =
@@ -425,7 +424,6 @@ let (tc_data :
                                       let type_u_tc =
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_type u_tc)
-                                          FStar_Pervasives_Native.None
                                           result.FStar_Syntax_Syntax.pos
                                          in
                                       let env'1 =
@@ -584,7 +582,6 @@ let (tc_data :
                                                                     FStar_Syntax_Syntax.mk
                                                                     (FStar_Syntax_Syntax.Tm_type
                                                                     u1)
-                                                                    FStar_Pervasives_Native.None
                                                                     FStar_Range.dummyRange
                                                                      in
                                                                     let uu____1324
@@ -593,7 +590,6 @@ let (tc_data :
                                                                     (FStar_Syntax_Syntax.Tm_type
                                                                     (FStar_Syntax_Syntax.U_name
                                                                     u2))
-                                                                    FStar_Pervasives_Native.None
                                                                     FStar_Range.dummyRange
                                                                      in
                                                                     FStar_TypeChecker_Rel.teq
@@ -849,7 +845,6 @@ let (generalize_and_inst_within :
                                                                 FStar_Syntax_Syntax.mk
                                                                   (FStar_Syntax_Syntax.Tm_arrow
                                                                     (rest, c))
-                                                                  FStar_Pervasives_Native.None
                                                                   (x.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
                                                              in
                                                           (tps1, t3))
@@ -1794,149 +1789,132 @@ let (get_optimized_haseq_axiom :
                      FStar_Syntax_Syntax.mk_Tm_uinst uu____4488 uu____4489
                       in
                    let ind1 =
-                     let uu____4495 =
-                       let uu____4500 =
-                         FStar_List.map
-                           (fun uu____4517  ->
-                              match uu____4517 with
-                              | (bv,aq) ->
-                                  let uu____4536 =
-                                    FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____4536, aq)) bs2
-                          in
-                       FStar_Syntax_Syntax.mk_Tm_app ind uu____4500  in
-                     uu____4495 FStar_Pervasives_Native.None
+                     let uu____4493 =
+                       FStar_List.map
+                         (fun uu____4510  ->
+                            match uu____4510 with
+                            | (bv,aq) ->
+                                let uu____4529 =
+                                  FStar_Syntax_Syntax.bv_to_name bv  in
+                                (uu____4529, aq)) bs2
+                        in
+                     FStar_Syntax_Syntax.mk_Tm_app ind uu____4493
                        FStar_Range.dummyRange
                       in
                    let ind2 =
-                     let uu____4542 =
-                       let uu____4547 =
-                         FStar_List.map
-                           (fun uu____4564  ->
-                              match uu____4564 with
-                              | (bv,aq) ->
-                                  let uu____4583 =
-                                    FStar_Syntax_Syntax.bv_to_name bv  in
-                                  (uu____4583, aq)) ibs1
-                          in
-                       FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4547  in
-                     uu____4542 FStar_Pervasives_Native.None
+                     let uu____4533 =
+                       FStar_List.map
+                         (fun uu____4550  ->
+                            match uu____4550 with
+                            | (bv,aq) ->
+                                let uu____4569 =
+                                  FStar_Syntax_Syntax.bv_to_name bv  in
+                                (uu____4569, aq)) ibs1
+                        in
+                     FStar_Syntax_Syntax.mk_Tm_app ind1 uu____4533
                        FStar_Range.dummyRange
                       in
                    let haseq_ind =
-                     let uu____4589 =
-                       let uu____4594 =
-                         let uu____4595 = FStar_Syntax_Syntax.as_arg ind2  in
-                         [uu____4595]  in
-                       FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.t_haseq uu____4594
-                        in
-                     uu____4589 FStar_Pervasives_Native.None
-                       FStar_Range.dummyRange
+                     let uu____4573 =
+                       let uu____4574 = FStar_Syntax_Syntax.as_arg ind2  in
+                       [uu____4574]  in
+                     FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.t_haseq
+                       uu____4573 FStar_Range.dummyRange
                       in
                    let bs' =
                      FStar_List.filter
                        (fun b  ->
-                          let uu____4644 =
-                            let uu____4645 = FStar_Syntax_Util.type_u ()  in
-                            FStar_Pervasives_Native.fst uu____4645  in
+                          let uu____4623 =
+                            let uu____4624 = FStar_Syntax_Util.type_u ()  in
+                            FStar_Pervasives_Native.fst uu____4624  in
                           FStar_TypeChecker_Rel.subtype_nosmt_force en
                             (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                            uu____4644) bs2
+                            uu____4623) bs2
                       in
                    let haseq_bs =
                      FStar_List.fold_left
                        (fun t3  ->
                           fun b  ->
-                            let uu____4658 =
-                              let uu____4661 =
-                                let uu____4666 =
-                                  let uu____4667 =
-                                    let uu____4676 =
-                                      FStar_Syntax_Syntax.bv_to_name
-                                        (FStar_Pervasives_Native.fst b)
-                                       in
-                                    FStar_Syntax_Syntax.as_arg uu____4676  in
-                                  [uu____4667]  in
-                                FStar_Syntax_Syntax.mk_Tm_app
-                                  FStar_Syntax_Util.t_haseq uu____4666
-                                 in
-                              uu____4661 FStar_Pervasives_Native.None
+                            let uu____4637 =
+                              let uu____4640 =
+                                let uu____4641 =
+                                  let uu____4650 =
+                                    FStar_Syntax_Syntax.bv_to_name
+                                      (FStar_Pervasives_Native.fst b)
+                                     in
+                                  FStar_Syntax_Syntax.as_arg uu____4650  in
+                                [uu____4641]  in
+                              FStar_Syntax_Syntax.mk_Tm_app
+                                FStar_Syntax_Util.t_haseq uu____4640
                                 FStar_Range.dummyRange
                                in
-                            FStar_Syntax_Util.mk_conj t3 uu____4658)
+                            FStar_Syntax_Util.mk_conj t3 uu____4637)
                        FStar_Syntax_Util.t_true bs'
                       in
                    let fml = FStar_Syntax_Util.mk_imp haseq_bs haseq_ind  in
                    let fml1 =
-                     let uu___675_4699 = fml  in
-                     let uu____4700 =
-                       let uu____4701 =
-                         let uu____4708 =
-                           let uu____4709 =
-                             let uu____4730 =
+                     let uu___675_4673 = fml  in
+                     let uu____4674 =
+                       let uu____4675 =
+                         let uu____4682 =
+                           let uu____4683 =
+                             let uu____4704 =
                                FStar_Syntax_Syntax.binders_to_names ibs1  in
-                             let uu____4735 =
-                               let uu____4748 =
-                                 let uu____4759 =
+                             let uu____4709 =
+                               let uu____4722 =
+                                 let uu____4733 =
                                    FStar_Syntax_Syntax.as_arg haseq_ind  in
-                                 [uu____4759]  in
-                               [uu____4748]  in
-                             (uu____4730, uu____4735)  in
-                           FStar_Syntax_Syntax.Meta_pattern uu____4709  in
-                         (fml, uu____4708)  in
-                       FStar_Syntax_Syntax.Tm_meta uu____4701  in
+                                 [uu____4733]  in
+                               [uu____4722]  in
+                             (uu____4704, uu____4709)  in
+                           FStar_Syntax_Syntax.Meta_pattern uu____4683  in
+                         (fml, uu____4682)  in
+                       FStar_Syntax_Syntax.Tm_meta uu____4675  in
                      {
-                       FStar_Syntax_Syntax.n = uu____4700;
+                       FStar_Syntax_Syntax.n = uu____4674;
                        FStar_Syntax_Syntax.pos =
-                         (uu___675_4699.FStar_Syntax_Syntax.pos);
+                         (uu___675_4673.FStar_Syntax_Syntax.pos);
                        FStar_Syntax_Syntax.vars =
-                         (uu___675_4699.FStar_Syntax_Syntax.vars)
+                         (uu___675_4673.FStar_Syntax_Syntax.vars)
                      }  in
                    let fml2 =
                      FStar_List.fold_right
                        (fun b  ->
                           fun t3  ->
-                            let uu____4828 =
-                              let uu____4833 =
-                                let uu____4834 =
-                                  let uu____4843 =
-                                    let uu____4844 =
-                                      FStar_Syntax_Subst.close [b] t3  in
-                                    FStar_Syntax_Util.abs
-                                      [((FStar_Pervasives_Native.fst b),
-                                         FStar_Pervasives_Native.None)]
-                                      uu____4844 FStar_Pervasives_Native.None
-                                     in
-                                  FStar_Syntax_Syntax.as_arg uu____4843  in
-                                [uu____4834]  in
-                              FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____4833
-                               in
-                            uu____4828 FStar_Pervasives_Native.None
+                            let uu____4802 =
+                              let uu____4803 =
+                                let uu____4812 =
+                                  let uu____4813 =
+                                    FStar_Syntax_Subst.close [b] t3  in
+                                  FStar_Syntax_Util.abs
+                                    [((FStar_Pervasives_Native.fst b),
+                                       FStar_Pervasives_Native.None)]
+                                    uu____4813 FStar_Pervasives_Native.None
+                                   in
+                                FStar_Syntax_Syntax.as_arg uu____4812  in
+                              [uu____4803]  in
+                            FStar_Syntax_Syntax.mk_Tm_app
+                              FStar_Syntax_Util.tforall uu____4802
                               FStar_Range.dummyRange) ibs1 fml1
                       in
                    let fml3 =
                      FStar_List.fold_right
                        (fun b  ->
                           fun t3  ->
-                            let uu____4897 =
-                              let uu____4902 =
-                                let uu____4903 =
-                                  let uu____4912 =
-                                    let uu____4913 =
-                                      FStar_Syntax_Subst.close [b] t3  in
-                                    FStar_Syntax_Util.abs
-                                      [((FStar_Pervasives_Native.fst b),
-                                         FStar_Pervasives_Native.None)]
-                                      uu____4913 FStar_Pervasives_Native.None
-                                     in
-                                  FStar_Syntax_Syntax.as_arg uu____4912  in
-                                [uu____4903]  in
-                              FStar_Syntax_Syntax.mk_Tm_app
-                                FStar_Syntax_Util.tforall uu____4902
-                               in
-                            uu____4897 FStar_Pervasives_Native.None
+                            let uu____4866 =
+                              let uu____4867 =
+                                let uu____4876 =
+                                  let uu____4877 =
+                                    FStar_Syntax_Subst.close [b] t3  in
+                                  FStar_Syntax_Util.abs
+                                    [((FStar_Pervasives_Native.fst b),
+                                       FStar_Pervasives_Native.None)]
+                                    uu____4877 FStar_Pervasives_Native.None
+                                   in
+                                FStar_Syntax_Syntax.as_arg uu____4876  in
+                              [uu____4867]  in
+                            FStar_Syntax_Syntax.mk_Tm_app
+                              FStar_Syntax_Util.tforall uu____4866
                               FStar_Range.dummyRange) bs2 fml2
                       in
                    let axiom_lid = get_haseq_axiom_lid lid  in
@@ -1954,49 +1932,46 @@ let (optimized_haseq_soundness_for_data :
         fun bs  ->
           let dt = datacon_typ data  in
           let dt1 = FStar_Syntax_Subst.subst usubst dt  in
-          let uu____4988 =
-            let uu____4989 = FStar_Syntax_Subst.compress dt1  in
-            uu____4989.FStar_Syntax_Syntax.n  in
-          match uu____4988 with
-          | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____4993) ->
+          let uu____4952 =
+            let uu____4953 = FStar_Syntax_Subst.compress dt1  in
+            uu____4953.FStar_Syntax_Syntax.n  in
+          match uu____4952 with
+          | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____4957) ->
               let dbs1 =
-                let uu____5023 =
+                let uu____4987 =
                   FStar_List.splitAt (FStar_List.length bs) dbs  in
-                FStar_Pervasives_Native.snd uu____5023  in
+                FStar_Pervasives_Native.snd uu____4987  in
               let dbs2 =
-                let uu____5073 = FStar_Syntax_Subst.opening_of_binders bs  in
-                FStar_Syntax_Subst.subst_binders uu____5073 dbs1  in
+                let uu____5037 = FStar_Syntax_Subst.opening_of_binders bs  in
+                FStar_Syntax_Subst.subst_binders uu____5037 dbs1  in
               let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
               let cond =
                 FStar_List.fold_left
                   (fun t  ->
                      fun b  ->
                        let haseq_b =
-                         let uu____5088 =
-                           let uu____5093 =
-                             let uu____5094 =
-                               FStar_Syntax_Syntax.as_arg
-                                 (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                                in
-                             [uu____5094]  in
-                           FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____5093
-                            in
-                         uu____5088 FStar_Pervasives_Native.None
+                         let uu____5050 =
+                           let uu____5051 =
+                             FStar_Syntax_Syntax.as_arg
+                               (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
+                              in
+                           [uu____5051]  in
+                         FStar_Syntax_Syntax.mk_Tm_app
+                           FStar_Syntax_Util.t_haseq uu____5050
                            FStar_Range.dummyRange
                           in
                        let sort_range =
                          ((FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
                           in
                        let haseq_b1 =
-                         let uu____5125 =
-                           let uu____5127 = FStar_Ident.string_of_lid ty_lid
+                         let uu____5082 =
+                           let uu____5084 = FStar_Ident.string_of_lid ty_lid
                               in
                            FStar_Util.format1
                              "Failed to prove that the type '%s' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier"
-                             uu____5127
+                             uu____5084
                             in
-                         FStar_TypeChecker_Util.label uu____5125 sort_range
+                         FStar_TypeChecker_Util.label uu____5082 sort_range
                            haseq_b
                           in
                        FStar_Syntax_Util.mk_conj t haseq_b1)
@@ -2005,25 +1980,21 @@ let (optimized_haseq_soundness_for_data :
               FStar_List.fold_right
                 (fun b  ->
                    fun t  ->
-                     let uu____5135 =
-                       let uu____5140 =
-                         let uu____5141 =
-                           let uu____5150 =
-                             let uu____5151 = FStar_Syntax_Subst.close [b] t
-                                in
-                             FStar_Syntax_Util.abs
-                               [((FStar_Pervasives_Native.fst b),
-                                  FStar_Pervasives_Native.None)] uu____5151
-                               FStar_Pervasives_Native.None
+                     let uu____5092 =
+                       let uu____5093 =
+                         let uu____5102 =
+                           let uu____5103 = FStar_Syntax_Subst.close [b] t
                               in
-                           FStar_Syntax_Syntax.as_arg uu____5150  in
-                         [uu____5141]  in
-                       FStar_Syntax_Syntax.mk_Tm_app
-                         FStar_Syntax_Util.tforall uu____5140
-                        in
-                     uu____5135 FStar_Pervasives_Native.None
-                       FStar_Range.dummyRange) dbs3 cond
-          | uu____5198 -> FStar_Syntax_Util.t_true
+                           FStar_Syntax_Util.abs
+                             [((FStar_Pervasives_Native.fst b),
+                                FStar_Pervasives_Native.None)] uu____5103
+                             FStar_Pervasives_Native.None
+                            in
+                         FStar_Syntax_Syntax.as_arg uu____5102  in
+                       [uu____5093]  in
+                     FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.tforall
+                       uu____5092 FStar_Range.dummyRange) dbs3 cond
+          | uu____5150 -> FStar_Syntax_Util.t_true
   
 let (optimized_haseq_ty :
   FStar_Syntax_Syntax.sigelts ->
@@ -2047,19 +2018,19 @@ let (optimized_haseq_ty :
             let lid =
               match ty.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_inductive_typ
-                  (lid,uu____5289,uu____5290,uu____5291,uu____5292,uu____5293)
+                  (lid,uu____5241,uu____5242,uu____5243,uu____5244,uu____5245)
                   -> lid
-              | uu____5302 -> failwith "Impossible!"  in
-            let uu____5304 = acc  in
-            match uu____5304 with
-            | (uu____5341,en,uu____5343,uu____5344) ->
-                let uu____5365 = get_optimized_haseq_axiom en ty usubst us
+              | uu____5254 -> failwith "Impossible!"  in
+            let uu____5256 = acc  in
+            match uu____5256 with
+            | (uu____5293,en,uu____5295,uu____5296) ->
+                let uu____5317 = get_optimized_haseq_axiom en ty usubst us
                    in
-                (match uu____5365 with
+                (match uu____5317 with
                  | (axiom_lid,fml,bs,ibs,haseq_bs) ->
                      let guard = FStar_Syntax_Util.mk_conj haseq_bs fml  in
-                     let uu____5402 = acc  in
-                     (match uu____5402 with
+                     let uu____5354 = acc  in
+                     (match uu____5354 with
                       | (l_axioms,env,guard',cond') ->
                           let env1 =
                             FStar_TypeChecker_Env.push_binders env bs  in
@@ -2070,28 +2041,28 @@ let (optimized_haseq_ty :
                               (fun s  ->
                                  match s.FStar_Syntax_Syntax.sigel with
                                  | FStar_Syntax_Syntax.Sig_datacon
-                                     (uu____5477,uu____5478,uu____5479,t_lid,uu____5481,uu____5482)
+                                     (uu____5429,uu____5430,uu____5431,t_lid,uu____5433,uu____5434)
                                      -> t_lid = lid
-                                 | uu____5489 -> failwith "Impossible")
+                                 | uu____5441 -> failwith "Impossible")
                               all_datas_in_the_bundle
                              in
                           let cond =
                             FStar_List.fold_left
                               (fun acc1  ->
                                  fun d  ->
-                                   let uu____5504 =
+                                   let uu____5456 =
                                      optimized_haseq_soundness_for_data lid d
                                        usubst bs
                                       in
-                                   FStar_Syntax_Util.mk_conj acc1 uu____5504)
+                                   FStar_Syntax_Util.mk_conj acc1 uu____5456)
                               FStar_Syntax_Util.t_true t_datas
                              in
-                          let uu____5507 =
+                          let uu____5459 =
                             FStar_Syntax_Util.mk_conj guard' guard  in
-                          let uu____5510 =
+                          let uu____5462 =
                             FStar_Syntax_Util.mk_conj cond' cond  in
                           ((FStar_List.append l_axioms [(axiom_lid, fml)]),
-                            env2, uu____5507, uu____5510)))
+                            env2, uu____5459, uu____5462)))
   
 let (optimized_haseq_scheme :
   FStar_Syntax_Syntax.sigelt ->
@@ -2103,17 +2074,17 @@ let (optimized_haseq_scheme :
     fun tcs  ->
       fun datas  ->
         fun env0  ->
-          let uu____5568 =
+          let uu____5520 =
             let ty = FStar_List.hd tcs  in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (uu____5578,us,uu____5580,t,uu____5582,uu____5583) -> 
+                (uu____5530,us,uu____5532,t,uu____5534,uu____5535) -> 
                 (us, t)
-            | uu____5592 -> failwith "Impossible!"  in
-          match uu____5568 with
+            | uu____5544 -> failwith "Impossible!"  in
+          match uu____5520 with
           | (us,t) ->
-              let uu____5602 = FStar_Syntax_Subst.univ_var_opening us  in
-              (match uu____5602 with
+              let uu____5554 = FStar_Syntax_Subst.univ_var_opening us  in
+              (match uu____5554 with
                | (usubst,us1) ->
                    let env = FStar_TypeChecker_Env.push_sigelt env0 sig_bndle
                       in
@@ -2123,49 +2094,49 @@ let (optimized_haseq_scheme :
                       env sig_bndle;
                     (let env1 = FStar_TypeChecker_Env.push_univ_vars env us1
                         in
-                     let uu____5628 =
+                     let uu____5580 =
                        FStar_List.fold_left
                          (optimized_haseq_ty datas usubst us1)
                          ([], env1, FStar_Syntax_Util.t_true,
                            FStar_Syntax_Util.t_true) tcs
                         in
-                     match uu____5628 with
+                     match uu____5580 with
                      | (axioms,env2,guard,cond) ->
                          let phi =
-                           let uu____5706 = FStar_Syntax_Util.arrow_formals t
+                           let uu____5658 = FStar_Syntax_Util.arrow_formals t
                               in
-                           match uu____5706 with
-                           | (uu____5713,t1) ->
-                               let uu____5719 =
+                           match uu____5658 with
+                           | (uu____5665,t1) ->
+                               let uu____5671 =
                                  FStar_Syntax_Util.is_eqtype_no_unrefine t1
                                   in
-                               if uu____5719
+                               if uu____5671
                                then cond
                                else FStar_Syntax_Util.mk_imp guard cond
                             in
-                         let uu____5724 =
+                         let uu____5676 =
                            FStar_TypeChecker_TcTerm.tc_trivial_guard env2 phi
                             in
-                         (match uu____5724 with
-                          | (phi1,uu____5732) ->
-                              ((let uu____5734 =
+                         (match uu____5676 with
+                          | (phi1,uu____5684) ->
+                              ((let uu____5686 =
                                   FStar_TypeChecker_Env.should_verify env2
                                    in
-                                if uu____5734
+                                if uu____5686
                                 then
-                                  let uu____5737 =
+                                  let uu____5689 =
                                     FStar_TypeChecker_Env.guard_of_guard_formula
                                       (FStar_TypeChecker_Common.NonTrivial
                                          phi1)
                                      in
                                   FStar_TypeChecker_Rel.force_trivial_guard
-                                    env2 uu____5737
+                                    env2 uu____5689
                                 else ());
                                (let ses =
                                   FStar_List.fold_left
                                     (fun l  ->
-                                       fun uu____5755  ->
-                                         match uu____5755 with
+                                       fun uu____5707  ->
+                                         match uu____5707 with
                                          | (lid,fml) ->
                                              let fml1 =
                                                FStar_Syntax_Subst.close_univ_vars
@@ -2210,51 +2181,51 @@ let (unoptimized_haseq_data :
           fun acc  ->
             fun data  ->
               let rec is_mutual t =
-                let uu____5827 =
-                  let uu____5828 = FStar_Syntax_Subst.compress t  in
-                  uu____5828.FStar_Syntax_Syntax.n  in
-                match uu____5827 with
+                let uu____5779 =
+                  let uu____5780 = FStar_Syntax_Subst.compress t  in
+                  uu____5780.FStar_Syntax_Syntax.n  in
+                match uu____5779 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_List.existsb
                       (fun lid  ->
                          FStar_Ident.lid_equals lid
                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                       mutuals
-                | FStar_Syntax_Syntax.Tm_uinst (t',uu____5836) ->
+                | FStar_Syntax_Syntax.Tm_uinst (t',uu____5788) ->
                     is_mutual t'
                 | FStar_Syntax_Syntax.Tm_refine (bv,t') ->
                     is_mutual bv.FStar_Syntax_Syntax.sort
                 | FStar_Syntax_Syntax.Tm_app (t',args) ->
-                    let uu____5873 = is_mutual t'  in
-                    if uu____5873
+                    let uu____5825 = is_mutual t'  in
+                    if uu____5825
                     then true
                     else
-                      (let uu____5880 =
+                      (let uu____5832 =
                          FStar_List.map FStar_Pervasives_Native.fst args  in
-                       exists_mutual uu____5880)
-                | FStar_Syntax_Syntax.Tm_meta (t',uu____5900) -> is_mutual t'
-                | uu____5905 -> false
+                       exists_mutual uu____5832)
+                | FStar_Syntax_Syntax.Tm_meta (t',uu____5852) -> is_mutual t'
+                | uu____5857 -> false
               
-              and exists_mutual uu___1_5907 =
-                match uu___1_5907 with
+              and exists_mutual uu___1_5859 =
+                match uu___1_5859 with
                 | [] -> false
                 | hd::tl -> (is_mutual hd) || (exists_mutual tl)
                in
               let dt = datacon_typ data  in
               let dt1 = FStar_Syntax_Subst.subst usubst dt  in
-              let uu____5928 =
-                let uu____5929 = FStar_Syntax_Subst.compress dt1  in
-                uu____5929.FStar_Syntax_Syntax.n  in
-              match uu____5928 with
-              | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____5935) ->
+              let uu____5880 =
+                let uu____5881 = FStar_Syntax_Subst.compress dt1  in
+                uu____5881.FStar_Syntax_Syntax.n  in
+              match uu____5880 with
+              | FStar_Syntax_Syntax.Tm_arrow (dbs,uu____5887) ->
                   let dbs1 =
-                    let uu____5965 =
+                    let uu____5917 =
                       FStar_List.splitAt (FStar_List.length bs) dbs  in
-                    FStar_Pervasives_Native.snd uu____5965  in
+                    FStar_Pervasives_Native.snd uu____5917  in
                   let dbs2 =
-                    let uu____6015 = FStar_Syntax_Subst.opening_of_binders bs
+                    let uu____5967 = FStar_Syntax_Subst.opening_of_binders bs
                        in
-                    FStar_Syntax_Subst.subst_binders uu____6015 dbs1  in
+                    FStar_Syntax_Subst.subst_binders uu____5967 dbs1  in
                   let dbs3 = FStar_Syntax_Subst.open_binders dbs2  in
                   let cond =
                     FStar_List.fold_left
@@ -2264,22 +2235,19 @@ let (unoptimized_haseq_data :
                              (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
                               in
                            let haseq_sort =
-                             let uu____6035 =
-                               let uu____6040 =
-                                 let uu____6041 =
-                                   FStar_Syntax_Syntax.as_arg
-                                     (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
-                                    in
-                                 [uu____6041]  in
-                               FStar_Syntax_Syntax.mk_Tm_app
-                                 FStar_Syntax_Util.t_haseq uu____6040
-                                in
-                             uu____6035 FStar_Pervasives_Native.None
+                             let uu____5985 =
+                               let uu____5986 =
+                                 FStar_Syntax_Syntax.as_arg
+                                   (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort
+                                  in
+                               [uu____5986]  in
+                             FStar_Syntax_Syntax.mk_Tm_app
+                               FStar_Syntax_Util.t_haseq uu____5985
                                FStar_Range.dummyRange
                               in
                            let haseq_sort1 =
-                             let uu____6071 = is_mutual sort  in
-                             if uu____6071
+                             let uu____6016 = is_mutual sort  in
+                             if uu____6016
                              then
                                FStar_Syntax_Util.mk_imp haseq_ind haseq_sort
                              else haseq_sort  in
@@ -2290,27 +2258,24 @@ let (unoptimized_haseq_data :
                     FStar_List.fold_right
                       (fun b  ->
                          fun t  ->
-                           let uu____6084 =
-                             let uu____6089 =
-                               let uu____6090 =
-                                 let uu____6099 =
-                                   let uu____6100 =
-                                     FStar_Syntax_Subst.close [b] t  in
-                                   FStar_Syntax_Util.abs
-                                     [((FStar_Pervasives_Native.fst b),
-                                        FStar_Pervasives_Native.None)]
-                                     uu____6100 FStar_Pervasives_Native.None
-                                    in
-                                 FStar_Syntax_Syntax.as_arg uu____6099  in
-                               [uu____6090]  in
-                             FStar_Syntax_Syntax.mk_Tm_app
-                               FStar_Syntax_Util.tforall uu____6089
-                              in
-                           uu____6084 FStar_Pervasives_Native.None
+                           let uu____6029 =
+                             let uu____6030 =
+                               let uu____6039 =
+                                 let uu____6040 =
+                                   FStar_Syntax_Subst.close [b] t  in
+                                 FStar_Syntax_Util.abs
+                                   [((FStar_Pervasives_Native.fst b),
+                                      FStar_Pervasives_Native.None)]
+                                   uu____6040 FStar_Pervasives_Native.None
+                                  in
+                               FStar_Syntax_Syntax.as_arg uu____6039  in
+                             [uu____6030]  in
+                           FStar_Syntax_Syntax.mk_Tm_app
+                             FStar_Syntax_Util.tforall uu____6029
                              FStar_Range.dummyRange) dbs3 cond
                      in
                   FStar_Syntax_Util.mk_conj acc cond1
-              | uu____6147 -> acc
+              | uu____6087 -> acc
   
 let (unoptimized_haseq_ty :
   FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -2327,87 +2292,80 @@ let (unoptimized_haseq_ty :
         fun us  ->
           fun acc  ->
             fun ty  ->
-              let uu____6197 =
+              let uu____6137 =
                 match ty.FStar_Syntax_Syntax.sigel with
                 | FStar_Syntax_Syntax.Sig_inductive_typ
-                    (lid,uu____6219,bs,t,uu____6222,d_lids) ->
+                    (lid,uu____6159,bs,t,uu____6162,d_lids) ->
                     (lid, bs, t, d_lids)
-                | uu____6234 -> failwith "Impossible!"  in
-              match uu____6197 with
+                | uu____6174 -> failwith "Impossible!"  in
+              match uu____6137 with
               | (lid,bs,t,d_lids) ->
                   let bs1 = FStar_Syntax_Subst.subst_binders usubst bs  in
                   let t1 =
-                    let uu____6258 =
+                    let uu____6198 =
                       FStar_Syntax_Subst.shift_subst (FStar_List.length bs1)
                         usubst
                        in
-                    FStar_Syntax_Subst.subst uu____6258 t  in
-                  let uu____6267 = FStar_Syntax_Subst.open_term bs1 t1  in
-                  (match uu____6267 with
+                    FStar_Syntax_Subst.subst uu____6198 t  in
+                  let uu____6207 = FStar_Syntax_Subst.open_term bs1 t1  in
+                  (match uu____6207 with
                    | (bs2,t2) ->
                        let ibs =
-                         let uu____6277 =
-                           let uu____6278 = FStar_Syntax_Subst.compress t2
+                         let uu____6217 =
+                           let uu____6218 = FStar_Syntax_Subst.compress t2
                               in
-                           uu____6278.FStar_Syntax_Syntax.n  in
-                         match uu____6277 with
-                         | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____6282) ->
+                           uu____6218.FStar_Syntax_Syntax.n  in
+                         match uu____6217 with
+                         | FStar_Syntax_Syntax.Tm_arrow (ibs,uu____6222) ->
                              ibs
-                         | uu____6303 -> []  in
+                         | uu____6243 -> []  in
                        let ibs1 = FStar_Syntax_Subst.open_binders ibs  in
                        let ind =
-                         let uu____6312 =
+                         let uu____6252 =
                            FStar_Syntax_Syntax.fvar lid
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None
                             in
-                         let uu____6313 =
+                         let uu____6253 =
                            FStar_List.map
                              (fun u  -> FStar_Syntax_Syntax.U_name u) us
                             in
-                         FStar_Syntax_Syntax.mk_Tm_uinst uu____6312
-                           uu____6313
+                         FStar_Syntax_Syntax.mk_Tm_uinst uu____6252
+                           uu____6253
                           in
                        let ind1 =
-                         let uu____6319 =
-                           let uu____6324 =
-                             FStar_List.map
-                               (fun uu____6341  ->
-                                  match uu____6341 with
-                                  | (bv,aq) ->
-                                      let uu____6360 =
-                                        FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____6360, aq)) bs2
-                              in
-                           FStar_Syntax_Syntax.mk_Tm_app ind uu____6324  in
-                         uu____6319 FStar_Pervasives_Native.None
+                         let uu____6257 =
+                           FStar_List.map
+                             (fun uu____6274  ->
+                                match uu____6274 with
+                                | (bv,aq) ->
+                                    let uu____6293 =
+                                      FStar_Syntax_Syntax.bv_to_name bv  in
+                                    (uu____6293, aq)) bs2
+                            in
+                         FStar_Syntax_Syntax.mk_Tm_app ind uu____6257
                            FStar_Range.dummyRange
                           in
                        let ind2 =
-                         let uu____6366 =
-                           let uu____6371 =
-                             FStar_List.map
-                               (fun uu____6388  ->
-                                  match uu____6388 with
-                                  | (bv,aq) ->
-                                      let uu____6407 =
-                                        FStar_Syntax_Syntax.bv_to_name bv  in
-                                      (uu____6407, aq)) ibs1
-                              in
-                           FStar_Syntax_Syntax.mk_Tm_app ind1 uu____6371  in
-                         uu____6366 FStar_Pervasives_Native.None
+                         let uu____6297 =
+                           FStar_List.map
+                             (fun uu____6314  ->
+                                match uu____6314 with
+                                | (bv,aq) ->
+                                    let uu____6333 =
+                                      FStar_Syntax_Syntax.bv_to_name bv  in
+                                    (uu____6333, aq)) ibs1
+                            in
+                         FStar_Syntax_Syntax.mk_Tm_app ind1 uu____6297
                            FStar_Range.dummyRange
                           in
                        let haseq_ind =
-                         let uu____6413 =
-                           let uu____6418 =
-                             let uu____6419 = FStar_Syntax_Syntax.as_arg ind2
-                                in
-                             [uu____6419]  in
-                           FStar_Syntax_Syntax.mk_Tm_app
-                             FStar_Syntax_Util.t_haseq uu____6418
-                            in
-                         uu____6413 FStar_Pervasives_Native.None
+                         let uu____6337 =
+                           let uu____6338 = FStar_Syntax_Syntax.as_arg ind2
+                              in
+                           [uu____6338]  in
+                         FStar_Syntax_Syntax.mk_Tm_app
+                           FStar_Syntax_Util.t_haseq uu____6337
                            FStar_Range.dummyRange
                           in
                        let t_datas =
@@ -2415,9 +2373,9 @@ let (unoptimized_haseq_ty :
                            (fun s  ->
                               match s.FStar_Syntax_Syntax.sigel with
                               | FStar_Syntax_Syntax.Sig_datacon
-                                  (uu____6456,uu____6457,uu____6458,t_lid,uu____6460,uu____6461)
+                                  (uu____6375,uu____6376,uu____6377,t_lid,uu____6379,uu____6380)
                                   -> t_lid = lid
-                              | uu____6468 -> failwith "Impossible")
+                              | uu____6387 -> failwith "Impossible")
                            all_datas_in_the_bundle
                           in
                        let data_cond =
@@ -2428,81 +2386,73 @@ let (unoptimized_haseq_ty :
                        let fml = FStar_Syntax_Util.mk_imp data_cond haseq_ind
                           in
                        let fml1 =
-                         let uu___912_6480 = fml  in
-                         let uu____6481 =
-                           let uu____6482 =
-                             let uu____6489 =
-                               let uu____6490 =
-                                 let uu____6511 =
+                         let uu___912_6399 = fml  in
+                         let uu____6400 =
+                           let uu____6401 =
+                             let uu____6408 =
+                               let uu____6409 =
+                                 let uu____6430 =
                                    FStar_Syntax_Syntax.binders_to_names ibs1
                                     in
-                                 let uu____6516 =
-                                   let uu____6529 =
-                                     let uu____6540 =
+                                 let uu____6435 =
+                                   let uu____6448 =
+                                     let uu____6459 =
                                        FStar_Syntax_Syntax.as_arg haseq_ind
                                         in
-                                     [uu____6540]  in
-                                   [uu____6529]  in
-                                 (uu____6511, uu____6516)  in
-                               FStar_Syntax_Syntax.Meta_pattern uu____6490
+                                     [uu____6459]  in
+                                   [uu____6448]  in
+                                 (uu____6430, uu____6435)  in
+                               FStar_Syntax_Syntax.Meta_pattern uu____6409
                                 in
-                             (fml, uu____6489)  in
-                           FStar_Syntax_Syntax.Tm_meta uu____6482  in
+                             (fml, uu____6408)  in
+                           FStar_Syntax_Syntax.Tm_meta uu____6401  in
                          {
-                           FStar_Syntax_Syntax.n = uu____6481;
+                           FStar_Syntax_Syntax.n = uu____6400;
                            FStar_Syntax_Syntax.pos =
-                             (uu___912_6480.FStar_Syntax_Syntax.pos);
+                             (uu___912_6399.FStar_Syntax_Syntax.pos);
                            FStar_Syntax_Syntax.vars =
-                             (uu___912_6480.FStar_Syntax_Syntax.vars)
+                             (uu___912_6399.FStar_Syntax_Syntax.vars)
                          }  in
                        let fml2 =
                          FStar_List.fold_right
                            (fun b  ->
                               fun t3  ->
-                                let uu____6609 =
-                                  let uu____6614 =
-                                    let uu____6615 =
-                                      let uu____6624 =
-                                        let uu____6625 =
-                                          FStar_Syntax_Subst.close [b] t3  in
-                                        FStar_Syntax_Util.abs
-                                          [((FStar_Pervasives_Native.fst b),
-                                             FStar_Pervasives_Native.None)]
-                                          uu____6625
-                                          FStar_Pervasives_Native.None
-                                         in
-                                      FStar_Syntax_Syntax.as_arg uu____6624
+                                let uu____6528 =
+                                  let uu____6529 =
+                                    let uu____6538 =
+                                      let uu____6539 =
+                                        FStar_Syntax_Subst.close [b] t3  in
+                                      FStar_Syntax_Util.abs
+                                        [((FStar_Pervasives_Native.fst b),
+                                           FStar_Pervasives_Native.None)]
+                                        uu____6539
+                                        FStar_Pervasives_Native.None
                                        in
-                                    [uu____6615]  in
-                                  FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____6614
-                                   in
-                                uu____6609 FStar_Pervasives_Native.None
+                                    FStar_Syntax_Syntax.as_arg uu____6538  in
+                                  [uu____6529]  in
+                                FStar_Syntax_Syntax.mk_Tm_app
+                                  FStar_Syntax_Util.tforall uu____6528
                                   FStar_Range.dummyRange) ibs1 fml1
                           in
                        let fml3 =
                          FStar_List.fold_right
                            (fun b  ->
                               fun t3  ->
-                                let uu____6678 =
-                                  let uu____6683 =
-                                    let uu____6684 =
-                                      let uu____6693 =
-                                        let uu____6694 =
-                                          FStar_Syntax_Subst.close [b] t3  in
-                                        FStar_Syntax_Util.abs
-                                          [((FStar_Pervasives_Native.fst b),
-                                             FStar_Pervasives_Native.None)]
-                                          uu____6694
-                                          FStar_Pervasives_Native.None
-                                         in
-                                      FStar_Syntax_Syntax.as_arg uu____6693
+                                let uu____6592 =
+                                  let uu____6593 =
+                                    let uu____6602 =
+                                      let uu____6603 =
+                                        FStar_Syntax_Subst.close [b] t3  in
+                                      FStar_Syntax_Util.abs
+                                        [((FStar_Pervasives_Native.fst b),
+                                           FStar_Pervasives_Native.None)]
+                                        uu____6603
+                                        FStar_Pervasives_Native.None
                                        in
-                                    [uu____6684]  in
-                                  FStar_Syntax_Syntax.mk_Tm_app
-                                    FStar_Syntax_Util.tforall uu____6683
-                                   in
-                                uu____6678 FStar_Pervasives_Native.None
+                                    FStar_Syntax_Syntax.as_arg uu____6602  in
+                                  [uu____6593]  in
+                                FStar_Syntax_Syntax.mk_Tm_app
+                                  FStar_Syntax_Util.tforall uu____6592
                                   FStar_Range.dummyRange) bs2 fml2
                           in
                        FStar_Syntax_Util.mk_conj acc fml3)
@@ -2522,21 +2472,21 @@ let (unoptimized_haseq_scheme :
               (fun ty  ->
                  match ty.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid,uu____6786,uu____6787,uu____6788,uu____6789,uu____6790)
+                     (lid,uu____6695,uu____6696,uu____6697,uu____6698,uu____6699)
                      -> lid
-                 | uu____6799 -> failwith "Impossible!") tcs
+                 | uu____6708 -> failwith "Impossible!") tcs
              in
-          let uu____6801 =
+          let uu____6710 =
             let ty = FStar_List.hd tcs  in
             match ty.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_inductive_typ
-                (lid,us,uu____6813,uu____6814,uu____6815,uu____6816) ->
+                (lid,us,uu____6722,uu____6723,uu____6724,uu____6725) ->
                 (lid, us)
-            | uu____6825 -> failwith "Impossible!"  in
-          match uu____6801 with
+            | uu____6734 -> failwith "Impossible!"  in
+          match uu____6710 with
           | (lid,us) ->
-              let uu____6835 = FStar_Syntax_Subst.univ_var_opening us  in
-              (match uu____6835 with
+              let uu____6744 = FStar_Syntax_Subst.univ_var_opening us  in
+              (match uu____6744 with
                | (usubst,us1) ->
                    let fml =
                      FStar_List.fold_left
@@ -2544,13 +2494,13 @@ let (unoptimized_haseq_scheme :
                        FStar_Syntax_Util.t_true tcs
                       in
                    let se =
-                     let uu____6862 =
-                       let uu____6863 =
-                         let uu____6870 = get_haseq_axiom_lid lid  in
-                         (uu____6870, us1, fml)  in
-                       FStar_Syntax_Syntax.Sig_assume uu____6863  in
+                     let uu____6771 =
+                       let uu____6772 =
+                         let uu____6779 = get_haseq_axiom_lid lid  in
+                         (uu____6779, us1, fml)  in
+                       FStar_Syntax_Syntax.Sig_assume uu____6772  in
                      {
-                       FStar_Syntax_Syntax.sigel = uu____6862;
+                       FStar_Syntax_Syntax.sigel = uu____6771;
                        FStar_Syntax_Syntax.sigrng = FStar_Range.dummyRange;
                        FStar_Syntax_Syntax.sigquals = [];
                        FStar_Syntax_Syntax.sigmeta =
@@ -2573,169 +2523,169 @@ let (check_inductive_well_typedness :
     fun ses  ->
       fun quals  ->
         fun lids  ->
-          let uu____6924 =
+          let uu____6833 =
             FStar_All.pipe_right ses
               (FStar_List.partition
-                 (fun uu___2_6950  ->
-                    match uu___2_6950 with
+                 (fun uu___2_6859  ->
+                    match uu___2_6859 with
                     | {
                         FStar_Syntax_Syntax.sigel =
-                          FStar_Syntax_Syntax.Sig_inductive_typ uu____6952;
-                        FStar_Syntax_Syntax.sigrng = uu____6953;
-                        FStar_Syntax_Syntax.sigquals = uu____6954;
-                        FStar_Syntax_Syntax.sigmeta = uu____6955;
-                        FStar_Syntax_Syntax.sigattrs = uu____6956;
-                        FStar_Syntax_Syntax.sigopts = uu____6957;_} -> true
-                    | uu____6981 -> false))
+                          FStar_Syntax_Syntax.Sig_inductive_typ uu____6861;
+                        FStar_Syntax_Syntax.sigrng = uu____6862;
+                        FStar_Syntax_Syntax.sigquals = uu____6863;
+                        FStar_Syntax_Syntax.sigmeta = uu____6864;
+                        FStar_Syntax_Syntax.sigattrs = uu____6865;
+                        FStar_Syntax_Syntax.sigopts = uu____6866;_} -> true
+                    | uu____6890 -> false))
              in
-          match uu____6924 with
+          match uu____6833 with
           | (tys,datas) ->
-              ((let uu____7004 =
+              ((let uu____6913 =
                   FStar_All.pipe_right datas
                     (FStar_Util.for_some
-                       (fun uu___3_7016  ->
-                          match uu___3_7016 with
+                       (fun uu___3_6925  ->
+                          match uu___3_6925 with
                           | {
                               FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_datacon uu____7018;
-                              FStar_Syntax_Syntax.sigrng = uu____7019;
-                              FStar_Syntax_Syntax.sigquals = uu____7020;
-                              FStar_Syntax_Syntax.sigmeta = uu____7021;
-                              FStar_Syntax_Syntax.sigattrs = uu____7022;
-                              FStar_Syntax_Syntax.sigopts = uu____7023;_} ->
+                                FStar_Syntax_Syntax.Sig_datacon uu____6927;
+                              FStar_Syntax_Syntax.sigrng = uu____6928;
+                              FStar_Syntax_Syntax.sigquals = uu____6929;
+                              FStar_Syntax_Syntax.sigmeta = uu____6930;
+                              FStar_Syntax_Syntax.sigattrs = uu____6931;
+                              FStar_Syntax_Syntax.sigopts = uu____6932;_} ->
                               false
-                          | uu____7046 -> true))
+                          | uu____6955 -> true))
                    in
-                if uu____7004
+                if uu____6913
                 then
-                  let uu____7049 = FStar_TypeChecker_Env.get_range env  in
+                  let uu____6958 = FStar_TypeChecker_Env.get_range env  in
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                       "Mutually defined type contains a non-inductive element")
-                    uu____7049
+                    uu____6958
                 else ());
                (let univs =
                   if (FStar_List.length tys) = Prims.int_zero
                   then []
                   else
-                    (let uu____7064 =
-                       let uu____7065 = FStar_List.hd tys  in
-                       uu____7065.FStar_Syntax_Syntax.sigel  in
-                     match uu____7064 with
+                    (let uu____6973 =
+                       let uu____6974 = FStar_List.hd tys  in
+                       uu____6974.FStar_Syntax_Syntax.sigel  in
+                     match uu____6973 with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (uu____7068,uvs,uu____7070,uu____7071,uu____7072,uu____7073)
+                         (uu____6977,uvs,uu____6979,uu____6980,uu____6981,uu____6982)
                          -> uvs
-                     | uu____7082 -> failwith "Impossible, can't happen!")
+                     | uu____6991 -> failwith "Impossible, can't happen!")
                    in
                 let env0 = env  in
-                let uu____7087 =
+                let uu____6996 =
                   FStar_List.fold_right
                     (fun tc  ->
-                       fun uu____7126  ->
-                         match uu____7126 with
+                       fun uu____7035  ->
+                         match uu____7035 with
                          | (env1,all_tcs,g) ->
-                             let uu____7166 = tc_tycon env1 tc  in
-                             (match uu____7166 with
+                             let uu____7075 = tc_tycon env1 tc  in
+                             (match uu____7075 with
                               | (env2,tc1,tc_u,guard) ->
                                   let g' =
                                     FStar_TypeChecker_Rel.universe_inequality
                                       FStar_Syntax_Syntax.U_zero tc_u
                                      in
-                                  ((let uu____7193 =
+                                  ((let uu____7102 =
                                       FStar_TypeChecker_Env.debug env2
                                         FStar_Options.Low
                                        in
-                                    if uu____7193
+                                    if uu____7102
                                     then
-                                      let uu____7196 =
+                                      let uu____7105 =
                                         FStar_Syntax_Print.sigelt_to_string
                                           tc1
                                          in
                                       FStar_Util.print1
-                                        "Checked inductive: %s\n" uu____7196
+                                        "Checked inductive: %s\n" uu____7105
                                     else ());
-                                   (let uu____7201 =
-                                      let uu____7202 =
+                                   (let uu____7110 =
+                                      let uu____7111 =
                                         FStar_TypeChecker_Env.conj_guard
                                           guard g'
                                          in
                                       FStar_TypeChecker_Env.conj_guard g
-                                        uu____7202
+                                        uu____7111
                                        in
                                     (env2, ((tc1, tc_u) :: all_tcs),
-                                      uu____7201))))) tys
+                                      uu____7110))))) tys
                     (env, [], FStar_TypeChecker_Env.trivial_guard)
                    in
-                match uu____7087 with
+                match uu____6996 with
                 | (env1,tcs,g) ->
-                    let uu____7248 =
+                    let uu____7157 =
                       FStar_List.fold_right
                         (fun se  ->
-                           fun uu____7270  ->
-                             match uu____7270 with
+                           fun uu____7179  ->
+                             match uu____7179 with
                              | (datas1,g1) ->
-                                 let uu____7289 =
-                                   let uu____7294 = tc_data env1 tcs  in
-                                   uu____7294 se  in
-                                 (match uu____7289 with
+                                 let uu____7198 =
+                                   let uu____7203 = tc_data env1 tcs  in
+                                   uu____7203 se  in
+                                 (match uu____7198 with
                                   | (data,g') ->
-                                      let uu____7311 =
+                                      let uu____7220 =
                                         FStar_TypeChecker_Env.conj_guard g1
                                           g'
                                          in
-                                      ((data :: datas1), uu____7311))) datas
+                                      ((data :: datas1), uu____7220))) datas
                         ([], g)
                        in
-                    (match uu____7248 with
+                    (match uu____7157 with
                      | (datas1,g1) ->
-                         let uu____7332 =
+                         let uu____7241 =
                            let tc_universe_vars =
                              FStar_List.map FStar_Pervasives_Native.snd tcs
                               in
                            let g2 =
-                             let uu___1023_7349 = g1  in
+                             let uu___1023_7258 = g1  in
                              {
                                FStar_TypeChecker_Common.guard_f =
-                                 (uu___1023_7349.FStar_TypeChecker_Common.guard_f);
+                                 (uu___1023_7258.FStar_TypeChecker_Common.guard_f);
                                FStar_TypeChecker_Common.deferred =
-                                 (uu___1023_7349.FStar_TypeChecker_Common.deferred);
+                                 (uu___1023_7258.FStar_TypeChecker_Common.deferred);
                                FStar_TypeChecker_Common.univ_ineqs =
                                  (tc_universe_vars,
                                    (FStar_Pervasives_Native.snd
                                       g1.FStar_TypeChecker_Common.univ_ineqs));
                                FStar_TypeChecker_Common.implicits =
-                                 (uu___1023_7349.FStar_TypeChecker_Common.implicits)
+                                 (uu___1023_7258.FStar_TypeChecker_Common.implicits)
                              }  in
-                           (let uu____7359 =
+                           (let uu____7268 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "GenUniverses")
                                in
-                            if uu____7359
+                            if uu____7268
                             then
-                              let uu____7364 =
+                              let uu____7273 =
                                 FStar_TypeChecker_Rel.guard_to_string env1 g2
                                  in
                               FStar_Util.print1
                                 "@@@@@@Guard before (possible) generalization: %s\n"
-                                uu____7364
+                                uu____7273
                             else ());
                            FStar_TypeChecker_Rel.force_trivial_guard env0 g2;
                            if (FStar_List.length univs) = Prims.int_zero
                            then generalize_and_inst_within env0 tcs datas1
                            else
-                             (let uu____7383 =
+                             (let uu____7292 =
                                 FStar_List.map FStar_Pervasives_Native.fst
                                   tcs
                                  in
-                              (uu____7383, datas1))
+                              (uu____7292, datas1))
                             in
-                         (match uu____7332 with
+                         (match uu____7241 with
                           | (tcs1,datas2) ->
                               let sig_bndle =
-                                let uu____7415 =
+                                let uu____7324 =
                                   FStar_TypeChecker_Env.get_range env0  in
-                                let uu____7416 =
+                                let uu____7325 =
                                   FStar_List.collect
                                     (fun s  -> s.FStar_Syntax_Syntax.sigattrs)
                                     ses
@@ -2745,11 +2695,11 @@ let (check_inductive_well_typedness :
                                     (FStar_Syntax_Syntax.Sig_bundle
                                        ((FStar_List.append tcs1 datas2),
                                          lids));
-                                  FStar_Syntax_Syntax.sigrng = uu____7415;
+                                  FStar_Syntax_Syntax.sigrng = uu____7324;
                                   FStar_Syntax_Syntax.sigquals = quals;
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
-                                  FStar_Syntax_Syntax.sigattrs = uu____7416;
+                                  FStar_Syntax_Syntax.sigattrs = uu____7325;
                                   FStar_Syntax_Syntax.sigopts =
                                     FStar_Pervasives_Native.None
                                 }  in
@@ -2759,63 +2709,58 @@ let (check_inductive_well_typedness :
                                        match se.FStar_Syntax_Syntax.sigel
                                        with
                                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                                           (l,univs1,binders,typ,uu____7442,uu____7443)
+                                           (l,univs1,binders,typ,uu____7351,uu____7352)
                                            ->
                                            let fail expected inferred =
-                                             let uu____7463 =
-                                               let uu____7469 =
-                                                 let uu____7471 =
+                                             let uu____7372 =
+                                               let uu____7378 =
+                                                 let uu____7380 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      expected
                                                     in
-                                                 let uu____7473 =
+                                                 let uu____7382 =
                                                    FStar_Syntax_Print.tscheme_to_string
                                                      inferred
                                                     in
                                                  FStar_Util.format2
                                                    "Expected an inductive with type %s; got %s"
-                                                   uu____7471 uu____7473
+                                                   uu____7380 uu____7382
                                                   in
                                                (FStar_Errors.Fatal_UnexpectedInductivetype,
-                                                 uu____7469)
+                                                 uu____7378)
                                                 in
                                              FStar_Errors.raise_error
-                                               uu____7463
+                                               uu____7372
                                                se.FStar_Syntax_Syntax.sigrng
                                               in
-                                           let uu____7477 =
+                                           let uu____7386 =
                                              FStar_TypeChecker_Env.try_lookup_val_decl
                                                env0 l
                                               in
-                                           (match uu____7477 with
+                                           (match uu____7386 with
                                             | FStar_Pervasives_Native.None 
                                                 -> ()
                                             | FStar_Pervasives_Native.Some
-                                                (expected_typ,uu____7493) ->
+                                                (expected_typ,uu____7402) ->
                                                 let inferred_typ =
                                                   let body =
                                                     match binders with
                                                     | [] -> typ
-                                                    | uu____7524 ->
-                                                        let uu____7525 =
-                                                          let uu____7532 =
-                                                            let uu____7533 =
-                                                              let uu____7548
-                                                                =
-                                                                FStar_Syntax_Syntax.mk_Total
-                                                                  typ
-                                                                 in
-                                                              (binders,
-                                                                uu____7548)
+                                                    | uu____7433 ->
+                                                        let uu____7434 =
+                                                          let uu____7435 =
+                                                            let uu____7450 =
+                                                              FStar_Syntax_Syntax.mk_Total
+                                                                typ
                                                                in
-                                                            FStar_Syntax_Syntax.Tm_arrow
-                                                              uu____7533
+                                                            (binders,
+                                                              uu____7450)
                                                              in
-                                                          FStar_Syntax_Syntax.mk
-                                                            uu____7532
+                                                          FStar_Syntax_Syntax.Tm_arrow
+                                                            uu____7435
                                                            in
-                                                        uu____7525
-                                                          FStar_Pervasives_Native.None
+                                                        FStar_Syntax_Syntax.mk
+                                                          uu____7434
                                                           se.FStar_Syntax_Syntax.sigrng
                                                      in
                                                   (univs1, body)  in
@@ -2826,25 +2771,25 @@ let (check_inductive_well_typedness :
                                                        (FStar_Pervasives_Native.fst
                                                           expected_typ))
                                                 then
-                                                  let uu____7570 =
+                                                  let uu____7472 =
                                                     FStar_TypeChecker_Env.inst_tscheme
                                                       inferred_typ
                                                      in
-                                                  (match uu____7570 with
-                                                   | (uu____7575,inferred) ->
-                                                       let uu____7577 =
+                                                  (match uu____7472 with
+                                                   | (uu____7477,inferred) ->
+                                                       let uu____7479 =
                                                          FStar_TypeChecker_Env.inst_tscheme
                                                            expected_typ
                                                           in
-                                                       (match uu____7577 with
-                                                        | (uu____7582,expected)
+                                                       (match uu____7479 with
+                                                        | (uu____7484,expected)
                                                             ->
-                                                            let uu____7584 =
+                                                            let uu____7486 =
                                                               FStar_TypeChecker_Rel.teq_nosmt_force
                                                                 env0 inferred
                                                                 expected
                                                                in
-                                                            if uu____7584
+                                                            if uu____7486
                                                             then ()
                                                             else
                                                               fail
@@ -2853,7 +2798,7 @@ let (check_inductive_well_typedness :
                                                 else
                                                   fail expected_typ
                                                     inferred_typ)
-                                       | uu____7591 -> ()));
+                                       | uu____7493 -> ()));
                                (sig_bndle, tcs1, datas2))))))
   
 let (early_prims_inductives : Prims.string Prims.list) =
@@ -2897,39 +2842,35 @@ let (mk_discriminator_and_indexed_projectors :
                           let tps = inductive_tps  in
                           let arg_typ =
                             let inst_tc =
-                              let uu____7718 =
-                                let uu____7725 =
-                                  let uu____7726 =
-                                    let uu____7733 =
-                                      let uu____7736 =
-                                        FStar_Syntax_Syntax.lid_as_fv tc
-                                          FStar_Syntax_Syntax.delta_constant
-                                          FStar_Pervasives_Native.None
-                                         in
-                                      FStar_Syntax_Syntax.fv_to_tm uu____7736
+                              let uu____7618 =
+                                let uu____7619 =
+                                  let uu____7626 =
+                                    let uu____7629 =
+                                      FStar_Syntax_Syntax.lid_as_fv tc
+                                        FStar_Syntax_Syntax.delta_constant
+                                        FStar_Pervasives_Native.None
                                        in
-                                    (uu____7733, inst_univs)  in
-                                  FStar_Syntax_Syntax.Tm_uinst uu____7726  in
-                                FStar_Syntax_Syntax.mk uu____7725  in
-                              uu____7718 FStar_Pervasives_Native.None p  in
+                                    FStar_Syntax_Syntax.fv_to_tm uu____7629
+                                     in
+                                  (uu____7626, inst_univs)  in
+                                FStar_Syntax_Syntax.Tm_uinst uu____7619  in
+                              FStar_Syntax_Syntax.mk uu____7618 p  in
                             let args =
                               FStar_All.pipe_right
                                 (FStar_List.append tps indices)
                                 (FStar_List.map
-                                   (fun uu____7770  ->
-                                      match uu____7770 with
+                                   (fun uu____7663  ->
+                                      match uu____7663 with
                                       | (x,imp) ->
-                                          let uu____7789 =
+                                          let uu____7682 =
                                             FStar_Syntax_Syntax.bv_to_name x
                                              in
-                                          (uu____7789, imp)))
+                                          (uu____7682, imp)))
                                in
-                            FStar_Syntax_Syntax.mk_Tm_app inst_tc args
-                              FStar_Pervasives_Native.None p
-                             in
+                            FStar_Syntax_Syntax.mk_Tm_app inst_tc args p  in
                           let unrefined_arg_binder =
-                            let uu____7793 = projectee arg_typ  in
-                            FStar_Syntax_Syntax.mk_binder uu____7793  in
+                            let uu____7686 = projectee arg_typ  in
+                            FStar_Syntax_Syntax.mk_binder uu____7686  in
                           let arg_binder =
                             if Prims.op_Negation refine_domain
                             then unrefined_arg_binder
@@ -2942,87 +2883,83 @@ let (mk_discriminator_and_indexed_projectors :
                                   in
                                let sort =
                                  let disc_fvar =
-                                   let uu____7816 =
+                                   let uu____7709 =
                                      FStar_Ident.set_lid_range disc_name p
                                       in
-                                   FStar_Syntax_Syntax.fvar uu____7816
+                                   FStar_Syntax_Syntax.fvar uu____7709
                                      (FStar_Syntax_Syntax.Delta_equational_at_level
                                         Prims.int_one)
                                      FStar_Pervasives_Native.None
                                     in
-                                 let uu____7818 =
-                                   let uu____7821 =
-                                     let uu____7824 =
-                                       let uu____7829 =
-                                         FStar_Syntax_Syntax.mk_Tm_uinst
-                                           disc_fvar inst_univs
-                                          in
-                                       let uu____7830 =
-                                         let uu____7831 =
-                                           let uu____7840 =
-                                             FStar_Syntax_Syntax.bv_to_name x
-                                              in
-                                           FStar_All.pipe_left
-                                             FStar_Syntax_Syntax.as_arg
-                                             uu____7840
-                                            in
-                                         [uu____7831]  in
-                                       FStar_Syntax_Syntax.mk_Tm_app
-                                         uu____7829 uu____7830
+                                 let uu____7711 =
+                                   let uu____7714 =
+                                     let uu____7717 =
+                                       FStar_Syntax_Syntax.mk_Tm_uinst
+                                         disc_fvar inst_univs
                                         in
-                                     uu____7824 FStar_Pervasives_Native.None
-                                       p
+                                     let uu____7718 =
+                                       let uu____7719 =
+                                         let uu____7728 =
+                                           FStar_Syntax_Syntax.bv_to_name x
+                                            in
+                                         FStar_All.pipe_left
+                                           FStar_Syntax_Syntax.as_arg
+                                           uu____7728
+                                          in
+                                       [uu____7719]  in
+                                     FStar_Syntax_Syntax.mk_Tm_app uu____7717
+                                       uu____7718 p
                                       in
-                                   FStar_Syntax_Util.b2t uu____7821  in
-                                 FStar_Syntax_Util.refine x uu____7818  in
-                               let uu____7865 =
-                                 let uu___1098_7866 = projectee arg_typ  in
+                                   FStar_Syntax_Util.b2t uu____7714  in
+                                 FStar_Syntax_Util.refine x uu____7711  in
+                               let uu____7753 =
+                                 let uu___1098_7754 = projectee arg_typ  in
                                  {
                                    FStar_Syntax_Syntax.ppname =
-                                     (uu___1098_7866.FStar_Syntax_Syntax.ppname);
+                                     (uu___1098_7754.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
-                                     (uu___1098_7866.FStar_Syntax_Syntax.index);
+                                     (uu___1098_7754.FStar_Syntax_Syntax.index);
                                    FStar_Syntax_Syntax.sort = sort
                                  }  in
-                               FStar_Syntax_Syntax.mk_binder uu____7865)
+                               FStar_Syntax_Syntax.mk_binder uu____7753)
                              in
                           let ntps = FStar_List.length tps  in
                           let all_params =
-                            let uu____7883 =
+                            let uu____7771 =
                               FStar_List.map
-                                (fun uu____7907  ->
-                                   match uu____7907 with
-                                   | (x,uu____7921) ->
+                                (fun uu____7795  ->
+                                   match uu____7795 with
+                                   | (x,uu____7809) ->
                                        (x,
                                          (FStar_Pervasives_Native.Some
                                             FStar_Syntax_Syntax.imp_tag)))
                                 tps
                                in
-                            FStar_List.append uu____7883 fields  in
+                            FStar_List.append uu____7771 fields  in
                           let imp_binders =
                             FStar_All.pipe_right
                               (FStar_List.append tps indices)
                               (FStar_List.map
-                                 (fun uu____7980  ->
-                                    match uu____7980 with
-                                    | (x,uu____7994) ->
+                                 (fun uu____7868  ->
+                                    match uu____7868 with
+                                    | (x,uu____7882) ->
                                         (x,
                                           (FStar_Pervasives_Native.Some
                                              FStar_Syntax_Syntax.imp_tag))))
                              in
                           let early_prims_inductive =
-                            (let uu____8005 =
+                            (let uu____7893 =
                                FStar_TypeChecker_Env.current_module env  in
                              FStar_Ident.lid_equals
-                               FStar_Parser_Const.prims_lid uu____8005)
+                               FStar_Parser_Const.prims_lid uu____7893)
                               &&
                               (FStar_List.existsb
                                  (fun s  ->
-                                    let uu____8011 =
-                                      let uu____8013 =
+                                    let uu____7899 =
+                                      let uu____7901 =
                                         FStar_Ident.ident_of_lid tc  in
-                                      FStar_Ident.text_of_id uu____8013  in
-                                    s = uu____8011) early_prims_inductives)
+                                      FStar_Ident.text_of_id uu____7901  in
+                                    s = uu____7899) early_prims_inductives)
                              in
                           let discriminator_ses =
                             if fvq <> FStar_Syntax_Syntax.Data_ctor
@@ -3033,21 +2970,21 @@ let (mk_discriminator_and_indexed_projectors :
                                let no_decl = false  in
                                let only_decl =
                                  early_prims_inductive ||
-                                   (let uu____8030 =
-                                      let uu____8032 =
+                                   (let uu____7918 =
+                                      let uu____7920 =
                                         FStar_TypeChecker_Env.current_module
                                           env
                                          in
-                                      FStar_Ident.string_of_lid uu____8032
+                                      FStar_Ident.string_of_lid uu____7920
                                        in
                                     FStar_Options.dont_gen_projectors
-                                      uu____8030)
+                                      uu____7918)
                                   in
                                let quals =
-                                 let uu____8036 =
+                                 let uu____7924 =
                                    FStar_List.filter
-                                     (fun uu___4_8040  ->
-                                        match uu___4_8040 with
+                                     (fun uu___4_7928  ->
+                                        match uu___4_7928 with
                                         | FStar_Syntax_Syntax.Abstract  ->
                                             Prims.op_Negation only_decl
                                         | FStar_Syntax_Syntax.Inline_for_extraction
@@ -3056,7 +2993,7 @@ let (mk_discriminator_and_indexed_projectors :
                                             true
                                         | FStar_Syntax_Syntax.Private  ->
                                             true
-                                        | uu____8045 -> false) iquals
+                                        | uu____7933 -> false) iquals
                                     in
                                  FStar_List.append
                                    ((FStar_Syntax_Syntax.Discriminator lid)
@@ -3065,7 +3002,7 @@ let (mk_discriminator_and_indexed_projectors :
                                     then
                                       [FStar_Syntax_Syntax.Logic;
                                       FStar_Syntax_Syntax.Assumption]
-                                    else [])) uu____8036
+                                    else [])) uu____7924
                                   in
                                let binders =
                                  FStar_List.append imp_binders
@@ -3081,15 +3018,15 @@ let (mk_discriminator_and_indexed_projectors :
                                      FStar_Syntax_Syntax.mk_Total
                                        FStar_Syntax_Util.t_bool
                                     in
-                                 let uu____8090 =
+                                 let uu____7978 =
                                    FStar_Syntax_Util.arrow binders bool_typ
                                     in
                                  FStar_All.pipe_left
                                    (FStar_Syntax_Subst.close_univ_vars uvs)
-                                   uu____8090
+                                   uu____7978
                                   in
                                let decl =
-                                 let uu____8094 =
+                                 let uu____7982 =
                                    FStar_Ident.range_of_lid
                                      discriminator_name
                                     in
@@ -3097,7 +3034,7 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_declare_typ
                                         (discriminator_name, uvs, t));
-                                   FStar_Syntax_Syntax.sigrng = uu____8094;
+                                   FStar_Syntax_Syntax.sigrng = uu____7982;
                                    FStar_Syntax_Syntax.sigquals = quals;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
@@ -3105,18 +3042,18 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.sigopts =
                                      FStar_Pervasives_Native.None
                                  }  in
-                               (let uu____8096 =
+                               (let uu____7984 =
                                   FStar_TypeChecker_Env.debug env
                                     (FStar_Options.Other "LogTypes")
                                    in
-                                if uu____8096
+                                if uu____7984
                                 then
-                                  let uu____8100 =
+                                  let uu____7988 =
                                     FStar_Syntax_Print.sigelt_to_string decl
                                      in
                                   FStar_Util.print1
                                     "Declaration of a discriminator %s\n"
-                                    uu____8100
+                                    uu____7988
                                 else ());
                                if only_decl
                                then [decl]
@@ -3129,8 +3066,8 @@ let (mk_discriminator_and_indexed_projectors :
                                          FStar_All.pipe_right all_params
                                            (FStar_List.mapi
                                               (fun j  ->
-                                                 fun uu____8161  ->
-                                                   match uu____8161 with
+                                                 fun uu____8049  ->
+                                                   match uu____8049 with
                                                    | (x,imp) ->
                                                        let b =
                                                          FStar_Syntax_Syntax.is_implicit
@@ -3138,84 +3075,84 @@ let (mk_discriminator_and_indexed_projectors :
                                                           in
                                                        if b && (j < ntps)
                                                        then
-                                                         let uu____8186 =
-                                                           let uu____8189 =
-                                                             let uu____8190 =
-                                                               let uu____8197
+                                                         let uu____8074 =
+                                                           let uu____8077 =
+                                                             let uu____8078 =
+                                                               let uu____8085
                                                                  =
-                                                                 let uu____8198
+                                                                 let uu____8086
                                                                    =
                                                                    FStar_Ident.text_of_id
                                                                     x.FStar_Syntax_Syntax.ppname
                                                                     in
                                                                  FStar_Syntax_Syntax.gen_bv
-                                                                   uu____8198
+                                                                   uu____8086
                                                                    FStar_Pervasives_Native.None
                                                                    FStar_Syntax_Syntax.tun
                                                                   in
-                                                               (uu____8197,
+                                                               (uu____8085,
                                                                  FStar_Syntax_Syntax.tun)
                                                                 in
                                                              FStar_Syntax_Syntax.Pat_dot_term
-                                                               uu____8190
+                                                               uu____8078
                                                               in
-                                                           pos uu____8189  in
-                                                         (uu____8186, b)
+                                                           pos uu____8077  in
+                                                         (uu____8074, b)
                                                        else
-                                                         (let uu____8207 =
-                                                            let uu____8210 =
-                                                              let uu____8211
+                                                         (let uu____8095 =
+                                                            let uu____8098 =
+                                                              let uu____8099
                                                                 =
-                                                                let uu____8212
+                                                                let uu____8100
                                                                   =
                                                                   FStar_Ident.text_of_id
                                                                     x.FStar_Syntax_Syntax.ppname
                                                                    in
                                                                 FStar_Syntax_Syntax.gen_bv
-                                                                  uu____8212
+                                                                  uu____8100
                                                                   FStar_Pervasives_Native.None
                                                                   FStar_Syntax_Syntax.tun
                                                                  in
                                                               FStar_Syntax_Syntax.Pat_wild
-                                                                uu____8211
+                                                                uu____8099
                                                                in
-                                                            pos uu____8210
+                                                            pos uu____8098
                                                              in
-                                                          (uu____8207, b))))
+                                                          (uu____8095, b))))
                                           in
                                        let pat_true =
-                                         let uu____8232 =
-                                           let uu____8235 =
-                                             let uu____8236 =
-                                               let uu____8250 =
+                                         let uu____8120 =
+                                           let uu____8123 =
+                                             let uu____8124 =
+                                               let uu____8138 =
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    lid
                                                    FStar_Syntax_Syntax.delta_constant
                                                    (FStar_Pervasives_Native.Some
                                                       fvq)
                                                   in
-                                               (uu____8250, arg_pats)  in
+                                               (uu____8138, arg_pats)  in
                                              FStar_Syntax_Syntax.Pat_cons
-                                               uu____8236
+                                               uu____8124
                                               in
-                                           pos uu____8235  in
-                                         (uu____8232,
+                                           pos uu____8123  in
+                                         (uu____8120,
                                            FStar_Pervasives_Native.None,
                                            FStar_Syntax_Util.exp_true_bool)
                                           in
                                        let pat_false =
-                                         let uu____8285 =
-                                           let uu____8288 =
-                                             let uu____8289 =
+                                         let uu____8173 =
+                                           let uu____8176 =
+                                             let uu____8177 =
                                                FStar_Syntax_Syntax.new_bv
                                                  FStar_Pervasives_Native.None
                                                  FStar_Syntax_Syntax.tun
                                                 in
                                              FStar_Syntax_Syntax.Pat_wild
-                                               uu____8289
+                                               uu____8177
                                               in
-                                           pos uu____8288  in
-                                         (uu____8285,
+                                           pos uu____8176  in
+                                         (uu____8173,
                                            FStar_Pervasives_Native.None,
                                            FStar_Syntax_Util.exp_false_bool)
                                           in
@@ -3224,37 +3161,33 @@ let (mk_discriminator_and_indexed_projectors :
                                            (FStar_Pervasives_Native.fst
                                               unrefined_arg_binder)
                                           in
-                                       let uu____8303 =
-                                         let uu____8310 =
-                                           let uu____8311 =
-                                             let uu____8334 =
-                                               let uu____8351 =
+                                       let uu____8191 =
+                                         let uu____8192 =
+                                           let uu____8215 =
+                                             let uu____8232 =
+                                               FStar_Syntax_Util.branch
+                                                 pat_true
+                                                in
+                                             let uu____8247 =
+                                               let uu____8264 =
                                                  FStar_Syntax_Util.branch
-                                                   pat_true
+                                                   pat_false
                                                   in
-                                               let uu____8366 =
-                                                 let uu____8383 =
-                                                   FStar_Syntax_Util.branch
-                                                     pat_false
-                                                    in
-                                                 [uu____8383]  in
-                                               uu____8351 :: uu____8366  in
-                                             (arg_exp, uu____8334)  in
-                                           FStar_Syntax_Syntax.Tm_match
-                                             uu____8311
-                                            in
-                                         FStar_Syntax_Syntax.mk uu____8310
+                                               [uu____8264]  in
+                                             uu____8232 :: uu____8247  in
+                                           (arg_exp, uu____8215)  in
+                                         FStar_Syntax_Syntax.Tm_match
+                                           uu____8192
                                           in
-                                       uu____8303
-                                         FStar_Pervasives_Native.None p)
+                                       FStar_Syntax_Syntax.mk uu____8191 p)
                                      in
                                   let dd =
-                                    let uu____8459 =
+                                    let uu____8340 =
                                       FStar_All.pipe_right quals
                                         (FStar_List.contains
                                            FStar_Syntax_Syntax.Abstract)
                                        in
-                                    if uu____8459
+                                    if uu____8340
                                     then
                                       FStar_Syntax_Syntax.Delta_abstract
                                         (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3272,42 +3205,42 @@ let (mk_discriminator_and_indexed_projectors :
                                     then t
                                     else FStar_Syntax_Syntax.tun  in
                                   let lb =
-                                    let uu____8481 =
-                                      let uu____8486 =
+                                    let uu____8362 =
+                                      let uu____8367 =
                                         FStar_Syntax_Syntax.lid_as_fv
                                           discriminator_name dd
                                           FStar_Pervasives_Native.None
                                          in
-                                      FStar_Util.Inr uu____8486  in
-                                    let uu____8487 =
+                                      FStar_Util.Inr uu____8367  in
+                                    let uu____8368 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
                                         imp
                                        in
                                     FStar_Syntax_Util.mk_letbinding
-                                      uu____8481 uvs lbtyp
+                                      uu____8362 uvs lbtyp
                                       FStar_Parser_Const.effect_Tot_lid
-                                      uu____8487 [] FStar_Range.dummyRange
+                                      uu____8368 [] FStar_Range.dummyRange
                                      in
                                   let impl =
-                                    let uu____8493 =
-                                      let uu____8494 =
-                                        let uu____8501 =
-                                          let uu____8504 =
-                                            let uu____8505 =
+                                    let uu____8374 =
+                                      let uu____8375 =
+                                        let uu____8382 =
+                                          let uu____8385 =
+                                            let uu____8386 =
                                               FStar_All.pipe_right
                                                 lb.FStar_Syntax_Syntax.lbname
                                                 FStar_Util.right
                                                in
-                                            FStar_All.pipe_right uu____8505
+                                            FStar_All.pipe_right uu____8386
                                               (fun fv  ->
                                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                              in
-                                          [uu____8504]  in
-                                        ((false, [lb]), uu____8501)  in
-                                      FStar_Syntax_Syntax.Sig_let uu____8494
+                                          [uu____8385]  in
+                                        ((false, [lb]), uu____8382)  in
+                                      FStar_Syntax_Syntax.Sig_let uu____8375
                                        in
                                     {
-                                      FStar_Syntax_Syntax.sigel = uu____8493;
+                                      FStar_Syntax_Syntax.sigel = uu____8374;
                                       FStar_Syntax_Syntax.sigrng = p;
                                       FStar_Syntax_Syntax.sigquals = quals;
                                       FStar_Syntax_Syntax.sigmeta =
@@ -3316,19 +3249,19 @@ let (mk_discriminator_and_indexed_projectors :
                                       FStar_Syntax_Syntax.sigopts =
                                         FStar_Pervasives_Native.None
                                     }  in
-                                  (let uu____8519 =
+                                  (let uu____8400 =
                                      FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "LogTypes")
                                       in
-                                   if uu____8519
+                                   if uu____8400
                                    then
-                                     let uu____8523 =
+                                     let uu____8404 =
                                        FStar_Syntax_Print.sigelt_to_string
                                          impl
                                         in
                                      FStar_Util.print1
                                        "Implementation of a discriminator %s\n"
-                                       uu____8523
+                                       uu____8404
                                    else ());
                                   [decl; impl]))
                              in
@@ -3346,16 +3279,16 @@ let (mk_discriminator_and_indexed_projectors :
                             FStar_All.pipe_right fields
                               (FStar_List.mapi
                                  (fun i  ->
-                                    fun uu____8594  ->
-                                      match uu____8594 with
-                                      | (a,uu____8603) ->
+                                    fun uu____8475  ->
+                                      match uu____8475 with
+                                      | (a,uu____8484) ->
                                           let field_name =
                                             FStar_Syntax_Util.mk_field_projector_name
                                               lid a i
                                              in
                                           let field_proj_tm =
-                                            let uu____8610 =
-                                              let uu____8611 =
+                                            let uu____8491 =
+                                              let uu____8492 =
                                                 FStar_Syntax_Syntax.lid_as_fv
                                                   field_name
                                                   (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3363,26 +3296,25 @@ let (mk_discriminator_and_indexed_projectors :
                                                   FStar_Pervasives_Native.None
                                                  in
                                               FStar_Syntax_Syntax.fv_to_tm
-                                                uu____8611
+                                                uu____8492
                                                in
                                             FStar_Syntax_Syntax.mk_Tm_uinst
-                                              uu____8610 inst_univs
+                                              uu____8491 inst_univs
                                              in
                                           let proj =
                                             FStar_Syntax_Syntax.mk_Tm_app
-                                              field_proj_tm [arg]
-                                              FStar_Pervasives_Native.None p
+                                              field_proj_tm [arg] p
                                              in
                                           FStar_Syntax_Syntax.NT (a, proj)))
                              in
                           let projectors_ses =
-                            let uu____8637 =
+                            let uu____8516 =
                               FStar_All.pipe_right fields
                                 (FStar_List.mapi
                                    (fun i  ->
-                                      fun uu____8677  ->
-                                        match uu____8677 with
-                                        | (x,uu____8688) ->
+                                      fun uu____8556  ->
+                                        match uu____8556 with
+                                        | (x,uu____8567) ->
                                             let p1 =
                                               FStar_Syntax_Syntax.range_of_bv
                                                 x
@@ -3406,49 +3338,49 @@ let (mk_discriminator_and_indexed_projectors :
                                                   FStar_Syntax_Syntax.mk_Total
                                                     t
                                                  in
-                                              let uu____8707 =
+                                              let uu____8586 =
                                                 FStar_Syntax_Util.arrow
                                                   binders result_comp
                                                  in
                                               FStar_All.pipe_left
                                                 (FStar_Syntax_Subst.close_univ_vars
-                                                   uvs) uu____8707
+                                                   uvs) uu____8586
                                                in
                                             let only_decl =
                                               early_prims_inductive ||
-                                                (let uu____8713 =
-                                                   let uu____8715 =
+                                                (let uu____8592 =
+                                                   let uu____8594 =
                                                      FStar_TypeChecker_Env.current_module
                                                        env
                                                       in
                                                    FStar_Ident.string_of_lid
-                                                     uu____8715
+                                                     uu____8594
                                                     in
                                                  FStar_Options.dont_gen_projectors
-                                                   uu____8713)
+                                                   uu____8592)
                                                in
                                             let no_decl = false  in
                                             let quals q =
                                               if only_decl
                                               then
-                                                let uu____8734 =
+                                                let uu____8613 =
                                                   FStar_List.filter
-                                                    (fun uu___5_8738  ->
-                                                       match uu___5_8738 with
+                                                    (fun uu___5_8617  ->
+                                                       match uu___5_8617 with
                                                        | FStar_Syntax_Syntax.Abstract
                                                             -> false
-                                                       | uu____8741 -> true)
+                                                       | uu____8620 -> true)
                                                     q
                                                    in
                                                 FStar_Syntax_Syntax.Assumption
-                                                  :: uu____8734
+                                                  :: uu____8613
                                               else q  in
                                             let quals1 =
                                               let iquals1 =
                                                 FStar_All.pipe_right iquals
                                                   (FStar_List.filter
-                                                     (fun uu___6_8756  ->
-                                                        match uu___6_8756
+                                                     (fun uu___6_8635  ->
+                                                        match uu___6_8635
                                                         with
                                                         | FStar_Syntax_Syntax.Inline_for_extraction
                                                              -> true
@@ -3458,7 +3390,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                              -> true
                                                         | FStar_Syntax_Syntax.Private
                                                              -> true
-                                                        | uu____8762 -> false))
+                                                        | uu____8641 -> false))
                                                  in
                                               quals
                                                 ((FStar_Syntax_Syntax.Projector
@@ -3475,7 +3407,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                 attrs
                                                in
                                             let decl =
-                                              let uu____8773 =
+                                              let uu____8652 =
                                                 FStar_Ident.range_of_lid
                                                   field_name
                                                  in
@@ -3484,7 +3416,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                   (FStar_Syntax_Syntax.Sig_declare_typ
                                                      (field_name, uvs, t));
                                                 FStar_Syntax_Syntax.sigrng =
-                                                  uu____8773;
+                                                  uu____8652;
                                                 FStar_Syntax_Syntax.sigquals
                                                   = quals1;
                                                 FStar_Syntax_Syntax.sigmeta =
@@ -3494,32 +3426,32 @@ let (mk_discriminator_and_indexed_projectors :
                                                 FStar_Syntax_Syntax.sigopts =
                                                   FStar_Pervasives_Native.None
                                               }  in
-                                            ((let uu____8775 =
+                                            ((let uu____8654 =
                                                 FStar_TypeChecker_Env.debug
                                                   env
                                                   (FStar_Options.Other
                                                      "LogTypes")
                                                  in
-                                              if uu____8775
+                                              if uu____8654
                                               then
-                                                let uu____8779 =
+                                                let uu____8658 =
                                                   FStar_Syntax_Print.sigelt_to_string
                                                     decl
                                                    in
                                                 FStar_Util.print1
                                                   "Declaration of a projector %s\n"
-                                                  uu____8779
+                                                  uu____8658
                                               else ());
                                              if only_decl
                                              then [decl]
                                              else
                                                (let projection =
-                                                  let uu____8790 =
+                                                  let uu____8669 =
                                                     FStar_Ident.text_of_id
                                                       x.FStar_Syntax_Syntax.ppname
                                                      in
                                                   FStar_Syntax_Syntax.gen_bv
-                                                    uu____8790
+                                                    uu____8669
                                                     FStar_Pervasives_Native.None
                                                     FStar_Syntax_Syntax.tun
                                                    in
@@ -3528,8 +3460,8 @@ let (mk_discriminator_and_indexed_projectors :
                                                     all_params
                                                     (FStar_List.mapi
                                                        (fun j  ->
-                                                          fun uu____8835  ->
-                                                            match uu____8835
+                                                          fun uu____8714  ->
+                                                            match uu____8714
                                                             with
                                                             | (x1,imp) ->
                                                                 let b =
@@ -3540,13 +3472,13 @@ let (mk_discriminator_and_indexed_projectors :
                                                                   (i + ntps)
                                                                     = j
                                                                 then
-                                                                  let uu____8861
+                                                                  let uu____8740
                                                                     =
                                                                     pos
                                                                     (FStar_Syntax_Syntax.Pat_var
                                                                     projection)
                                                                      in
-                                                                  (uu____8861,
+                                                                  (uu____8740,
                                                                     b)
                                                                 else
                                                                   if
@@ -3554,109 +3486,104 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     (j < ntps)
                                                                   then
                                                                     (
-                                                                    let uu____8877
+                                                                    let uu____8756
                                                                     =
-                                                                    let uu____8880
+                                                                    let uu____8759
                                                                     =
-                                                                    let uu____8881
+                                                                    let uu____8760
                                                                     =
-                                                                    let uu____8888
+                                                                    let uu____8767
                                                                     =
-                                                                    let uu____8889
+                                                                    let uu____8768
                                                                     =
                                                                     FStar_Ident.text_of_id
                                                                     x1.FStar_Syntax_Syntax.ppname
                                                                      in
                                                                     FStar_Syntax_Syntax.gen_bv
-                                                                    uu____8889
+                                                                    uu____8768
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
-                                                                    (uu____8888,
+                                                                    (uu____8767,
                                                                     FStar_Syntax_Syntax.tun)
                                                                      in
                                                                     FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu____8881
+                                                                    uu____8760
                                                                      in
                                                                     pos
-                                                                    uu____8880
+                                                                    uu____8759
                                                                      in
-                                                                    (uu____8877,
+                                                                    (uu____8756,
                                                                     b))
                                                                   else
                                                                     (
-                                                                    let uu____8898
+                                                                    let uu____8777
                                                                     =
-                                                                    let uu____8901
+                                                                    let uu____8780
                                                                     =
-                                                                    let uu____8902
+                                                                    let uu____8781
                                                                     =
-                                                                    let uu____8903
+                                                                    let uu____8782
                                                                     =
                                                                     FStar_Ident.text_of_id
                                                                     x1.FStar_Syntax_Syntax.ppname
                                                                      in
                                                                     FStar_Syntax_Syntax.gen_bv
-                                                                    uu____8903
+                                                                    uu____8782
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun
                                                                      in
                                                                     FStar_Syntax_Syntax.Pat_wild
-                                                                    uu____8902
+                                                                    uu____8781
                                                                      in
                                                                     pos
-                                                                    uu____8901
+                                                                    uu____8780
                                                                      in
-                                                                    (uu____8898,
+                                                                    (uu____8777,
                                                                     b))))
                                                    in
                                                 let pat =
-                                                  let uu____8923 =
-                                                    let uu____8926 =
-                                                      let uu____8927 =
-                                                        let uu____8941 =
+                                                  let uu____8802 =
+                                                    let uu____8805 =
+                                                      let uu____8806 =
+                                                        let uu____8820 =
                                                           FStar_Syntax_Syntax.lid_as_fv
                                                             lid
                                                             FStar_Syntax_Syntax.delta_constant
                                                             (FStar_Pervasives_Native.Some
                                                                fvq)
                                                            in
-                                                        (uu____8941,
+                                                        (uu____8820,
                                                           arg_pats)
                                                          in
                                                       FStar_Syntax_Syntax.Pat_cons
-                                                        uu____8927
+                                                        uu____8806
                                                        in
-                                                    pos uu____8926  in
-                                                  let uu____8951 =
+                                                    pos uu____8805  in
+                                                  let uu____8830 =
                                                     FStar_Syntax_Syntax.bv_to_name
                                                       projection
                                                      in
-                                                  (uu____8923,
+                                                  (uu____8802,
                                                     FStar_Pervasives_Native.None,
-                                                    uu____8951)
+                                                    uu____8830)
                                                    in
                                                 let body =
-                                                  let uu____8967 =
-                                                    let uu____8974 =
-                                                      let uu____8975 =
-                                                        let uu____8998 =
-                                                          let uu____9015 =
-                                                            FStar_Syntax_Util.branch
-                                                              pat
-                                                             in
-                                                          [uu____9015]  in
-                                                        (arg_exp, uu____8998)
-                                                         in
-                                                      FStar_Syntax_Syntax.Tm_match
-                                                        uu____8975
+                                                  let uu____8846 =
+                                                    let uu____8847 =
+                                                      let uu____8870 =
+                                                        let uu____8887 =
+                                                          FStar_Syntax_Util.branch
+                                                            pat
+                                                           in
+                                                        [uu____8887]  in
+                                                      (arg_exp, uu____8870)
                                                        in
-                                                    FStar_Syntax_Syntax.mk
-                                                      uu____8974
+                                                    FStar_Syntax_Syntax.Tm_match
+                                                      uu____8847
                                                      in
-                                                  uu____8967
-                                                    FStar_Pervasives_Native.None
-                                                    p1
+                                                  FStar_Syntax_Syntax.mk
+                                                    uu____8846 p1
                                                    in
                                                 let imp =
                                                   FStar_Syntax_Util.abs
@@ -3664,13 +3591,13 @@ let (mk_discriminator_and_indexed_projectors :
                                                     FStar_Pervasives_Native.None
                                                    in
                                                 let dd =
-                                                  let uu____9080 =
+                                                  let uu____8952 =
                                                     FStar_All.pipe_right
                                                       quals1
                                                       (FStar_List.contains
                                                          FStar_Syntax_Syntax.Abstract)
                                                      in
-                                                  if uu____9080
+                                                  if uu____8952
                                                   then
                                                     FStar_Syntax_Syntax.Delta_abstract
                                                       (FStar_Syntax_Syntax.Delta_equational_at_level
@@ -3686,21 +3613,21 @@ let (mk_discriminator_and_indexed_projectors :
                                                     FStar_Syntax_Syntax.tun
                                                    in
                                                 let lb =
-                                                  let uu____9099 =
-                                                    let uu____9104 =
+                                                  let uu____8971 =
+                                                    let uu____8976 =
                                                       FStar_Syntax_Syntax.lid_as_fv
                                                         field_name dd
                                                         FStar_Pervasives_Native.None
                                                        in
-                                                    FStar_Util.Inr uu____9104
+                                                    FStar_Util.Inr uu____8976
                                                      in
-                                                  let uu____9105 =
+                                                  let uu____8977 =
                                                     FStar_Syntax_Subst.close_univ_vars
                                                       uvs imp
                                                      in
                                                   {
                                                     FStar_Syntax_Syntax.lbname
-                                                      = uu____9099;
+                                                      = uu____8971;
                                                     FStar_Syntax_Syntax.lbunivs
                                                       = uvs;
                                                     FStar_Syntax_Syntax.lbtyp
@@ -3709,7 +3636,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                       =
                                                       FStar_Parser_Const.effect_Tot_lid;
                                                     FStar_Syntax_Syntax.lbdef
-                                                      = uu____9105;
+                                                      = uu____8977;
                                                     FStar_Syntax_Syntax.lbattrs
                                                       = [];
                                                     FStar_Syntax_Syntax.lbpos
@@ -3717,30 +3644,30 @@ let (mk_discriminator_and_indexed_projectors :
                                                       FStar_Range.dummyRange
                                                   }  in
                                                 let impl =
-                                                  let uu____9111 =
-                                                    let uu____9112 =
-                                                      let uu____9119 =
-                                                        let uu____9122 =
-                                                          let uu____9123 =
+                                                  let uu____8983 =
+                                                    let uu____8984 =
+                                                      let uu____8991 =
+                                                        let uu____8994 =
+                                                          let uu____8995 =
                                                             FStar_All.pipe_right
                                                               lb.FStar_Syntax_Syntax.lbname
                                                               FStar_Util.right
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____9123
+                                                            uu____8995
                                                             (fun fv  ->
                                                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
                                                            in
-                                                        [uu____9122]  in
+                                                        [uu____8994]  in
                                                       ((false, [lb]),
-                                                        uu____9119)
+                                                        uu____8991)
                                                        in
                                                     FStar_Syntax_Syntax.Sig_let
-                                                      uu____9112
+                                                      uu____8984
                                                      in
                                                   {
                                                     FStar_Syntax_Syntax.sigel
-                                                      = uu____9111;
+                                                      = uu____8983;
                                                     FStar_Syntax_Syntax.sigrng
                                                       = p1;
                                                     FStar_Syntax_Syntax.sigquals
@@ -3754,27 +3681,27 @@ let (mk_discriminator_and_indexed_projectors :
                                                       =
                                                       FStar_Pervasives_Native.None
                                                   }  in
-                                                (let uu____9137 =
+                                                (let uu____9009 =
                                                    FStar_TypeChecker_Env.debug
                                                      env
                                                      (FStar_Options.Other
                                                         "LogTypes")
                                                     in
-                                                 if uu____9137
+                                                 if uu____9009
                                                  then
-                                                   let uu____9141 =
+                                                   let uu____9013 =
                                                      FStar_Syntax_Print.sigelt_to_string
                                                        impl
                                                       in
                                                    FStar_Util.print1
                                                      "Implementation of a projector %s\n"
-                                                     uu____9141
+                                                     uu____9013
                                                  else ());
                                                 if no_decl
                                                 then [impl]
                                                 else [decl; impl]))))
                                in
-                            FStar_All.pipe_right uu____8637
+                            FStar_All.pipe_right uu____8516
                               FStar_List.flatten
                              in
                           FStar_List.append discriminator_ses projectors_ses
@@ -3793,53 +3720,53 @@ let (mk_data_operations :
           fun se  ->
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_datacon
-                (constr_lid,uvs,t,typ_lid,n_typars,uu____9204) when
-                let uu____9211 =
+                (constr_lid,uvs,t,typ_lid,n_typars,uu____9076) when
+                let uu____9083 =
                   FStar_Ident.lid_equals constr_lid
                     FStar_Parser_Const.lexcons_lid
                    in
-                Prims.op_Negation uu____9211 ->
-                let uu____9213 = FStar_Syntax_Subst.univ_var_opening uvs  in
-                (match uu____9213 with
+                Prims.op_Negation uu____9083 ->
+                let uu____9085 = FStar_Syntax_Subst.univ_var_opening uvs  in
+                (match uu____9085 with
                  | (univ_opening,uvs1) ->
                      let t1 = FStar_Syntax_Subst.subst univ_opening t  in
-                     let uu____9235 = FStar_Syntax_Util.arrow_formals t1  in
-                     (match uu____9235 with
-                      | (formals,uu____9245) ->
-                          let uu____9250 =
+                     let uu____9107 = FStar_Syntax_Util.arrow_formals t1  in
+                     (match uu____9107 with
+                      | (formals,uu____9117) ->
+                          let uu____9122 =
                             let tps_opt =
                               FStar_Util.find_map tcs
                                 (fun se1  ->
-                                   let uu____9285 =
-                                     let uu____9287 =
-                                       let uu____9288 =
+                                   let uu____9157 =
+                                     let uu____9159 =
+                                       let uu____9160 =
                                          FStar_Syntax_Util.lid_of_sigelt se1
                                           in
-                                       FStar_Util.must uu____9288  in
+                                       FStar_Util.must uu____9160  in
                                      FStar_Ident.lid_equals typ_lid
-                                       uu____9287
+                                       uu____9159
                                       in
-                                   if uu____9285
+                                   if uu____9157
                                    then
                                      match se1.FStar_Syntax_Syntax.sigel with
                                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                                         (uu____9310,uvs',tps,typ0,uu____9314,constrs)
+                                         (uu____9182,uvs',tps,typ0,uu____9186,constrs)
                                          ->
                                          FStar_Pervasives_Native.Some
                                            (tps, typ0,
                                              ((FStar_List.length constrs) >
                                                 Prims.int_one))
-                                     | uu____9334 -> failwith "Impossible"
+                                     | uu____9206 -> failwith "Impossible"
                                    else FStar_Pervasives_Native.None)
                                in
                             match tps_opt with
                             | FStar_Pervasives_Native.Some x -> x
                             | FStar_Pervasives_Native.None  ->
-                                let uu____9383 =
+                                let uu____9255 =
                                   FStar_Ident.lid_equals typ_lid
                                     FStar_Parser_Const.exn_lid
                                    in
-                                if uu____9383
+                                if uu____9255
                                 then ([], FStar_Syntax_Util.ktype0, true)
                                 else
                                   FStar_Errors.raise_error
@@ -3847,7 +3774,7 @@ let (mk_data_operations :
                                       "Unexpected data constructor")
                                     se.FStar_Syntax_Syntax.sigrng
                              in
-                          (match uu____9250 with
+                          (match uu____9122 with
                            | (inductive_tps,typ0,should_refine) ->
                                let inductive_tps1 =
                                  FStar_Syntax_Subst.subst_binders
@@ -3856,41 +3783,41 @@ let (mk_data_operations :
                                let typ01 =
                                  FStar_Syntax_Subst.subst univ_opening typ0
                                   in
-                               let uu____9421 =
+                               let uu____9293 =
                                  FStar_Syntax_Util.arrow_formals typ01  in
-                               (match uu____9421 with
-                                | (indices,uu____9431) ->
+                               (match uu____9293 with
+                                | (indices,uu____9303) ->
                                     let refine_domain =
-                                      let uu____9438 =
+                                      let uu____9310 =
                                         FStar_All.pipe_right
                                           se.FStar_Syntax_Syntax.sigquals
                                           (FStar_Util.for_some
-                                             (fun uu___7_9445  ->
-                                                match uu___7_9445 with
+                                             (fun uu___7_9317  ->
+                                                match uu___7_9317 with
                                                 | FStar_Syntax_Syntax.RecordConstructor
-                                                    uu____9447 -> true
-                                                | uu____9457 -> false))
+                                                    uu____9319 -> true
+                                                | uu____9329 -> false))
                                          in
-                                      if uu____9438
+                                      if uu____9310
                                       then false
                                       else should_refine  in
                                     let fv_qual =
-                                      let filter_records uu___8_9472 =
-                                        match uu___8_9472 with
+                                      let filter_records uu___8_9344 =
+                                        match uu___8_9344 with
                                         | FStar_Syntax_Syntax.RecordConstructor
-                                            (uu____9475,fns) ->
+                                            (uu____9347,fns) ->
                                             FStar_Pervasives_Native.Some
                                               (FStar_Syntax_Syntax.Record_ctor
                                                  (typ_lid, fns))
-                                        | uu____9487 ->
+                                        | uu____9359 ->
                                             FStar_Pervasives_Native.None
                                          in
-                                      let uu____9488 =
+                                      let uu____9360 =
                                         FStar_Util.find_map
                                           se.FStar_Syntax_Syntax.sigquals
                                           filter_records
                                          in
-                                      match uu____9488 with
+                                      match uu____9360 with
                                       | FStar_Pervasives_Native.None  ->
                                           FStar_Syntax_Syntax.Data_ctor
                                       | FStar_Pervasives_Native.Some q -> q
@@ -3909,28 +3836,28 @@ let (mk_data_operations :
                                         iquals
                                       else iquals  in
                                     let fields =
-                                      let uu____9501 =
+                                      let uu____9373 =
                                         FStar_Util.first_N n_typars formals
                                          in
-                                      match uu____9501 with
+                                      match uu____9373 with
                                       | (imp_tps,fields) ->
                                           let rename =
                                             FStar_List.map2
-                                              (fun uu____9584  ->
-                                                 fun uu____9585  ->
-                                                   match (uu____9584,
-                                                           uu____9585)
+                                              (fun uu____9456  ->
+                                                 fun uu____9457  ->
+                                                   match (uu____9456,
+                                                           uu____9457)
                                                    with
-                                                   | ((x,uu____9611),
-                                                      (x',uu____9613)) ->
-                                                       let uu____9634 =
-                                                         let uu____9641 =
+                                                   | ((x,uu____9483),
+                                                      (x',uu____9485)) ->
+                                                       let uu____9506 =
+                                                         let uu____9513 =
                                                            FStar_Syntax_Syntax.bv_to_name
                                                              x'
                                                             in
-                                                         (x, uu____9641)  in
+                                                         (x, uu____9513)  in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____9634) imp_tps
+                                                         uu____9506) imp_tps
                                               inductive_tps1
                                              in
                                           FStar_Syntax_Subst.subst_binders
@@ -3945,5 +3872,5 @@ let (mk_data_operations :
                                       iquals1 attrs fv_qual refine_domain env
                                       typ_lid constr_lid uvs1 inductive_tps1
                                       indices fields erasable))))
-            | uu____9648 -> []
+            | uu____9520 -> []
   

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -193,28 +193,24 @@ let (mk_lex_list :
                  tl.FStar_Syntax_Syntax.pos
               in
            let uu____49 =
-             let uu____54 =
-               let uu____55 = FStar_Syntax_Syntax.as_arg v  in
-               let uu____64 =
-                 let uu____75 = FStar_Syntax_Syntax.as_arg tl  in [uu____75]
-                  in
-               uu____55 :: uu____64  in
-             FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.lex_pair
-               uu____54
-              in
-           uu____49 FStar_Pervasives_Native.None r) vs
-      FStar_Syntax_Util.lex_top
+             let uu____50 = FStar_Syntax_Syntax.as_arg v  in
+             let uu____59 =
+               let uu____70 = FStar_Syntax_Syntax.as_arg tl  in [uu____70]
+                in
+             uu____50 :: uu____59  in
+           FStar_Syntax_Syntax.mk_Tm_app FStar_Syntax_Util.lex_pair uu____49
+             r) vs FStar_Syntax_Util.lex_top
   
 let (is_eq :
   FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
     Prims.bool)
   =
-  fun uu___0_116  ->
-    match uu___0_116 with
+  fun uu___0_111  ->
+    match uu___0_111 with
     | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality ) -> true
-    | uu____121 -> false
+    | uu____116 -> false
   
-let steps : 'uuuuuu130 . 'uuuuuu130 -> FStar_TypeChecker_Env.step Prims.list
+let steps : 'uuuuuu125 . 'uuuuuu125 -> FStar_TypeChecker_Env.step Prims.list
   =
   fun env  ->
     [FStar_TypeChecker_Env.Beta;
@@ -249,79 +245,79 @@ let (check_no_escape :
           let rec aux try_norm t =
             match fvs with
             | [] -> (t, FStar_TypeChecker_Env.trivial_guard)
-            | uu____218 ->
+            | uu____213 ->
                 let t1 = if try_norm then norm env t else t  in
                 let fvs' = FStar_Syntax_Free.names t1  in
-                let uu____232 =
+                let uu____227 =
                   FStar_List.tryFind (fun x  -> FStar_Util.set_mem x fvs')
                     fvs
                    in
-                (match uu____232 with
+                (match uu____227 with
                  | FStar_Pervasives_Native.None  ->
                      (t1, FStar_TypeChecker_Env.trivial_guard)
                  | FStar_Pervasives_Native.Some x ->
                      if Prims.op_Negation try_norm
                      then aux true t1
                      else
-                       (let fail uu____259 =
+                       (let fail uu____254 =
                           let msg =
                             match head_opt with
                             | FStar_Pervasives_Native.None  ->
-                                let uu____263 =
+                                let uu____258 =
                                   FStar_Syntax_Print.bv_to_string x  in
                                 FStar_Util.format1
                                   "Bound variables '%s' escapes; add a type annotation"
-                                  uu____263
+                                  uu____258
                             | FStar_Pervasives_Native.Some head ->
-                                let uu____267 =
+                                let uu____262 =
                                   FStar_Syntax_Print.bv_to_string x  in
-                                let uu____269 =
+                                let uu____264 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env head
                                    in
                                 FStar_Util.format2
                                   "Bound variables '%s' in the type of '%s' escape because of impure applications; add explicit let-bindings"
-                                  uu____267 uu____269
+                                  uu____262 uu____264
                              in
-                          let uu____272 = FStar_TypeChecker_Env.get_range env
+                          let uu____267 = FStar_TypeChecker_Env.get_range env
                              in
                           FStar_Errors.raise_error
                             (FStar_Errors.Fatal_EscapedBoundVar, msg)
-                            uu____272
+                            uu____267
                            in
-                        let uu____278 =
-                          let uu____291 = FStar_TypeChecker_Env.get_range env
+                        let uu____273 =
+                          let uu____286 = FStar_TypeChecker_Env.get_range env
                              in
-                          let uu____292 =
-                            let uu____293 = FStar_Syntax_Util.type_u ()  in
+                          let uu____287 =
+                            let uu____288 = FStar_Syntax_Util.type_u ()  in
                             FStar_All.pipe_left FStar_Pervasives_Native.fst
-                              uu____293
+                              uu____288
                              in
                           FStar_TypeChecker_Util.new_implicit_var "no escape"
-                            uu____291 env uu____292
+                            uu____286 env uu____287
                            in
-                        match uu____278 with
-                        | (s,uu____308,g0) ->
-                            let uu____322 =
+                        match uu____273 with
+                        | (s,uu____303,g0) ->
+                            let uu____317 =
                               FStar_TypeChecker_Rel.try_teq true env t1 s  in
-                            (match uu____322 with
+                            (match uu____317 with
                              | FStar_Pervasives_Native.Some g ->
                                  let g1 =
-                                   let uu____332 =
+                                   let uu____327 =
                                      FStar_TypeChecker_Env.conj_guard g g0
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____332
+                                     env uu____327
                                     in
                                  (s, g1)
-                             | uu____333 -> fail ())))
+                             | uu____328 -> fail ())))
              in
           aux false kt
   
 let push_binding :
-  'uuuuuu344 .
+  'uuuuuu339 .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu344) -> FStar_TypeChecker_Env.env
+      (FStar_Syntax_Syntax.bv * 'uuuuuu339) -> FStar_TypeChecker_Env.env
   =
   fun env  ->
     fun b  ->
@@ -337,8 +333,8 @@ let (maybe_extend_subst :
   fun s  ->
     fun b  ->
       fun v  ->
-        let uu____399 = FStar_Syntax_Syntax.is_null_binder b  in
-        if uu____399
+        let uu____394 = FStar_Syntax_Syntax.is_null_binder b  in
+        if uu____394
         then s
         else (FStar_Syntax_Syntax.NT ((FStar_Pervasives_Native.fst b), v)) ::
           s
@@ -352,15 +348,15 @@ let (set_lcomp_result :
     fun t  ->
       FStar_TypeChecker_Common.apply_lcomp
         (fun c  -> FStar_Syntax_Util.set_result_typ c t) (fun g  -> g)
-        (let uu___66_429 = lc  in
+        (let uu___66_424 = lc  in
          {
            FStar_TypeChecker_Common.eff_name =
-             (uu___66_429.FStar_TypeChecker_Common.eff_name);
+             (uu___66_424.FStar_TypeChecker_Common.eff_name);
            FStar_TypeChecker_Common.res_typ = t;
            FStar_TypeChecker_Common.cflags =
-             (uu___66_429.FStar_TypeChecker_Common.cflags);
+             (uu___66_424.FStar_TypeChecker_Common.cflags);
            FStar_TypeChecker_Common.comp_thunk =
-             (uu___66_429.FStar_TypeChecker_Common.comp_thunk)
+             (uu___66_424.FStar_TypeChecker_Common.comp_thunk)
          })
   
 let (memo_tk :
@@ -371,29 +367,29 @@ let (maybe_warn_on_use :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.fv -> unit) =
   fun env  ->
     fun fv  ->
-      let uu____452 =
+      let uu____447 =
         FStar_TypeChecker_Env.lookup_attrs_of_lid env
           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
          in
-      match uu____452 with
+      match uu____447 with
       | FStar_Pervasives_Native.None  -> ()
       | FStar_Pervasives_Native.Some attrs ->
           FStar_All.pipe_right attrs
             (FStar_List.iter
                (fun a  ->
-                  let uu____475 = FStar_Syntax_Util.head_and_args a  in
-                  match uu____475 with
+                  let uu____470 = FStar_Syntax_Util.head_and_args a  in
+                  match uu____470 with
                   | (head,args) ->
                       let msg_arg m =
                         match args with
                         | ({
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.Tm_constant
-                               (FStar_Const.Const_string (s,uu____529));
-                             FStar_Syntax_Syntax.pos = uu____530;
-                             FStar_Syntax_Syntax.vars = uu____531;_},uu____532)::[]
+                               (FStar_Const.Const_string (s,uu____524));
+                             FStar_Syntax_Syntax.pos = uu____525;
+                             FStar_Syntax_Syntax.vars = uu____526;_},uu____527)::[]
                             -> Prims.op_Hat m (Prims.op_Hat ": " s)
-                        | uu____560 -> m  in
+                        | uu____555 -> m  in
                       (match head.FStar_Syntax_Syntax.n with
                        | FStar_Syntax_Syntax.Tm_fvar attr_fv when
                            FStar_Ident.lid_equals
@@ -401,18 +397,18 @@ let (maybe_warn_on_use :
                              FStar_Parser_Const.warn_on_use_attr
                            ->
                            let m =
-                             let uu____574 =
+                             let uu____569 =
                                FStar_Ident.string_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                 in
                              FStar_Util.format1
-                               "Every use of %s triggers a warning" uu____574
+                               "Every use of %s triggers a warning" uu____569
                               in
-                           let uu____577 =
+                           let uu____572 =
                              FStar_Ident.range_of_lid
                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                               in
-                           FStar_Errors.log_issue uu____577
+                           FStar_Errors.log_issue uu____572
                              (FStar_Errors.Warning_WarnOnUse, (msg_arg m))
                        | FStar_Syntax_Syntax.Tm_fvar attr_fv when
                            FStar_Ident.lid_equals
@@ -420,20 +416,20 @@ let (maybe_warn_on_use :
                              FStar_Parser_Const.deprecated_attr
                            ->
                            let m =
-                             let uu____582 =
+                             let uu____577 =
                                FStar_Ident.string_of_lid
                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                 in
-                             FStar_Util.format1 "%s is deprecated" uu____582
+                             FStar_Util.format1 "%s is deprecated" uu____577
                               in
-                           let uu____585 =
+                           let uu____580 =
                              FStar_Ident.range_of_lid
                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                               in
-                           FStar_Errors.log_issue uu____585
+                           FStar_Errors.log_issue uu____580
                              (FStar_Errors.Warning_DeprecatedDefinition,
                                (msg_arg m))
-                       | uu____587 -> ())))
+                       | uu____582 -> ())))
   
 let (value_check_expected_typ :
   FStar_TypeChecker_Env.env ->
@@ -453,64 +449,64 @@ let (value_check_expected_typ :
           (let lc =
              match tlc with
              | FStar_Util.Inl t ->
-                 let uu____633 = FStar_Syntax_Syntax.mk_Total t  in
+                 let uu____628 = FStar_Syntax_Syntax.mk_Total t  in
                  FStar_All.pipe_left FStar_TypeChecker_Common.lcomp_of_comp
-                   uu____633
+                   uu____628
              | FStar_Util.Inr lc -> lc  in
            let t = lc.FStar_TypeChecker_Common.res_typ  in
-           let uu____636 =
-             let uu____643 = FStar_TypeChecker_Env.expected_typ env  in
-             match uu____643 with
+           let uu____631 =
+             let uu____638 = FStar_TypeChecker_Env.expected_typ env  in
+             match uu____638 with
              | FStar_Pervasives_Native.None  -> ((memo_tk e t), lc, guard)
              | FStar_Pervasives_Native.Some t' ->
-                 let uu____653 =
+                 let uu____648 =
                    FStar_TypeChecker_Util.check_has_type env e lc t'  in
-                 (match uu____653 with
+                 (match uu____648 with
                   | (e1,lc1,g) ->
-                      ((let uu____670 =
+                      ((let uu____665 =
                           FStar_TypeChecker_Env.debug env
                             FStar_Options.Medium
                            in
-                        if uu____670
+                        if uu____665
                         then
-                          let uu____673 =
+                          let uu____668 =
                             FStar_TypeChecker_Common.lcomp_to_string lc1  in
-                          let uu____675 =
+                          let uu____670 =
                             FStar_Syntax_Print.term_to_string t'  in
-                          let uu____677 =
+                          let uu____672 =
                             FStar_TypeChecker_Rel.guard_to_string env g  in
-                          let uu____679 =
+                          let uu____674 =
                             FStar_TypeChecker_Rel.guard_to_string env guard
                              in
                           FStar_Util.print4
                             "value_check_expected_typ: type is %s<:%s \tguard is %s, %s\n"
-                            uu____673 uu____675 uu____677 uu____679
+                            uu____668 uu____670 uu____672 uu____674
                         else ());
                        (let t1 = lc1.FStar_TypeChecker_Common.res_typ  in
                         let g1 = FStar_TypeChecker_Env.conj_guard g guard  in
                         let msg =
-                          let uu____693 =
+                          let uu____688 =
                             FStar_TypeChecker_Env.is_trivial_guard_formula g1
                              in
-                          if uu____693
+                          if uu____688
                           then FStar_Pervasives_Native.None
                           else
                             FStar_All.pipe_left
-                              (fun uu____722  ->
-                                 FStar_Pervasives_Native.Some uu____722)
+                              (fun uu____717  ->
+                                 FStar_Pervasives_Native.Some uu____717)
                               (FStar_TypeChecker_Err.subtyping_failed env t1
                                  t')
                            in
-                        let uu____723 =
+                        let uu____718 =
                           FStar_TypeChecker_Util.strengthen_precondition msg
                             env e1 lc1 g1
                            in
-                        match uu____723 with
+                        match uu____718 with
                         | (lc2,g2) ->
-                            let uu____736 = set_lcomp_result lc2 t'  in
-                            ((memo_tk e1 t'), uu____736, g2))))
+                            let uu____731 = set_lcomp_result lc2 t'  in
+                            ((memo_tk e1 t'), uu____731, g2))))
               in
-           match uu____636 with | (e1,lc1,g) -> (e1, lc1, g))
+           match uu____631 with | (e1,lc1,g) -> (e1, lc1, g))
   
 let (comp_check_expected_typ :
   FStar_TypeChecker_Env.env ->
@@ -522,22 +518,22 @@ let (comp_check_expected_typ :
   fun env  ->
     fun e  ->
       fun lc  ->
-        let uu____774 = FStar_TypeChecker_Env.expected_typ env  in
-        match uu____774 with
+        let uu____769 = FStar_TypeChecker_Env.expected_typ env  in
+        match uu____769 with
         | FStar_Pervasives_Native.None  ->
             (e, lc, FStar_TypeChecker_Env.trivial_guard)
         | FStar_Pervasives_Native.Some t ->
-            let uu____784 = FStar_TypeChecker_Util.maybe_coerce_lc env e lc t
+            let uu____779 = FStar_TypeChecker_Util.maybe_coerce_lc env e lc t
                in
-            (match uu____784 with
+            (match uu____779 with
              | (e1,lc1,g_c) ->
-                 let uu____800 =
+                 let uu____795 =
                    FStar_TypeChecker_Util.weaken_result_typ env e1 lc1 t  in
-                 (match uu____800 with
+                 (match uu____795 with
                   | (e2,lc2,g) ->
-                      let uu____816 = FStar_TypeChecker_Env.conj_guard g g_c
+                      let uu____811 = FStar_TypeChecker_Env.conj_guard g g_c
                          in
-                      (e2, lc2, uu____816)))
+                      (e2, lc2, uu____811)))
   
 let (check_expected_effect :
   FStar_TypeChecker_Env.env ->
@@ -549,31 +545,31 @@ let (check_expected_effect :
   fun env  ->
     fun copt  ->
       fun ec  ->
-        let uu____857 = ec  in
-        match uu____857 with
+        let uu____852 = ec  in
+        match uu____852 with
         | (e,c) ->
             let tot_or_gtot c1 =
-              let uu____880 = FStar_Syntax_Util.is_pure_comp c1  in
-              if uu____880
+              let uu____875 = FStar_Syntax_Util.is_pure_comp c1  in
+              if uu____875
               then
                 FStar_Syntax_Syntax.mk_Total
                   (FStar_Syntax_Util.comp_result c1)
               else
-                (let uu____885 = FStar_Syntax_Util.is_pure_or_ghost_comp c1
+                (let uu____880 = FStar_Syntax_Util.is_pure_or_ghost_comp c1
                     in
-                 if uu____885
+                 if uu____880
                  then
                    FStar_Syntax_Syntax.mk_GTotal
                      (FStar_Syntax_Util.comp_result c1)
                  else failwith "Impossible: Expected pure_or_ghost comp")
                in
-            let uu____891 =
+            let uu____886 =
               let ct = FStar_Syntax_Util.comp_result c  in
               match copt with
-              | FStar_Pervasives_Native.Some uu____915 ->
+              | FStar_Pervasives_Native.Some uu____910 ->
                   (copt, c, FStar_Pervasives_Native.None)
               | FStar_Pervasives_Native.None  ->
-                  let uu____920 =
+                  let uu____915 =
                     ((FStar_Options.ml_ish ()) &&
                        (FStar_Ident.lid_equals
                           FStar_Parser_Const.effect_ALL_lid
@@ -582,91 +578,91 @@ let (check_expected_effect :
                       (((FStar_Options.ml_ish ()) &&
                           env.FStar_TypeChecker_Env.lax)
                          &&
-                         (let uu____923 =
+                         (let uu____918 =
                             FStar_Syntax_Util.is_pure_or_ghost_comp c  in
-                          Prims.op_Negation uu____923))
+                          Prims.op_Negation uu____918))
                      in
-                  if uu____920
+                  if uu____915
                   then
-                    let uu____936 =
-                      let uu____939 =
+                    let uu____931 =
+                      let uu____934 =
                         FStar_Syntax_Util.ml_comp ct
                           e.FStar_Syntax_Syntax.pos
                          in
-                      FStar_Pervasives_Native.Some uu____939  in
-                    (uu____936, c, FStar_Pervasives_Native.None)
+                      FStar_Pervasives_Native.Some uu____934  in
+                    (uu____931, c, FStar_Pervasives_Native.None)
                   else
-                    (let uu____946 = FStar_Syntax_Util.is_tot_or_gtot_comp c
+                    (let uu____941 = FStar_Syntax_Util.is_tot_or_gtot_comp c
                         in
-                     if uu____946
+                     if uu____941
                      then
-                       let uu____959 = tot_or_gtot c  in
-                       (FStar_Pervasives_Native.None, uu____959,
+                       let uu____954 = tot_or_gtot c  in
+                       (FStar_Pervasives_Native.None, uu____954,
                          FStar_Pervasives_Native.None)
                      else
-                       (let uu____966 =
+                       (let uu____961 =
                           FStar_Syntax_Util.is_pure_or_ghost_comp c  in
-                        if uu____966
+                        if uu____961
                         then
-                          let uu____979 =
-                            let uu____982 = tot_or_gtot c  in
-                            FStar_Pervasives_Native.Some uu____982  in
-                          (uu____979, c, FStar_Pervasives_Native.None)
+                          let uu____974 =
+                            let uu____977 = tot_or_gtot c  in
+                            FStar_Pervasives_Native.Some uu____977  in
+                          (uu____974, c, FStar_Pervasives_Native.None)
                         else
-                          (let uu____989 =
-                             let uu____991 =
+                          (let uu____984 =
+                             let uu____986 =
                                FStar_All.pipe_right
                                  (FStar_Syntax_Util.comp_effect_name c)
                                  (FStar_TypeChecker_Env.norm_eff_name env)
                                 in
-                             FStar_All.pipe_right uu____991
+                             FStar_All.pipe_right uu____986
                                (FStar_TypeChecker_Env.is_layered_effect env)
                               in
-                           if uu____989
+                           if uu____984
                            then
-                             let uu____1004 =
-                               let uu____1010 =
-                                 let uu____1012 =
-                                   let uu____1014 =
+                             let uu____999 =
+                               let uu____1005 =
+                                 let uu____1007 =
+                                   let uu____1009 =
                                      FStar_All.pipe_right c
                                        FStar_Syntax_Util.comp_effect_name
                                       in
-                                   FStar_All.pipe_right uu____1014
+                                   FStar_All.pipe_right uu____1009
                                      FStar_Ident.string_of_lid
                                     in
-                                 let uu____1018 =
+                                 let uu____1013 =
                                    FStar_Range.string_of_range
                                      e.FStar_Syntax_Syntax.pos
                                     in
                                  FStar_Util.format2
                                    "Missing annotation for a layered effect (%s) computation at %s"
-                                   uu____1012 uu____1018
+                                   uu____1007 uu____1013
                                   in
-                               (FStar_Errors.Fatal_IllTyped, uu____1010)  in
-                             FStar_Errors.raise_error uu____1004
+                               (FStar_Errors.Fatal_IllTyped, uu____1005)  in
+                             FStar_Errors.raise_error uu____999
                                e.FStar_Syntax_Syntax.pos
                            else
-                             (let uu____1034 =
+                             (let uu____1029 =
                                 FStar_Options.trivial_pre_for_unannotated_effectful_fns
                                   ()
                                  in
-                              if uu____1034
+                              if uu____1029
                               then
-                                let uu____1047 =
-                                  let uu____1050 =
+                                let uu____1042 =
+                                  let uu____1045 =
                                     FStar_TypeChecker_Util.check_trivial_precondition
                                       env c
                                      in
-                                  match uu____1050 with
-                                  | (uu____1059,uu____1060,g) ->
+                                  match uu____1045 with
+                                  | (uu____1054,uu____1055,g) ->
                                       FStar_Pervasives_Native.Some g
                                    in
-                                (FStar_Pervasives_Native.None, c, uu____1047)
+                                (FStar_Pervasives_Native.None, c, uu____1042)
                               else
                                 (FStar_Pervasives_Native.None, c,
                                   FStar_Pervasives_Native.None)))))
                in
-            (match uu____891 with
+            (match uu____886 with
              | (expected_c_opt,c1,gopt) ->
                  let c2 = norm_c env c1  in
                  (match expected_c_opt with
@@ -679,68 +675,68 @@ let (check_expected_effect :
                   | FStar_Pervasives_Native.Some expected_c ->
                       ((match gopt with
                         | FStar_Pervasives_Native.None  -> ()
-                        | FStar_Pervasives_Native.Some uu____1099 ->
+                        | FStar_Pervasives_Native.Some uu____1094 ->
                             failwith
                               "Impossible! check_expected_effect, gopt should have been None");
                        (let c3 =
-                          let uu____1102 =
+                          let uu____1097 =
                             FStar_TypeChecker_Common.lcomp_of_comp c2  in
                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
-                            env e uu____1102
+                            env e uu____1097
                            in
-                        let uu____1103 =
+                        let uu____1098 =
                           FStar_TypeChecker_Common.lcomp_comp c3  in
-                        match uu____1103 with
+                        match uu____1098 with
                         | (c4,g_c) ->
-                            ((let uu____1117 =
+                            ((let uu____1112 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   FStar_Options.Medium
                                  in
-                              if uu____1117
+                              if uu____1112
                               then
-                                let uu____1121 =
+                                let uu____1116 =
                                   FStar_Syntax_Print.term_to_string e  in
-                                let uu____1123 =
+                                let uu____1118 =
                                   FStar_Syntax_Print.comp_to_string c4  in
-                                let uu____1125 =
+                                let uu____1120 =
                                   FStar_Syntax_Print.comp_to_string
                                     expected_c
                                    in
                                 FStar_Util.print3
                                   "In check_expected_effect, asking rel to solve the problem on e=(%s) and c=(%s) and expected_c=(%s)\n"
-                                  uu____1121 uu____1123 uu____1125
+                                  uu____1116 uu____1118 uu____1120
                               else ());
-                             (let uu____1130 =
+                             (let uu____1125 =
                                 FStar_TypeChecker_Util.check_comp env e c4
                                   expected_c
                                  in
-                              match uu____1130 with
-                              | (e1,uu____1144,g) ->
+                              match uu____1125 with
+                              | (e1,uu____1139,g) ->
                                   let g1 =
-                                    let uu____1147 =
+                                    let uu____1142 =
                                       FStar_TypeChecker_Env.get_range env  in
                                     FStar_TypeChecker_Util.label_guard
-                                      uu____1147
+                                      uu____1142
                                       "could not prove post-condition" g
                                      in
-                                  ((let uu____1150 =
+                                  ((let uu____1145 =
                                       FStar_TypeChecker_Env.debug env
                                         FStar_Options.Medium
                                        in
-                                    if uu____1150
+                                    if uu____1145
                                     then
-                                      let uu____1153 =
+                                      let uu____1148 =
                                         FStar_Range.string_of_range
                                           e1.FStar_Syntax_Syntax.pos
                                          in
-                                      let uu____1155 =
+                                      let uu____1150 =
                                         FStar_TypeChecker_Rel.guard_to_string
                                           env g1
                                          in
                                       FStar_Util.print2
                                         "(%s) DONE check_expected_effect;\n\tguard is: %s\n"
-                                        uu____1153 uu____1155
+                                        uu____1148 uu____1150
                                     else ());
                                    (let e2 =
                                       FStar_TypeChecker_Util.maybe_lift env
@@ -751,41 +747,41 @@ let (check_expected_effect :
                                            expected_c)
                                         (FStar_Syntax_Util.comp_result c4)
                                        in
-                                    let uu____1161 =
+                                    let uu____1156 =
                                       FStar_TypeChecker_Env.conj_guard g_c g1
                                        in
-                                    (e2, expected_c, uu____1161)))))))))
+                                    (e2, expected_c, uu____1156)))))))))
   
 let no_logical_guard :
-  'uuuuuu1171 'uuuuuu1172 .
+  'uuuuuu1166 'uuuuuu1167 .
     FStar_TypeChecker_Env.env ->
-      ('uuuuuu1171 * 'uuuuuu1172 * FStar_TypeChecker_Env.guard_t) ->
-        ('uuuuuu1171 * 'uuuuuu1172 * FStar_TypeChecker_Env.guard_t)
+      ('uuuuuu1166 * 'uuuuuu1167 * FStar_TypeChecker_Env.guard_t) ->
+        ('uuuuuu1166 * 'uuuuuu1167 * FStar_TypeChecker_Env.guard_t)
   =
   fun env  ->
-    fun uu____1194  ->
-      match uu____1194 with
+    fun uu____1189  ->
+      match uu____1189 with
       | (te,kt,f) ->
-          let uu____1204 = FStar_TypeChecker_Env.guard_form f  in
-          (match uu____1204 with
+          let uu____1199 = FStar_TypeChecker_Env.guard_form f  in
+          (match uu____1199 with
            | FStar_TypeChecker_Common.Trivial  -> (te, kt, f)
            | FStar_TypeChecker_Common.NonTrivial f1 ->
-               let uu____1212 =
+               let uu____1207 =
                  FStar_TypeChecker_Err.unexpected_non_trivial_precondition_on_term
                    env f1
                   in
-               let uu____1218 = FStar_TypeChecker_Env.get_range env  in
-               FStar_Errors.raise_error uu____1212 uu____1218)
+               let uu____1213 = FStar_TypeChecker_Env.get_range env  in
+               FStar_Errors.raise_error uu____1207 uu____1213)
   
 let (print_expected_ty : FStar_TypeChecker_Env.env -> unit) =
   fun env  ->
-    let uu____1231 = FStar_TypeChecker_Env.expected_typ env  in
-    match uu____1231 with
+    let uu____1226 = FStar_TypeChecker_Env.expected_typ env  in
+    match uu____1226 with
     | FStar_Pervasives_Native.None  ->
         FStar_Util.print_string "Expected type is None\n"
     | FStar_Pervasives_Native.Some t ->
-        let uu____1236 = FStar_Syntax_Print.term_to_string t  in
-        FStar_Util.print1 "Expected type is %s" uu____1236
+        let uu____1231 = FStar_Syntax_Print.term_to_string t  in
+        FStar_Util.print1 "Expected type is %s" uu____1231
   
 let rec (get_pat_vars' :
   FStar_Syntax_Syntax.bv Prims.list ->
@@ -796,24 +792,24 @@ let rec (get_pat_vars' :
     fun andlist  ->
       fun pats  ->
         let pats1 = FStar_Syntax_Util.unmeta pats  in
-        let uu____1266 = FStar_Syntax_Util.head_and_args pats1  in
-        match uu____1266 with
+        let uu____1261 = FStar_Syntax_Util.head_and_args pats1  in
+        match uu____1261 with
         | (head,args) ->
-            let uu____1311 =
-              let uu____1326 =
-                let uu____1327 = FStar_Syntax_Util.un_uinst head  in
-                uu____1327.FStar_Syntax_Syntax.n  in
-              (uu____1326, args)  in
-            (match uu____1311 with
-             | (FStar_Syntax_Syntax.Tm_fvar fv,uu____1343) when
+            let uu____1306 =
+              let uu____1321 =
+                let uu____1322 = FStar_Syntax_Util.un_uinst head  in
+                uu____1322.FStar_Syntax_Syntax.n  in
+              (uu____1321, args)  in
+            (match uu____1306 with
+             | (FStar_Syntax_Syntax.Tm_fvar fv,uu____1338) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid
                  ->
                  if andlist
                  then FStar_Util.as_set all FStar_Syntax_Syntax.order_bv
                  else FStar_Util.new_set FStar_Syntax_Syntax.order_bv
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,(uu____1370,FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Implicit uu____1371))::(hd,FStar_Pervasives_Native.None
+                fv,(uu____1365,FStar_Pervasives_Native.Some
+                    (FStar_Syntax_Syntax.Implicit uu____1366))::(hd,FStar_Pervasives_Native.None
                                                                  )::(tl,FStar_Pervasives_Native.None
                                                                     )::[])
                  when
@@ -825,8 +821,8 @@ let rec (get_pat_vars' :
                  then FStar_Util.set_intersect hdvs tlvs
                  else FStar_Util.set_union hdvs tlvs
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,(uu____1448,FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Implicit uu____1449))::(pat,FStar_Pervasives_Native.None
+                fv,(uu____1443,FStar_Pervasives_Native.Some
+                    (FStar_Syntax_Syntax.Implicit uu____1444))::(pat,FStar_Pervasives_Native.None
                                                                  )::[])
                  when
                  FStar_Syntax_Syntax.fv_eq_lid fv
@@ -837,52 +833,52 @@ let rec (get_pat_vars' :
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpatOr_lid
                  -> get_pat_vars' all true subpats
-             | uu____1533 -> FStar_Util.new_set FStar_Syntax_Syntax.order_bv)
+             | uu____1528 -> FStar_Util.new_set FStar_Syntax_Syntax.order_bv)
   
 let (get_pat_vars :
   FStar_Syntax_Syntax.bv Prims.list ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Util.set)
   = fun all  -> fun pats  -> get_pat_vars' all false pats 
 let check_pat_fvs :
-  'uuuuuu1577 .
+  'uuuuuu1572 .
     FStar_Range.range ->
       FStar_TypeChecker_Env.env ->
         FStar_Syntax_Syntax.term ->
-          (FStar_Syntax_Syntax.bv * 'uuuuuu1577) Prims.list -> unit
+          (FStar_Syntax_Syntax.bv * 'uuuuuu1572) Prims.list -> unit
   =
   fun rng  ->
     fun env  ->
       fun pats  ->
         fun bs  ->
           let pat_vars =
-            let uu____1613 = FStar_List.map FStar_Pervasives_Native.fst bs
+            let uu____1608 = FStar_List.map FStar_Pervasives_Native.fst bs
                in
-            let uu____1620 =
+            let uu____1615 =
               FStar_TypeChecker_Normalize.normalize
                 [FStar_TypeChecker_Env.Beta] env pats
                in
-            get_pat_vars uu____1613 uu____1620  in
-          let uu____1621 =
+            get_pat_vars uu____1608 uu____1615  in
+          let uu____1616 =
             FStar_All.pipe_right bs
               (FStar_Util.find_opt
-                 (fun uu____1648  ->
-                    match uu____1648 with
-                    | (b,uu____1655) ->
-                        let uu____1656 = FStar_Util.set_mem b pat_vars  in
-                        Prims.op_Negation uu____1656))
+                 (fun uu____1643  ->
+                    match uu____1643 with
+                    | (b,uu____1650) ->
+                        let uu____1651 = FStar_Util.set_mem b pat_vars  in
+                        Prims.op_Negation uu____1651))
              in
-          match uu____1621 with
+          match uu____1616 with
           | FStar_Pervasives_Native.None  -> ()
-          | FStar_Pervasives_Native.Some (x,uu____1663) ->
-              let uu____1668 =
-                let uu____1674 =
-                  let uu____1676 = FStar_Syntax_Print.bv_to_string x  in
+          | FStar_Pervasives_Native.Some (x,uu____1658) ->
+              let uu____1663 =
+                let uu____1669 =
+                  let uu____1671 = FStar_Syntax_Print.bv_to_string x  in
                   FStar_Util.format1
                     "Pattern misses at least one bound variable: %s"
-                    uu____1676
+                    uu____1671
                    in
-                (FStar_Errors.Warning_SMTPatternIllFormed, uu____1674)  in
-              FStar_Errors.log_issue rng uu____1668
+                (FStar_Errors.Warning_SMTPatternIllFormed, uu____1669)  in
+              FStar_Errors.log_issue rng uu____1663
   
 let (check_no_smt_theory_symbols :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> unit) =
@@ -890,27 +886,27 @@ let (check_no_smt_theory_symbols :
     fun t  ->
       let rec pat_terms t1 =
         let t2 = FStar_Syntax_Util.unmeta t1  in
-        let uu____1702 = FStar_Syntax_Util.head_and_args t2  in
-        match uu____1702 with
+        let uu____1697 = FStar_Syntax_Util.head_and_args t2  in
+        match uu____1697 with
         | (head,args) ->
-            let uu____1747 =
-              let uu____1762 =
-                let uu____1763 = FStar_Syntax_Util.un_uinst head  in
-                uu____1763.FStar_Syntax_Syntax.n  in
-              (uu____1762, args)  in
-            (match uu____1747 with
-             | (FStar_Syntax_Syntax.Tm_fvar fv,uu____1779) when
+            let uu____1742 =
+              let uu____1757 =
+                let uu____1758 = FStar_Syntax_Util.un_uinst head  in
+                uu____1758.FStar_Syntax_Syntax.n  in
+              (uu____1757, args)  in
+            (match uu____1742 with
+             | (FStar_Syntax_Syntax.Tm_fvar fv,uu____1774) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.nil_lid
                  -> []
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,uu____1801::(hd,uu____1803)::(tl,uu____1805)::[]) when
+                fv,uu____1796::(hd,uu____1798)::(tl,uu____1800)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.cons_lid
                  ->
-                 let uu____1872 = pat_terms hd  in
-                 let uu____1875 = pat_terms tl  in
-                 FStar_List.append uu____1872 uu____1875
+                 let uu____1867 = pat_terms hd  in
+                 let uu____1870 = pat_terms tl  in
+                 FStar_List.append uu____1867 uu____1870
              | (FStar_Syntax_Syntax.Tm_fvar
-                fv,uu____1879::(pat,uu____1881)::[]) when
+                fv,uu____1874::(pat,uu____1876)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpat_lid
                  -> [pat]
@@ -919,49 +915,49 @@ let (check_no_smt_theory_symbols :
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.smtpatOr_lid
                  -> pat_terms subpats
-             | uu____1966 -> [])
+             | uu____1961 -> [])
          in
       let rec aux t1 =
-        let uu____1991 =
-          let uu____1992 = FStar_Syntax_Subst.compress t1  in
-          uu____1992.FStar_Syntax_Syntax.n  in
-        match uu____1991 with
-        | FStar_Syntax_Syntax.Tm_bvar uu____1997 -> []
-        | FStar_Syntax_Syntax.Tm_name uu____1998 -> []
-        | FStar_Syntax_Syntax.Tm_type uu____1999 -> []
-        | FStar_Syntax_Syntax.Tm_uvar uu____2000 -> []
-        | FStar_Syntax_Syntax.Tm_lazy uu____2013 -> []
+        let uu____1986 =
+          let uu____1987 = FStar_Syntax_Subst.compress t1  in
+          uu____1987.FStar_Syntax_Syntax.n  in
+        match uu____1986 with
+        | FStar_Syntax_Syntax.Tm_bvar uu____1992 -> []
+        | FStar_Syntax_Syntax.Tm_name uu____1993 -> []
+        | FStar_Syntax_Syntax.Tm_type uu____1994 -> []
+        | FStar_Syntax_Syntax.Tm_uvar uu____1995 -> []
+        | FStar_Syntax_Syntax.Tm_lazy uu____2008 -> []
         | FStar_Syntax_Syntax.Tm_unknown  -> []
-        | FStar_Syntax_Syntax.Tm_constant uu____2014 -> [t1]
-        | FStar_Syntax_Syntax.Tm_abs uu____2015 -> [t1]
-        | FStar_Syntax_Syntax.Tm_arrow uu____2034 -> [t1]
-        | FStar_Syntax_Syntax.Tm_refine uu____2049 -> [t1]
-        | FStar_Syntax_Syntax.Tm_match uu____2056 -> [t1]
-        | FStar_Syntax_Syntax.Tm_let uu____2079 -> [t1]
-        | FStar_Syntax_Syntax.Tm_delayed uu____2093 -> [t1]
-        | FStar_Syntax_Syntax.Tm_quoted uu____2108 -> [t1]
+        | FStar_Syntax_Syntax.Tm_constant uu____2009 -> [t1]
+        | FStar_Syntax_Syntax.Tm_abs uu____2010 -> [t1]
+        | FStar_Syntax_Syntax.Tm_arrow uu____2029 -> [t1]
+        | FStar_Syntax_Syntax.Tm_refine uu____2044 -> [t1]
+        | FStar_Syntax_Syntax.Tm_match uu____2051 -> [t1]
+        | FStar_Syntax_Syntax.Tm_let uu____2074 -> [t1]
+        | FStar_Syntax_Syntax.Tm_delayed uu____2088 -> [t1]
+        | FStar_Syntax_Syntax.Tm_quoted uu____2103 -> [t1]
         | FStar_Syntax_Syntax.Tm_fvar fv ->
-            let uu____2116 =
+            let uu____2111 =
               FStar_TypeChecker_Env.fv_has_attr en fv
                 FStar_Parser_Const.smt_theory_symbol_attr_lid
                in
-            if uu____2116 then [t1] else []
+            if uu____2111 then [t1] else []
         | FStar_Syntax_Syntax.Tm_app (t2,args) ->
-            let uu____2149 = aux t2  in
+            let uu____2144 = aux t2  in
             FStar_List.fold_left
               (fun acc  ->
-                 fun uu____2166  ->
-                   match uu____2166 with
-                   | (t3,uu____2178) ->
-                       let uu____2183 = aux t3  in
-                       FStar_List.append acc uu____2183) uu____2149 args
-        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____2187,uu____2188) ->
+                 fun uu____2161  ->
+                   match uu____2161 with
+                   | (t3,uu____2173) ->
+                       let uu____2178 = aux t3  in
+                       FStar_List.append acc uu____2178) uu____2144 args
+        | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____2182,uu____2183) ->
             aux t2
-        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____2230) -> aux t2
-        | FStar_Syntax_Syntax.Tm_meta (t2,uu____2236) -> aux t2  in
+        | FStar_Syntax_Syntax.Tm_uinst (t2,uu____2225) -> aux t2
+        | FStar_Syntax_Syntax.Tm_meta (t2,uu____2231) -> aux t2  in
       let tlist =
-        let uu____2244 = FStar_All.pipe_right t pat_terms  in
-        FStar_All.pipe_right uu____2244 (FStar_List.collect aux)  in
+        let uu____2239 = FStar_All.pipe_right t pat_terms  in
+        FStar_All.pipe_right uu____2239 (FStar_List.collect aux)  in
       if (FStar_List.length tlist) = Prims.int_zero
       then ()
       else
@@ -969,46 +965,46 @@ let (check_no_smt_theory_symbols :
            FStar_List.fold_left
              (fun s  ->
                 fun t1  ->
-                  let uu____2267 =
-                    let uu____2269 = FStar_Syntax_Print.term_to_string t1  in
-                    Prims.op_Hat " " uu____2269  in
-                  Prims.op_Hat s uu____2267) "" tlist
+                  let uu____2262 =
+                    let uu____2264 = FStar_Syntax_Print.term_to_string t1  in
+                    Prims.op_Hat " " uu____2264  in
+                  Prims.op_Hat s uu____2262) "" tlist
             in
-         let uu____2273 =
-           let uu____2279 =
+         let uu____2268 =
+           let uu____2274 =
              FStar_Util.format1
                "Pattern uses these theory symbols or terms that should not be in an smt pattern: %s"
                msg
               in
-           (FStar_Errors.Warning_SMTPatternIllFormed, uu____2279)  in
-         FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2273)
+           (FStar_Errors.Warning_SMTPatternIllFormed, uu____2274)  in
+         FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____2268)
   
 let check_smt_pat :
-  'uuuuuu2294 .
+  'uuuuuu2289 .
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        (FStar_Syntax_Syntax.bv * 'uuuuuu2294) Prims.list ->
+        (FStar_Syntax_Syntax.bv * 'uuuuuu2289) Prims.list ->
           FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> unit
   =
   fun env  ->
     fun t  ->
       fun bs  ->
         fun c  ->
-          let uu____2335 = FStar_Syntax_Util.is_smt_lemma t  in
-          if uu____2335
+          let uu____2330 = FStar_Syntax_Util.is_smt_lemma t  in
+          if uu____2330
           then
             match c.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Comp
-                { FStar_Syntax_Syntax.comp_univs = uu____2338;
-                  FStar_Syntax_Syntax.effect_name = uu____2339;
-                  FStar_Syntax_Syntax.result_typ = uu____2340;
+                { FStar_Syntax_Syntax.comp_univs = uu____2333;
+                  FStar_Syntax_Syntax.effect_name = uu____2334;
+                  FStar_Syntax_Syntax.result_typ = uu____2335;
                   FStar_Syntax_Syntax.effect_args =
-                    _pre::_post::(pats,uu____2344)::[];
-                  FStar_Syntax_Syntax.flags = uu____2345;_}
+                    _pre::_post::(pats,uu____2339)::[];
+                  FStar_Syntax_Syntax.flags = uu____2340;_}
                 ->
                 (check_pat_fvs t.FStar_Syntax_Syntax.pos env pats bs;
                  check_no_smt_theory_symbols env pats)
-            | uu____2407 -> failwith "Impossible"
+            | uu____2402 -> failwith "Impossible"
           else ()
   
 let (guard_letrecs :
@@ -1026,267 +1022,265 @@ let (guard_letrecs :
         | letrecs ->
             let r = FStar_TypeChecker_Env.get_range env  in
             let env1 =
-              let uu___396_2470 = env  in
+              let uu___396_2465 = env  in
               {
                 FStar_TypeChecker_Env.solver =
-                  (uu___396_2470.FStar_TypeChecker_Env.solver);
+                  (uu___396_2465.FStar_TypeChecker_Env.solver);
                 FStar_TypeChecker_Env.range =
-                  (uu___396_2470.FStar_TypeChecker_Env.range);
+                  (uu___396_2465.FStar_TypeChecker_Env.range);
                 FStar_TypeChecker_Env.curmodule =
-                  (uu___396_2470.FStar_TypeChecker_Env.curmodule);
+                  (uu___396_2465.FStar_TypeChecker_Env.curmodule);
                 FStar_TypeChecker_Env.gamma =
-                  (uu___396_2470.FStar_TypeChecker_Env.gamma);
+                  (uu___396_2465.FStar_TypeChecker_Env.gamma);
                 FStar_TypeChecker_Env.gamma_sig =
-                  (uu___396_2470.FStar_TypeChecker_Env.gamma_sig);
+                  (uu___396_2465.FStar_TypeChecker_Env.gamma_sig);
                 FStar_TypeChecker_Env.gamma_cache =
-                  (uu___396_2470.FStar_TypeChecker_Env.gamma_cache);
+                  (uu___396_2465.FStar_TypeChecker_Env.gamma_cache);
                 FStar_TypeChecker_Env.modules =
-                  (uu___396_2470.FStar_TypeChecker_Env.modules);
+                  (uu___396_2465.FStar_TypeChecker_Env.modules);
                 FStar_TypeChecker_Env.expected_typ =
-                  (uu___396_2470.FStar_TypeChecker_Env.expected_typ);
+                  (uu___396_2465.FStar_TypeChecker_Env.expected_typ);
                 FStar_TypeChecker_Env.sigtab =
-                  (uu___396_2470.FStar_TypeChecker_Env.sigtab);
+                  (uu___396_2465.FStar_TypeChecker_Env.sigtab);
                 FStar_TypeChecker_Env.attrtab =
-                  (uu___396_2470.FStar_TypeChecker_Env.attrtab);
+                  (uu___396_2465.FStar_TypeChecker_Env.attrtab);
                 FStar_TypeChecker_Env.instantiate_imp =
-                  (uu___396_2470.FStar_TypeChecker_Env.instantiate_imp);
+                  (uu___396_2465.FStar_TypeChecker_Env.instantiate_imp);
                 FStar_TypeChecker_Env.effects =
-                  (uu___396_2470.FStar_TypeChecker_Env.effects);
+                  (uu___396_2465.FStar_TypeChecker_Env.effects);
                 FStar_TypeChecker_Env.generalize =
-                  (uu___396_2470.FStar_TypeChecker_Env.generalize);
+                  (uu___396_2465.FStar_TypeChecker_Env.generalize);
                 FStar_TypeChecker_Env.letrecs = [];
                 FStar_TypeChecker_Env.top_level =
-                  (uu___396_2470.FStar_TypeChecker_Env.top_level);
+                  (uu___396_2465.FStar_TypeChecker_Env.top_level);
                 FStar_TypeChecker_Env.check_uvars =
-                  (uu___396_2470.FStar_TypeChecker_Env.check_uvars);
+                  (uu___396_2465.FStar_TypeChecker_Env.check_uvars);
                 FStar_TypeChecker_Env.use_eq =
-                  (uu___396_2470.FStar_TypeChecker_Env.use_eq);
+                  (uu___396_2465.FStar_TypeChecker_Env.use_eq);
                 FStar_TypeChecker_Env.use_eq_strict =
-                  (uu___396_2470.FStar_TypeChecker_Env.use_eq_strict);
+                  (uu___396_2465.FStar_TypeChecker_Env.use_eq_strict);
                 FStar_TypeChecker_Env.is_iface =
-                  (uu___396_2470.FStar_TypeChecker_Env.is_iface);
+                  (uu___396_2465.FStar_TypeChecker_Env.is_iface);
                 FStar_TypeChecker_Env.admit =
-                  (uu___396_2470.FStar_TypeChecker_Env.admit);
+                  (uu___396_2465.FStar_TypeChecker_Env.admit);
                 FStar_TypeChecker_Env.lax =
-                  (uu___396_2470.FStar_TypeChecker_Env.lax);
+                  (uu___396_2465.FStar_TypeChecker_Env.lax);
                 FStar_TypeChecker_Env.lax_universes =
-                  (uu___396_2470.FStar_TypeChecker_Env.lax_universes);
+                  (uu___396_2465.FStar_TypeChecker_Env.lax_universes);
                 FStar_TypeChecker_Env.phase1 =
-                  (uu___396_2470.FStar_TypeChecker_Env.phase1);
+                  (uu___396_2465.FStar_TypeChecker_Env.phase1);
                 FStar_TypeChecker_Env.failhard =
-                  (uu___396_2470.FStar_TypeChecker_Env.failhard);
+                  (uu___396_2465.FStar_TypeChecker_Env.failhard);
                 FStar_TypeChecker_Env.nosynth =
-                  (uu___396_2470.FStar_TypeChecker_Env.nosynth);
+                  (uu___396_2465.FStar_TypeChecker_Env.nosynth);
                 FStar_TypeChecker_Env.uvar_subtyping =
-                  (uu___396_2470.FStar_TypeChecker_Env.uvar_subtyping);
+                  (uu___396_2465.FStar_TypeChecker_Env.uvar_subtyping);
                 FStar_TypeChecker_Env.tc_term =
-                  (uu___396_2470.FStar_TypeChecker_Env.tc_term);
+                  (uu___396_2465.FStar_TypeChecker_Env.tc_term);
                 FStar_TypeChecker_Env.type_of =
-                  (uu___396_2470.FStar_TypeChecker_Env.type_of);
+                  (uu___396_2465.FStar_TypeChecker_Env.type_of);
                 FStar_TypeChecker_Env.universe_of =
-                  (uu___396_2470.FStar_TypeChecker_Env.universe_of);
+                  (uu___396_2465.FStar_TypeChecker_Env.universe_of);
                 FStar_TypeChecker_Env.check_type_of =
-                  (uu___396_2470.FStar_TypeChecker_Env.check_type_of);
+                  (uu___396_2465.FStar_TypeChecker_Env.check_type_of);
                 FStar_TypeChecker_Env.use_bv_sorts =
-                  (uu___396_2470.FStar_TypeChecker_Env.use_bv_sorts);
+                  (uu___396_2465.FStar_TypeChecker_Env.use_bv_sorts);
                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                  (uu___396_2470.FStar_TypeChecker_Env.qtbl_name_and_index);
+                  (uu___396_2465.FStar_TypeChecker_Env.qtbl_name_and_index);
                 FStar_TypeChecker_Env.normalized_eff_names =
-                  (uu___396_2470.FStar_TypeChecker_Env.normalized_eff_names);
+                  (uu___396_2465.FStar_TypeChecker_Env.normalized_eff_names);
                 FStar_TypeChecker_Env.fv_delta_depths =
-                  (uu___396_2470.FStar_TypeChecker_Env.fv_delta_depths);
+                  (uu___396_2465.FStar_TypeChecker_Env.fv_delta_depths);
                 FStar_TypeChecker_Env.proof_ns =
-                  (uu___396_2470.FStar_TypeChecker_Env.proof_ns);
+                  (uu___396_2465.FStar_TypeChecker_Env.proof_ns);
                 FStar_TypeChecker_Env.synth_hook =
-                  (uu___396_2470.FStar_TypeChecker_Env.synth_hook);
+                  (uu___396_2465.FStar_TypeChecker_Env.synth_hook);
                 FStar_TypeChecker_Env.try_solve_implicits_hook =
-                  (uu___396_2470.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                  (uu___396_2465.FStar_TypeChecker_Env.try_solve_implicits_hook);
                 FStar_TypeChecker_Env.splice =
-                  (uu___396_2470.FStar_TypeChecker_Env.splice);
+                  (uu___396_2465.FStar_TypeChecker_Env.splice);
                 FStar_TypeChecker_Env.mpreprocess =
-                  (uu___396_2470.FStar_TypeChecker_Env.mpreprocess);
+                  (uu___396_2465.FStar_TypeChecker_Env.mpreprocess);
                 FStar_TypeChecker_Env.postprocess =
-                  (uu___396_2470.FStar_TypeChecker_Env.postprocess);
+                  (uu___396_2465.FStar_TypeChecker_Env.postprocess);
                 FStar_TypeChecker_Env.identifier_info =
-                  (uu___396_2470.FStar_TypeChecker_Env.identifier_info);
+                  (uu___396_2465.FStar_TypeChecker_Env.identifier_info);
                 FStar_TypeChecker_Env.tc_hooks =
-                  (uu___396_2470.FStar_TypeChecker_Env.tc_hooks);
+                  (uu___396_2465.FStar_TypeChecker_Env.tc_hooks);
                 FStar_TypeChecker_Env.dsenv =
-                  (uu___396_2470.FStar_TypeChecker_Env.dsenv);
+                  (uu___396_2465.FStar_TypeChecker_Env.dsenv);
                 FStar_TypeChecker_Env.nbe =
-                  (uu___396_2470.FStar_TypeChecker_Env.nbe);
+                  (uu___396_2465.FStar_TypeChecker_Env.nbe);
                 FStar_TypeChecker_Env.strict_args_tab =
-                  (uu___396_2470.FStar_TypeChecker_Env.strict_args_tab);
+                  (uu___396_2465.FStar_TypeChecker_Env.strict_args_tab);
                 FStar_TypeChecker_Env.erasable_types_tab =
-                  (uu___396_2470.FStar_TypeChecker_Env.erasable_types_tab)
+                  (uu___396_2465.FStar_TypeChecker_Env.erasable_types_tab)
               }  in
             let precedes =
               FStar_TypeChecker_Util.fvar_const env1
                 FStar_Parser_Const.precedes_lid
                in
             let decreases_clause bs c =
-              (let uu____2496 =
+              (let uu____2491 =
                  FStar_TypeChecker_Env.debug env1 FStar_Options.Low  in
-               if uu____2496
+               if uu____2491
                then
-                 let uu____2499 =
+                 let uu____2494 =
                    FStar_Syntax_Print.binders_to_string ", " bs  in
-                 let uu____2502 = FStar_Syntax_Print.comp_to_string c  in
+                 let uu____2497 = FStar_Syntax_Print.comp_to_string c  in
                  FStar_Util.print2
                    "Building a decreases clause over (%s) and %s\n"
-                   uu____2499 uu____2502
+                   uu____2494 uu____2497
                else ());
               (let filter_types_and_functions bs1 =
                  FStar_All.pipe_right bs1
                    (FStar_List.collect
-                      (fun uu____2536  ->
-                         match uu____2536 with
-                         | (b,uu____2546) ->
+                      (fun uu____2531  ->
+                         match uu____2531 with
+                         | (b,uu____2541) ->
                              let t =
-                               let uu____2552 =
+                               let uu____2547 =
                                  FStar_Syntax_Util.unrefine
                                    b.FStar_Syntax_Syntax.sort
                                   in
                                FStar_TypeChecker_Normalize.unfold_whnf env1
-                                 uu____2552
+                                 uu____2547
                                 in
                              (match t.FStar_Syntax_Syntax.n with
-                              | FStar_Syntax_Syntax.Tm_type uu____2555 -> []
-                              | FStar_Syntax_Syntax.Tm_arrow uu____2556 -> []
-                              | uu____2571 ->
-                                  let uu____2572 =
+                              | FStar_Syntax_Syntax.Tm_type uu____2550 -> []
+                              | FStar_Syntax_Syntax.Tm_arrow uu____2551 -> []
+                              | uu____2566 ->
+                                  let uu____2567 =
                                     FStar_Syntax_Syntax.bv_to_name b  in
-                                  [uu____2572])))
+                                  [uu____2567])))
                   in
                let as_lex_list dec =
-                 let uu____2585 = FStar_Syntax_Util.head_and_args dec  in
-                 match uu____2585 with
-                 | (head,uu____2605) ->
+                 let uu____2580 = FStar_Syntax_Util.head_and_args dec  in
+                 match uu____2580 with
+                 | (head,uu____2600) ->
                      (match head.FStar_Syntax_Syntax.n with
                       | FStar_Syntax_Syntax.Tm_fvar fv when
                           FStar_Syntax_Syntax.fv_eq_lid fv
                             FStar_Parser_Const.lexcons_lid
                           -> dec
-                      | uu____2633 -> mk_lex_list [dec])
+                      | uu____2628 -> mk_lex_list [dec])
                   in
                let cflags = FStar_Syntax_Util.comp_flags c  in
-               let uu____2641 =
+               let uu____2636 =
                  FStar_All.pipe_right cflags
                    (FStar_List.tryFind
-                      (fun uu___1_2650  ->
-                         match uu___1_2650 with
-                         | FStar_Syntax_Syntax.DECREASES uu____2652 -> true
-                         | uu____2656 -> false))
+                      (fun uu___1_2645  ->
+                         match uu___1_2645 with
+                         | FStar_Syntax_Syntax.DECREASES uu____2647 -> true
+                         | uu____2651 -> false))
                   in
-               match uu____2641 with
+               match uu____2636 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                    dec) -> as_lex_list dec
-               | uu____2663 ->
+               | uu____2658 ->
                    let xs =
                      FStar_All.pipe_right bs filter_types_and_functions  in
-                   (match xs with | x::[] -> x | uu____2684 -> mk_lex_list xs))
+                   (match xs with | x::[] -> x | uu____2679 -> mk_lex_list xs))
                in
             let previous_dec = decreases_clause actuals expected_c  in
-            let guard_one_letrec uu____2713 =
-              match uu____2713 with
+            let guard_one_letrec uu____2708 =
+              match uu____2708 with
               | (l,t,u_names) ->
-                  let uu____2737 =
-                    let uu____2738 = FStar_Syntax_Subst.compress t  in
-                    uu____2738.FStar_Syntax_Syntax.n  in
-                  (match uu____2737 with
+                  let uu____2732 =
+                    let uu____2733 = FStar_Syntax_Subst.compress t  in
+                    uu____2733.FStar_Syntax_Syntax.n  in
+                  (match uu____2732 with
                    | FStar_Syntax_Syntax.Tm_arrow (formals,c) ->
                        let formals1 =
                          FStar_All.pipe_right formals
                            (FStar_List.map
-                              (fun uu____2797  ->
-                                 match uu____2797 with
+                              (fun uu____2792  ->
+                                 match uu____2792 with
                                  | (x,imp) ->
-                                     let uu____2816 =
+                                     let uu____2811 =
                                        FStar_Syntax_Syntax.is_null_bv x  in
-                                     if uu____2816
+                                     if uu____2811
                                      then
-                                       let uu____2825 =
-                                         let uu____2826 =
-                                           let uu____2829 =
+                                       let uu____2820 =
+                                         let uu____2821 =
+                                           let uu____2824 =
                                              FStar_Syntax_Syntax.range_of_bv
                                                x
                                               in
                                            FStar_Pervasives_Native.Some
-                                             uu____2829
+                                             uu____2824
                                             in
                                          FStar_Syntax_Syntax.new_bv
-                                           uu____2826
+                                           uu____2821
                                            x.FStar_Syntax_Syntax.sort
                                           in
-                                       (uu____2825, imp)
+                                       (uu____2820, imp)
                                      else (x, imp)))
                           in
-                       let uu____2836 =
+                       let uu____2831 =
                          FStar_Syntax_Subst.open_comp formals1 c  in
-                       (match uu____2836 with
+                       (match uu____2831 with
                         | (formals2,c1) ->
                             let dec = decreases_clause formals2 c1  in
                             let precedes1 =
-                              let uu____2857 =
-                                let uu____2862 =
-                                  let uu____2863 =
-                                    FStar_Syntax_Syntax.as_arg dec  in
-                                  let uu____2872 =
-                                    let uu____2883 =
-                                      FStar_Syntax_Syntax.as_arg previous_dec
-                                       in
-                                    [uu____2883]  in
-                                  uu____2863 :: uu____2872  in
-                                FStar_Syntax_Syntax.mk_Tm_app precedes
-                                  uu____2862
-                                 in
-                              uu____2857 FStar_Pervasives_Native.None r  in
+                              let uu____2850 =
+                                let uu____2851 =
+                                  FStar_Syntax_Syntax.as_arg dec  in
+                                let uu____2860 =
+                                  let uu____2871 =
+                                    FStar_Syntax_Syntax.as_arg previous_dec
+                                     in
+                                  [uu____2871]  in
+                                uu____2851 :: uu____2860  in
+                              FStar_Syntax_Syntax.mk_Tm_app precedes
+                                uu____2850 r
+                               in
                             let precedes2 =
                               FStar_TypeChecker_Util.label
                                 "Could not prove termination of this recursive call"
                                 r precedes1
                                in
-                            let uu____2918 = FStar_Util.prefix formals2  in
-                            (match uu____2918 with
+                            let uu____2906 = FStar_Util.prefix formals2  in
+                            (match uu____2906 with
                              | (bs,(last,imp)) ->
                                  let last1 =
-                                   let uu___463_2981 = last  in
-                                   let uu____2982 =
+                                   let uu___463_2969 = last  in
+                                   let uu____2970 =
                                      FStar_Syntax_Util.refine last precedes2
                                       in
                                    {
                                      FStar_Syntax_Syntax.ppname =
-                                       (uu___463_2981.FStar_Syntax_Syntax.ppname);
+                                       (uu___463_2969.FStar_Syntax_Syntax.ppname);
                                      FStar_Syntax_Syntax.index =
-                                       (uu___463_2981.FStar_Syntax_Syntax.index);
-                                     FStar_Syntax_Syntax.sort = uu____2982
+                                       (uu___463_2969.FStar_Syntax_Syntax.index);
+                                     FStar_Syntax_Syntax.sort = uu____2970
                                    }  in
                                  let refined_formals =
                                    FStar_List.append bs [(last1, imp)]  in
                                  let t' =
                                    FStar_Syntax_Util.arrow refined_formals c1
                                     in
-                                 ((let uu____3018 =
+                                 ((let uu____3006 =
                                      FStar_TypeChecker_Env.debug env1
                                        FStar_Options.Medium
                                       in
-                                   if uu____3018
+                                   if uu____3006
                                    then
-                                     let uu____3021 =
+                                     let uu____3009 =
                                        FStar_Syntax_Print.lbname_to_string l
                                         in
-                                     let uu____3023 =
+                                     let uu____3011 =
                                        FStar_Syntax_Print.term_to_string t
                                         in
-                                     let uu____3025 =
+                                     let uu____3013 =
                                        FStar_Syntax_Print.term_to_string t'
                                         in
                                      FStar_Util.print3
                                        "Refined let rec %s\n\tfrom type %s\n\tto type %s\n"
-                                       uu____3021 uu____3023 uu____3025
+                                       uu____3009 uu____3011 uu____3013
                                    else ());
                                   (l, t', u_names))))
-                   | uu____3032 ->
+                   | uu____3020 ->
                        FStar_Errors.raise_error
                          (FStar_Errors.Fatal_ExpectedArrowAnnotatedType,
                            "Annotated type of 'let rec' must be an arrow")
@@ -1305,10 +1299,10 @@ let (wrap_guard_with_tactic_opt :
       | FStar_Pervasives_Native.Some tactic ->
           FStar_TypeChecker_Env.always_map_guard g
             (fun g1  ->
-               let uu____3096 =
+               let uu____3084 =
                  FStar_Syntax_Util.mk_squash FStar_Syntax_Syntax.U_zero g1
                   in
-               FStar_TypeChecker_Common.mk_by_tactic tactic uu____3096)
+               FStar_TypeChecker_Common.mk_by_tactic tactic uu____3084)
   
 let (is_comp_ascribed_reflect :
   FStar_Syntax_Syntax.term ->
@@ -1316,37 +1310,37 @@ let (is_comp_ascribed_reflect :
       FStar_Syntax_Syntax.aqual) FStar_Pervasives_Native.option)
   =
   fun e  ->
-    let uu____3119 =
-      let uu____3120 = FStar_Syntax_Subst.compress e  in
-      uu____3120.FStar_Syntax_Syntax.n  in
-    match uu____3119 with
+    let uu____3107 =
+      let uu____3108 = FStar_Syntax_Subst.compress e  in
+      uu____3108.FStar_Syntax_Syntax.n  in
+    match uu____3107 with
     | FStar_Syntax_Syntax.Tm_ascribed
-        (e1,(FStar_Util.Inr uu____3132,uu____3133),uu____3134) ->
-        let uu____3181 =
-          let uu____3182 = FStar_Syntax_Subst.compress e1  in
-          uu____3182.FStar_Syntax_Syntax.n  in
-        (match uu____3181 with
+        (e1,(FStar_Util.Inr uu____3120,uu____3121),uu____3122) ->
+        let uu____3169 =
+          let uu____3170 = FStar_Syntax_Subst.compress e1  in
+          uu____3170.FStar_Syntax_Syntax.n  in
+        (match uu____3169 with
          | FStar_Syntax_Syntax.Tm_app (head,args) when
              (FStar_List.length args) = Prims.int_one ->
-             let uu____3229 =
-               let uu____3230 = FStar_Syntax_Subst.compress head  in
-               uu____3230.FStar_Syntax_Syntax.n  in
-             (match uu____3229 with
+             let uu____3217 =
+               let uu____3218 = FStar_Syntax_Subst.compress head  in
+               uu____3218.FStar_Syntax_Syntax.n  in
+             (match uu____3217 with
               | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect l)
                   ->
-                  let uu____3242 =
-                    let uu____3249 = FStar_All.pipe_right args FStar_List.hd
+                  let uu____3230 =
+                    let uu____3237 = FStar_All.pipe_right args FStar_List.hd
                        in
-                    FStar_All.pipe_right uu____3249
-                      (fun uu____3305  ->
-                         match uu____3305 with | (e2,aqual) -> (l, e2, aqual))
+                    FStar_All.pipe_right uu____3237
+                      (fun uu____3293  ->
+                         match uu____3293 with | (e2,aqual) -> (l, e2, aqual))
                      in
-                  FStar_All.pipe_right uu____3242
-                    (fun uu____3358  ->
-                       FStar_Pervasives_Native.Some uu____3358)
-              | uu____3359 -> FStar_Pervasives_Native.None)
-         | uu____3366 -> FStar_Pervasives_Native.None)
-    | uu____3373 -> FStar_Pervasives_Native.None
+                  FStar_All.pipe_right uu____3230
+                    (fun uu____3346  ->
+                       FStar_Pervasives_Native.Some uu____3346)
+              | uu____3347 -> FStar_Pervasives_Native.None)
+         | uu____3354 -> FStar_Pervasives_Native.None)
+    | uu____3361 -> FStar_Pervasives_Native.None
   
 let rec (tc_term :
   FStar_TypeChecker_Env.env ->
@@ -1356,164 +1350,164 @@ let rec (tc_term :
   =
   fun env  ->
     fun e  ->
-      (let uu____4098 = FStar_TypeChecker_Env.debug env FStar_Options.Medium
+      (let uu____4086 = FStar_TypeChecker_Env.debug env FStar_Options.Medium
           in
-       if uu____4098
+       if uu____4086
        then
-         let uu____4101 =
-           let uu____4103 = FStar_TypeChecker_Env.get_range env  in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____4103  in
-         let uu____4105 =
+         let uu____4089 =
+           let uu____4091 = FStar_TypeChecker_Env.get_range env  in
+           FStar_All.pipe_left FStar_Range.string_of_range uu____4091  in
+         let uu____4093 =
            FStar_Util.string_of_bool env.FStar_TypeChecker_Env.phase1  in
-         let uu____4107 = FStar_Syntax_Print.term_to_string e  in
-         let uu____4109 =
-           let uu____4111 = FStar_Syntax_Subst.compress e  in
-           FStar_Syntax_Print.tag_of_term uu____4111  in
-         let uu____4112 =
-           let uu____4114 = FStar_TypeChecker_Env.expected_typ env  in
-           match uu____4114 with
+         let uu____4095 = FStar_Syntax_Print.term_to_string e  in
+         let uu____4097 =
+           let uu____4099 = FStar_Syntax_Subst.compress e  in
+           FStar_Syntax_Print.tag_of_term uu____4099  in
+         let uu____4100 =
+           let uu____4102 = FStar_TypeChecker_Env.expected_typ env  in
+           match uu____4102 with
            | FStar_Pervasives_Native.None  -> "None"
            | FStar_Pervasives_Native.Some t ->
                FStar_Syntax_Print.term_to_string t
             in
          FStar_Util.print5
            "(%s) Starting tc_term (phase1=%s) of %s (%s) with expected type: %s {\n"
-           uu____4101 uu____4105 uu____4107 uu____4109 uu____4112
+           uu____4089 uu____4093 uu____4095 uu____4097 uu____4100
        else ());
-      (let uu____4123 =
+      (let uu____4111 =
          FStar_Util.record_time
-           (fun uu____4142  ->
+           (fun uu____4130  ->
               tc_maybe_toplevel_term
-                (let uu___507_4145 = env  in
+                (let uu___507_4133 = env  in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___507_4145.FStar_TypeChecker_Env.solver);
+                     (uu___507_4133.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___507_4145.FStar_TypeChecker_Env.range);
+                     (uu___507_4133.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___507_4145.FStar_TypeChecker_Env.curmodule);
+                     (uu___507_4133.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
-                     (uu___507_4145.FStar_TypeChecker_Env.gamma);
+                     (uu___507_4133.FStar_TypeChecker_Env.gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___507_4145.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___507_4133.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___507_4145.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___507_4133.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___507_4145.FStar_TypeChecker_Env.modules);
+                     (uu___507_4133.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___507_4145.FStar_TypeChecker_Env.expected_typ);
+                     (uu___507_4133.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___507_4145.FStar_TypeChecker_Env.sigtab);
+                     (uu___507_4133.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___507_4145.FStar_TypeChecker_Env.attrtab);
+                     (uu___507_4133.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___507_4145.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___507_4133.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___507_4145.FStar_TypeChecker_Env.effects);
+                     (uu___507_4133.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___507_4145.FStar_TypeChecker_Env.generalize);
+                     (uu___507_4133.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___507_4145.FStar_TypeChecker_Env.letrecs);
+                     (uu___507_4133.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level = false;
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___507_4145.FStar_TypeChecker_Env.check_uvars);
+                     (uu___507_4133.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___507_4145.FStar_TypeChecker_Env.use_eq);
+                     (uu___507_4133.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.use_eq_strict =
-                     (uu___507_4145.FStar_TypeChecker_Env.use_eq_strict);
+                     (uu___507_4133.FStar_TypeChecker_Env.use_eq_strict);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___507_4145.FStar_TypeChecker_Env.is_iface);
+                     (uu___507_4133.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___507_4145.FStar_TypeChecker_Env.admit);
+                     (uu___507_4133.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___507_4145.FStar_TypeChecker_Env.lax);
+                     (uu___507_4133.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___507_4145.FStar_TypeChecker_Env.lax_universes);
+                     (uu___507_4133.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___507_4145.FStar_TypeChecker_Env.phase1);
+                     (uu___507_4133.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___507_4145.FStar_TypeChecker_Env.failhard);
+                     (uu___507_4133.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___507_4145.FStar_TypeChecker_Env.nosynth);
+                     (uu___507_4133.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___507_4145.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___507_4133.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___507_4145.FStar_TypeChecker_Env.tc_term);
+                     (uu___507_4133.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___507_4145.FStar_TypeChecker_Env.type_of);
+                     (uu___507_4133.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___507_4145.FStar_TypeChecker_Env.universe_of);
+                     (uu___507_4133.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___507_4145.FStar_TypeChecker_Env.check_type_of);
+                     (uu___507_4133.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___507_4145.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___507_4133.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___507_4145.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___507_4133.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___507_4145.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___507_4133.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___507_4145.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___507_4133.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___507_4145.FStar_TypeChecker_Env.proof_ns);
+                     (uu___507_4133.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___507_4145.FStar_TypeChecker_Env.synth_hook);
+                     (uu___507_4133.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.try_solve_implicits_hook =
-                     (uu___507_4145.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     (uu___507_4133.FStar_TypeChecker_Env.try_solve_implicits_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___507_4145.FStar_TypeChecker_Env.splice);
+                     (uu___507_4133.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.mpreprocess =
-                     (uu___507_4145.FStar_TypeChecker_Env.mpreprocess);
+                     (uu___507_4133.FStar_TypeChecker_Env.mpreprocess);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___507_4145.FStar_TypeChecker_Env.postprocess);
+                     (uu___507_4133.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___507_4145.FStar_TypeChecker_Env.identifier_info);
+                     (uu___507_4133.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___507_4145.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___507_4133.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___507_4145.FStar_TypeChecker_Env.dsenv);
+                     (uu___507_4133.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___507_4145.FStar_TypeChecker_Env.nbe);
+                     (uu___507_4133.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___507_4145.FStar_TypeChecker_Env.strict_args_tab);
+                     (uu___507_4133.FStar_TypeChecker_Env.strict_args_tab);
                    FStar_TypeChecker_Env.erasable_types_tab =
-                     (uu___507_4145.FStar_TypeChecker_Env.erasable_types_tab)
+                     (uu___507_4133.FStar_TypeChecker_Env.erasable_types_tab)
                  }) e)
           in
-       match uu____4123 with
+       match uu____4111 with
        | (r,ms) ->
-           ((let uu____4170 =
+           ((let uu____4158 =
                FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
-             if uu____4170
+             if uu____4158
              then
-               ((let uu____4174 =
-                   let uu____4176 = FStar_TypeChecker_Env.get_range env  in
-                   FStar_All.pipe_left FStar_Range.string_of_range uu____4176
+               ((let uu____4162 =
+                   let uu____4164 = FStar_TypeChecker_Env.get_range env  in
+                   FStar_All.pipe_left FStar_Range.string_of_range uu____4164
                     in
-                 let uu____4178 = FStar_Syntax_Print.term_to_string e  in
-                 let uu____4180 =
-                   let uu____4182 = FStar_Syntax_Subst.compress e  in
-                   FStar_Syntax_Print.tag_of_term uu____4182  in
-                 let uu____4183 = FStar_Util.string_of_int ms  in
+                 let uu____4166 = FStar_Syntax_Print.term_to_string e  in
+                 let uu____4168 =
+                   let uu____4170 = FStar_Syntax_Subst.compress e  in
+                   FStar_Syntax_Print.tag_of_term uu____4170  in
+                 let uu____4171 = FStar_Util.string_of_int ms  in
                  FStar_Util.print4 "(%s) } tc_term of %s (%s) took %sms\n"
-                   uu____4174 uu____4178 uu____4180 uu____4183);
-                (let uu____4186 = r  in
-                 match uu____4186 with
-                 | (e1,lc,uu____4195) ->
-                     let uu____4196 =
-                       let uu____4198 = FStar_TypeChecker_Env.get_range env
+                   uu____4162 uu____4166 uu____4168 uu____4171);
+                (let uu____4174 = r  in
+                 match uu____4174 with
+                 | (e1,lc,uu____4183) ->
+                     let uu____4184 =
+                       let uu____4186 = FStar_TypeChecker_Env.get_range env
                           in
                        FStar_All.pipe_left FStar_Range.string_of_range
-                         uu____4198
+                         uu____4186
                         in
-                     let uu____4200 = FStar_Syntax_Print.term_to_string e1
+                     let uu____4188 = FStar_Syntax_Print.term_to_string e1
                         in
-                     let uu____4202 =
+                     let uu____4190 =
                        FStar_TypeChecker_Common.lcomp_to_string lc  in
-                     let uu____4204 =
-                       let uu____4206 = FStar_Syntax_Subst.compress e1  in
-                       FStar_Syntax_Print.tag_of_term uu____4206  in
+                     let uu____4192 =
+                       let uu____4194 = FStar_Syntax_Subst.compress e1  in
+                       FStar_Syntax_Print.tag_of_term uu____4194  in
                      FStar_Util.print4 "(%s) Result is: (%s:%s) (%s)\n"
-                       uu____4196 uu____4200 uu____4202 uu____4204))
+                       uu____4184 uu____4188 uu____4190 uu____4192))
              else ());
             r))
 
@@ -1531,50 +1525,50 @@ and (tc_maybe_toplevel_term :
         else FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos
          in
       let top = FStar_Syntax_Subst.compress e  in
-      (let uu____4224 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium
+      (let uu____4212 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium
           in
-       if uu____4224
+       if uu____4212
        then
-         let uu____4227 =
-           let uu____4229 = FStar_TypeChecker_Env.get_range env1  in
-           FStar_All.pipe_left FStar_Range.string_of_range uu____4229  in
-         let uu____4231 = FStar_Syntax_Print.tag_of_term top  in
-         let uu____4233 = FStar_Syntax_Print.term_to_string top  in
-         FStar_Util.print3 "Typechecking %s (%s): %s\n" uu____4227 uu____4231
-           uu____4233
+         let uu____4215 =
+           let uu____4217 = FStar_TypeChecker_Env.get_range env1  in
+           FStar_All.pipe_left FStar_Range.string_of_range uu____4217  in
+         let uu____4219 = FStar_Syntax_Print.tag_of_term top  in
+         let uu____4221 = FStar_Syntax_Print.term_to_string top  in
+         FStar_Util.print3 "Typechecking %s (%s): %s\n" uu____4215 uu____4219
+           uu____4221
        else ());
       (match top.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu____4244 -> failwith "Impossible"
-       | FStar_Syntax_Syntax.Tm_uinst uu____4266 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_uvar uu____4273 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_bvar uu____4286 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_name uu____4287 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_fvar uu____4288 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_constant uu____4289 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_abs uu____4290 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_arrow uu____4309 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_refine uu____4324 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_type uu____4331 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_delayed uu____4232 -> failwith "Impossible"
+       | FStar_Syntax_Syntax.Tm_uinst uu____4254 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_uvar uu____4261 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_bvar uu____4274 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_name uu____4275 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_fvar uu____4276 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_constant uu____4277 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_abs uu____4278 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_arrow uu____4297 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_refine uu____4312 -> tc_value env1 e
+       | FStar_Syntax_Syntax.Tm_type uu____4319 -> tc_value env1 e
        | FStar_Syntax_Syntax.Tm_unknown  -> tc_value env1 e
        | FStar_Syntax_Syntax.Tm_quoted (qt,qi) ->
-           let projl uu___2_4347 =
-             match uu___2_4347 with
+           let projl uu___2_4335 =
+             match uu___2_4335 with
              | FStar_Util.Inl x -> x
-             | FStar_Util.Inr uu____4353 -> failwith "projl fail"  in
+             | FStar_Util.Inr uu____4341 -> failwith "projl fail"  in
            let non_trivial_antiquotes qi1 =
              let is_name t =
-               let uu____4369 =
-                 let uu____4370 = FStar_Syntax_Subst.compress t  in
-                 uu____4370.FStar_Syntax_Syntax.n  in
-               match uu____4369 with
-               | FStar_Syntax_Syntax.Tm_name uu____4374 -> true
-               | uu____4376 -> false  in
+               let uu____4357 =
+                 let uu____4358 = FStar_Syntax_Subst.compress t  in
+                 uu____4358.FStar_Syntax_Syntax.n  in
+               match uu____4357 with
+               | FStar_Syntax_Syntax.Tm_name uu____4362 -> true
+               | uu____4364 -> false  in
              FStar_Util.for_some
-               (fun uu____4386  ->
-                  match uu____4386 with
-                  | (uu____4392,t) ->
-                      let uu____4394 = is_name t  in
-                      Prims.op_Negation uu____4394)
+               (fun uu____4374  ->
+                  match uu____4374 with
+                  | (uu____4380,t) ->
+                      let uu____4382 = is_name t  in
+                      Prims.op_Negation uu____4382)
                qi1.FStar_Syntax_Syntax.antiquotes
               in
            (match qi.FStar_Syntax_Syntax.qkind with
@@ -1583,7 +1577,7 @@ and (tc_maybe_toplevel_term :
                 let e0 = e  in
                 let newbvs =
                   FStar_List.map
-                    (fun uu____4413  ->
+                    (fun uu____4401  ->
                        FStar_Syntax_Syntax.new_bv
                          FStar_Pervasives_Native.None
                          FStar_Syntax_Syntax.t_term)
@@ -1593,8 +1587,8 @@ and (tc_maybe_toplevel_term :
                   FStar_List.zip qi.FStar_Syntax_Syntax.antiquotes newbvs  in
                 let lbs =
                   FStar_List.map
-                    (fun uu____4456  ->
-                       match uu____4456 with
+                    (fun uu____4444  ->
+                       match uu____4444 with
                        | ((bv,t),bv') ->
                            FStar_Syntax_Util.close_univs_and_mk_letbinding
                              FStar_Pervasives_Native.None
@@ -1604,47 +1598,44 @@ and (tc_maybe_toplevel_term :
                              t.FStar_Syntax_Syntax.pos) z
                    in
                 let qi1 =
-                  let uu___580_4485 = qi  in
-                  let uu____4486 =
+                  let uu___580_4473 = qi  in
+                  let uu____4474 =
                     FStar_List.map
-                      (fun uu____4514  ->
-                         match uu____4514 with
-                         | ((bv,uu____4530),bv') ->
-                             let uu____4542 =
+                      (fun uu____4502  ->
+                         match uu____4502 with
+                         | ((bv,uu____4518),bv') ->
+                             let uu____4530 =
                                FStar_Syntax_Syntax.bv_to_name bv'  in
-                             (bv, uu____4542)) z
+                             (bv, uu____4530)) z
                      in
                   {
                     FStar_Syntax_Syntax.qkind =
-                      (uu___580_4485.FStar_Syntax_Syntax.qkind);
-                    FStar_Syntax_Syntax.antiquotes = uu____4486
+                      (uu___580_4473.FStar_Syntax_Syntax.qkind);
+                    FStar_Syntax_Syntax.antiquotes = uu____4474
                   }  in
                 let nq =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+                    top.FStar_Syntax_Syntax.pos
                    in
                 let e1 =
                   FStar_List.fold_left
                     (fun t  ->
                        fun lb  ->
-                         let uu____4554 =
-                           let uu____4561 =
-                             let uu____4562 =
-                               let uu____4576 =
-                                 let uu____4579 =
-                                   let uu____4580 =
-                                     let uu____4587 =
-                                       projl lb.FStar_Syntax_Syntax.lbname
-                                        in
-                                     FStar_Syntax_Syntax.mk_binder uu____4587
-                                      in
-                                   [uu____4580]  in
-                                 FStar_Syntax_Subst.close uu____4579 t  in
-                               ((false, [lb]), uu____4576)  in
-                             FStar_Syntax_Syntax.Tm_let uu____4562  in
-                           FStar_Syntax_Syntax.mk uu____4561  in
-                         uu____4554 FStar_Pervasives_Native.None
+                         let uu____4542 =
+                           let uu____4543 =
+                             let uu____4557 =
+                               let uu____4560 =
+                                 let uu____4561 =
+                                   let uu____4568 =
+                                     projl lb.FStar_Syntax_Syntax.lbname  in
+                                   FStar_Syntax_Syntax.mk_binder uu____4568
+                                    in
+                                 [uu____4561]  in
+                               FStar_Syntax_Subst.close uu____4560 t  in
+                             ((false, [lb]), uu____4557)  in
+                           FStar_Syntax_Syntax.Tm_let uu____4543  in
+                         FStar_Syntax_Syntax.mk uu____4542
                            top.FStar_Syntax_Syntax.pos) nq lbs
                    in
                 tc_maybe_toplevel_term env1 e1
@@ -1654,35 +1645,34 @@ and (tc_maybe_toplevel_term :
                   FStar_TypeChecker_Env.set_expected_typ env1
                     FStar_Syntax_Syntax.t_term
                    in
-                let uu____4623 =
+                let uu____4604 =
                   FStar_List.fold_right
-                    (fun uu____4659  ->
-                       fun uu____4660  ->
-                         match (uu____4659, uu____4660) with
+                    (fun uu____4640  ->
+                       fun uu____4641  ->
+                         match (uu____4640, uu____4641) with
                          | ((bv,tm),(aqs_rev,guard)) ->
-                             let uu____4729 = tc_term env_tm tm  in
-                             (match uu____4729 with
-                              | (tm1,uu____4747,g) ->
-                                  let uu____4749 =
+                             let uu____4710 = tc_term env_tm tm  in
+                             (match uu____4710 with
+                              | (tm1,uu____4728,g) ->
+                                  let uu____4730 =
                                     FStar_TypeChecker_Env.conj_guard g guard
                                      in
-                                  (((bv, tm1) :: aqs_rev), uu____4749))) aqs
+                                  (((bv, tm1) :: aqs_rev), uu____4730))) aqs
                     ([], FStar_TypeChecker_Env.trivial_guard)
                    in
-                (match uu____4623 with
+                (match uu____4604 with
                  | (aqs_rev,guard) ->
                      let qi1 =
-                       let uu___608_4791 = qi  in
+                       let uu___608_4772 = qi  in
                        {
                          FStar_Syntax_Syntax.qkind =
-                           (uu___608_4791.FStar_Syntax_Syntax.qkind);
+                           (uu___608_4772.FStar_Syntax_Syntax.qkind);
                          FStar_Syntax_Syntax.antiquotes =
                            (FStar_List.rev aqs_rev)
                        }  in
                      let tm =
                        FStar_Syntax_Syntax.mk
                          (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
-                         FStar_Pervasives_Native.None
                          top.FStar_Syntax_Syntax.pos
                         in
                      value_check_expected_typ env1 tm
@@ -1690,124 +1680,123 @@ and (tc_maybe_toplevel_term :
             | FStar_Syntax_Syntax.Quote_dynamic  ->
                 let c = FStar_Syntax_Syntax.mk_Tac FStar_Syntax_Syntax.t_term
                    in
-                let uu____4802 =
+                let uu____4783 =
                   FStar_TypeChecker_Env.clear_expected_typ env1  in
-                (match uu____4802 with
-                 | (env',uu____4816) ->
-                     let uu____4821 =
+                (match uu____4783 with
+                 | (env',uu____4797) ->
+                     let uu____4802 =
                        tc_term
-                         (let uu___617_4830 = env'  in
+                         (let uu___617_4811 = env'  in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___617_4830.FStar_TypeChecker_Env.solver);
+                              (uu___617_4811.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___617_4830.FStar_TypeChecker_Env.range);
+                              (uu___617_4811.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___617_4830.FStar_TypeChecker_Env.curmodule);
+                              (uu___617_4811.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___617_4830.FStar_TypeChecker_Env.gamma);
+                              (uu___617_4811.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___617_4830.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___617_4811.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___617_4830.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___617_4811.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___617_4830.FStar_TypeChecker_Env.modules);
+                              (uu___617_4811.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___617_4830.FStar_TypeChecker_Env.expected_typ);
+                              (uu___617_4811.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___617_4830.FStar_TypeChecker_Env.sigtab);
+                              (uu___617_4811.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___617_4830.FStar_TypeChecker_Env.attrtab);
+                              (uu___617_4811.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___617_4830.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___617_4811.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___617_4830.FStar_TypeChecker_Env.effects);
+                              (uu___617_4811.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___617_4830.FStar_TypeChecker_Env.generalize);
+                              (uu___617_4811.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___617_4830.FStar_TypeChecker_Env.letrecs);
+                              (uu___617_4811.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___617_4830.FStar_TypeChecker_Env.top_level);
+                              (uu___617_4811.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___617_4830.FStar_TypeChecker_Env.check_uvars);
+                              (uu___617_4811.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___617_4830.FStar_TypeChecker_Env.use_eq);
+                              (uu___617_4811.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___617_4830.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___617_4811.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___617_4830.FStar_TypeChecker_Env.is_iface);
+                              (uu___617_4811.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___617_4830.FStar_TypeChecker_Env.admit);
+                              (uu___617_4811.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___617_4830.FStar_TypeChecker_Env.lax_universes);
+                              (uu___617_4811.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =
-                              (uu___617_4830.FStar_TypeChecker_Env.phase1);
+                              (uu___617_4811.FStar_TypeChecker_Env.phase1);
                             FStar_TypeChecker_Env.failhard =
-                              (uu___617_4830.FStar_TypeChecker_Env.failhard);
+                              (uu___617_4811.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___617_4830.FStar_TypeChecker_Env.nosynth);
+                              (uu___617_4811.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___617_4830.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___617_4811.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___617_4830.FStar_TypeChecker_Env.tc_term);
+                              (uu___617_4811.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___617_4830.FStar_TypeChecker_Env.type_of);
+                              (uu___617_4811.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___617_4830.FStar_TypeChecker_Env.universe_of);
+                              (uu___617_4811.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___617_4830.FStar_TypeChecker_Env.check_type_of);
+                              (uu___617_4811.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___617_4830.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___617_4811.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___617_4830.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___617_4811.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___617_4830.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___617_4811.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___617_4830.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___617_4811.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___617_4830.FStar_TypeChecker_Env.proof_ns);
+                              (uu___617_4811.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___617_4830.FStar_TypeChecker_Env.synth_hook);
+                              (uu___617_4811.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___617_4830.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___617_4811.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___617_4830.FStar_TypeChecker_Env.splice);
+                              (uu___617_4811.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___617_4830.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___617_4811.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___617_4830.FStar_TypeChecker_Env.postprocess);
+                              (uu___617_4811.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___617_4830.FStar_TypeChecker_Env.identifier_info);
+                              (uu___617_4811.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___617_4830.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___617_4811.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___617_4830.FStar_TypeChecker_Env.dsenv);
+                              (uu___617_4811.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___617_4830.FStar_TypeChecker_Env.nbe);
+                              (uu___617_4811.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___617_4830.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___617_4811.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___617_4830.FStar_TypeChecker_Env.erasable_types_tab)
+                              (uu___617_4811.FStar_TypeChecker_Env.erasable_types_tab)
                           }) qt
                         in
-                     (match uu____4821 with
-                      | (qt1,uu____4839,uu____4840) ->
+                     (match uu____4802 with
+                      | (qt1,uu____4820,uu____4821) ->
                           let t =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_quoted (qt1, qi))
-                              FStar_Pervasives_Native.None
                               top.FStar_Syntax_Syntax.pos
                              in
-                          let uu____4846 =
-                            let uu____4853 =
-                              let uu____4858 =
+                          let uu____4827 =
+                            let uu____4834 =
+                              let uu____4839 =
                                 FStar_TypeChecker_Common.lcomp_of_comp c  in
-                              FStar_Util.Inr uu____4858  in
-                            value_check_expected_typ env1 top uu____4853
+                              FStar_Util.Inr uu____4839  in
+                            value_check_expected_typ env1 top uu____4834
                               FStar_TypeChecker_Env.trivial_guard
                              in
-                          (match uu____4846 with
+                          (match uu____4827 with
                            | (t1,lc,g) ->
                                let t2 =
                                  FStar_Syntax_Syntax.mk
@@ -1817,19 +1806,18 @@ and (tc_maybe_toplevel_term :
                                            (FStar_Parser_Const.effect_PURE_lid,
                                              FStar_Parser_Const.effect_TAC_lid,
                                              FStar_Syntax_Syntax.t_term))))
-                                   FStar_Pervasives_Native.None
                                    t1.FStar_Syntax_Syntax.pos
                                   in
                                (t2, lc, g)))))
        | FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____4875;
+           { FStar_Syntax_Syntax.blob = uu____4856;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____4876;
-             FStar_Syntax_Syntax.ltyp = uu____4877;
-             FStar_Syntax_Syntax.rng = uu____4878;_}
+               uu____4857;
+             FStar_Syntax_Syntax.ltyp = uu____4858;
+             FStar_Syntax_Syntax.rng = uu____4859;_}
            ->
-           let uu____4889 = FStar_Syntax_Util.unlazy top  in
-           tc_term env1 uu____4889
+           let uu____4870 = FStar_Syntax_Util.unlazy top  in
+           tc_term env1 uu____4870
        | FStar_Syntax_Syntax.Tm_lazy i ->
            value_check_expected_typ env1 top
              (FStar_Util.Inl (i.FStar_Syntax_Syntax.ltyp))
@@ -1838,96 +1826,95 @@ and (tc_maybe_toplevel_term :
            (e1,FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Meta_smt_pat ))
            ->
-           let uu____4896 = tc_tot_or_gtot_term env1 e1  in
-           (match uu____4896 with
+           let uu____4877 = tc_tot_or_gtot_term env1 e1  in
+           (match uu____4877 with
             | (e2,c,g) ->
                 let g1 =
-                  let uu___647_4913 = g  in
+                  let uu___647_4894 = g  in
                   {
                     FStar_TypeChecker_Common.guard_f =
                       FStar_TypeChecker_Common.Trivial;
                     FStar_TypeChecker_Common.deferred =
-                      (uu___647_4913.FStar_TypeChecker_Common.deferred);
+                      (uu___647_4894.FStar_TypeChecker_Common.deferred);
                     FStar_TypeChecker_Common.univ_ineqs =
-                      (uu___647_4913.FStar_TypeChecker_Common.univ_ineqs);
+                      (uu___647_4894.FStar_TypeChecker_Common.univ_ineqs);
                     FStar_TypeChecker_Common.implicits =
-                      (uu___647_4913.FStar_TypeChecker_Common.implicits)
+                      (uu___647_4894.FStar_TypeChecker_Common.implicits)
                   }  in
-                let uu____4914 =
+                let uu____4895 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_meta
                        (e2,
                          (FStar_Syntax_Syntax.Meta_desugared
                             FStar_Syntax_Syntax.Meta_smt_pat)))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+                    top.FStar_Syntax_Syntax.pos
                    in
-                (uu____4914, c, g1))
+                (uu____4895, c, g1))
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_pattern (names,pats)) ->
-           let uu____4956 = FStar_Syntax_Util.type_u ()  in
-           (match uu____4956 with
+           let uu____4937 = FStar_Syntax_Util.type_u ()  in
+           (match uu____4937 with
             | (t,u) ->
-                let uu____4969 = tc_check_tot_or_gtot_term env1 e1 t ""  in
-                (match uu____4969 with
+                let uu____4950 = tc_check_tot_or_gtot_term env1 e1 t ""  in
+                (match uu____4950 with
                  | (e2,c,g) ->
-                     let uu____4986 =
-                       let uu____5003 =
+                     let uu____4967 =
+                       let uu____4984 =
                          FStar_TypeChecker_Env.clear_expected_typ env1  in
-                       match uu____5003 with
-                       | (env2,uu____5027) -> tc_smt_pats env2 pats  in
-                     (match uu____4986 with
+                       match uu____4984 with
+                       | (env2,uu____5008) -> tc_smt_pats env2 pats  in
+                     (match uu____4967 with
                       | (pats1,g') ->
                           let g'1 =
-                            let uu___670_5065 = g'  in
+                            let uu___670_5046 = g'  in
                             {
                               FStar_TypeChecker_Common.guard_f =
                                 FStar_TypeChecker_Common.Trivial;
                               FStar_TypeChecker_Common.deferred =
-                                (uu___670_5065.FStar_TypeChecker_Common.deferred);
+                                (uu___670_5046.FStar_TypeChecker_Common.deferred);
                               FStar_TypeChecker_Common.univ_ineqs =
-                                (uu___670_5065.FStar_TypeChecker_Common.univ_ineqs);
+                                (uu___670_5046.FStar_TypeChecker_Common.univ_ineqs);
                               FStar_TypeChecker_Common.implicits =
-                                (uu___670_5065.FStar_TypeChecker_Common.implicits)
+                                (uu___670_5046.FStar_TypeChecker_Common.implicits)
                             }  in
-                          let uu____5066 =
+                          let uu____5047 =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_meta
                                  (e2,
                                    (FStar_Syntax_Syntax.Meta_pattern
                                       (names, pats1))))
-                              FStar_Pervasives_Native.None
                               top.FStar_Syntax_Syntax.pos
                              in
-                          let uu____5085 =
+                          let uu____5066 =
                             FStar_TypeChecker_Env.conj_guard g g'1  in
-                          (uu____5066, c, uu____5085))))
+                          (uu____5047, c, uu____5066))))
        | FStar_Syntax_Syntax.Tm_meta
            (e1,FStar_Syntax_Syntax.Meta_desugared
             (FStar_Syntax_Syntax.Sequence ))
            ->
-           let uu____5091 =
-             let uu____5092 = FStar_Syntax_Subst.compress e1  in
-             uu____5092.FStar_Syntax_Syntax.n  in
-           (match uu____5091 with
+           let uu____5072 =
+             let uu____5073 = FStar_Syntax_Subst.compress e1  in
+             uu____5073.FStar_Syntax_Syntax.n  in
+           (match uu____5072 with
             | FStar_Syntax_Syntax.Tm_let
-                ((uu____5101,{ FStar_Syntax_Syntax.lbname = x;
-                               FStar_Syntax_Syntax.lbunivs = uu____5103;
-                               FStar_Syntax_Syntax.lbtyp = uu____5104;
-                               FStar_Syntax_Syntax.lbeff = uu____5105;
+                ((uu____5082,{ FStar_Syntax_Syntax.lbname = x;
+                               FStar_Syntax_Syntax.lbunivs = uu____5084;
+                               FStar_Syntax_Syntax.lbtyp = uu____5085;
+                               FStar_Syntax_Syntax.lbeff = uu____5086;
                                FStar_Syntax_Syntax.lbdef = e11;
-                               FStar_Syntax_Syntax.lbattrs = uu____5107;
-                               FStar_Syntax_Syntax.lbpos = uu____5108;_}::[]),e2)
+                               FStar_Syntax_Syntax.lbattrs = uu____5088;
+                               FStar_Syntax_Syntax.lbpos = uu____5089;_}::[]),e2)
                 ->
-                let uu____5139 =
-                  let uu____5146 =
+                let uu____5120 =
+                  let uu____5127 =
                     FStar_TypeChecker_Env.set_expected_typ env1
                       FStar_Syntax_Syntax.t_unit
                      in
-                  tc_term uu____5146 e11  in
-                (match uu____5139 with
+                  tc_term uu____5127 e11  in
+                (match uu____5120 with
                  | (e12,c1,g1) ->
-                     let uu____5156 = tc_term env1 e2  in
-                     (match uu____5156 with
+                     let uu____5137 = tc_term env1 e2  in
+                     (match uu____5137 with
                       | (e21,c2,g2) ->
                           let c =
                             FStar_TypeChecker_Util.maybe_return_e2_and_bind
@@ -1948,33 +1935,31 @@ and (tc_maybe_toplevel_term :
                               c2.FStar_TypeChecker_Common.res_typ
                              in
                           let attrs =
-                            let uu____5180 =
+                            let uu____5161 =
                               FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                 env1 c1.FStar_TypeChecker_Common.eff_name
                                in
-                            if uu____5180
+                            if uu____5161
                             then [FStar_Syntax_Util.inline_let_attr]
                             else []  in
                           let e3 =
-                            let uu____5190 =
-                              let uu____5197 =
-                                let uu____5198 =
-                                  let uu____5212 =
-                                    let uu____5220 =
-                                      let uu____5223 =
-                                        FStar_Syntax_Syntax.mk_lb
-                                          (x, [],
-                                            (c1.FStar_TypeChecker_Common.eff_name),
-                                            FStar_Syntax_Syntax.t_unit, e13,
-                                            attrs,
-                                            (e13.FStar_Syntax_Syntax.pos))
-                                         in
-                                      [uu____5223]  in
-                                    (false, uu____5220)  in
-                                  (uu____5212, e22)  in
-                                FStar_Syntax_Syntax.Tm_let uu____5198  in
-                              FStar_Syntax_Syntax.mk uu____5197  in
-                            uu____5190 FStar_Pervasives_Native.None
+                            let uu____5171 =
+                              let uu____5172 =
+                                let uu____5186 =
+                                  let uu____5194 =
+                                    let uu____5197 =
+                                      FStar_Syntax_Syntax.mk_lb
+                                        (x, [],
+                                          (c1.FStar_TypeChecker_Common.eff_name),
+                                          FStar_Syntax_Syntax.t_unit, e13,
+                                          attrs,
+                                          (e13.FStar_Syntax_Syntax.pos))
+                                       in
+                                    [uu____5197]  in
+                                  (false, uu____5194)  in
+                                (uu____5186, e22)  in
+                              FStar_Syntax_Syntax.Tm_let uu____5172  in
+                            FStar_Syntax_Syntax.mk uu____5171
                               e1.FStar_Syntax_Syntax.pos
                              in
                           let e4 =
@@ -1988,15 +1973,14 @@ and (tc_maybe_toplevel_term :
                                  (e4,
                                    (FStar_Syntax_Syntax.Meta_desugared
                                       FStar_Syntax_Syntax.Sequence)))
-                              FStar_Pervasives_Native.None
                               top.FStar_Syntax_Syntax.pos
                              in
-                          let uu____5247 =
+                          let uu____5221 =
                             FStar_TypeChecker_Env.conj_guard g1 g2  in
-                          (e5, c, uu____5247)))
-            | uu____5248 ->
-                let uu____5249 = tc_term env1 e1  in
-                (match uu____5249 with
+                          (e5, c, uu____5221)))
+            | uu____5222 ->
+                let uu____5223 = tc_term env1 e1  in
+                (match uu____5223 with
                  | (e2,c,g) ->
                      let e3 =
                        FStar_Syntax_Syntax.mk
@@ -2004,94 +1988,93 @@ and (tc_maybe_toplevel_term :
                             (e2,
                               (FStar_Syntax_Syntax.Meta_desugared
                                  FStar_Syntax_Syntax.Sequence)))
-                         FStar_Pervasives_Native.None
                          top.FStar_Syntax_Syntax.pos
                         in
                      (e3, c, g)))
        | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_monadic uu____5271) ->
+           (e1,FStar_Syntax_Syntax.Meta_monadic uu____5245) ->
            tc_term env1 e1
        | FStar_Syntax_Syntax.Tm_meta
-           (e1,FStar_Syntax_Syntax.Meta_monadic_lift uu____5283) ->
+           (e1,FStar_Syntax_Syntax.Meta_monadic_lift uu____5257) ->
            tc_term env1 e1
        | FStar_Syntax_Syntax.Tm_meta (e1,m) ->
-           let uu____5302 = tc_term env1 e1  in
-           (match uu____5302 with
+           let uu____5276 = tc_term env1 e1  in
+           (match uu____5276 with
             | (e2,c,g) ->
                 let e3 =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_meta (e2, m))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+                    top.FStar_Syntax_Syntax.pos
                    in
                 (e3, c, g))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (uu____5323,(FStar_Util.Inr expected_c,_tacopt),uu____5326) when
-           let uu____5373 = FStar_All.pipe_right top is_comp_ascribed_reflect
+           (uu____5297,(FStar_Util.Inr expected_c,_tacopt),uu____5300) when
+           let uu____5347 = FStar_All.pipe_right top is_comp_ascribed_reflect
               in
-           FStar_All.pipe_right uu____5373 FStar_Util.is_some ->
-           let uu____5405 =
-             let uu____5416 =
+           FStar_All.pipe_right uu____5347 FStar_Util.is_some ->
+           let uu____5379 =
+             let uu____5390 =
                FStar_All.pipe_right top is_comp_ascribed_reflect  in
-             FStar_All.pipe_right uu____5416 FStar_Util.must  in
-           (match uu____5405 with
+             FStar_All.pipe_right uu____5390 FStar_Util.must  in
+           (match uu____5379 with
             | (effect_lid,e1,aqual) ->
-                let uu____5490 =
+                let uu____5464 =
                   FStar_TypeChecker_Env.clear_expected_typ env1  in
-                (match uu____5490 with
-                 | (env0,uu____5504) ->
-                     let uu____5509 = tc_comp env0 expected_c  in
-                     (match uu____5509 with
-                      | (expected_c1,uu____5523,g_c) ->
+                (match uu____5464 with
+                 | (env0,uu____5478) ->
+                     let uu____5483 = tc_comp env0 expected_c  in
+                     (match uu____5483 with
+                      | (expected_c1,uu____5497,g_c) ->
                           let expected_ct =
                             FStar_TypeChecker_Env.unfold_effect_abbrev env0
                               expected_c1
                              in
-                          ((let uu____5527 =
-                              let uu____5529 =
+                          ((let uu____5501 =
+                              let uu____5503 =
                                 FStar_Ident.lid_equals effect_lid
                                   expected_ct.FStar_Syntax_Syntax.effect_name
                                  in
-                              Prims.op_Negation uu____5529  in
-                            if uu____5527
+                              Prims.op_Negation uu____5503  in
+                            if uu____5501
                             then
-                              let uu____5532 =
-                                let uu____5538 =
-                                  let uu____5540 =
+                              let uu____5506 =
+                                let uu____5512 =
+                                  let uu____5514 =
                                     FStar_Ident.string_of_lid effect_lid  in
-                                  let uu____5542 =
+                                  let uu____5516 =
                                     FStar_Ident.string_of_lid
                                       expected_ct.FStar_Syntax_Syntax.effect_name
                                      in
                                   FStar_Util.format2
                                     "The effect on reflect %s does not match with the annotation %s\n"
-                                    uu____5540 uu____5542
+                                    uu____5514 uu____5516
                                    in
                                 (FStar_Errors.Fatal_UnexpectedEffect,
-                                  uu____5538)
+                                  uu____5512)
                                  in
-                              FStar_Errors.raise_error uu____5532
+                              FStar_Errors.raise_error uu____5506
                                 top.FStar_Syntax_Syntax.pos
                             else ());
-                           (let uu____5549 =
-                              let uu____5551 =
+                           (let uu____5523 =
+                              let uu____5525 =
                                 FStar_TypeChecker_Env.is_user_reflectable_effect
                                   env1 effect_lid
                                  in
-                              Prims.op_Negation uu____5551  in
-                            if uu____5549
+                              Prims.op_Negation uu____5525  in
+                            if uu____5523
                             then
-                              let uu____5554 =
-                                let uu____5560 =
-                                  let uu____5562 =
+                              let uu____5528 =
+                                let uu____5534 =
+                                  let uu____5536 =
                                     FStar_Ident.string_of_lid effect_lid  in
                                   FStar_Util.format1
                                     "Effect %s cannot be reflected"
-                                    uu____5562
+                                    uu____5536
                                    in
                                 (FStar_Errors.Fatal_EffectCannotBeReified,
-                                  uu____5560)
+                                  uu____5534)
                                  in
-                              FStar_Errors.raise_error uu____5554
+                              FStar_Errors.raise_error uu____5528
                                 top.FStar_Syntax_Syntax.pos
                             else ());
                            (let u_c =
@@ -2100,73 +2083,71 @@ and (tc_maybe_toplevel_term :
                                 FStar_List.hd
                                in
                             let repr =
-                              let uu____5572 =
-                                let uu____5575 =
+                              let uu____5546 =
+                                let uu____5549 =
                                   FStar_All.pipe_right expected_ct
                                     FStar_Syntax_Syntax.mk_Comp
                                    in
                                 FStar_TypeChecker_Env.effect_repr env0
-                                  uu____5575 u_c
+                                  uu____5549 u_c
                                  in
-                              FStar_All.pipe_right uu____5572 FStar_Util.must
+                              FStar_All.pipe_right uu____5546 FStar_Util.must
                                in
                             let e2 =
-                              let uu____5581 =
-                                let uu____5588 =
-                                  let uu____5589 =
-                                    let uu____5616 =
-                                      let uu____5633 =
-                                        let uu____5642 =
-                                          FStar_Syntax_Syntax.mk_Total' repr
-                                            (FStar_Pervasives_Native.Some u_c)
-                                           in
-                                        FStar_Util.Inr uu____5642  in
-                                      (uu____5633,
-                                        FStar_Pervasives_Native.None)
-                                       in
-                                    (e1, uu____5616,
+                              let uu____5555 =
+                                let uu____5556 =
+                                  let uu____5583 =
+                                    let uu____5600 =
+                                      let uu____5609 =
+                                        FStar_Syntax_Syntax.mk_Total' repr
+                                          (FStar_Pervasives_Native.Some u_c)
+                                         in
+                                      FStar_Util.Inr uu____5609  in
+                                    (uu____5600,
                                       FStar_Pervasives_Native.None)
                                      in
-                                  FStar_Syntax_Syntax.Tm_ascribed uu____5589
+                                  (e1, uu____5583,
+                                    FStar_Pervasives_Native.None)
                                    in
-                                FStar_Syntax_Syntax.mk uu____5588  in
-                              uu____5581 FStar_Pervasives_Native.None
+                                FStar_Syntax_Syntax.Tm_ascribed uu____5556
+                                 in
+                              FStar_Syntax_Syntax.mk uu____5555
                                 e1.FStar_Syntax_Syntax.pos
                                in
-                            (let uu____5684 =
+                            (let uu____5651 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env0)
                                  FStar_Options.Extreme
                                 in
-                             if uu____5684
+                             if uu____5651
                              then
-                               let uu____5688 =
+                               let uu____5655 =
                                  FStar_Syntax_Print.term_to_string e2  in
                                FStar_Util.print1
                                  "Typechecking ascribed reflect, inner ascribed term: %s\n"
-                                 uu____5688
+                                 uu____5655
                              else ());
-                            (let uu____5693 = tc_tot_or_gtot_term env0 e2  in
-                             match uu____5693 with
-                             | (e3,uu____5707,g_e) ->
+                            (let uu____5660 = tc_tot_or_gtot_term env0 e2  in
+                             match uu____5660 with
+                             | (e3,uu____5674,g_e) ->
                                  let e4 = FStar_Syntax_Util.unascribe e3  in
-                                 ((let uu____5711 =
+                                 ((let uu____5678 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env0)
                                        FStar_Options.Extreme
                                       in
-                                   if uu____5711
+                                   if uu____5678
                                    then
-                                     let uu____5715 =
+                                     let uu____5682 =
                                        FStar_Syntax_Print.term_to_string e4
                                         in
-                                     let uu____5717 =
+                                     let uu____5684 =
                                        FStar_TypeChecker_Rel.guard_to_string
                                          env0 g_e
                                         in
                                      FStar_Util.print2
                                        "Typechecking ascribed reflect, after typechecking inner ascribed term: %s and guard: %s\n"
-                                       uu____5715 uu____5717
+                                       uu____5682 uu____5684
                                    else ());
                                   (let top1 =
                                      let r = top.FStar_Syntax_Syntax.pos  in
@@ -2174,94 +2155,87 @@ and (tc_maybe_toplevel_term :
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_constant
                                             (FStar_Const.Const_reflect
-                                               effect_lid))
-                                         FStar_Pervasives_Native.None r
+                                               effect_lid)) r
                                         in
                                      let tm1 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_app
-                                            (tm, [(e4, aqual)]))
-                                         FStar_Pervasives_Native.None r
+                                            (tm, [(e4, aqual)])) r
                                         in
-                                     let uu____5764 =
-                                       let uu____5771 =
-                                         let uu____5772 =
-                                           let uu____5799 =
-                                             let uu____5802 =
-                                               FStar_All.pipe_right
-                                                 expected_c1
-                                                 FStar_Syntax_Util.comp_effect_name
-                                                in
-                                             FStar_All.pipe_right uu____5802
-                                               (fun uu____5807  ->
-                                                  FStar_Pervasives_Native.Some
-                                                    uu____5807)
+                                     let uu____5731 =
+                                       let uu____5732 =
+                                         let uu____5759 =
+                                           let uu____5762 =
+                                             FStar_All.pipe_right expected_c1
+                                               FStar_Syntax_Util.comp_effect_name
                                               in
-                                           (tm1,
-                                             ((FStar_Util.Inr expected_c1),
-                                               _tacopt), uu____5799)
+                                           FStar_All.pipe_right uu____5762
+                                             (fun uu____5767  ->
+                                                FStar_Pervasives_Native.Some
+                                                  uu____5767)
                                             in
-                                         FStar_Syntax_Syntax.Tm_ascribed
-                                           uu____5772
+                                         (tm1,
+                                           ((FStar_Util.Inr expected_c1),
+                                             _tacopt), uu____5759)
                                           in
-                                       FStar_Syntax_Syntax.mk uu____5771  in
-                                     uu____5764 FStar_Pervasives_Native.None
-                                       r
-                                      in
-                                   let uu____5844 =
-                                     let uu____5851 =
+                                       FStar_Syntax_Syntax.Tm_ascribed
+                                         uu____5732
+                                        in
+                                     FStar_Syntax_Syntax.mk uu____5731 r  in
+                                   let uu____5804 =
+                                     let uu____5811 =
                                        FStar_All.pipe_right expected_c1
                                          FStar_TypeChecker_Common.lcomp_of_comp
                                         in
                                      comp_check_expected_typ env1 top1
-                                       uu____5851
+                                       uu____5811
                                       in
-                                   match uu____5844 with
+                                   match uu____5804 with
                                    | (top2,c,g_env) ->
-                                       let uu____5861 =
+                                       let uu____5821 =
                                          FStar_TypeChecker_Env.conj_guards
                                            [g_c; g_e; g_env]
                                           in
-                                       (top2, c, uu____5861)))))))))
+                                       (top2, c, uu____5821)))))))))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,(FStar_Util.Inr expected_c,topt),uu____5865) ->
-           let uu____5912 = FStar_TypeChecker_Env.clear_expected_typ env1  in
-           (match uu____5912 with
-            | (env0,uu____5926) ->
-                let uu____5931 = tc_comp env0 expected_c  in
-                (match uu____5931 with
-                 | (expected_c1,uu____5945,g) ->
-                     let uu____5947 =
-                       let uu____5954 =
+           (e1,(FStar_Util.Inr expected_c,topt),uu____5825) ->
+           let uu____5872 = FStar_TypeChecker_Env.clear_expected_typ env1  in
+           (match uu____5872 with
+            | (env0,uu____5886) ->
+                let uu____5891 = tc_comp env0 expected_c  in
+                (match uu____5891 with
+                 | (expected_c1,uu____5905,g) ->
+                     let uu____5907 =
+                       let uu____5914 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.comp_result expected_c1)
                            (FStar_TypeChecker_Env.set_expected_typ env0)
                           in
-                       tc_term uu____5954 e1  in
-                     (match uu____5947 with
+                       tc_term uu____5914 e1  in
+                     (match uu____5907 with
                       | (e2,c',g') ->
-                          let uu____5964 =
-                            let uu____5975 =
+                          let uu____5924 =
+                            let uu____5935 =
                               FStar_TypeChecker_Common.lcomp_comp c'  in
-                            match uu____5975 with
+                            match uu____5935 with
                             | (c'1,g_c') ->
-                                let uu____5992 =
+                                let uu____5952 =
                                   check_expected_effect env0
                                     (FStar_Pervasives_Native.Some expected_c1)
                                     (e2, c'1)
                                    in
-                                (match uu____5992 with
+                                (match uu____5952 with
                                  | (e3,expected_c2,g'') ->
-                                     let uu____6012 =
+                                     let uu____5972 =
                                        FStar_TypeChecker_Env.conj_guard g_c'
                                          g''
                                         in
-                                     (e3, expected_c2, uu____6012))
+                                     (e3, expected_c2, uu____5972))
                              in
-                          (match uu____5964 with
+                          (match uu____5924 with
                            | (e3,expected_c2,g'') ->
-                               let uu____6034 = tc_tactic_opt env0 topt  in
-                               (match uu____6034 with
+                               let uu____5994 = tc_tactic_opt env0 topt  in
+                               (match uu____5994 with
                                 | (topt1,gtac) ->
                                     let e4 =
                                       FStar_Syntax_Syntax.mk
@@ -2272,7 +2246,6 @@ and (tc_maybe_toplevel_term :
                                              (FStar_Pervasives_Native.Some
                                                 (FStar_Syntax_Util.comp_effect_name
                                                    expected_c2))))
-                                        FStar_Pervasives_Native.None
                                         top.FStar_Syntax_Syntax.pos
                                        in
                                     let lc =
@@ -2280,280 +2253,285 @@ and (tc_maybe_toplevel_term :
                                         expected_c2
                                        in
                                     let f =
-                                      let uu____6094 =
+                                      let uu____6054 =
                                         FStar_TypeChecker_Env.conj_guard g'
                                           g''
                                          in
                                       FStar_TypeChecker_Env.conj_guard g
-                                        uu____6094
+                                        uu____6054
                                        in
-                                    let uu____6095 =
+                                    let uu____6055 =
                                       comp_check_expected_typ env1 e4 lc  in
-                                    (match uu____6095 with
+                                    (match uu____6055 with
                                      | (e5,c,f2) ->
                                          let final_guard =
-                                           let uu____6112 =
+                                           let uu____6072 =
                                              FStar_TypeChecker_Env.conj_guard
                                                f f2
                                               in
                                            wrap_guard_with_tactic_opt topt1
-                                             uu____6112
+                                             uu____6072
                                             in
-                                         let uu____6113 =
+                                         let uu____6073 =
                                            FStar_TypeChecker_Env.conj_guard
                                              final_guard gtac
                                             in
-                                         (e5, c, uu____6113)))))))
+                                         (e5, c, uu____6073)))))))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,(FStar_Util.Inl t,topt),uu____6117) ->
-           let uu____6164 = FStar_Syntax_Util.type_u ()  in
-           (match uu____6164 with
+           (e1,(FStar_Util.Inl t,topt),uu____6077) ->
+           let uu____6124 = FStar_Syntax_Util.type_u ()  in
+           (match uu____6124 with
             | (k,u) ->
-                let uu____6177 = tc_check_tot_or_gtot_term env1 t k ""  in
-                (match uu____6177 with
-                 | (t1,uu____6192,f) ->
-                     let uu____6194 = tc_tactic_opt env1 topt  in
-                     (match uu____6194 with
+                let uu____6137 = tc_check_tot_or_gtot_term env1 t k ""  in
+                (match uu____6137 with
+                 | (t1,uu____6152,f) ->
+                     let uu____6154 = tc_tactic_opt env1 topt  in
+                     (match uu____6154 with
                       | (topt1,gtac) ->
-                          let uu____6213 =
-                            let uu____6220 =
+                          let uu____6173 =
+                            let uu____6180 =
                               FStar_TypeChecker_Env.set_expected_typ env1 t1
                                in
-                            tc_term uu____6220 e1  in
-                          (match uu____6213 with
+                            tc_term uu____6180 e1  in
+                          (match uu____6173 with
                            | (e2,c,g) ->
-                               let uu____6230 =
-                                 let uu____6235 =
+                               let uu____6190 =
+                                 let uu____6195 =
                                    FStar_TypeChecker_Env.set_range env1
                                      t1.FStar_Syntax_Syntax.pos
                                     in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    (FStar_Pervasives_Native.Some
-                                      (fun uu____6241  ->
+                                      (fun uu____6201  ->
                                          FStar_Util.return_all
                                            FStar_TypeChecker_Err.ill_kinded_type))
-                                   uu____6235 e2 c f
+                                   uu____6195 e2 c f
                                   in
-                               (match uu____6230 with
+                               (match uu____6190 with
                                 | (c1,f1) ->
-                                    let uu____6251 =
-                                      let uu____6258 =
+                                    let uu____6211 =
+                                      let uu____6218 =
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_ascribed
                                              (e2,
                                                ((FStar_Util.Inl t1), topt1),
                                                (FStar_Pervasives_Native.Some
                                                   (c1.FStar_TypeChecker_Common.eff_name))))
-                                          FStar_Pervasives_Native.None
                                           top.FStar_Syntax_Syntax.pos
                                          in
-                                      comp_check_expected_typ env1 uu____6258
+                                      comp_check_expected_typ env1 uu____6218
                                         c1
                                        in
-                                    (match uu____6251 with
+                                    (match uu____6211 with
                                      | (e3,c2,f2) ->
                                          let final_guard =
-                                           let uu____6305 =
+                                           let uu____6265 =
                                              FStar_TypeChecker_Env.conj_guard
                                                g f2
                                               in
                                            FStar_TypeChecker_Env.conj_guard
-                                             f1 uu____6305
+                                             f1 uu____6265
                                             in
                                          let final_guard1 =
                                            wrap_guard_with_tactic_opt topt1
                                              final_guard
                                             in
-                                         let uu____6307 =
+                                         let uu____6267 =
                                            FStar_TypeChecker_Env.conj_guard
                                              final_guard1 gtac
                                             in
-                                         (e3, c2, uu____6307)))))))
+                                         (e3, c2, uu____6267)))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____6308;
-              FStar_Syntax_Syntax.vars = uu____6309;_},a::hd::rest)
+              FStar_Syntax_Syntax.pos = uu____6268;
+              FStar_Syntax_Syntax.vars = uu____6269;_},a::hd::rest)
            ->
            let rest1 = hd :: rest  in
-           let uu____6388 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____6388 with
-            | (unary_op,uu____6412) ->
+           let uu____6348 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____6348 with
+            | (unary_op,uu____6372) ->
                 let head =
-                  let uu____6440 =
+                  let uu____6400 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                    FStar_Pervasives_Native.None uu____6440
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6400
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+                    top.FStar_Syntax_Syntax.pos
                    in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify );
-              FStar_Syntax_Syntax.pos = uu____6488;
-              FStar_Syntax_Syntax.vars = uu____6489;_},a::hd::rest)
+              FStar_Syntax_Syntax.pos = uu____6448;
+              FStar_Syntax_Syntax.vars = uu____6449;_},a::hd::rest)
            ->
            let rest1 = hd :: rest  in
-           let uu____6568 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____6568 with
-            | (unary_op,uu____6592) ->
+           let uu____6528 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____6528 with
+            | (unary_op,uu____6552) ->
                 let head =
-                  let uu____6620 =
+                  let uu____6580 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                    FStar_Pervasives_Native.None uu____6620
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6580
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+                    top.FStar_Syntax_Syntax.pos
                    in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____6668);
-              FStar_Syntax_Syntax.pos = uu____6669;
-              FStar_Syntax_Syntax.vars = uu____6670;_},a::hd::rest)
+                (FStar_Const.Const_reflect uu____6628);
+              FStar_Syntax_Syntax.pos = uu____6629;
+              FStar_Syntax_Syntax.vars = uu____6630;_},a::hd::rest)
            ->
            let rest1 = hd :: rest  in
-           let uu____6749 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____6749 with
-            | (unary_op,uu____6773) ->
+           let uu____6709 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____6709 with
+            | (unary_op,uu____6733) ->
                 let head =
-                  let uu____6801 =
+                  let uu____6761 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                    FStar_Pervasives_Native.None uu____6801
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6761
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+                    top.FStar_Syntax_Syntax.pos
                    in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____6849;
-              FStar_Syntax_Syntax.vars = uu____6850;_},a1::a2::hd::rest)
+              FStar_Syntax_Syntax.pos = uu____6809;
+              FStar_Syntax_Syntax.vars = uu____6810;_},a1::a2::hd::rest)
            ->
            let rest1 = hd :: rest  in
-           let uu____6946 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____6946 with
-            | (unary_op,uu____6970) ->
+           let uu____6906 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____6906 with
+            | (unary_op,uu____6930) ->
                 let head =
-                  let uu____6998 =
+                  let uu____6958 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos
                      in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                    FStar_Pervasives_Native.None uu____6998
+                    uu____6958
                    in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+                    top.FStar_Syntax_Syntax.pos
                    in
                 tc_term env1 t)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
-              FStar_Syntax_Syntax.pos = uu____7054;
-              FStar_Syntax_Syntax.vars = uu____7055;_},(e1,FStar_Pervasives_Native.None
+              FStar_Syntax_Syntax.pos = uu____7014;
+              FStar_Syntax_Syntax.vars = uu____7015;_},(e1,FStar_Pervasives_Native.None
                                                         )::[])
            ->
-           let uu____7093 =
-             let uu____7100 =
-               let uu____7101 = FStar_TypeChecker_Env.clear_expected_typ env1
+           let uu____7053 =
+             let uu____7060 =
+               let uu____7061 = FStar_TypeChecker_Env.clear_expected_typ env1
                   in
-               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7101  in
-             tc_term uu____7100 e1  in
-           (match uu____7093 with
+               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7061  in
+             tc_term uu____7060 e1  in
+           (match uu____7053 with
             | (e2,c,g) ->
-                let uu____7125 = FStar_Syntax_Util.head_and_args top  in
-                (match uu____7125 with
-                 | (head,uu____7149) ->
-                     let uu____7174 =
+                let uu____7085 = FStar_Syntax_Util.head_and_args top  in
+                (match uu____7085 with
+                 | (head,uu____7109) ->
+                     let uu____7134 =
                        FStar_Syntax_Syntax.mk
                          (FStar_Syntax_Syntax.Tm_app
                             (head, [(e2, FStar_Pervasives_Native.None)]))
-                         FStar_Pervasives_Native.None
                          top.FStar_Syntax_Syntax.pos
                         in
-                     let uu____7207 =
-                       let uu____7208 =
-                         let uu____7209 =
+                     let uu____7167 =
+                       let uu____7168 =
+                         let uu____7169 =
                            FStar_Syntax_Syntax.tabbrev
                              FStar_Parser_Const.range_lid
                             in
-                         FStar_Syntax_Syntax.mk_Total uu____7209  in
+                         FStar_Syntax_Syntax.mk_Total uu____7169  in
                        FStar_All.pipe_left
-                         FStar_TypeChecker_Common.lcomp_of_comp uu____7208
+                         FStar_TypeChecker_Common.lcomp_of_comp uu____7168
                         in
-                     (uu____7174, uu____7207, g)))
+                     (uu____7134, uu____7167, g)))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____7210;
-              FStar_Syntax_Syntax.vars = uu____7211;_},(t,FStar_Pervasives_Native.None
+              FStar_Syntax_Syntax.pos = uu____7170;
+              FStar_Syntax_Syntax.vars = uu____7171;_},(t,FStar_Pervasives_Native.None
                                                         )::(r,FStar_Pervasives_Native.None
                                                             )::[])
            ->
-           let uu____7264 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____7264 with
-            | (head,uu____7288) ->
+           let uu____7224 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____7224 with
+            | (head,uu____7248) ->
                 let env' =
-                  let uu____7314 =
+                  let uu____7274 =
                     FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid
                      in
-                  FStar_TypeChecker_Env.set_expected_typ env1 uu____7314  in
-                let uu____7315 = tc_term env' r  in
-                (match uu____7315 with
-                 | (er,uu____7329,gr) ->
-                     let uu____7331 = tc_term env1 t  in
-                     (match uu____7331 with
+                  FStar_TypeChecker_Env.set_expected_typ env1 uu____7274  in
+                let uu____7275 = tc_term env' r  in
+                (match uu____7275 with
+                 | (er,uu____7289,gr) ->
+                     let uu____7291 = tc_term env1 t  in
+                     (match uu____7291 with
                       | (t1,tt,gt) ->
                           let g = FStar_TypeChecker_Env.conj_guard gr gt  in
-                          let uu____7348 =
-                            let uu____7349 =
-                              let uu____7354 =
-                                let uu____7355 =
-                                  FStar_Syntax_Syntax.as_arg t1  in
-                                let uu____7364 =
-                                  let uu____7375 =
-                                    FStar_Syntax_Syntax.as_arg r  in
-                                  [uu____7375]  in
-                                uu____7355 :: uu____7364  in
-                              FStar_Syntax_Syntax.mk_Tm_app head uu____7354
-                               in
-                            uu____7349 FStar_Pervasives_Native.None
+                          let uu____7308 =
+                            let uu____7309 =
+                              let uu____7310 = FStar_Syntax_Syntax.as_arg t1
+                                 in
+                              let uu____7319 =
+                                let uu____7330 = FStar_Syntax_Syntax.as_arg r
+                                   in
+                                [uu____7330]  in
+                              uu____7310 :: uu____7319  in
+                            FStar_Syntax_Syntax.mk_Tm_app head uu____7309
                               top.FStar_Syntax_Syntax.pos
                              in
-                          (uu____7348, tt, g))))
+                          (uu____7308, tt, g))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of );
+              FStar_Syntax_Syntax.pos = uu____7363;
+              FStar_Syntax_Syntax.vars = uu____7364;_},uu____7365)
+           ->
+           let uu____7390 =
+             let uu____7396 =
+               let uu____7398 = FStar_Syntax_Print.term_to_string top  in
+               FStar_Util.format1 "Ill-applied constant %s" uu____7398  in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu____7396)  in
+           FStar_Errors.raise_error uu____7390 e.FStar_Syntax_Syntax.pos
+       | FStar_Syntax_Syntax.Tm_app
+           ({
+              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                (FStar_Const.Const_set_range_of );
               FStar_Syntax_Syntax.pos = uu____7408;
               FStar_Syntax_Syntax.vars = uu____7409;_},uu____7410)
            ->
@@ -2566,22 +2544,9 @@ and (tc_maybe_toplevel_term :
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_set_range_of );
-              FStar_Syntax_Syntax.pos = uu____7453;
-              FStar_Syntax_Syntax.vars = uu____7454;_},uu____7455)
-           ->
-           let uu____7480 =
-             let uu____7486 =
-               let uu____7488 = FStar_Syntax_Print.term_to_string top  in
-               FStar_Util.format1 "Ill-applied constant %s" uu____7488  in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____7486)  in
-           FStar_Errors.raise_error uu____7480 e.FStar_Syntax_Syntax.pos
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify );
-              FStar_Syntax_Syntax.pos = uu____7498;
-              FStar_Syntax_Syntax.vars = uu____7499;_},(e1,aqual)::[])
+              FStar_Syntax_Syntax.pos = uu____7453;
+              FStar_Syntax_Syntax.vars = uu____7454;_},(e1,aqual)::[])
            ->
            (if FStar_Option.isSome aqual
             then
@@ -2589,47 +2554,47 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReify,
                   "Qualifier on argument to reify is irrelevant and will be ignored")
             else ();
-            (let uu____7546 = FStar_TypeChecker_Env.clear_expected_typ env1
+            (let uu____7501 = FStar_TypeChecker_Env.clear_expected_typ env1
                 in
-             match uu____7546 with
-             | (env0,uu____7560) ->
-                 let uu____7565 = tc_term env0 e1  in
-                 (match uu____7565 with
+             match uu____7501 with
+             | (env0,uu____7515) ->
+                 let uu____7520 = tc_term env0 e1  in
+                 (match uu____7520 with
                   | (e2,c,g) ->
-                      let uu____7581 = FStar_Syntax_Util.head_and_args top
+                      let uu____7536 = FStar_Syntax_Util.head_and_args top
                          in
-                      (match uu____7581 with
-                       | (reify_op,uu____7605) ->
+                      (match uu____7536 with
+                       | (reify_op,uu____7560) ->
                            let u_c =
                              env1.FStar_TypeChecker_Env.universe_of env1
                                c.FStar_TypeChecker_Common.res_typ
                               in
-                           let uu____7631 =
+                           let uu____7586 =
                              FStar_TypeChecker_Common.lcomp_comp c  in
-                           (match uu____7631 with
+                           (match uu____7586 with
                             | (c1,g_c) ->
                                 let ef =
                                   FStar_Syntax_Util.comp_effect_name c1  in
-                                ((let uu____7646 =
-                                    let uu____7648 =
+                                ((let uu____7601 =
+                                    let uu____7603 =
                                       FStar_TypeChecker_Env.is_user_reifiable_effect
                                         env1 ef
                                        in
-                                    Prims.op_Negation uu____7648  in
-                                  if uu____7646
+                                    Prims.op_Negation uu____7603  in
+                                  if uu____7601
                                   then
-                                    let uu____7651 =
-                                      let uu____7657 =
-                                        let uu____7659 =
+                                    let uu____7606 =
+                                      let uu____7612 =
+                                        let uu____7614 =
                                           FStar_Ident.string_of_lid ef  in
                                         FStar_Util.format1
                                           "Effect %s cannot be reified"
-                                          uu____7659
+                                          uu____7614
                                          in
                                       (FStar_Errors.Fatal_EffectCannotBeReified,
-                                        uu____7657)
+                                        uu____7612)
                                        in
-                                    FStar_Errors.raise_error uu____7651
+                                    FStar_Errors.raise_error uu____7606
                                       e2.FStar_Syntax_Syntax.pos
                                   else ());
                                  (let repr =
@@ -2640,28 +2605,27 @@ and (tc_maybe_toplevel_term :
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_app
                                          (reify_op, [(e2, aqual)]))
-                                      FStar_Pervasives_Native.None
                                       top.FStar_Syntax_Syntax.pos
                                      in
                                   let c2 =
-                                    let uu____7702 =
+                                    let uu____7657 =
                                       (FStar_TypeChecker_Env.is_total_effect
                                          env1 ef)
                                         ||
-                                        (let uu____7705 =
+                                        (let uu____7660 =
                                            FStar_All.pipe_right ef
                                              (FStar_TypeChecker_Env.norm_eff_name
                                                 env1)
                                             in
-                                         FStar_All.pipe_right uu____7705
+                                         FStar_All.pipe_right uu____7660
                                            (FStar_TypeChecker_Env.is_layered_effect
                                               env1))
                                        in
-                                    if uu____7702
+                                    if uu____7657
                                     then
-                                      let uu____7708 =
+                                      let uu____7663 =
                                         FStar_Syntax_Syntax.mk_Total repr  in
-                                      FStar_All.pipe_right uu____7708
+                                      FStar_All.pipe_right uu____7663
                                         FStar_TypeChecker_Common.lcomp_of_comp
                                     else
                                       (let ct =
@@ -2676,30 +2640,30 @@ and (tc_maybe_toplevel_term :
                                              [];
                                            FStar_Syntax_Syntax.flags = []
                                          }  in
-                                       let uu____7720 =
+                                       let uu____7675 =
                                          FStar_Syntax_Syntax.mk_Comp ct  in
-                                       FStar_All.pipe_right uu____7720
+                                       FStar_All.pipe_right uu____7675
                                          FStar_TypeChecker_Common.lcomp_of_comp)
                                      in
-                                  let uu____7721 =
+                                  let uu____7676 =
                                     comp_check_expected_typ env1 e3 c2  in
-                                  match uu____7721 with
+                                  match uu____7676 with
                                   | (e4,c3,g') ->
-                                      let uu____7737 =
-                                        let uu____7738 =
+                                      let uu____7692 =
+                                        let uu____7693 =
                                           FStar_TypeChecker_Env.conj_guard
                                             g_c g'
                                            in
                                         FStar_TypeChecker_Env.conj_guard g
-                                          uu____7738
+                                          uu____7693
                                          in
-                                      (e4, c3, uu____7737))))))))
+                                      (e4, c3, uu____7692))))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reflect l);
-              FStar_Syntax_Syntax.pos = uu____7740;
-              FStar_Syntax_Syntax.vars = uu____7741;_},(e1,aqual)::[])
+              FStar_Syntax_Syntax.pos = uu____7695;
+              FStar_Syntax_Syntax.vars = uu____7696;_},(e1,aqual)::[])
            ->
            (if FStar_Option.isSome aqual
             then
@@ -2707,56 +2671,56 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReflect,
                   "Qualifier on argument to reflect is irrelevant and will be ignored")
             else ();
-            (let uu____7789 =
-               let uu____7791 =
+            (let uu____7744 =
+               let uu____7746 =
                  FStar_TypeChecker_Env.is_user_reflectable_effect env1 l  in
-               Prims.op_Negation uu____7791  in
-             if uu____7789
+               Prims.op_Negation uu____7746  in
+             if uu____7744
              then
-               let uu____7794 =
-                 let uu____7800 =
-                   let uu____7802 = FStar_Ident.string_of_lid l  in
+               let uu____7749 =
+                 let uu____7755 =
+                   let uu____7757 = FStar_Ident.string_of_lid l  in
                    FStar_Util.format1 "Effect %s cannot be reflected"
-                     uu____7802
+                     uu____7757
                     in
-                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____7800)  in
-               FStar_Errors.raise_error uu____7794 e1.FStar_Syntax_Syntax.pos
+                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____7755)  in
+               FStar_Errors.raise_error uu____7749 e1.FStar_Syntax_Syntax.pos
              else ());
-            (let uu____7808 = FStar_Syntax_Util.head_and_args top  in
-             match uu____7808 with
-             | (reflect_op,uu____7832) ->
-                 let uu____7857 =
+            (let uu____7763 = FStar_Syntax_Util.head_and_args top  in
+             match uu____7763 with
+             | (reflect_op,uu____7787) ->
+                 let uu____7812 =
                    FStar_TypeChecker_Env.effect_decl_opt env1 l  in
-                 (match uu____7857 with
+                 (match uu____7812 with
                   | FStar_Pervasives_Native.None  ->
-                      let uu____7878 =
-                        let uu____7884 =
-                          let uu____7886 = FStar_Ident.string_of_lid l  in
+                      let uu____7833 =
+                        let uu____7839 =
+                          let uu____7841 = FStar_Ident.string_of_lid l  in
                           FStar_Util.format1
-                            "Effect %s not found (for reflect)" uu____7886
+                            "Effect %s not found (for reflect)" uu____7841
                            in
-                        (FStar_Errors.Fatal_EffectNotFound, uu____7884)  in
-                      FStar_Errors.raise_error uu____7878
+                        (FStar_Errors.Fatal_EffectNotFound, uu____7839)  in
+                      FStar_Errors.raise_error uu____7833
                         e1.FStar_Syntax_Syntax.pos
                   | FStar_Pervasives_Native.Some (ed,qualifiers) ->
-                      let uu____7908 =
+                      let uu____7863 =
                         FStar_TypeChecker_Env.clear_expected_typ env1  in
-                      (match uu____7908 with
-                       | (env_no_ex,uu____7922) ->
-                           let uu____7927 =
-                             let uu____7936 =
+                      (match uu____7863 with
+                       | (env_no_ex,uu____7877) ->
+                           let uu____7882 =
+                             let uu____7891 =
                                tc_tot_or_gtot_term env_no_ex e1  in
-                             match uu____7936 with
+                             match uu____7891 with
                              | (e2,c,g) ->
-                                 ((let uu____7955 =
-                                     let uu____7957 =
+                                 ((let uu____7910 =
+                                     let uu____7912 =
                                        FStar_TypeChecker_Common.is_total_lcomp
                                          c
                                         in
                                      FStar_All.pipe_left Prims.op_Negation
-                                       uu____7957
+                                       uu____7912
                                       in
-                                   if uu____7955
+                                   if uu____7910
                                    then
                                      FStar_TypeChecker_Err.add_errors env1
                                        [(FStar_Errors.Error_UnexpectedGTotComputation,
@@ -2765,29 +2729,29 @@ and (tc_maybe_toplevel_term :
                                    else ());
                                   (e2, c, g))
                               in
-                           (match uu____7927 with
+                           (match uu____7882 with
                             | (e2,c_e,g_e) ->
-                                let uu____7995 =
-                                  let uu____8010 =
+                                let uu____7950 =
+                                  let uu____7965 =
                                     FStar_Syntax_Util.type_u ()  in
-                                  match uu____8010 with
+                                  match uu____7965 with
                                   | (a,u_a) ->
-                                      let uu____8031 =
+                                      let uu____7986 =
                                         FStar_TypeChecker_Util.new_implicit_var
                                           "" e2.FStar_Syntax_Syntax.pos
                                           env_no_ex a
                                          in
-                                      (match uu____8031 with
-                                       | (a_uvar,uu____8060,g_a) ->
-                                           let uu____8074 =
+                                      (match uu____7986 with
+                                       | (a_uvar,uu____8015,g_a) ->
+                                           let uu____8029 =
                                              FStar_TypeChecker_Util.fresh_effect_repr_en
                                                env_no_ex
                                                e2.FStar_Syntax_Syntax.pos l
                                                u_a a_uvar
                                               in
-                                           (uu____8074, u_a, a_uvar, g_a))
+                                           (uu____8029, u_a, a_uvar, g_a))
                                    in
-                                (match uu____7995 with
+                                (match uu____7950 with
                                  | ((expected_repr_typ,g_repr),u_a,a,g_a) ->
                                      let g_eq =
                                        FStar_TypeChecker_Rel.teq env_no_ex
@@ -2795,44 +2759,44 @@ and (tc_maybe_toplevel_term :
                                          expected_repr_typ
                                         in
                                      let eff_args =
-                                       let uu____8116 =
-                                         let uu____8117 =
+                                       let uu____8071 =
+                                         let uu____8072 =
                                            FStar_Syntax_Subst.compress
                                              expected_repr_typ
                                             in
-                                         uu____8117.FStar_Syntax_Syntax.n  in
-                                       match uu____8116 with
+                                         uu____8072.FStar_Syntax_Syntax.n  in
+                                       match uu____8071 with
                                        | FStar_Syntax_Syntax.Tm_app
-                                           (uu____8130,uu____8131::args) ->
+                                           (uu____8085,uu____8086::args) ->
                                            args
-                                       | uu____8173 ->
-                                           let uu____8174 =
-                                             let uu____8180 =
-                                               let uu____8182 =
+                                       | uu____8128 ->
+                                           let uu____8129 =
+                                             let uu____8135 =
+                                               let uu____8137 =
                                                  FStar_Ident.string_of_lid l
                                                   in
-                                               let uu____8184 =
+                                               let uu____8139 =
                                                  FStar_Syntax_Print.tag_of_term
                                                    expected_repr_typ
                                                   in
-                                               let uu____8186 =
+                                               let uu____8141 =
                                                  FStar_Syntax_Print.term_to_string
                                                    expected_repr_typ
                                                   in
                                                FStar_Util.format3
                                                  "Expected repr type for %s is not an application node (%s:%s)"
-                                                 uu____8182 uu____8184
-                                                 uu____8186
+                                                 uu____8137 uu____8139
+                                                 uu____8141
                                                 in
                                              (FStar_Errors.Fatal_UnexpectedEffect,
-                                               uu____8180)
+                                               uu____8135)
                                               in
                                            FStar_Errors.raise_error
-                                             uu____8174
+                                             uu____8129
                                              top.FStar_Syntax_Syntax.pos
                                         in
                                      let c =
-                                       let uu____8201 =
+                                       let uu____8156 =
                                          FStar_Syntax_Syntax.mk_Comp
                                            {
                                              FStar_Syntax_Syntax.comp_univs =
@@ -2847,19 +2811,18 @@ and (tc_maybe_toplevel_term :
                                              FStar_Syntax_Syntax.flags = []
                                            }
                                           in
-                                       FStar_All.pipe_right uu____8201
+                                       FStar_All.pipe_right uu____8156
                                          FStar_TypeChecker_Common.lcomp_of_comp
                                         in
                                      let e3 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_app
                                             (reflect_op, [(e2, aqual)]))
-                                         FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
-                                     let uu____8237 =
+                                     let uu____8192 =
                                        comp_check_expected_typ env1 e3 c  in
-                                     (match uu____8237 with
+                                     (match uu____8192 with
                                       | (e4,c1,g') ->
                                           let e5 =
                                             FStar_Syntax_Syntax.mk
@@ -2868,40 +2831,39 @@ and (tc_maybe_toplevel_term :
                                                    (FStar_Syntax_Syntax.Meta_monadic
                                                       ((c1.FStar_TypeChecker_Common.eff_name),
                                                         (c1.FStar_TypeChecker_Common.res_typ)))))
-                                              FStar_Pervasives_Native.None
                                               e4.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____8260 =
+                                          let uu____8215 =
                                             FStar_TypeChecker_Env.conj_guards
                                               [g_e; g_repr; g_a; g_eq; g']
                                              in
-                                          (e5, c1, uu____8260))))))))
+                                          (e5, c1, uu____8215))))))))
        | FStar_Syntax_Syntax.Tm_app
            (head,(tau,FStar_Pervasives_Native.None )::[]) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8299 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____8299 with
+           let uu____8254 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____8254 with
             | (head1,args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app
-           (head,(uu____8349,FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Implicit uu____8350))::(tau,FStar_Pervasives_Native.None
+           (head,(uu____8304,FStar_Pervasives_Native.Some
+                  (FStar_Syntax_Syntax.Implicit uu____8305))::(tau,FStar_Pervasives_Native.None
                                                                )::[])
            when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8403 = FStar_Syntax_Util.head_and_args top  in
-           (match uu____8403 with
+           let uu____8358 = FStar_Syntax_Util.head_and_args top  in
+           (match uu____8358 with
             | (head1,args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app (head,args) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8478 =
+           let uu____8433 =
              match args with
              | (tau,FStar_Pervasives_Native.None )::rest ->
                  ([(tau, FStar_Pervasives_Native.None)], rest)
@@ -2911,13 +2873,13 @@ and (tc_maybe_toplevel_term :
                      (FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Implicit b)));
                   (tau, FStar_Pervasives_Native.None)], rest)
-             | uu____8688 ->
+             | uu____8643 ->
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_SynthByTacticError,
                      "synth_by_tactic: bad application")
                    top.FStar_Syntax_Syntax.pos
               in
-           (match uu____8478 with
+           (match uu____8433 with
             | (args1,args2) ->
                 let t1 = FStar_Syntax_Util.mk_app head args1  in
                 let t2 = FStar_Syntax_Util.mk_app t1 args2  in
@@ -2925,114 +2887,114 @@ and (tc_maybe_toplevel_term :
        | FStar_Syntax_Syntax.Tm_app (head,args) ->
            let env0 = env1  in
            let env2 =
-             let uu____8807 =
-               let uu____8808 = FStar_TypeChecker_Env.clear_expected_typ env1
+             let uu____8762 =
+               let uu____8763 = FStar_TypeChecker_Env.clear_expected_typ env1
                   in
-               FStar_All.pipe_right uu____8808 FStar_Pervasives_Native.fst
+               FStar_All.pipe_right uu____8763 FStar_Pervasives_Native.fst
                 in
-             FStar_All.pipe_right uu____8807 instantiate_both  in
-           ((let uu____8824 =
+             FStar_All.pipe_right uu____8762 instantiate_both  in
+           ((let uu____8779 =
                FStar_TypeChecker_Env.debug env2 FStar_Options.High  in
-             if uu____8824
+             if uu____8779
              then
-               let uu____8827 =
+               let uu____8782 =
                  FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos  in
-               let uu____8829 = FStar_Syntax_Print.term_to_string top  in
-               let uu____8831 =
-                 let uu____8833 = FStar_TypeChecker_Env.expected_typ env0  in
-                 FStar_All.pipe_right uu____8833
-                   (fun uu___3_8840  ->
-                      match uu___3_8840 with
+               let uu____8784 = FStar_Syntax_Print.term_to_string top  in
+               let uu____8786 =
+                 let uu____8788 = FStar_TypeChecker_Env.expected_typ env0  in
+                 FStar_All.pipe_right uu____8788
+                   (fun uu___3_8795  ->
+                      match uu___3_8795 with
                       | FStar_Pervasives_Native.None  -> "none"
                       | FStar_Pervasives_Native.Some t ->
                           FStar_Syntax_Print.term_to_string t)
                   in
                FStar_Util.print3
-                 "(%s) Checking app %s, expected type is %s\n" uu____8827
-                 uu____8829 uu____8831
+                 "(%s) Checking app %s, expected type is %s\n" uu____8782
+                 uu____8784 uu____8786
              else ());
-            (let uu____8849 = tc_term (no_inst env2) head  in
-             match uu____8849 with
+            (let uu____8804 = tc_term (no_inst env2) head  in
+             match uu____8804 with
              | (head1,chead,g_head) ->
-                 let uu____8865 =
-                   let uu____8870 = FStar_TypeChecker_Common.lcomp_comp chead
+                 let uu____8820 =
+                   let uu____8825 = FStar_TypeChecker_Common.lcomp_comp chead
                       in
-                   FStar_All.pipe_right uu____8870
-                     (fun uu____8887  ->
-                        match uu____8887 with
+                   FStar_All.pipe_right uu____8825
+                     (fun uu____8842  ->
+                        match uu____8842 with
                         | (c,g) ->
-                            let uu____8898 =
+                            let uu____8853 =
                               FStar_TypeChecker_Env.conj_guard g_head g  in
-                            (c, uu____8898))
+                            (c, uu____8853))
                     in
-                 (match uu____8865 with
+                 (match uu____8820 with
                   | (chead1,g_head1) ->
-                      let uu____8907 =
-                        let uu____8914 =
+                      let uu____8862 =
+                        let uu____8869 =
                           ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax)
                              &&
-                             (let uu____8917 = FStar_Options.lax ()  in
-                              Prims.op_Negation uu____8917))
+                             (let uu____8872 = FStar_Options.lax ()  in
+                              Prims.op_Negation uu____8872))
                             &&
                             (FStar_TypeChecker_Util.short_circuit_head head1)
                            in
-                        if uu____8914
+                        if uu____8869
                         then
-                          let uu____8926 =
-                            let uu____8933 =
+                          let uu____8881 =
+                            let uu____8888 =
                               FStar_TypeChecker_Env.expected_typ env0  in
                             check_short_circuit_args env2 head1 chead1
-                              g_head1 args uu____8933
+                              g_head1 args uu____8888
                              in
-                          match uu____8926 with | (e1,c,g) -> (e1, c, g)
+                          match uu____8881 with | (e1,c,g) -> (e1, c, g)
                         else
-                          (let uu____8947 =
+                          (let uu____8902 =
                              FStar_TypeChecker_Env.expected_typ env0  in
                            check_application_args env2 head1 chead1 g_head1
-                             args uu____8947)
+                             args uu____8902)
                          in
-                      (match uu____8907 with
+                      (match uu____8862 with
                        | (e1,c,g) ->
-                           let uu____8959 =
-                             let uu____8966 =
+                           let uu____8914 =
+                             let uu____8921 =
                                FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  c
                                 in
-                             if uu____8966
+                             if uu____8921
                              then
-                               let uu____8975 =
+                               let uu____8930 =
                                  FStar_TypeChecker_Util.maybe_instantiate
                                    env0 e1 c.FStar_TypeChecker_Common.res_typ
                                   in
-                               match uu____8975 with
+                               match uu____8930 with
                                | (e2,res_typ,implicits) ->
-                                   let uu____8991 =
+                                   let uu____8946 =
                                      FStar_TypeChecker_Common.set_result_typ_lc
                                        c res_typ
                                       in
-                                   (e2, uu____8991, implicits)
+                                   (e2, uu____8946, implicits)
                              else
                                (e1, c, FStar_TypeChecker_Env.trivial_guard)
                               in
-                           (match uu____8959 with
+                           (match uu____8914 with
                             | (e2,c1,implicits) ->
-                                ((let uu____9004 =
+                                ((let uu____8959 =
                                     FStar_TypeChecker_Env.debug env2
                                       FStar_Options.Extreme
                                      in
-                                  if uu____9004
+                                  if uu____8959
                                   then
-                                    let uu____9007 =
+                                    let uu____8962 =
                                       FStar_TypeChecker_Rel.print_pending_implicits
                                         g
                                        in
                                     FStar_Util.print1
                                       "Introduced {%s} implicits in application\n"
-                                      uu____9007
+                                      uu____8962
                                   else ());
-                                 (let uu____9012 =
+                                 (let uu____8967 =
                                     comp_check_expected_typ env0 e2 c1  in
-                                  match uu____9012 with
+                                  match uu____8967 with
                                   | (e3,c2,g') ->
                                       let gres =
                                         FStar_TypeChecker_Env.conj_guard g g'
@@ -3041,49 +3003,49 @@ and (tc_maybe_toplevel_term :
                                         FStar_TypeChecker_Env.conj_guard gres
                                           implicits
                                          in
-                                      ((let uu____9031 =
+                                      ((let uu____8986 =
                                           FStar_TypeChecker_Env.debug env2
                                             FStar_Options.Extreme
                                            in
-                                        if uu____9031
+                                        if uu____8986
                                         then
-                                          let uu____9034 =
+                                          let uu____8989 =
                                             FStar_Syntax_Print.term_to_string
                                               e3
                                              in
-                                          let uu____9036 =
+                                          let uu____8991 =
                                             FStar_TypeChecker_Rel.guard_to_string
                                               env2 gres1
                                              in
                                           FStar_Util.print2
                                             "Guard from application node %s is %s\n"
-                                            uu____9034 uu____9036
+                                            uu____8989 uu____8991
                                         else ());
                                        (e3, c2, gres1)))))))))
-       | FStar_Syntax_Syntax.Tm_match uu____9041 -> tc_match env1 top
+       | FStar_Syntax_Syntax.Tm_match uu____8996 -> tc_match env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((false
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9064;
-                FStar_Syntax_Syntax.lbunivs = uu____9065;
-                FStar_Syntax_Syntax.lbtyp = uu____9066;
-                FStar_Syntax_Syntax.lbeff = uu____9067;
-                FStar_Syntax_Syntax.lbdef = uu____9068;
-                FStar_Syntax_Syntax.lbattrs = uu____9069;
-                FStar_Syntax_Syntax.lbpos = uu____9070;_}::[]),uu____9071)
+             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9019;
+                FStar_Syntax_Syntax.lbunivs = uu____9020;
+                FStar_Syntax_Syntax.lbtyp = uu____9021;
+                FStar_Syntax_Syntax.lbeff = uu____9022;
+                FStar_Syntax_Syntax.lbdef = uu____9023;
+                FStar_Syntax_Syntax.lbattrs = uu____9024;
+                FStar_Syntax_Syntax.lbpos = uu____9025;_}::[]),uu____9026)
            -> check_top_level_let env1 top
-       | FStar_Syntax_Syntax.Tm_let ((false ,uu____9097),uu____9098) ->
+       | FStar_Syntax_Syntax.Tm_let ((false ,uu____9052),uu____9053) ->
            check_inner_let env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((true
-             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9116;
-                FStar_Syntax_Syntax.lbunivs = uu____9117;
-                FStar_Syntax_Syntax.lbtyp = uu____9118;
-                FStar_Syntax_Syntax.lbeff = uu____9119;
-                FStar_Syntax_Syntax.lbdef = uu____9120;
-                FStar_Syntax_Syntax.lbattrs = uu____9121;
-                FStar_Syntax_Syntax.lbpos = uu____9122;_}::uu____9123),uu____9124)
+             ,{ FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____9071;
+                FStar_Syntax_Syntax.lbunivs = uu____9072;
+                FStar_Syntax_Syntax.lbtyp = uu____9073;
+                FStar_Syntax_Syntax.lbeff = uu____9074;
+                FStar_Syntax_Syntax.lbdef = uu____9075;
+                FStar_Syntax_Syntax.lbattrs = uu____9076;
+                FStar_Syntax_Syntax.lbpos = uu____9077;_}::uu____9078),uu____9079)
            -> check_top_level_let_rec env1 top
-       | FStar_Syntax_Syntax.Tm_let ((true ,uu____9152),uu____9153) ->
+       | FStar_Syntax_Syntax.Tm_let ((true ,uu____9107),uu____9108) ->
            check_inner_let_rec env1 top)
 
 and (tc_match :
@@ -3094,67 +3056,67 @@ and (tc_match :
   =
   fun env  ->
     fun top  ->
-      let uu____9179 =
-        let uu____9180 = FStar_Syntax_Subst.compress top  in
-        uu____9180.FStar_Syntax_Syntax.n  in
-      match uu____9179 with
+      let uu____9134 =
+        let uu____9135 = FStar_Syntax_Subst.compress top  in
+        uu____9135.FStar_Syntax_Syntax.n  in
+      match uu____9134 with
       | FStar_Syntax_Syntax.Tm_match (e1,eqns) ->
-          let uu____9227 = FStar_TypeChecker_Env.clear_expected_typ env  in
-          (match uu____9227 with
+          let uu____9182 = FStar_TypeChecker_Env.clear_expected_typ env  in
+          (match uu____9182 with
            | (env1,topt) ->
                let env11 = instantiate_both env1  in
-               let uu____9247 = tc_term env11 e1  in
-               (match uu____9247 with
+               let uu____9202 = tc_term env11 e1  in
+               (match uu____9202 with
                 | (e11,c1,g1) ->
-                    let uu____9263 =
-                      let uu____9274 =
+                    let uu____9218 =
+                      let uu____9229 =
                         FStar_TypeChecker_Util.coerce_views env e11 c1  in
-                      match uu____9274 with
+                      match uu____9229 with
                       | FStar_Pervasives_Native.Some (e12,c11) ->
                           (e12, c11, eqns)
                       | FStar_Pervasives_Native.None  -> (e11, c1, eqns)  in
-                    (match uu____9263 with
+                    (match uu____9218 with
                      | (e12,c11,eqns1) ->
                          let eqns2 = eqns1  in
-                         let uu____9329 =
+                         let uu____9284 =
                            match topt with
                            | FStar_Pervasives_Native.Some t -> (env, t, g1)
                            | FStar_Pervasives_Native.None  ->
-                               let uu____9343 = FStar_Syntax_Util.type_u ()
+                               let uu____9298 = FStar_Syntax_Util.type_u ()
                                   in
-                               (match uu____9343 with
-                                | (k,uu____9355) ->
-                                    let uu____9356 =
+                               (match uu____9298 with
+                                | (k,uu____9310) ->
+                                    let uu____9311 =
                                       FStar_TypeChecker_Util.new_implicit_var
                                         "match result"
                                         e12.FStar_Syntax_Syntax.pos env k
                                        in
-                                    (match uu____9356 with
-                                     | (res_t,uu____9377,g) ->
-                                         let uu____9391 =
+                                    (match uu____9311 with
+                                     | (res_t,uu____9332,g) ->
+                                         let uu____9346 =
                                            FStar_TypeChecker_Env.set_expected_typ
                                              env res_t
                                             in
-                                         let uu____9392 =
+                                         let uu____9347 =
                                            FStar_TypeChecker_Env.conj_guard
                                              g1 g
                                             in
-                                         (uu____9391, res_t, uu____9392)))
+                                         (uu____9346, res_t, uu____9347)))
                             in
-                         (match uu____9329 with
+                         (match uu____9284 with
                           | (env_branches,res_t,g11) ->
-                              ((let uu____9403 =
+                              ((let uu____9358 =
                                   FStar_TypeChecker_Env.debug env
                                     FStar_Options.Extreme
                                    in
-                                if uu____9403
+                                if uu____9358
                                 then
-                                  let uu____9406 =
+                                  let uu____9361 =
                                     FStar_Syntax_Print.term_to_string res_t
                                      in
                                   FStar_Util.print1
                                     "Tm_match: expected type of branches is %s\n"
-                                    uu____9406
+                                    uu____9361
                                 else ());
                                (let guard_x =
                                   FStar_Syntax_Syntax.new_bv
@@ -3167,36 +3129,36 @@ and (tc_match :
                                     (FStar_List.map
                                        (tc_eqn guard_x env_branches))
                                    in
-                                let uu____9514 =
-                                  let uu____9522 =
+                                let uu____9469 =
+                                  let uu____9477 =
                                     FStar_List.fold_right
-                                      (fun uu____9615  ->
-                                         fun uu____9616  ->
-                                           match (uu____9615, uu____9616)
+                                      (fun uu____9570  ->
+                                         fun uu____9571  ->
+                                           match (uu____9570, uu____9571)
                                            with
                                            | ((branch,f,eff_label,cflags,c,g,erasable_branch),
                                               (caccum,gaccum,erasable)) ->
-                                               let uu____9888 =
+                                               let uu____9843 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g gaccum
                                                   in
                                                (((f, eff_label, cflags, c) ::
-                                                 caccum), uu____9888,
+                                                 caccum), uu____9843,
                                                  (erasable || erasable_branch)))
                                       t_eqns
                                       ([],
                                         FStar_TypeChecker_Env.trivial_guard,
                                         false)
                                      in
-                                  match uu____9522 with
+                                  match uu____9477 with
                                   | (cases,g,erasable) ->
-                                      let uu____10002 =
+                                      let uu____9957 =
                                         FStar_TypeChecker_Util.bind_cases env
                                           res_t cases guard_x
                                          in
-                                      (uu____10002, g, erasable)
+                                      (uu____9957, g, erasable)
                                    in
-                                match uu____9514 with
+                                match uu____9469 with
                                 | (c_branches,g_branches,erasable) ->
                                     let cres =
                                       FStar_TypeChecker_Util.bind
@@ -3217,14 +3179,14 @@ and (tc_match :
                                             (FStar_Pervasives_Native.Some
                                                FStar_Syntax_Syntax.U_zero)
                                            in
-                                        let uu____10022 =
+                                        let uu____9977 =
                                           FStar_TypeChecker_Common.lcomp_of_comp
                                             c
                                            in
                                         FStar_TypeChecker_Util.bind
                                           e.FStar_Syntax_Syntax.pos env
                                           (FStar_Pervasives_Native.Some e)
-                                          uu____10022
+                                          uu____9977
                                           (FStar_Pervasives_Native.None,
                                             cres)
                                       else cres  in
@@ -3233,24 +3195,23 @@ and (tc_match :
                                         let branches =
                                           FStar_All.pipe_right t_eqns
                                             (FStar_List.map
-                                               (fun uu____10164  ->
-                                                  match uu____10164 with
-                                                  | ((pat,wopt,br),uu____10212,eff_label,uu____10214,uu____10215,uu____10216,uu____10217)
+                                               (fun uu____10119  ->
+                                                  match uu____10119 with
+                                                  | ((pat,wopt,br),uu____10167,eff_label,uu____10169,uu____10170,uu____10171,uu____10172)
                                                       ->
-                                                      let uu____10256 =
+                                                      let uu____10211 =
                                                         FStar_TypeChecker_Util.maybe_lift
                                                           env br eff_label
                                                           cres1.FStar_TypeChecker_Common.eff_name
                                                           res_t
                                                          in
                                                       (pat, wopt,
-                                                        uu____10256)))
+                                                        uu____10211)))
                                            in
                                         let e =
                                           FStar_Syntax_Syntax.mk
                                             (FStar_Syntax_Syntax.Tm_match
                                                (scrutinee, branches))
-                                            FStar_Pervasives_Native.None
                                             top.FStar_Syntax_Syntax.pos
                                            in
                                         let e2 =
@@ -3267,25 +3228,24 @@ and (tc_match :
                                                  FStar_Pervasives_Native.None),
                                                (FStar_Pervasives_Native.Some
                                                   (cres1.FStar_TypeChecker_Common.eff_name))))
-                                          FStar_Pervasives_Native.None
                                           e2.FStar_Syntax_Syntax.pos
                                          in
-                                      let uu____10323 =
+                                      let uu____10278 =
                                         FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                           env
                                           c11.FStar_TypeChecker_Common.eff_name
                                          in
-                                      if uu____10323
+                                      if uu____10278
                                       then mk_match e12
                                       else
                                         (let e_match =
-                                           let uu____10331 =
+                                           let uu____10286 =
                                              FStar_Syntax_Syntax.bv_to_name
                                                guard_x
                                               in
-                                           mk_match uu____10331  in
+                                           mk_match uu____10286  in
                                          let lb =
-                                           let uu____10335 =
+                                           let uu____10290 =
                                              FStar_TypeChecker_Env.norm_eff_name
                                                env
                                                c11.FStar_TypeChecker_Common.eff_name
@@ -3293,33 +3253,28 @@ and (tc_match :
                                            FStar_Syntax_Util.mk_letbinding
                                              (FStar_Util.Inl guard_x) []
                                              c11.FStar_TypeChecker_Common.res_typ
-                                             uu____10335 e12 []
+                                             uu____10290 e12 []
                                              e12.FStar_Syntax_Syntax.pos
                                             in
                                          let e =
-                                           let uu____10341 =
-                                             let uu____10348 =
-                                               let uu____10349 =
-                                                 let uu____10363 =
-                                                   let uu____10366 =
-                                                     let uu____10367 =
-                                                       FStar_Syntax_Syntax.mk_binder
-                                                         guard_x
-                                                        in
-                                                     [uu____10367]  in
-                                                   FStar_Syntax_Subst.close
-                                                     uu____10366 e_match
-                                                    in
-                                                 ((false, [lb]), uu____10363)
+                                           let uu____10296 =
+                                             let uu____10297 =
+                                               let uu____10311 =
+                                                 let uu____10314 =
+                                                   let uu____10315 =
+                                                     FStar_Syntax_Syntax.mk_binder
+                                                       guard_x
+                                                      in
+                                                   [uu____10315]  in
+                                                 FStar_Syntax_Subst.close
+                                                   uu____10314 e_match
                                                   in
-                                               FStar_Syntax_Syntax.Tm_let
-                                                 uu____10349
+                                               ((false, [lb]), uu____10311)
                                                 in
-                                             FStar_Syntax_Syntax.mk
-                                               uu____10348
+                                             FStar_Syntax_Syntax.Tm_let
+                                               uu____10297
                                               in
-                                           uu____10341
-                                             FStar_Pervasives_Native.None
+                                           FStar_Syntax_Syntax.mk uu____10296
                                              top.FStar_Syntax_Syntax.pos
                                             in
                                          FStar_TypeChecker_Util.maybe_monadic
@@ -3327,34 +3282,34 @@ and (tc_match :
                                            cres1.FStar_TypeChecker_Common.eff_name
                                            cres1.FStar_TypeChecker_Common.res_typ)
                                        in
-                                    ((let uu____10400 =
+                                    ((let uu____10348 =
                                         FStar_TypeChecker_Env.debug env
                                           FStar_Options.Extreme
                                          in
-                                      if uu____10400
+                                      if uu____10348
                                       then
-                                        let uu____10403 =
+                                        let uu____10351 =
                                           FStar_Range.string_of_range
                                             top.FStar_Syntax_Syntax.pos
                                            in
-                                        let uu____10405 =
+                                        let uu____10353 =
                                           FStar_TypeChecker_Common.lcomp_to_string
                                             cres1
                                            in
                                         FStar_Util.print2
                                           "(%s) Typechecked Tm_match, comp type = %s\n"
-                                          uu____10403 uu____10405
+                                          uu____10351 uu____10353
                                       else ());
-                                     (let uu____10410 =
+                                     (let uu____10358 =
                                         FStar_TypeChecker_Env.conj_guard g11
                                           g_branches
                                          in
-                                      (e, cres1, uu____10410)))))))))
-      | uu____10411 ->
-          let uu____10412 =
-            let uu____10414 = FStar_Syntax_Print.tag_of_term top  in
-            FStar_Util.format1 "tc_match called on %s\n" uu____10414  in
-          failwith uu____10412
+                                      (e, cres1, uu____10358)))))))))
+      | uu____10359 ->
+          let uu____10360 =
+            let uu____10362 = FStar_Syntax_Print.tag_of_term top  in
+            FStar_Util.format1 "tc_match called on %s\n" uu____10362  in
+          failwith uu____10360
 
 and (tc_synth :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -3370,87 +3325,87 @@ and (tc_synth :
     fun env  ->
       fun args  ->
         fun rng  ->
-          let uu____10439 =
+          let uu____10387 =
             match args with
             | (tau,FStar_Pervasives_Native.None )::[] ->
                 (tau, FStar_Pervasives_Native.None)
             | (a,FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
-               uu____10478))::(tau,FStar_Pervasives_Native.None )::[] ->
+               uu____10426))::(tau,FStar_Pervasives_Native.None )::[] ->
                 (tau, (FStar_Pervasives_Native.Some a))
-            | uu____10519 ->
+            | uu____10467 ->
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_SynthByTacticError,
                     "synth_by_tactic: bad application") rng
              in
-          match uu____10439 with
+          match uu____10387 with
           | (tau,atyp) ->
               let typ =
                 match atyp with
                 | FStar_Pervasives_Native.Some t -> t
                 | FStar_Pervasives_Native.None  ->
-                    let uu____10552 = FStar_TypeChecker_Env.expected_typ env
+                    let uu____10500 = FStar_TypeChecker_Env.expected_typ env
                        in
-                    (match uu____10552 with
+                    (match uu____10500 with
                      | FStar_Pervasives_Native.Some t -> t
                      | FStar_Pervasives_Native.None  ->
-                         let uu____10556 =
+                         let uu____10504 =
                            FStar_TypeChecker_Env.get_range env  in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_SynthByTacticError,
                              "synth_by_tactic: need a type annotation when no expected type is present")
-                           uu____10556)
+                           uu____10504)
                  in
-              let uu____10559 =
-                let uu____10566 =
-                  let uu____10567 =
-                    let uu____10568 = FStar_Syntax_Util.type_u ()  in
+              let uu____10507 =
+                let uu____10514 =
+                  let uu____10515 =
+                    let uu____10516 = FStar_Syntax_Util.type_u ()  in
                     FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____10568
+                      uu____10516
                      in
-                  FStar_TypeChecker_Env.set_expected_typ env uu____10567  in
-                tc_term uu____10566 typ  in
-              (match uu____10559 with
-               | (typ1,uu____10584,g1) ->
+                  FStar_TypeChecker_Env.set_expected_typ env uu____10515  in
+                tc_term uu____10514 typ  in
+              (match uu____10507 with
+               | (typ1,uu____10532,g1) ->
                    (FStar_TypeChecker_Rel.force_trivial_guard env g1;
-                    (let uu____10587 =
+                    (let uu____10535 =
                        tc_tactic FStar_Syntax_Syntax.t_unit
                          FStar_Syntax_Syntax.t_unit env tau
                         in
-                     match uu____10587 with
-                     | (tau1,uu____10601,g2) ->
+                     match uu____10535 with
+                     | (tau1,uu____10549,g2) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env g2;
                           (let t =
                              env.FStar_TypeChecker_Env.synth_hook env typ1
-                               (let uu___1347_10606 = tau1  in
+                               (let uu___1347_10554 = tau1  in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1347_10606.FStar_Syntax_Syntax.n);
+                                    (uu___1347_10554.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos = rng;
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1347_10606.FStar_Syntax_Syntax.vars)
+                                    (uu___1347_10554.FStar_Syntax_Syntax.vars)
                                 })
                               in
-                           (let uu____10608 =
+                           (let uu____10556 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Tac")
                                in
-                            if uu____10608
+                            if uu____10556
                             then
-                              let uu____10613 =
+                              let uu____10561 =
                                 FStar_Syntax_Print.term_to_string t  in
-                              FStar_Util.print1 "Got %s\n" uu____10613
+                              FStar_Util.print1 "Got %s\n" uu____10561
                             else ());
                            FStar_TypeChecker_Util.check_uvars
                              tau1.FStar_Syntax_Syntax.pos t;
-                           (let uu____10619 =
-                              let uu____10620 =
+                           (let uu____10567 =
+                              let uu____10568 =
                                 FStar_Syntax_Syntax.mk_Total typ1  in
                               FStar_All.pipe_left
                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                uu____10620
+                                uu____10568
                                in
-                            (t, uu____10619,
+                            (t, uu____10567,
                               FStar_TypeChecker_Env.trivial_guard)))))))
 
 and (tc_tactic :
@@ -3466,102 +3421,102 @@ and (tc_tactic :
       fun env  ->
         fun tau  ->
           let env1 =
-            let uu___1357_10626 = env  in
+            let uu___1357_10574 = env  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___1357_10626.FStar_TypeChecker_Env.solver);
+                (uu___1357_10574.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___1357_10626.FStar_TypeChecker_Env.range);
+                (uu___1357_10574.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___1357_10626.FStar_TypeChecker_Env.curmodule);
+                (uu___1357_10574.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___1357_10626.FStar_TypeChecker_Env.gamma);
+                (uu___1357_10574.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___1357_10626.FStar_TypeChecker_Env.gamma_sig);
+                (uu___1357_10574.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___1357_10626.FStar_TypeChecker_Env.gamma_cache);
+                (uu___1357_10574.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___1357_10626.FStar_TypeChecker_Env.modules);
+                (uu___1357_10574.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___1357_10626.FStar_TypeChecker_Env.expected_typ);
+                (uu___1357_10574.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___1357_10626.FStar_TypeChecker_Env.sigtab);
+                (uu___1357_10574.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___1357_10626.FStar_TypeChecker_Env.attrtab);
+                (uu___1357_10574.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___1357_10626.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___1357_10574.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___1357_10626.FStar_TypeChecker_Env.effects);
+                (uu___1357_10574.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___1357_10626.FStar_TypeChecker_Env.generalize);
+                (uu___1357_10574.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___1357_10626.FStar_TypeChecker_Env.letrecs);
+                (uu___1357_10574.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___1357_10626.FStar_TypeChecker_Env.top_level);
+                (uu___1357_10574.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___1357_10626.FStar_TypeChecker_Env.check_uvars);
+                (uu___1357_10574.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___1357_10626.FStar_TypeChecker_Env.use_eq);
+                (uu___1357_10574.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___1357_10626.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___1357_10574.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___1357_10626.FStar_TypeChecker_Env.is_iface);
+                (uu___1357_10574.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___1357_10626.FStar_TypeChecker_Env.admit);
+                (uu___1357_10574.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___1357_10626.FStar_TypeChecker_Env.lax);
+                (uu___1357_10574.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___1357_10626.FStar_TypeChecker_Env.lax_universes);
+                (uu___1357_10574.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___1357_10626.FStar_TypeChecker_Env.phase1);
+                (uu___1357_10574.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard = true;
               FStar_TypeChecker_Env.nosynth =
-                (uu___1357_10626.FStar_TypeChecker_Env.nosynth);
+                (uu___1357_10574.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___1357_10626.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___1357_10574.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___1357_10626.FStar_TypeChecker_Env.tc_term);
+                (uu___1357_10574.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___1357_10626.FStar_TypeChecker_Env.type_of);
+                (uu___1357_10574.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___1357_10626.FStar_TypeChecker_Env.universe_of);
+                (uu___1357_10574.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___1357_10626.FStar_TypeChecker_Env.check_type_of);
+                (uu___1357_10574.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___1357_10626.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___1357_10574.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___1357_10626.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___1357_10574.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___1357_10626.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___1357_10574.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___1357_10626.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___1357_10574.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___1357_10626.FStar_TypeChecker_Env.proof_ns);
+                (uu___1357_10574.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___1357_10626.FStar_TypeChecker_Env.synth_hook);
+                (uu___1357_10574.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___1357_10626.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___1357_10574.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___1357_10626.FStar_TypeChecker_Env.splice);
+                (uu___1357_10574.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___1357_10626.FStar_TypeChecker_Env.mpreprocess);
+                (uu___1357_10574.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___1357_10626.FStar_TypeChecker_Env.postprocess);
+                (uu___1357_10574.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___1357_10626.FStar_TypeChecker_Env.identifier_info);
+                (uu___1357_10574.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___1357_10626.FStar_TypeChecker_Env.tc_hooks);
+                (uu___1357_10574.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___1357_10626.FStar_TypeChecker_Env.dsenv);
+                (uu___1357_10574.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___1357_10626.FStar_TypeChecker_Env.nbe);
+                (uu___1357_10574.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___1357_10626.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___1357_10574.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___1357_10626.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___1357_10574.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let uu____10628 = FStar_Syntax_Syntax.t_tac_of a b  in
-          tc_check_tot_or_gtot_term env1 tau uu____10628 ""
+          let uu____10576 = FStar_Syntax_Syntax.t_tac_of a b  in
+          tc_check_tot_or_gtot_term env1 tau uu____10576 ""
 
 and (tc_tactic_opt :
   FStar_TypeChecker_Env.env ->
@@ -3576,12 +3531,12 @@ and (tc_tactic_opt :
       | FStar_Pervasives_Native.None  ->
           (FStar_Pervasives_Native.None, FStar_TypeChecker_Env.trivial_guard)
       | FStar_Pervasives_Native.Some tactic ->
-          let uu____10651 =
+          let uu____10599 =
             tc_tactic FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_unit
               env tactic
              in
-          (match uu____10651 with
-           | (tactic1,uu____10665,g) ->
+          (match uu____10599 with
+           | (tactic1,uu____10613,g) ->
                ((FStar_Pervasives_Native.Some tactic1), g))
 
 and (tc_value :
@@ -3594,49 +3549,49 @@ and (tc_value :
     fun e  ->
       let check_instantiated_fvar env1 v dc e1 t0 =
         let t = FStar_Syntax_Util.remove_inacc t0  in
-        let uu____10718 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t
+        let uu____10666 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t
            in
-        match uu____10718 with
+        match uu____10666 with
         | (e2,t1,implicits) ->
             let tc =
-              let uu____10739 = FStar_TypeChecker_Env.should_verify env1  in
-              if uu____10739
+              let uu____10687 = FStar_TypeChecker_Env.should_verify env1  in
+              if uu____10687
               then FStar_Util.Inl t1
               else
-                (let uu____10748 =
-                   let uu____10749 = FStar_Syntax_Syntax.mk_Total t1  in
+                (let uu____10696 =
+                   let uu____10697 = FStar_Syntax_Syntax.mk_Total t1  in
                    FStar_All.pipe_left FStar_TypeChecker_Common.lcomp_of_comp
-                     uu____10749
+                     uu____10697
                     in
-                 FStar_Util.Inr uu____10748)
+                 FStar_Util.Inr uu____10696)
                in
-            let is_data_ctor uu___4_10758 =
-              match uu___4_10758 with
+            let is_data_ctor uu___4_10706 =
+              match uu___4_10706 with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor )
                   -> true
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-                  uu____10763) -> true
-              | uu____10771 -> false  in
-            let uu____10775 =
+                  uu____10711) -> true
+              | uu____10719 -> false  in
+            let uu____10723 =
               (is_data_ctor dc) &&
-                (let uu____10778 =
+                (let uu____10726 =
                    FStar_TypeChecker_Env.is_datacon env1
                      v.FStar_Syntax_Syntax.v
                     in
-                 Prims.op_Negation uu____10778)
+                 Prims.op_Negation uu____10726)
                in
-            if uu____10775
+            if uu____10723
             then
-              let uu____10787 =
-                let uu____10793 =
-                  let uu____10795 =
+              let uu____10735 =
+                let uu____10741 =
+                  let uu____10743 =
                     FStar_Ident.string_of_lid v.FStar_Syntax_Syntax.v  in
                   FStar_Util.format1 "Expected a data constructor; got %s"
-                    uu____10795
+                    uu____10743
                    in
-                (FStar_Errors.Fatal_MissingDataConstructor, uu____10793)  in
-              let uu____10799 = FStar_TypeChecker_Env.get_range env1  in
-              FStar_Errors.raise_error uu____10787 uu____10799
+                (FStar_Errors.Fatal_MissingDataConstructor, uu____10741)  in
+              let uu____10747 = FStar_TypeChecker_Env.get_range env1  in
+              FStar_Errors.raise_error uu____10735 uu____10747
             else value_check_expected_typ env1 e2 tc implicits
          in
       let env1 =
@@ -3644,150 +3599,150 @@ and (tc_value :
       let top = FStar_Syntax_Subst.compress e  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_bvar x ->
-          let uu____10817 =
-            let uu____10823 =
-              let uu____10825 = FStar_Syntax_Print.term_to_string top  in
+          let uu____10765 =
+            let uu____10771 =
+              let uu____10773 = FStar_Syntax_Print.term_to_string top  in
               FStar_Util.format1
-                "Violation of locally nameless convention: %s" uu____10825
+                "Violation of locally nameless convention: %s" uu____10773
                in
-            (FStar_Errors.Error_IllScopedTerm, uu____10823)  in
-          FStar_Errors.raise_error uu____10817 top.FStar_Syntax_Syntax.pos
+            (FStar_Errors.Error_IllScopedTerm, uu____10771)  in
+          FStar_Errors.raise_error uu____10765 top.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-          let uu____10853 =
-            let uu____10858 =
+          let uu____10801 =
+            let uu____10806 =
               FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
                in
-            FStar_Util.Inl uu____10858  in
-          value_check_expected_typ env1 e uu____10853
+            FStar_Util.Inl uu____10806  in
+          value_check_expected_typ env1 e uu____10801
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_unknown  ->
           let r = FStar_TypeChecker_Env.get_range env1  in
-          let uu____10860 =
-            let uu____10873 = FStar_TypeChecker_Env.expected_typ env1  in
-            match uu____10873 with
+          let uu____10808 =
+            let uu____10821 = FStar_TypeChecker_Env.expected_typ env1  in
+            match uu____10821 with
             | FStar_Pervasives_Native.None  ->
-                let uu____10888 = FStar_Syntax_Util.type_u ()  in
-                (match uu____10888 with
+                let uu____10836 = FStar_Syntax_Util.type_u ()  in
+                (match uu____10836 with
                  | (k,u) ->
                      FStar_TypeChecker_Util.new_implicit_var
                        "type of user-provided implicit term" r env1 k)
             | FStar_Pervasives_Native.Some t ->
                 (t, [], FStar_TypeChecker_Env.trivial_guard)
              in
-          (match uu____10860 with
-           | (t,uu____10926,g0) ->
-               let uu____10940 =
-                 let uu____10953 =
-                   let uu____10955 = FStar_Range.string_of_range r  in
-                   Prims.op_Hat "user-provided implicit term at " uu____10955
+          (match uu____10808 with
+           | (t,uu____10874,g0) ->
+               let uu____10888 =
+                 let uu____10901 =
+                   let uu____10903 = FStar_Range.string_of_range r  in
+                   Prims.op_Hat "user-provided implicit term at " uu____10903
                     in
-                 FStar_TypeChecker_Util.new_implicit_var uu____10953 r env1 t
+                 FStar_TypeChecker_Util.new_implicit_var uu____10901 r env1 t
                   in
-               (match uu____10940 with
-                | (e1,uu____10965,g1) ->
-                    let uu____10979 =
-                      let uu____10980 = FStar_Syntax_Syntax.mk_Total t  in
-                      FStar_All.pipe_right uu____10980
+               (match uu____10888 with
+                | (e1,uu____10913,g1) ->
+                    let uu____10927 =
+                      let uu____10928 = FStar_Syntax_Syntax.mk_Total t  in
+                      FStar_All.pipe_right uu____10928
                         FStar_TypeChecker_Common.lcomp_of_comp
                        in
-                    let uu____10981 = FStar_TypeChecker_Env.conj_guard g0 g1
+                    let uu____10929 = FStar_TypeChecker_Env.conj_guard g0 g1
                        in
-                    (e1, uu____10979, uu____10981)))
+                    (e1, uu____10927, uu____10929)))
       | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____10983 =
+          let uu____10931 =
             if env1.FStar_TypeChecker_Env.use_bv_sorts
             then
-              let uu____10993 = FStar_Syntax_Syntax.range_of_bv x  in
-              ((x.FStar_Syntax_Syntax.sort), uu____10993)
+              let uu____10941 = FStar_Syntax_Syntax.range_of_bv x  in
+              ((x.FStar_Syntax_Syntax.sort), uu____10941)
             else FStar_TypeChecker_Env.lookup_bv env1 x  in
-          (match uu____10983 with
+          (match uu____10931 with
            | (t,rng) ->
                let x1 =
                  FStar_Syntax_Syntax.set_range_of_bv
-                   (let uu___1423_11007 = x  in
+                   (let uu___1423_10955 = x  in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___1423_11007.FStar_Syntax_Syntax.ppname);
+                        (uu___1423_10955.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___1423_11007.FStar_Syntax_Syntax.index);
+                        (uu___1423_10955.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = t
                     }) rng
                   in
                (FStar_TypeChecker_Env.insert_bv_info env1 x1 t;
                 (let e1 = FStar_Syntax_Syntax.bv_to_name x1  in
-                 let uu____11010 =
+                 let uu____10958 =
                    FStar_TypeChecker_Util.maybe_instantiate env1 e1 t  in
-                 match uu____11010 with
+                 match uu____10958 with
                  | (e2,t1,implicits) ->
                      let tc =
-                       let uu____11031 =
+                       let uu____10979 =
                          FStar_TypeChecker_Env.should_verify env1  in
-                       if uu____11031
+                       if uu____10979
                        then FStar_Util.Inl t1
                        else
-                         (let uu____11040 =
-                            let uu____11041 = FStar_Syntax_Syntax.mk_Total t1
+                         (let uu____10988 =
+                            let uu____10989 = FStar_Syntax_Syntax.mk_Total t1
                                in
                             FStar_All.pipe_left
                               FStar_TypeChecker_Common.lcomp_of_comp
-                              uu____11041
+                              uu____10989
                              in
-                          FStar_Util.Inr uu____11040)
+                          FStar_Util.Inr uu____10988)
                         in
                      value_check_expected_typ env1 e2 tc implicits)))
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____11043;
-             FStar_Syntax_Syntax.vars = uu____11044;_},uu____11045)
+             FStar_Syntax_Syntax.pos = uu____10991;
+             FStar_Syntax_Syntax.vars = uu____10992;_},uu____10993)
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____11050 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____10998 = FStar_TypeChecker_Env.get_range env1  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____11050
+              "Badly instantiated synth_by_tactic") uu____10998
       | FStar_Syntax_Syntax.Tm_fvar fv when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____11060 = FStar_TypeChecker_Env.get_range env1  in
+          let uu____11008 = FStar_TypeChecker_Env.get_range env1  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____11060
+              "Badly instantiated synth_by_tactic") uu____11008
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____11070;
-             FStar_Syntax_Syntax.vars = uu____11071;_},us)
+             FStar_Syntax_Syntax.pos = uu____11018;
+             FStar_Syntax_Syntax.vars = uu____11019;_},us)
           ->
           let us1 = FStar_List.map (tc_universe env1) us  in
-          let uu____11080 =
+          let uu____11028 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____11080 with
+          (match uu____11028 with
            | ((us',t),range) ->
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range  in
                (maybe_warn_on_use env1 fv1;
                 if (FStar_List.length us1) <> (FStar_List.length us')
                 then
-                  (let uu____11106 =
-                     let uu____11112 =
-                       let uu____11114 = FStar_Syntax_Print.fv_to_string fv1
+                  (let uu____11054 =
+                     let uu____11060 =
+                       let uu____11062 = FStar_Syntax_Print.fv_to_string fv1
                           in
-                       let uu____11116 =
+                       let uu____11064 =
                          FStar_Util.string_of_int (FStar_List.length us1)  in
-                       let uu____11118 =
+                       let uu____11066 =
                          FStar_Util.string_of_int (FStar_List.length us')  in
                        FStar_Util.format3
                          "Unexpected number of universe instantiations for \"%s\" (%s vs %s)"
-                         uu____11114 uu____11116 uu____11118
+                         uu____11062 uu____11064 uu____11066
                         in
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                       uu____11112)
+                       uu____11060)
                       in
-                   let uu____11122 = FStar_TypeChecker_Env.get_range env1  in
-                   FStar_Errors.raise_error uu____11106 uu____11122)
+                   let uu____11070 = FStar_TypeChecker_Env.get_range env1  in
+                   FStar_Errors.raise_error uu____11054 uu____11070)
                 else
                   FStar_List.iter2
                     (fun u'  ->
@@ -3795,94 +3750,94 @@ and (tc_value :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____11141 -> failwith "Impossible") us' us1;
+                         | uu____11089 -> failwith "Impossible") us' us1;
                 FStar_TypeChecker_Env.insert_fv_info env1 fv1 t;
                 (let e1 =
-                   let uu____11145 =
+                   let uu____11093 =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv1)
-                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+                       e.FStar_Syntax_Syntax.pos
                       in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____11145 us1  in
+                   FStar_Syntax_Syntax.mk_Tm_uinst uu____11093 us1  in
                  check_instantiated_fvar env1 fv1.FStar_Syntax_Syntax.fv_name
                    fv1.FStar_Syntax_Syntax.fv_qual e1 t)))
-      | FStar_Syntax_Syntax.Tm_uinst (uu____11146,us) ->
-          let uu____11152 = FStar_TypeChecker_Env.get_range env1  in
+      | FStar_Syntax_Syntax.Tm_uinst (uu____11094,us) ->
+          let uu____11100 = FStar_TypeChecker_Env.get_range env1  in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
               "Universe applications are only allowed on top-level identifiers")
-            uu____11152
+            uu____11100
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____11162 =
+          let uu____11110 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____11162 with
+          (match uu____11110 with
            | ((us,t),range) ->
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range  in
                (maybe_warn_on_use env1 fv1;
-                (let uu____11187 =
+                (let uu____11135 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Range")
                     in
-                 if uu____11187
+                 if uu____11135
                  then
-                   let uu____11192 =
-                     let uu____11194 = FStar_Syntax_Syntax.lid_of_fv fv1  in
-                     FStar_Syntax_Print.lid_to_string uu____11194  in
-                   let uu____11195 =
+                   let uu____11140 =
+                     let uu____11142 = FStar_Syntax_Syntax.lid_of_fv fv1  in
+                     FStar_Syntax_Print.lid_to_string uu____11142  in
+                   let uu____11143 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos
                       in
-                   let uu____11197 = FStar_Range.string_of_range range  in
-                   let uu____11199 = FStar_Range.string_of_use_range range
+                   let uu____11145 = FStar_Range.string_of_range range  in
+                   let uu____11147 = FStar_Range.string_of_use_range range
                       in
-                   let uu____11201 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____11149 = FStar_Syntax_Print.term_to_string t  in
                    FStar_Util.print5
                      "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got universes type %s"
-                     uu____11192 uu____11195 uu____11197 uu____11199
-                     uu____11201
+                     uu____11140 uu____11143 uu____11145 uu____11147
+                     uu____11149
                  else ());
                 FStar_TypeChecker_Env.insert_fv_info env1 fv1 t;
                 (let e1 =
-                   let uu____11208 =
+                   let uu____11156 =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv1)
-                       FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+                       e.FStar_Syntax_Syntax.pos
                       in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____11208 us  in
+                   FStar_Syntax_Syntax.mk_Tm_uinst uu____11156 us  in
                  check_instantiated_fvar env1 fv1.FStar_Syntax_Syntax.fv_name
                    fv1.FStar_Syntax_Syntax.fv_qual e1 t)))
       | FStar_Syntax_Syntax.Tm_constant c ->
           let t = tc_constant env1 top.FStar_Syntax_Syntax.pos c  in
           let e1 =
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant c)
-              FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+              e.FStar_Syntax_Syntax.pos
              in
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____11236 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____11236 with
+          let uu____11184 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____11184 with
            | (bs1,c1) ->
                let env0 = env1  in
-               let uu____11250 =
+               let uu____11198 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____11250 with
-                | (env2,uu____11264) ->
-                    let uu____11269 = tc_binders env2 bs1  in
-                    (match uu____11269 with
+               (match uu____11198 with
+                | (env2,uu____11212) ->
+                    let uu____11217 = tc_binders env2 bs1  in
+                    (match uu____11217 with
                      | (bs2,env3,g,us) ->
-                         let uu____11288 = tc_comp env3 c1  in
-                         (match uu____11288 with
+                         let uu____11236 = tc_comp env3 c1  in
+                         (match uu____11236 with
                           | (c2,uc,f) ->
                               let e1 =
-                                let uu___1509_11307 =
+                                let uu___1509_11255 =
                                   FStar_Syntax_Util.arrow bs2 c2  in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1509_11307.FStar_Syntax_Syntax.n);
+                                    (uu___1509_11255.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos =
                                     (top.FStar_Syntax_Syntax.pos);
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1509_11307.FStar_Syntax_Syntax.vars)
+                                    (uu___1509_11255.FStar_Syntax_Syntax.vars)
                                 }  in
                               (check_smt_pat env3 e1 bs2 c2;
                                (let u = FStar_Syntax_Syntax.U_max (uc :: us)
@@ -3890,16 +3845,15 @@ and (tc_value :
                                 let t =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_type u)
-                                    FStar_Pervasives_Native.None
                                     top.FStar_Syntax_Syntax.pos
                                    in
                                 let g1 =
-                                  let uu____11318 =
+                                  let uu____11266 =
                                     FStar_TypeChecker_Env.close_guard_univs
                                       us bs2 f
                                      in
                                   FStar_TypeChecker_Env.conj_guard g
-                                    uu____11318
+                                    uu____11266
                                    in
                                 let g2 =
                                   FStar_TypeChecker_Util.close_guard_implicits
@@ -3912,88 +3866,87 @@ and (tc_value :
           let t =
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u1))
-              FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+              top.FStar_Syntax_Syntax.pos
              in
           let e1 =
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u1)
-              FStar_Pervasives_Native.None top.FStar_Syntax_Syntax.pos
+              top.FStar_Syntax_Syntax.pos
              in
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_refine (x,phi) ->
-          let uu____11335 =
-            let uu____11340 =
-              let uu____11341 = FStar_Syntax_Syntax.mk_binder x  in
-              [uu____11341]  in
-            FStar_Syntax_Subst.open_term uu____11340 phi  in
-          (match uu____11335 with
+          let uu____11283 =
+            let uu____11288 =
+              let uu____11289 = FStar_Syntax_Syntax.mk_binder x  in
+              [uu____11289]  in
+            FStar_Syntax_Subst.open_term uu____11288 phi  in
+          (match uu____11283 with
            | (x1,phi1) ->
                let env0 = env1  in
-               let uu____11369 =
+               let uu____11317 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____11369 with
-                | (env2,uu____11383) ->
-                    let uu____11388 =
-                      let uu____11403 = FStar_List.hd x1  in
-                      tc_binder env2 uu____11403  in
-                    (match uu____11388 with
+               (match uu____11317 with
+                | (env2,uu____11331) ->
+                    let uu____11336 =
+                      let uu____11351 = FStar_List.hd x1  in
+                      tc_binder env2 uu____11351  in
+                    (match uu____11336 with
                      | (x2,env3,f1,u) ->
-                         ((let uu____11439 =
+                         ((let uu____11387 =
                              FStar_TypeChecker_Env.debug env3
                                FStar_Options.High
                               in
-                           if uu____11439
+                           if uu____11387
                            then
-                             let uu____11442 =
+                             let uu____11390 =
                                FStar_Range.string_of_range
                                  top.FStar_Syntax_Syntax.pos
                                 in
-                             let uu____11444 =
+                             let uu____11392 =
                                FStar_Syntax_Print.term_to_string phi1  in
-                             let uu____11446 =
+                             let uu____11394 =
                                FStar_Syntax_Print.bv_to_string
                                  (FStar_Pervasives_Native.fst x2)
                                 in
                              FStar_Util.print3
                                "(%s) Checking refinement formula %s; binder is %s\n"
-                               uu____11442 uu____11444 uu____11446
+                               uu____11390 uu____11392 uu____11394
                            else ());
-                          (let uu____11453 = FStar_Syntax_Util.type_u ()  in
-                           match uu____11453 with
-                           | (t_phi,uu____11465) ->
-                               let uu____11466 =
+                          (let uu____11401 = FStar_Syntax_Util.type_u ()  in
+                           match uu____11401 with
+                           | (t_phi,uu____11413) ->
+                               let uu____11414 =
                                  tc_check_tot_or_gtot_term env3 phi1 t_phi
                                    "refinement formula must be pure or ghost"
                                   in
-                               (match uu____11466 with
-                                | (phi2,uu____11481,f2) ->
+                               (match uu____11414 with
+                                | (phi2,uu____11429,f2) ->
                                     let e1 =
-                                      let uu___1547_11486 =
+                                      let uu___1547_11434 =
                                         FStar_Syntax_Util.refine
                                           (FStar_Pervasives_Native.fst x2)
                                           phi2
                                          in
                                       {
                                         FStar_Syntax_Syntax.n =
-                                          (uu___1547_11486.FStar_Syntax_Syntax.n);
+                                          (uu___1547_11434.FStar_Syntax_Syntax.n);
                                         FStar_Syntax_Syntax.pos =
                                           (top.FStar_Syntax_Syntax.pos);
                                         FStar_Syntax_Syntax.vars =
-                                          (uu___1547_11486.FStar_Syntax_Syntax.vars)
+                                          (uu___1547_11434.FStar_Syntax_Syntax.vars)
                                       }  in
                                     let t =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_type u)
-                                        FStar_Pervasives_Native.None
                                         top.FStar_Syntax_Syntax.pos
                                        in
                                     let g =
-                                      let uu____11495 =
+                                      let uu____11443 =
                                         FStar_TypeChecker_Env.close_guard_univs
                                           [u] [x2] f2
                                          in
                                       FStar_TypeChecker_Env.conj_guard f1
-                                        uu____11495
+                                        uu____11443
                                        in
                                     let g1 =
                                       FStar_TypeChecker_Util.close_guard_implicits
@@ -4001,38 +3954,38 @@ and (tc_value :
                                        in
                                     value_check_expected_typ env0 e1
                                       (FStar_Util.Inl t) g1))))))
-      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____11524) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs,body,uu____11472) ->
           let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs
              in
-          ((let uu____11551 =
+          ((let uu____11499 =
               FStar_TypeChecker_Env.debug env1 FStar_Options.Medium  in
-            if uu____11551
+            if uu____11499
             then
-              let uu____11554 =
+              let uu____11502 =
                 FStar_Syntax_Print.term_to_string
-                  (let uu___1560_11558 = top  in
+                  (let uu___1560_11506 = top  in
                    {
                      FStar_Syntax_Syntax.n =
                        (FStar_Syntax_Syntax.Tm_abs
                           (bs1, body, FStar_Pervasives_Native.None));
                      FStar_Syntax_Syntax.pos =
-                       (uu___1560_11558.FStar_Syntax_Syntax.pos);
+                       (uu___1560_11506.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___1560_11558.FStar_Syntax_Syntax.vars)
+                       (uu___1560_11506.FStar_Syntax_Syntax.vars)
                    })
                  in
-              FStar_Util.print1 "Abstraction is: %s\n" uu____11554
+              FStar_Util.print1 "Abstraction is: %s\n" uu____11502
             else ());
-           (let uu____11574 = FStar_Syntax_Subst.open_term bs1 body  in
-            match uu____11574 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
-      | uu____11587 ->
-          let uu____11588 =
-            let uu____11590 = FStar_Syntax_Print.term_to_string top  in
-            let uu____11592 = FStar_Syntax_Print.tag_of_term top  in
-            FStar_Util.format2 "Unexpected value: %s (%s)" uu____11590
-              uu____11592
+           (let uu____11522 = FStar_Syntax_Subst.open_term bs1 body  in
+            match uu____11522 with | (bs2,body1) -> tc_abs env1 top bs2 body1))
+      | uu____11535 ->
+          let uu____11536 =
+            let uu____11538 = FStar_Syntax_Print.term_to_string top  in
+            let uu____11540 = FStar_Syntax_Print.tag_of_term top  in
+            FStar_Util.format2 "Unexpected value: %s (%s)" uu____11538
+              uu____11540
              in
-          failwith uu____11588
+          failwith uu____11536
 
 and (tc_constant :
   FStar_TypeChecker_Env.env ->
@@ -4044,11 +3997,11 @@ and (tc_constant :
         let res =
           match c with
           | FStar_Const.Const_unit  -> FStar_Syntax_Syntax.t_unit
-          | FStar_Const.Const_bool uu____11605 -> FStar_Syntax_Util.t_bool
-          | FStar_Const.Const_int (uu____11607,FStar_Pervasives_Native.None )
+          | FStar_Const.Const_bool uu____11553 -> FStar_Syntax_Util.t_bool
+          | FStar_Const.Const_int (uu____11555,FStar_Pervasives_Native.None )
               -> FStar_Syntax_Syntax.t_int
           | FStar_Const.Const_int
-              (uu____11620,FStar_Pervasives_Native.Some msize) ->
+              (uu____11568,FStar_Pervasives_Native.Some msize) ->
               FStar_Syntax_Syntax.tconst
                 (match msize with
                  | (FStar_Const.Signed ,FStar_Const.Int8 ) ->
@@ -4067,61 +4020,61 @@ and (tc_constant :
                      FStar_Parser_Const.uint32_lid
                  | (FStar_Const.Unsigned ,FStar_Const.Int64 ) ->
                      FStar_Parser_Const.uint64_lid)
-          | FStar_Const.Const_string uu____11638 ->
+          | FStar_Const.Const_string uu____11586 ->
               FStar_Syntax_Syntax.t_string
-          | FStar_Const.Const_real uu____11644 -> FStar_Syntax_Syntax.t_real
-          | FStar_Const.Const_float uu____11646 ->
+          | FStar_Const.Const_real uu____11592 -> FStar_Syntax_Syntax.t_real
+          | FStar_Const.Const_float uu____11594 ->
               FStar_Syntax_Syntax.t_float
-          | FStar_Const.Const_char uu____11647 ->
-              let uu____11649 =
+          | FStar_Const.Const_char uu____11595 ->
+              let uu____11597 =
                 FStar_Syntax_DsEnv.try_lookup_lid
                   env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid
                  in
-              FStar_All.pipe_right uu____11649 FStar_Util.must
+              FStar_All.pipe_right uu____11597 FStar_Util.must
           | FStar_Const.Const_effect  -> FStar_Syntax_Util.ktype0
-          | FStar_Const.Const_range uu____11654 ->
+          | FStar_Const.Const_range uu____11602 ->
               FStar_Syntax_Syntax.t_range
           | FStar_Const.Const_range_of  ->
-              let uu____11655 =
-                let uu____11661 =
-                  let uu____11663 = FStar_Parser_Const.const_to_string c  in
+              let uu____11603 =
+                let uu____11609 =
+                  let uu____11611 = FStar_Parser_Const.const_to_string c  in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11663
+                    uu____11611
                    in
-                (FStar_Errors.Fatal_IllTyped, uu____11661)  in
-              FStar_Errors.raise_error uu____11655 r
+                (FStar_Errors.Fatal_IllTyped, uu____11609)  in
+              FStar_Errors.raise_error uu____11603 r
           | FStar_Const.Const_set_range_of  ->
-              let uu____11667 =
-                let uu____11673 =
-                  let uu____11675 = FStar_Parser_Const.const_to_string c  in
+              let uu____11615 =
+                let uu____11621 =
+                  let uu____11623 = FStar_Parser_Const.const_to_string c  in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11675
+                    uu____11623
                    in
-                (FStar_Errors.Fatal_IllTyped, uu____11673)  in
-              FStar_Errors.raise_error uu____11667 r
+                (FStar_Errors.Fatal_IllTyped, uu____11621)  in
+              FStar_Errors.raise_error uu____11615 r
           | FStar_Const.Const_reify  ->
-              let uu____11679 =
-                let uu____11685 =
-                  let uu____11687 = FStar_Parser_Const.const_to_string c  in
+              let uu____11627 =
+                let uu____11633 =
+                  let uu____11635 = FStar_Parser_Const.const_to_string c  in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11687
+                    uu____11635
                    in
-                (FStar_Errors.Fatal_IllTyped, uu____11685)  in
-              FStar_Errors.raise_error uu____11679 r
-          | FStar_Const.Const_reflect uu____11691 ->
-              let uu____11692 =
-                let uu____11698 =
-                  let uu____11700 = FStar_Parser_Const.const_to_string c  in
+                (FStar_Errors.Fatal_IllTyped, uu____11633)  in
+              FStar_Errors.raise_error uu____11627 r
+          | FStar_Const.Const_reflect uu____11639 ->
+              let uu____11640 =
+                let uu____11646 =
+                  let uu____11648 = FStar_Parser_Const.const_to_string c  in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11700
+                    uu____11648
                    in
-                (FStar_Errors.Fatal_IllTyped, uu____11698)  in
-              FStar_Errors.raise_error uu____11692 r
-          | uu____11704 ->
+                (FStar_Errors.Fatal_IllTyped, uu____11646)  in
+              FStar_Errors.raise_error uu____11640 r
+          | uu____11652 ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnsupportedConstant,
                   "Unsupported constant") r
@@ -4138,30 +4091,30 @@ and (tc_comp :
     fun c  ->
       let c0 = c  in
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total (t,uu____11723) ->
-          let uu____11732 = FStar_Syntax_Util.type_u ()  in
-          (match uu____11732 with
+      | FStar_Syntax_Syntax.Total (t,uu____11671) ->
+          let uu____11680 = FStar_Syntax_Util.type_u ()  in
+          (match uu____11680 with
            | (k,u) ->
-               let uu____11745 = tc_check_tot_or_gtot_term env t k ""  in
-               (match uu____11745 with
-                | (t1,uu____11760,g) ->
-                    let uu____11762 =
+               let uu____11693 = tc_check_tot_or_gtot_term env t k ""  in
+               (match uu____11693 with
+                | (t1,uu____11708,g) ->
+                    let uu____11710 =
                       FStar_Syntax_Syntax.mk_Total' t1
                         (FStar_Pervasives_Native.Some u)
                        in
-                    (uu____11762, u, g)))
-      | FStar_Syntax_Syntax.GTotal (t,uu____11764) ->
-          let uu____11773 = FStar_Syntax_Util.type_u ()  in
-          (match uu____11773 with
+                    (uu____11710, u, g)))
+      | FStar_Syntax_Syntax.GTotal (t,uu____11712) ->
+          let uu____11721 = FStar_Syntax_Util.type_u ()  in
+          (match uu____11721 with
            | (k,u) ->
-               let uu____11786 = tc_check_tot_or_gtot_term env t k ""  in
-               (match uu____11786 with
-                | (t1,uu____11801,g) ->
-                    let uu____11803 =
+               let uu____11734 = tc_check_tot_or_gtot_term env t k ""  in
+               (match uu____11734 with
+                | (t1,uu____11749,g) ->
+                    let uu____11751 =
                       FStar_Syntax_Syntax.mk_GTotal' t1
                         (FStar_Pervasives_Native.Some u)
                        in
-                    (uu____11803, u, g)))
+                    (uu____11751, u, g)))
       | FStar_Syntax_Syntax.Comp c1 ->
           let head =
             FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
@@ -4173,75 +4126,72 @@ and (tc_comp :
             | us ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_uinst (head, us))
-                  FStar_Pervasives_Native.None c0.FStar_Syntax_Syntax.pos
+                  c0.FStar_Syntax_Syntax.pos
              in
           let tc =
-            let uu____11813 =
-              let uu____11818 =
-                let uu____11819 =
-                  FStar_Syntax_Syntax.as_arg
-                    c1.FStar_Syntax_Syntax.result_typ
-                   in
-                uu____11819 :: (c1.FStar_Syntax_Syntax.effect_args)  in
-              FStar_Syntax_Syntax.mk_Tm_app head1 uu____11818  in
-            uu____11813 FStar_Pervasives_Native.None
+            let uu____11759 =
+              let uu____11760 =
+                FStar_Syntax_Syntax.as_arg c1.FStar_Syntax_Syntax.result_typ
+                 in
+              uu____11760 :: (c1.FStar_Syntax_Syntax.effect_args)  in
+            FStar_Syntax_Syntax.mk_Tm_app head1 uu____11759
               (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
              in
-          let uu____11836 =
+          let uu____11777 =
             tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff ""  in
-          (match uu____11836 with
-           | (tc1,uu____11851,f) ->
-               let uu____11853 = FStar_Syntax_Util.head_and_args tc1  in
-               (match uu____11853 with
+          (match uu____11777 with
+           | (tc1,uu____11792,f) ->
+               let uu____11794 = FStar_Syntax_Util.head_and_args tc1  in
+               (match uu____11794 with
                 | (head2,args) ->
                     let comp_univs =
-                      let uu____11903 =
-                        let uu____11904 = FStar_Syntax_Subst.compress head2
+                      let uu____11844 =
+                        let uu____11845 = FStar_Syntax_Subst.compress head2
                            in
-                        uu____11904.FStar_Syntax_Syntax.n  in
-                      match uu____11903 with
-                      | FStar_Syntax_Syntax.Tm_uinst (uu____11907,us) -> us
-                      | uu____11913 -> []  in
-                    let uu____11914 = FStar_Syntax_Util.head_and_args tc1  in
-                    (match uu____11914 with
-                     | (uu____11937,args1) ->
-                         let uu____11963 =
-                           let uu____11986 = FStar_List.hd args1  in
-                           let uu____12003 = FStar_List.tl args1  in
-                           (uu____11986, uu____12003)  in
-                         (match uu____11963 with
+                        uu____11845.FStar_Syntax_Syntax.n  in
+                      match uu____11844 with
+                      | FStar_Syntax_Syntax.Tm_uinst (uu____11848,us) -> us
+                      | uu____11854 -> []  in
+                    let uu____11855 = FStar_Syntax_Util.head_and_args tc1  in
+                    (match uu____11855 with
+                     | (uu____11878,args1) ->
+                         let uu____11904 =
+                           let uu____11927 = FStar_List.hd args1  in
+                           let uu____11944 = FStar_List.tl args1  in
+                           (uu____11927, uu____11944)  in
+                         (match uu____11904 with
                           | (res,args2) ->
-                              let uu____12084 =
-                                let uu____12093 =
+                              let uu____12025 =
+                                let uu____12034 =
                                   FStar_All.pipe_right
                                     c1.FStar_Syntax_Syntax.flags
                                     (FStar_List.map
-                                       (fun uu___5_12121  ->
-                                          match uu___5_12121 with
+                                       (fun uu___5_12062  ->
+                                          match uu___5_12062 with
                                           | FStar_Syntax_Syntax.DECREASES e
                                               ->
-                                              let uu____12129 =
+                                              let uu____12070 =
                                                 FStar_TypeChecker_Env.clear_expected_typ
                                                   env
                                                  in
-                                              (match uu____12129 with
-                                               | (env1,uu____12141) ->
-                                                   let uu____12146 =
+                                              (match uu____12070 with
+                                               | (env1,uu____12082) ->
+                                                   let uu____12087 =
                                                      tc_tot_or_gtot_term env1
                                                        e
                                                       in
-                                                   (match uu____12146 with
-                                                    | (e1,uu____12158,g) ->
+                                                   (match uu____12087 with
+                                                    | (e1,uu____12099,g) ->
                                                         ((FStar_Syntax_Syntax.DECREASES
                                                             e1), g)))
                                           | f1 ->
                                               (f1,
                                                 FStar_TypeChecker_Env.trivial_guard)))
                                    in
-                                FStar_All.pipe_right uu____12093
+                                FStar_All.pipe_right uu____12034
                                   FStar_List.unzip
                                  in
-                              (match uu____12084 with
+                              (match uu____12025 with
                                | (flags,guards) ->
                                    let u =
                                      env.FStar_TypeChecker_Env.universe_of
@@ -4249,12 +4199,12 @@ and (tc_comp :
                                       in
                                    let c2 =
                                      FStar_Syntax_Syntax.mk_Comp
-                                       (let uu___1690_12199 = c1  in
+                                       (let uu___1690_12140 = c1  in
                                         {
                                           FStar_Syntax_Syntax.comp_univs =
                                             comp_univs;
                                           FStar_Syntax_Syntax.effect_name =
-                                            (uu___1690_12199.FStar_Syntax_Syntax.effect_name);
+                                            (uu___1690_12140.FStar_Syntax_Syntax.effect_name);
                                           FStar_Syntax_Syntax.result_typ =
                                             (FStar_Pervasives_Native.fst res);
                                           FStar_Syntax_Syntax.effect_args =
@@ -4267,12 +4217,12 @@ and (tc_comp :
                                        (FStar_TypeChecker_Util.universe_of_comp
                                           env u)
                                       in
-                                   let uu____12205 =
+                                   let uu____12146 =
                                      FStar_List.fold_left
                                        FStar_TypeChecker_Env.conj_guard f
                                        guards
                                       in
-                                   (c2, u_c, uu____12205))))))
+                                   (c2, u_c, uu____12146))))))
 
 and (tc_universe :
   FStar_TypeChecker_Env.env ->
@@ -4283,40 +4233,40 @@ and (tc_universe :
       let rec aux u1 =
         let u2 = FStar_Syntax_Subst.compress_univ u1  in
         match u2 with
-        | FStar_Syntax_Syntax.U_bvar uu____12215 ->
+        | FStar_Syntax_Syntax.U_bvar uu____12156 ->
             failwith "Impossible: locally nameless"
         | FStar_Syntax_Syntax.U_unknown  -> failwith "Unknown universe"
-        | FStar_Syntax_Syntax.U_unif uu____12219 -> u2
+        | FStar_Syntax_Syntax.U_unif uu____12160 -> u2
         | FStar_Syntax_Syntax.U_zero  -> u2
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____12231 = aux u3  in
-            FStar_Syntax_Syntax.U_succ uu____12231
+            let uu____12172 = aux u3  in
+            FStar_Syntax_Syntax.U_succ uu____12172
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____12235 = FStar_List.map aux us  in
-            FStar_Syntax_Syntax.U_max uu____12235
+            let uu____12176 = FStar_List.map aux us  in
+            FStar_Syntax_Syntax.U_max uu____12176
         | FStar_Syntax_Syntax.U_name x ->
-            let uu____12239 =
+            let uu____12180 =
               env.FStar_TypeChecker_Env.use_bv_sorts ||
                 (FStar_TypeChecker_Env.lookup_univ env x)
                in
-            if uu____12239
+            if uu____12180
             then u2
             else
-              (let uu____12244 =
-                 let uu____12246 =
-                   let uu____12248 = FStar_Syntax_Print.univ_to_string u2  in
-                   Prims.op_Hat uu____12248 " not found"  in
-                 Prims.op_Hat "Universe variable " uu____12246  in
-               failwith uu____12244)
+              (let uu____12185 =
+                 let uu____12187 =
+                   let uu____12189 = FStar_Syntax_Print.univ_to_string u2  in
+                   Prims.op_Hat uu____12189 " not found"  in
+                 Prims.op_Hat "Universe variable " uu____12187  in
+               failwith uu____12185)
          in
       if env.FStar_TypeChecker_Env.lax_universes
       then FStar_Syntax_Syntax.U_zero
       else
         (match u with
          | FStar_Syntax_Syntax.U_unknown  ->
-             let uu____12255 = FStar_Syntax_Util.type_u ()  in
-             FStar_All.pipe_right uu____12255 FStar_Pervasives_Native.snd
-         | uu____12264 -> aux u)
+             let uu____12196 = FStar_Syntax_Util.type_u ()  in
+             FStar_All.pipe_right uu____12196 FStar_Pervasives_Native.snd
+         | uu____12205 -> aux u)
 
 and (tc_abs_expected_function_typ :
   FStar_TypeChecker_Env.env ->
@@ -4337,97 +4287,97 @@ and (tc_abs_expected_function_typ :
           | FStar_Pervasives_Native.None  ->
               ((match env.FStar_TypeChecker_Env.letrecs with
                 | [] -> ()
-                | uu____12296 ->
+                | uu____12237 ->
                     failwith
                       "Impossible: Can't have a let rec annotation but no expected type");
-               (let uu____12306 = tc_binders env bs  in
-                match uu____12306 with
-                | (bs1,envbody,g_env,uu____12336) ->
+               (let uu____12247 = tc_binders env bs  in
+                match uu____12247 with
+                | (bs1,envbody,g_env,uu____12277) ->
                     (FStar_Pervasives_Native.None, bs1, [],
                       FStar_Pervasives_Native.None, envbody, body, g_env)))
           | FStar_Pervasives_Native.Some t ->
               let t1 = FStar_Syntax_Subst.compress t  in
               let rec as_function_typ norm1 t2 =
-                let uu____12382 =
-                  let uu____12383 = FStar_Syntax_Subst.compress t2  in
-                  uu____12383.FStar_Syntax_Syntax.n  in
-                match uu____12382 with
-                | FStar_Syntax_Syntax.Tm_uvar uu____12406 ->
+                let uu____12323 =
+                  let uu____12324 = FStar_Syntax_Subst.compress t2  in
+                  uu____12324.FStar_Syntax_Syntax.n  in
+                match uu____12323 with
+                | FStar_Syntax_Syntax.Tm_uvar uu____12347 ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu____12426 -> failwith "Impossible");
-                     (let uu____12436 = tc_binders env bs  in
-                      match uu____12436 with
-                      | (bs1,envbody,g_env,uu____12468) ->
-                          let uu____12469 =
+                      | uu____12367 -> failwith "Impossible");
+                     (let uu____12377 = tc_binders env bs  in
+                      match uu____12377 with
+                      | (bs1,envbody,g_env,uu____12409) ->
+                          let uu____12410 =
                             FStar_TypeChecker_Env.clear_expected_typ envbody
                              in
-                          (match uu____12469 with
-                           | (envbody1,uu____12497) ->
+                          (match uu____12410 with
+                           | (envbody1,uu____12438) ->
                                ((FStar_Pervasives_Native.Some t2), bs1, [],
                                  FStar_Pervasives_Native.None, envbody1,
                                  body, g_env))))
                 | FStar_Syntax_Syntax.Tm_app
                     ({
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                         uu____12508;
-                       FStar_Syntax_Syntax.pos = uu____12509;
-                       FStar_Syntax_Syntax.vars = uu____12510;_},uu____12511)
+                         uu____12449;
+                       FStar_Syntax_Syntax.pos = uu____12450;
+                       FStar_Syntax_Syntax.vars = uu____12451;_},uu____12452)
                     ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu____12555 -> failwith "Impossible");
-                     (let uu____12565 = tc_binders env bs  in
-                      match uu____12565 with
-                      | (bs1,envbody,g_env,uu____12597) ->
-                          let uu____12598 =
+                      | uu____12496 -> failwith "Impossible");
+                     (let uu____12506 = tc_binders env bs  in
+                      match uu____12506 with
+                      | (bs1,envbody,g_env,uu____12538) ->
+                          let uu____12539 =
                             FStar_TypeChecker_Env.clear_expected_typ envbody
                              in
-                          (match uu____12598 with
-                           | (envbody1,uu____12626) ->
+                          (match uu____12539 with
+                           | (envbody1,uu____12567) ->
                                ((FStar_Pervasives_Native.Some t2), bs1, [],
                                  FStar_Pervasives_Native.None, envbody1,
                                  body, g_env))))
-                | FStar_Syntax_Syntax.Tm_refine (b,uu____12638) ->
-                    let uu____12643 =
+                | FStar_Syntax_Syntax.Tm_refine (b,uu____12579) ->
+                    let uu____12584 =
                       as_function_typ norm1 b.FStar_Syntax_Syntax.sort  in
-                    (match uu____12643 with
-                     | (uu____12684,bs1,bs',copt,env_body,body1,g_env) ->
+                    (match uu____12584 with
+                     | (uu____12625,bs1,bs',copt,env_body,body1,g_env) ->
                          ((FStar_Pervasives_Native.Some t2), bs1, bs', copt,
                            env_body, body1, g_env))
                 | FStar_Syntax_Syntax.Tm_arrow (bs_expected,c_expected) ->
-                    let uu____12731 =
+                    let uu____12672 =
                       FStar_Syntax_Subst.open_comp bs_expected c_expected  in
-                    (match uu____12731 with
+                    (match uu____12672 with
                      | (bs_expected1,c_expected1) ->
                          let check_actuals_against_formals env1 bs1
                            bs_expected2 body1 =
-                           let rec handle_more uu____12866 c_expected2 body2
+                           let rec handle_more uu____12807 c_expected2 body2
                              =
-                             match uu____12866 with
+                             match uu____12807 with
                              | (env_bs,bs2,more,guard_env,subst) ->
                                  (match more with
                                   | FStar_Pervasives_Native.None  ->
-                                      let uu____12980 =
+                                      let uu____12921 =
                                         FStar_Syntax_Subst.subst_comp subst
                                           c_expected2
                                          in
-                                      (env_bs, bs2, guard_env, uu____12980,
+                                      (env_bs, bs2, guard_env, uu____12921,
                                         body2)
                                   | FStar_Pervasives_Native.Some
                                       (FStar_Util.Inr more_bs_expected) ->
                                       let c =
-                                        let uu____12997 =
+                                        let uu____12938 =
                                           FStar_Syntax_Util.arrow
                                             more_bs_expected c_expected2
                                            in
                                         FStar_Syntax_Syntax.mk_Total
-                                          uu____12997
+                                          uu____12938
                                          in
-                                      let uu____12998 =
+                                      let uu____12939 =
                                         FStar_Syntax_Subst.subst_comp subst c
                                          in
-                                      (env_bs, bs2, guard_env, uu____12998,
+                                      (env_bs, bs2, guard_env, uu____12939,
                                         body2)
                                   | FStar_Pervasives_Native.Some
                                       (FStar_Util.Inl more_bs) ->
@@ -4435,11 +4385,11 @@ and (tc_abs_expected_function_typ :
                                         FStar_Syntax_Subst.subst_comp subst
                                           c_expected2
                                          in
-                                      let uu____13015 =
+                                      let uu____12956 =
                                         (FStar_Options.ml_ish ()) ||
                                           (FStar_Syntax_Util.is_named_tot c)
                                          in
-                                      if uu____13015
+                                      if uu____12956
                                       then
                                         let t3 =
                                           FStar_TypeChecker_Normalize.unfold_whnf
@@ -4449,18 +4399,18 @@ and (tc_abs_expected_function_typ :
                                         (match t3.FStar_Syntax_Syntax.n with
                                          | FStar_Syntax_Syntax.Tm_arrow
                                              (bs_expected3,c_expected3) ->
-                                             let uu____13081 =
+                                             let uu____13022 =
                                                FStar_Syntax_Subst.open_comp
                                                  bs_expected3 c_expected3
                                                 in
-                                             (match uu____13081 with
+                                             (match uu____13022 with
                                               | (bs_expected4,c_expected4) ->
-                                                  let uu____13108 =
+                                                  let uu____13049 =
                                                     tc_abs_check_binders
                                                       env_bs more_bs
                                                       bs_expected4
                                                      in
-                                                  (match uu____13108 with
+                                                  (match uu____13049 with
                                                    | (env_bs_bs',bs',more1,guard'_env_bs,subst1)
                                                        ->
                                                        let guard'_env =
@@ -4468,8 +4418,8 @@ and (tc_abs_expected_function_typ :
                                                            env_bs bs2
                                                            guard'_env_bs
                                                           in
-                                                       let uu____13163 =
-                                                         let uu____13190 =
+                                                       let uu____13104 =
+                                                         let uu____13131 =
                                                            FStar_TypeChecker_Env.conj_guard
                                                              guard_env
                                                              guard'_env
@@ -4478,13 +4428,13 @@ and (tc_abs_expected_function_typ :
                                                            (FStar_List.append
                                                               bs2 bs'),
                                                            more1,
-                                                           uu____13190,
+                                                           uu____13131,
                                                            subst1)
                                                           in
                                                        handle_more
-                                                         uu____13163
+                                                         uu____13104
                                                          c_expected4 body2))
-                                         | uu____13213 ->
+                                         | uu____13154 ->
                                              let body3 =
                                                FStar_Syntax_Util.abs more_bs
                                                  body2
@@ -4500,128 +4450,128 @@ and (tc_abs_expected_function_typ :
                                             in
                                          (env_bs, bs2, guard_env, c, body3)))
                               in
-                           let uu____13242 =
+                           let uu____13183 =
                              tc_abs_check_binders env1 bs1 bs_expected2  in
-                           handle_more uu____13242 c_expected1 body1  in
+                           handle_more uu____13183 c_expected1 body1  in
                          let mk_letrec_env envbody bs1 c =
                            let letrecs = guard_letrecs envbody bs1 c  in
                            let envbody1 =
-                             let uu___1821_13307 = envbody  in
+                             let uu___1821_13248 = envbody  in
                              {
                                FStar_TypeChecker_Env.solver =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.solver);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.solver);
                                FStar_TypeChecker_Env.range =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.range);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.range);
                                FStar_TypeChecker_Env.curmodule =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.curmodule);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.curmodule);
                                FStar_TypeChecker_Env.gamma =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.gamma);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.gamma);
                                FStar_TypeChecker_Env.gamma_sig =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.gamma_sig);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.gamma_sig);
                                FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.gamma_cache);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.gamma_cache);
                                FStar_TypeChecker_Env.modules =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.modules);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.modules);
                                FStar_TypeChecker_Env.expected_typ =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.expected_typ);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.expected_typ);
                                FStar_TypeChecker_Env.sigtab =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.sigtab);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.sigtab);
                                FStar_TypeChecker_Env.attrtab =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.attrtab);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.attrtab);
                                FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.instantiate_imp);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.instantiate_imp);
                                FStar_TypeChecker_Env.effects =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.effects);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.effects);
                                FStar_TypeChecker_Env.generalize =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.generalize);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.generalize);
                                FStar_TypeChecker_Env.letrecs = [];
                                FStar_TypeChecker_Env.top_level =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.top_level);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.top_level);
                                FStar_TypeChecker_Env.check_uvars =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.check_uvars);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.check_uvars);
                                FStar_TypeChecker_Env.use_eq =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.use_eq);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.use_eq);
                                FStar_TypeChecker_Env.use_eq_strict =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.use_eq_strict);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.use_eq_strict);
                                FStar_TypeChecker_Env.is_iface =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.is_iface);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.is_iface);
                                FStar_TypeChecker_Env.admit =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.admit);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.admit);
                                FStar_TypeChecker_Env.lax =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.lax);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.lax);
                                FStar_TypeChecker_Env.lax_universes =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.lax_universes);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.phase1);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.phase1);
                                FStar_TypeChecker_Env.failhard =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.failhard);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.failhard);
                                FStar_TypeChecker_Env.nosynth =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.nosynth);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.nosynth);
                                FStar_TypeChecker_Env.uvar_subtyping =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.uvar_subtyping);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.tc_term =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.tc_term);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.type_of =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.type_of);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.type_of);
                                FStar_TypeChecker_Env.universe_of =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.universe_of);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.universe_of);
                                FStar_TypeChecker_Env.check_type_of =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.check_type_of);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.check_type_of);
                                FStar_TypeChecker_Env.use_bv_sorts =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.use_bv_sorts);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.qtbl_name_and_index);
                                FStar_TypeChecker_Env.normalized_eff_names =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.normalized_eff_names);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.normalized_eff_names);
                                FStar_TypeChecker_Env.fv_delta_depths =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.fv_delta_depths);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.fv_delta_depths);
                                FStar_TypeChecker_Env.proof_ns =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.proof_ns);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.proof_ns);
                                FStar_TypeChecker_Env.synth_hook =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.synth_hook);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.synth_hook);
                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                  =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                FStar_TypeChecker_Env.splice =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.splice);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.splice);
                                FStar_TypeChecker_Env.mpreprocess =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.mpreprocess);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.mpreprocess);
                                FStar_TypeChecker_Env.postprocess =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.postprocess);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.postprocess);
                                FStar_TypeChecker_Env.identifier_info =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.identifier_info);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.identifier_info);
                                FStar_TypeChecker_Env.tc_hooks =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.tc_hooks);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.tc_hooks);
                                FStar_TypeChecker_Env.dsenv =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.dsenv);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.nbe =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.nbe);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.nbe);
                                FStar_TypeChecker_Env.strict_args_tab =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.strict_args_tab);
+                                 (uu___1821_13248.FStar_TypeChecker_Env.strict_args_tab);
                                FStar_TypeChecker_Env.erasable_types_tab =
-                                 (uu___1821_13307.FStar_TypeChecker_Env.erasable_types_tab)
+                                 (uu___1821_13248.FStar_TypeChecker_Env.erasable_types_tab)
                              }  in
-                           let uu____13314 =
+                           let uu____13255 =
                              FStar_All.pipe_right letrecs
                                (FStar_List.fold_left
-                                  (fun uu____13380  ->
-                                     fun uu____13381  ->
-                                       match (uu____13380, uu____13381) with
+                                  (fun uu____13321  ->
+                                     fun uu____13322  ->
+                                       match (uu____13321, uu____13322) with
                                        | ((env1,letrec_binders,g),(l,t3,u_names))
                                            ->
-                                           let uu____13472 =
-                                             let uu____13479 =
-                                               let uu____13480 =
+                                           let uu____13413 =
+                                             let uu____13420 =
+                                               let uu____13421 =
                                                  FStar_TypeChecker_Env.clear_expected_typ
                                                    env1
                                                   in
                                                FStar_All.pipe_right
-                                                 uu____13480
+                                                 uu____13421
                                                  FStar_Pervasives_Native.fst
                                                 in
-                                             tc_term uu____13479 t3  in
-                                           (match uu____13472 with
-                                            | (t4,uu____13504,g') ->
+                                             tc_term uu____13420 t3  in
+                                           (match uu____13413 with
+                                            | (t4,uu____13445,g') ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.push_let_binding
                                                     env1 l (u_names, t4)
@@ -4629,84 +4579,84 @@ and (tc_abs_expected_function_typ :
                                                 let lb =
                                                   match l with
                                                   | FStar_Util.Inl x ->
-                                                      let uu____13517 =
+                                                      let uu____13458 =
                                                         FStar_Syntax_Syntax.mk_binder
-                                                          (let uu___1839_13520
+                                                          (let uu___1839_13461
                                                              = x  in
                                                            {
                                                              FStar_Syntax_Syntax.ppname
                                                                =
-                                                               (uu___1839_13520.FStar_Syntax_Syntax.ppname);
+                                                               (uu___1839_13461.FStar_Syntax_Syntax.ppname);
                                                              FStar_Syntax_Syntax.index
                                                                =
-                                                               (uu___1839_13520.FStar_Syntax_Syntax.index);
+                                                               (uu___1839_13461.FStar_Syntax_Syntax.index);
                                                              FStar_Syntax_Syntax.sort
                                                                = t4
                                                            })
                                                          in
-                                                      uu____13517 ::
+                                                      uu____13458 ::
                                                         letrec_binders
-                                                  | uu____13521 ->
+                                                  | uu____13462 ->
                                                       letrec_binders
                                                    in
-                                                let uu____13526 =
+                                                let uu____13467 =
                                                   FStar_TypeChecker_Env.conj_guard
                                                     g g'
                                                    in
-                                                (env2, lb, uu____13526)))
+                                                (env2, lb, uu____13467)))
                                   (envbody1, [],
                                     FStar_TypeChecker_Env.trivial_guard))
                               in
-                           match uu____13314 with
+                           match uu____13255 with
                            | (envbody2,letrec_binders,g) ->
-                               let uu____13546 =
+                               let uu____13487 =
                                  FStar_TypeChecker_Env.close_guard envbody2
                                    bs1 g
                                   in
-                               (envbody2, letrec_binders, uu____13546)
+                               (envbody2, letrec_binders, uu____13487)
                             in
-                         let uu____13549 =
+                         let uu____13490 =
                            check_actuals_against_formals env bs bs_expected1
                              body
                             in
-                         (match uu____13549 with
+                         (match uu____13490 with
                           | (envbody,bs1,g_env,c,body1) ->
-                              let uu____13585 = mk_letrec_env envbody bs1 c
+                              let uu____13526 = mk_letrec_env envbody bs1 c
                                  in
-                              (match uu____13585 with
+                              (match uu____13526 with
                                | (envbody1,letrecs,g_annots) ->
                                    let envbody2 =
                                      FStar_TypeChecker_Env.set_expected_typ
                                        envbody1
                                        (FStar_Syntax_Util.comp_result c)
                                       in
-                                   let uu____13622 =
+                                   let uu____13563 =
                                      FStar_TypeChecker_Env.conj_guard g_env
                                        g_annots
                                       in
                                    ((FStar_Pervasives_Native.Some t2), bs1,
                                      letrecs,
                                      (FStar_Pervasives_Native.Some c),
-                                     envbody2, body1, uu____13622))))
-                | uu____13629 ->
+                                     envbody2, body1, uu____13563))))
+                | uu____13570 ->
                     if Prims.op_Negation norm1
                     then
-                      let uu____13651 =
-                        let uu____13652 =
+                      let uu____13592 =
+                        let uu____13593 =
                           FStar_All.pipe_right t2
                             (FStar_TypeChecker_Normalize.unfold_whnf env)
                            in
-                        FStar_All.pipe_right uu____13652
+                        FStar_All.pipe_right uu____13593
                           FStar_Syntax_Util.unascribe
                          in
-                      as_function_typ true uu____13651
+                      as_function_typ true uu____13592
                     else
-                      (let uu____13656 =
+                      (let uu____13597 =
                          tc_abs_expected_function_typ env bs
                            FStar_Pervasives_Native.None body
                           in
-                       match uu____13656 with
-                       | (uu____13695,bs1,uu____13697,c_opt,envbody,body1,g_env)
+                       match uu____13597 with
+                       | (uu____13636,bs1,uu____13638,c_opt,envbody,body1,g_env)
                            ->
                            ((FStar_Pervasives_Native.Some t2), bs1, [],
                              c_opt, envbody, body1, g_env))
@@ -4725,128 +4675,128 @@ and (tc_abs_check_binders :
   fun env  ->
     fun bs  ->
       fun bs_expected  ->
-        let rec aux uu____13771 bs1 bs_expected1 =
-          match uu____13771 with
+        let rec aux uu____13712 bs1 bs_expected1 =
+          match uu____13712 with
           | (env1,subst) ->
               (match (bs1, bs_expected1) with
                | ([],[]) ->
                    (env1, [], FStar_Pervasives_Native.None,
                      FStar_TypeChecker_Env.trivial_guard, subst)
-               | ((uu____13878,FStar_Pervasives_Native.None )::uu____13879,
-                  (hd_e,q)::uu____13882) when
+               | ((uu____13819,FStar_Pervasives_Native.None )::uu____13820,
+                  (hd_e,q)::uu____13823) when
                    FStar_Syntax_Syntax.is_implicit_or_meta q ->
                    let bv =
-                     let uu____13934 =
-                       let uu____13937 =
+                     let uu____13875 =
+                       let uu____13878 =
                          FStar_Ident.range_of_id
                            hd_e.FStar_Syntax_Syntax.ppname
                           in
-                       FStar_Pervasives_Native.Some uu____13937  in
-                     let uu____13938 =
+                       FStar_Pervasives_Native.Some uu____13878  in
+                     let uu____13879 =
                        FStar_Syntax_Subst.subst subst
                          hd_e.FStar_Syntax_Syntax.sort
                         in
-                     FStar_Syntax_Syntax.new_bv uu____13934 uu____13938  in
+                     FStar_Syntax_Syntax.new_bv uu____13875 uu____13879  in
                    aux (env1, subst) ((bv, q) :: bs1) bs_expected1
                | ((hd,imp)::bs2,(hd_expected,imp')::bs_expected2) ->
                    ((let special q1 q2 =
                        match (q1, q2) with
                        | (FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.Meta
-                          uu____14033),FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____14034)) -> true
+                          uu____13974),FStar_Pervasives_Native.Some
+                          (FStar_Syntax_Syntax.Meta uu____13975)) -> true
                        | (FStar_Pervasives_Native.None
                           ,FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.Equality )) -> true
                        | (FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.Implicit
-                          uu____14049),FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____14050)) -> true
-                       | uu____14059 -> false  in
-                     let uu____14069 =
+                          uu____13990),FStar_Pervasives_Native.Some
+                          (FStar_Syntax_Syntax.Meta uu____13991)) -> true
+                       | uu____14000 -> false  in
+                     let uu____14010 =
                        (Prims.op_Negation (special imp imp')) &&
-                         (let uu____14072 =
+                         (let uu____14013 =
                             FStar_Syntax_Util.eq_aqual imp imp'  in
-                          uu____14072 <> FStar_Syntax_Util.Equal)
+                          uu____14013 <> FStar_Syntax_Util.Equal)
                         in
-                     if uu____14069
+                     if uu____14010
                      then
-                       let uu____14074 =
-                         let uu____14080 =
-                           let uu____14082 =
+                       let uu____14015 =
+                         let uu____14021 =
+                           let uu____14023 =
                              FStar_Syntax_Print.bv_to_string hd  in
                            FStar_Util.format1
                              "Inconsistent implicit argument annotation on argument %s"
-                             uu____14082
+                             uu____14023
                             in
                          (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                           uu____14080)
+                           uu____14021)
                           in
-                       let uu____14086 = FStar_Syntax_Syntax.range_of_bv hd
+                       let uu____14027 = FStar_Syntax_Syntax.range_of_bv hd
                           in
-                       FStar_Errors.raise_error uu____14074 uu____14086
+                       FStar_Errors.raise_error uu____14015 uu____14027
                      else ());
                     (let expected_t =
                        FStar_Syntax_Subst.subst subst
                          hd_expected.FStar_Syntax_Syntax.sort
                         in
-                     let uu____14090 =
-                       let uu____14097 =
-                         let uu____14098 =
+                     let uu____14031 =
+                       let uu____14038 =
+                         let uu____14039 =
                            FStar_Syntax_Util.unmeta
                              hd.FStar_Syntax_Syntax.sort
                             in
-                         uu____14098.FStar_Syntax_Syntax.n  in
-                       match uu____14097 with
+                         uu____14039.FStar_Syntax_Syntax.n  in
+                       match uu____14038 with
                        | FStar_Syntax_Syntax.Tm_unknown  ->
                            (expected_t, FStar_TypeChecker_Env.trivial_guard)
-                       | uu____14109 ->
-                           ((let uu____14111 =
+                       | uu____14050 ->
+                           ((let uu____14052 =
                                FStar_TypeChecker_Env.debug env1
                                  FStar_Options.High
                                 in
-                             if uu____14111
+                             if uu____14052
                              then
-                               let uu____14114 =
+                               let uu____14055 =
                                  FStar_Syntax_Print.bv_to_string hd  in
                                FStar_Util.print1 "Checking binder %s\n"
-                                 uu____14114
+                                 uu____14055
                              else ());
-                            (let uu____14119 =
+                            (let uu____14060 =
                                tc_tot_or_gtot_term env1
                                  hd.FStar_Syntax_Syntax.sort
                                 in
-                             match uu____14119 with
-                             | (t,uu____14133,g1_env) ->
+                             match uu____14060 with
+                             | (t,uu____14074,g1_env) ->
                                  let g2_env =
-                                   let uu____14136 =
+                                   let uu____14077 =
                                      FStar_TypeChecker_Rel.teq_nosmt env1 t
                                        expected_t
                                       in
-                                   match uu____14136 with
+                                   match uu____14077 with
                                    | FStar_Pervasives_Native.Some g ->
                                        FStar_All.pipe_right g
                                          (FStar_TypeChecker_Rel.resolve_implicits
                                             env1)
                                    | FStar_Pervasives_Native.None  ->
-                                       let uu____14140 =
+                                       let uu____14081 =
                                          FStar_TypeChecker_Rel.get_subtyping_prop
                                            env1 expected_t t
                                           in
-                                       (match uu____14140 with
+                                       (match uu____14081 with
                                         | FStar_Pervasives_Native.None  ->
-                                            let uu____14143 =
+                                            let uu____14084 =
                                               FStar_TypeChecker_Err.basic_type_error
                                                 env1
                                                 FStar_Pervasives_Native.None
                                                 expected_t t
                                                in
-                                            let uu____14149 =
+                                            let uu____14090 =
                                               FStar_TypeChecker_Env.get_range
                                                 env1
                                                in
                                             FStar_Errors.raise_error
-                                              uu____14143 uu____14149
+                                              uu____14084 uu____14090
                                         | FStar_Pervasives_Native.Some g_env
                                             ->
                                             FStar_TypeChecker_Util.label_guard
@@ -4854,43 +4804,43 @@ and (tc_abs_check_binders :
                                               "Type annotation on parameter incompatible with the expected type"
                                               g_env)
                                     in
-                                 let uu____14152 =
+                                 let uu____14093 =
                                    FStar_TypeChecker_Env.conj_guard g1_env
                                      g2_env
                                     in
-                                 (t, uu____14152)))
+                                 (t, uu____14093)))
                         in
-                     match uu____14090 with
+                     match uu____14031 with
                      | (t,g_env) ->
                          let hd1 =
-                           let uu___1946_14178 = hd  in
+                           let uu___1946_14119 = hd  in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___1946_14178.FStar_Syntax_Syntax.ppname);
+                               (uu___1946_14119.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___1946_14178.FStar_Syntax_Syntax.index);
+                               (uu___1946_14119.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t
                            }  in
                          let b = (hd1, imp)  in
                          let b_expected = (hd_expected, imp')  in
                          let env_b = push_binding env1 b  in
                          let subst1 =
-                           let uu____14201 =
+                           let uu____14142 =
                              FStar_Syntax_Syntax.bv_to_name hd1  in
-                           maybe_extend_subst subst b_expected uu____14201
+                           maybe_extend_subst subst b_expected uu____14142
                             in
-                         let uu____14204 =
+                         let uu____14145 =
                            aux (env_b, subst1) bs2 bs_expected2  in
-                         (match uu____14204 with
+                         (match uu____14145 with
                           | (env_bs,bs3,rest,g'_env_b,subst2) ->
                               let g'_env =
                                 FStar_TypeChecker_Env.close_guard env_bs 
                                   [b] g'_env_b
                                  in
-                              let uu____14269 =
+                              let uu____14210 =
                                 FStar_TypeChecker_Env.conj_guard g_env g'_env
                                  in
-                              (env_bs, (b :: bs3), rest, uu____14269, subst2))))
+                              (env_bs, (b :: bs3), rest, uu____14210, subst2))))
                | (rest,[]) ->
                    (env1, [],
                      (FStar_Pervasives_Native.Some (FStar_Util.Inl rest)),
@@ -4915,21 +4865,21 @@ and (tc_abs :
       fun bs  ->
         fun body  ->
           let fail msg t =
-            let uu____14408 =
+            let uu____14349 =
               FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function
                 env msg t top
                in
-            FStar_Errors.raise_error uu____14408 top.FStar_Syntax_Syntax.pos
+            FStar_Errors.raise_error uu____14349 top.FStar_Syntax_Syntax.pos
              in
           let use_eq = env.FStar_TypeChecker_Env.use_eq  in
-          let uu____14416 = FStar_TypeChecker_Env.clear_expected_typ env  in
-          match uu____14416 with
+          let uu____14357 = FStar_TypeChecker_Env.clear_expected_typ env  in
+          match uu____14357 with
           | (env1,topt) ->
-              ((let uu____14436 =
+              ((let uu____14377 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.High  in
-                if uu____14436
+                if uu____14377
                 then
-                  let uu____14439 =
+                  let uu____14380 =
                     match topt with
                     | FStar_Pervasives_Native.None  -> "None"
                     | FStar_Pervasives_Native.Some t ->
@@ -4937,242 +4887,240 @@ and (tc_abs :
                      in
                   FStar_Util.print2
                     "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
-                    uu____14439
+                    uu____14380
                     (if env1.FStar_TypeChecker_Env.top_level
                      then "true"
                      else "false")
                 else ());
-               (let uu____14453 =
+               (let uu____14394 =
                   tc_abs_expected_function_typ env1 bs topt body  in
-                match uu____14453 with
+                match uu____14394 with
                 | (tfun_opt,bs1,letrec_binders,c_opt,envbody,body1,g_env) ->
-                    ((let uu____14494 =
+                    ((let uu____14435 =
                         FStar_TypeChecker_Env.debug env1
                           FStar_Options.Extreme
                          in
-                      if uu____14494
+                      if uu____14435
                       then
-                        let uu____14497 =
+                        let uu____14438 =
                           match tfun_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
-                        let uu____14502 =
+                        let uu____14443 =
                           match c_opt with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.comp_to_string t
                            in
-                        let uu____14507 =
-                          let uu____14509 =
+                        let uu____14448 =
+                          let uu____14450 =
                             FStar_TypeChecker_Env.expected_typ envbody  in
-                          match uu____14509 with
+                          match uu____14450 with
                           | FStar_Pervasives_Native.None  -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t
                            in
                         FStar_Util.print3
                           "After expected_function_typ, tfun_opt: %s, c_opt: %s, and expected type in envbody: %s\n"
-                          uu____14497 uu____14502 uu____14507
+                          uu____14438 uu____14443 uu____14448
                       else ());
-                     (let uu____14519 =
+                     (let uu____14460 =
                         FStar_All.pipe_left
                           (FStar_TypeChecker_Env.debug env1)
                           (FStar_Options.Other "NYC")
                          in
-                      if uu____14519
+                      if uu____14460
                       then
-                        let uu____14524 =
+                        let uu____14465 =
                           FStar_Syntax_Print.binders_to_string ", " bs1  in
-                        let uu____14527 =
+                        let uu____14468 =
                           FStar_TypeChecker_Rel.guard_to_string env1 g_env
                            in
                         FStar_Util.print2
                           "!!!!!!!!!!!!!!!Guard for function with binders %s is %s\n"
-                          uu____14524 uu____14527
+                          uu____14465 uu____14468
                       else ());
                      (let envbody1 =
                         FStar_TypeChecker_Env.set_range envbody
                           body1.FStar_Syntax_Syntax.pos
                          in
-                      let uu____14533 =
-                        let uu____14544 =
-                          let uu____14552 =
+                      let uu____14474 =
+                        let uu____14485 =
+                          let uu____14493 =
                             (FStar_All.pipe_right c_opt FStar_Util.is_some)
                               &&
-                              (let uu____14562 =
-                                 let uu____14563 =
+                              (let uu____14503 =
+                                 let uu____14504 =
                                    FStar_Syntax_Subst.compress body1  in
-                                 uu____14563.FStar_Syntax_Syntax.n  in
-                               match uu____14562 with
+                                 uu____14504.FStar_Syntax_Syntax.n  in
+                               match uu____14503 with
                                | FStar_Syntax_Syntax.Tm_app (head,args) when
                                    (FStar_List.length args) = Prims.int_one
                                    ->
-                                   let uu____14603 =
-                                     let uu____14604 =
+                                   let uu____14544 =
+                                     let uu____14545 =
                                        FStar_Syntax_Subst.compress head  in
-                                     uu____14604.FStar_Syntax_Syntax.n  in
-                                   (match uu____14603 with
+                                     uu____14545.FStar_Syntax_Syntax.n  in
+                                   (match uu____14544 with
                                     | FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_reflect
-                                        uu____14608) -> true
-                                    | uu____14610 -> false)
-                               | uu____14612 -> false)
+                                        uu____14549) -> true
+                                    | uu____14551 -> false)
+                               | uu____14553 -> false)
                              in
-                          if uu____14552
+                          if uu____14493
                           then
-                            let uu____14622 =
-                              let uu____14623 =
+                            let uu____14563 =
+                              let uu____14564 =
                                 FStar_TypeChecker_Env.clear_expected_typ
                                   envbody1
                                  in
-                              FStar_All.pipe_right uu____14623
+                              FStar_All.pipe_right uu____14564
                                 FStar_Pervasives_Native.fst
                                in
-                            let uu____14638 =
-                              let uu____14639 =
-                                let uu____14646 =
-                                  let uu____14647 =
-                                    let uu____14674 =
-                                      let uu____14691 =
-                                        let uu____14700 =
-                                          FStar_All.pipe_right c_opt
-                                            FStar_Util.must
-                                           in
-                                        FStar_Util.Inr uu____14700  in
-                                      (uu____14691,
-                                        FStar_Pervasives_Native.None)
-                                       in
-                                    (body1, uu____14674,
+                            let uu____14579 =
+                              let uu____14580 =
+                                let uu____14581 =
+                                  let uu____14608 =
+                                    let uu____14625 =
+                                      let uu____14634 =
+                                        FStar_All.pipe_right c_opt
+                                          FStar_Util.must
+                                         in
+                                      FStar_Util.Inr uu____14634  in
+                                    (uu____14625,
                                       FStar_Pervasives_Native.None)
                                      in
-                                  FStar_Syntax_Syntax.Tm_ascribed uu____14647
+                                  (body1, uu____14608,
+                                    FStar_Pervasives_Native.None)
                                    in
-                                FStar_Syntax_Syntax.mk uu____14646  in
-                              uu____14639 FStar_Pervasives_Native.None
+                                FStar_Syntax_Syntax.Tm_ascribed uu____14581
+                                 in
+                              FStar_Syntax_Syntax.mk uu____14580
                                 FStar_Range.dummyRange
                                in
-                            (uu____14622, uu____14638, false)
+                            (uu____14563, uu____14579, false)
                           else
-                            (let uu____14749 =
-                               let uu____14751 =
-                                 let uu____14758 =
-                                   let uu____14759 =
+                            (let uu____14683 =
+                               let uu____14685 =
+                                 let uu____14692 =
+                                   let uu____14693 =
                                      FStar_Syntax_Subst.compress body1  in
-                                   uu____14759.FStar_Syntax_Syntax.n  in
-                                 (c_opt, uu____14758)  in
-                               match uu____14751 with
+                                   uu____14693.FStar_Syntax_Syntax.n  in
+                                 (c_opt, uu____14692)  in
+                               match uu____14685 with
                                | (FStar_Pervasives_Native.None
                                   ,FStar_Syntax_Syntax.Tm_ascribed
-                                  (uu____14765,(FStar_Util.Inr
-                                                expected_c,uu____14767),uu____14768))
+                                  (uu____14699,(FStar_Util.Inr
+                                                expected_c,uu____14701),uu____14702))
                                    -> false
-                               | uu____14818 -> true  in
-                             (envbody1, body1, uu____14749))
+                               | uu____14752 -> true  in
+                             (envbody1, body1, uu____14683))
                            in
-                        match uu____14544 with
+                        match uu____14485 with
                         | (envbody2,body2,should_check_expected_effect) ->
-                            let uu____14842 =
+                            let uu____14776 =
                               tc_term
-                                (let uu___2031_14851 = envbody2  in
+                                (let uu___2031_14785 = envbody2  in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.solver);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.range);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.curmodule);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.gamma);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.modules);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.sigtab);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.attrtab);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.effects);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.generalize);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.letrecs);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level = false;
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq = use_eq;
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.is_iface);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.admit);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.lax);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.lax);
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.phase1);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.failhard);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.nosynth);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.tc_term);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.type_of);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.universe_of);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.splice);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.postprocess);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.dsenv);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.nbe);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___2031_14785.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___2031_14851.FStar_TypeChecker_Env.erasable_types_tab)
+                                     (uu___2031_14785.FStar_TypeChecker_Env.erasable_types_tab)
                                  }) body2
                                in
-                            (match uu____14842 with
+                            (match uu____14776 with
                              | (body3,cbody,guard_body) ->
                                  let guard_body1 =
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
@@ -5180,201 +5128,201 @@ and (tc_abs :
                                     in
                                  if should_check_expected_effect
                                  then
-                                   let uu____14878 =
+                                   let uu____14812 =
                                      FStar_TypeChecker_Common.lcomp_comp
                                        cbody
                                       in
-                                   (match uu____14878 with
+                                   (match uu____14812 with
                                     | (cbody1,g_lc) ->
-                                        let uu____14895 =
+                                        let uu____14829 =
                                           check_expected_effect
-                                            (let uu___2042_14904 = envbody2
+                                            (let uu___2042_14838 = envbody2
                                                 in
                                              {
                                                FStar_TypeChecker_Env.solver =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.solver);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.solver);
                                                FStar_TypeChecker_Env.range =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.range);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.range);
                                                FStar_TypeChecker_Env.curmodule
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.curmodule);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.curmodule);
                                                FStar_TypeChecker_Env.gamma =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.gamma);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.gamma);
                                                FStar_TypeChecker_Env.gamma_sig
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.gamma_sig);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.gamma_sig);
                                                FStar_TypeChecker_Env.gamma_cache
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.gamma_cache);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.gamma_cache);
                                                FStar_TypeChecker_Env.modules
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.modules);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.modules);
                                                FStar_TypeChecker_Env.expected_typ
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.expected_typ);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.expected_typ);
                                                FStar_TypeChecker_Env.sigtab =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.sigtab);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.sigtab);
                                                FStar_TypeChecker_Env.attrtab
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.attrtab);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.attrtab);
                                                FStar_TypeChecker_Env.instantiate_imp
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.instantiate_imp);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.instantiate_imp);
                                                FStar_TypeChecker_Env.effects
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.effects);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.effects);
                                                FStar_TypeChecker_Env.generalize
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.generalize);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.generalize);
                                                FStar_TypeChecker_Env.letrecs
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.letrecs);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.letrecs);
                                                FStar_TypeChecker_Env.top_level
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.top_level);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.top_level);
                                                FStar_TypeChecker_Env.check_uvars
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.check_uvars);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.check_uvars);
                                                FStar_TypeChecker_Env.use_eq =
                                                  use_eq;
                                                FStar_TypeChecker_Env.use_eq_strict
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.use_eq_strict);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.use_eq_strict);
                                                FStar_TypeChecker_Env.is_iface
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.is_iface);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.is_iface);
                                                FStar_TypeChecker_Env.admit =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.admit);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.admit);
                                                FStar_TypeChecker_Env.lax =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.lax);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.lax);
                                                FStar_TypeChecker_Env.lax_universes
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.lax_universes);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.lax_universes);
                                                FStar_TypeChecker_Env.phase1 =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.phase1);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.phase1);
                                                FStar_TypeChecker_Env.failhard
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.failhard);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.failhard);
                                                FStar_TypeChecker_Env.nosynth
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.nosynth);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.nosynth);
                                                FStar_TypeChecker_Env.uvar_subtyping
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.uvar_subtyping);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.uvar_subtyping);
                                                FStar_TypeChecker_Env.tc_term
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.tc_term);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.tc_term);
                                                FStar_TypeChecker_Env.type_of
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.type_of);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.type_of);
                                                FStar_TypeChecker_Env.universe_of
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.universe_of);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.universe_of);
                                                FStar_TypeChecker_Env.check_type_of
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.check_type_of);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.check_type_of);
                                                FStar_TypeChecker_Env.use_bv_sorts
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.use_bv_sorts);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.use_bv_sorts);
                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                FStar_TypeChecker_Env.normalized_eff_names
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.normalized_eff_names);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.normalized_eff_names);
                                                FStar_TypeChecker_Env.fv_delta_depths
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.fv_delta_depths);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.fv_delta_depths);
                                                FStar_TypeChecker_Env.proof_ns
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.proof_ns);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.proof_ns);
                                                FStar_TypeChecker_Env.synth_hook
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.synth_hook);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.synth_hook);
                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                FStar_TypeChecker_Env.splice =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.splice);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.splice);
                                                FStar_TypeChecker_Env.mpreprocess
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.mpreprocess);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.mpreprocess);
                                                FStar_TypeChecker_Env.postprocess
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.postprocess);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.postprocess);
                                                FStar_TypeChecker_Env.identifier_info
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.identifier_info);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.identifier_info);
                                                FStar_TypeChecker_Env.tc_hooks
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.tc_hooks);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.tc_hooks);
                                                FStar_TypeChecker_Env.dsenv =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.dsenv);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.dsenv);
                                                FStar_TypeChecker_Env.nbe =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.nbe);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.nbe);
                                                FStar_TypeChecker_Env.strict_args_tab
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.strict_args_tab);
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.strict_args_tab);
                                                FStar_TypeChecker_Env.erasable_types_tab
                                                  =
-                                                 (uu___2042_14904.FStar_TypeChecker_Env.erasable_types_tab)
+                                                 (uu___2042_14838.FStar_TypeChecker_Env.erasable_types_tab)
                                              }) c_opt (body3, cbody1)
                                            in
-                                        (match uu____14895 with
+                                        (match uu____14829 with
                                          | (body4,cbody2,guard) ->
-                                             let uu____14918 =
-                                               let uu____14919 =
+                                             let uu____14852 =
+                                               let uu____14853 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g_lc guard
                                                   in
                                                FStar_TypeChecker_Env.conj_guard
-                                                 guard_body1 uu____14919
+                                                 guard_body1 uu____14853
                                                 in
-                                             (body4, cbody2, uu____14918)))
+                                             (body4, cbody2, uu____14852)))
                                  else
-                                   (let uu____14926 =
+                                   (let uu____14860 =
                                       FStar_TypeChecker_Common.lcomp_comp
                                         cbody
                                        in
-                                    match uu____14926 with
+                                    match uu____14860 with
                                     | (cbody1,g_lc) ->
-                                        let uu____14943 =
+                                        let uu____14877 =
                                           FStar_TypeChecker_Env.conj_guard
                                             guard_body1 g_lc
                                            in
-                                        (body3, cbody1, uu____14943)))
+                                        (body3, cbody1, uu____14877)))
                          in
-                      match uu____14533 with
+                      match uu____14474 with
                       | (body2,cbody,guard_body) ->
                           let guard =
-                            let uu____14966 =
+                            let uu____14900 =
                               env1.FStar_TypeChecker_Env.top_level ||
-                                (let uu____14969 =
+                                (let uu____14903 =
                                    FStar_TypeChecker_Env.should_verify env1
                                     in
-                                 Prims.op_Negation uu____14969)
+                                 Prims.op_Negation uu____14903)
                                in
-                            if uu____14966
+                            if uu____14900
                             then
-                              let uu____14972 =
+                              let uu____14906 =
                                 FStar_TypeChecker_Rel.discharge_guard env1
                                   g_env
                                  in
-                              let uu____14973 =
+                              let uu____14907 =
                                 FStar_TypeChecker_Rel.discharge_guard
                                   envbody1 guard_body
                                  in
-                              FStar_TypeChecker_Env.conj_guard uu____14972
-                                uu____14973
+                              FStar_TypeChecker_Env.conj_guard uu____14906
+                                uu____14907
                             else
                               (let guard =
-                                 let uu____14977 =
+                                 let uu____14911 =
                                    FStar_TypeChecker_Env.close_guard env1
                                      (FStar_List.append bs1 letrec_binders)
                                      guard_body
                                     in
                                  FStar_TypeChecker_Env.conj_guard g_env
-                                   uu____14977
+                                   uu____14911
                                   in
                                guard)
                              in
@@ -5390,7 +5338,7 @@ and (tc_abs :
                                  (FStar_Syntax_Util.residual_comp_of_comp
                                     (FStar_Util.dflt cbody c_opt)))
                              in
-                          let uu____14992 =
+                          let uu____14926 =
                             match tfun_opt with
                             | FStar_Pervasives_Native.Some t ->
                                 let t1 = FStar_Syntax_Subst.compress t  in
@@ -5402,43 +5350,43 @@ and (tc_abs :
                                         "Impossible! tc_abs: if tfun_computed is Some, expected topt to also be Some"
                                    in
                                 (match t1.FStar_Syntax_Syntax.n with
-                                 | FStar_Syntax_Syntax.Tm_arrow uu____15016
+                                 | FStar_Syntax_Syntax.Tm_arrow uu____14950
                                      -> (e, t_annot, guard1)
-                                 | uu____15031 ->
+                                 | uu____14965 ->
                                      let lc =
-                                       let uu____15033 =
+                                       let uu____14967 =
                                          FStar_Syntax_Syntax.mk_Total
                                            tfun_computed
                                           in
-                                       FStar_All.pipe_right uu____15033
+                                       FStar_All.pipe_right uu____14967
                                          FStar_TypeChecker_Common.lcomp_of_comp
                                         in
-                                     let uu____15034 =
+                                     let uu____14968 =
                                        FStar_TypeChecker_Util.check_has_type
                                          env1 e lc t1
                                         in
-                                     (match uu____15034 with
-                                      | (e1,uu____15048,guard') ->
-                                          let uu____15050 =
+                                     (match uu____14968 with
+                                      | (e1,uu____14982,guard') ->
+                                          let uu____14984 =
                                             FStar_TypeChecker_Env.conj_guard
                                               guard1 guard'
                                              in
-                                          (e1, t_annot, uu____15050)))
+                                          (e1, t_annot, uu____14984)))
                             | FStar_Pervasives_Native.None  ->
                                 (e, tfun_computed, guard1)
                              in
-                          (match uu____14992 with
+                          (match uu____14926 with
                            | (e1,tfun,guard2) ->
                                let c = FStar_Syntax_Syntax.mk_Total tfun  in
-                               let uu____15061 =
-                                 let uu____15066 =
+                               let uu____14995 =
+                                 let uu____15000 =
                                    FStar_TypeChecker_Common.lcomp_of_comp c
                                     in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    FStar_Pervasives_Native.None env1 e1
-                                   uu____15066 guard2
+                                   uu____15000 guard2
                                   in
-                               (match uu____15061 with
+                               (match uu____14995 with
                                 | (c1,g) -> (e1, c1, g)))))))
 
 and (check_application_args :
@@ -5462,98 +5410,98 @@ and (check_application_args :
               let n_args = FStar_List.length args  in
               let r = FStar_TypeChecker_Env.get_range env  in
               let thead = FStar_Syntax_Util.comp_result chead  in
-              (let uu____15117 =
+              (let uu____15051 =
                  FStar_TypeChecker_Env.debug env FStar_Options.High  in
-               if uu____15117
+               if uu____15051
                then
-                 let uu____15120 =
+                 let uu____15054 =
                    FStar_Range.string_of_range head.FStar_Syntax_Syntax.pos
                     in
-                 let uu____15122 = FStar_Syntax_Print.term_to_string thead
+                 let uu____15056 = FStar_Syntax_Print.term_to_string thead
                     in
-                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____15120
-                   uu____15122
+                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____15054
+                   uu____15056
                else ());
-              (let monadic_application uu____15204 subst arg_comps_rev
+              (let monadic_application uu____15138 subst arg_comps_rev
                  arg_rets_rev guard fvs bs =
-                 match uu____15204 with
+                 match uu____15138 with
                  | (head1,chead1,ghead1,cres) ->
-                     let uu____15273 =
+                     let uu____15207 =
                        check_no_escape (FStar_Pervasives_Native.Some head1)
                          env fvs (FStar_Syntax_Util.comp_result cres)
                         in
-                     (match uu____15273 with
+                     (match uu____15207 with
                       | (rt,g0) ->
                           let cres1 =
                             FStar_Syntax_Util.set_result_typ cres rt  in
-                          let uu____15287 =
+                          let uu____15221 =
                             match bs with
                             | [] ->
                                 let g =
-                                  let uu____15303 =
+                                  let uu____15237 =
                                     FStar_TypeChecker_Env.conj_guard ghead1
                                       guard
                                      in
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.conj_guard g0)
-                                    uu____15303
+                                    uu____15237
                                    in
                                 (cres1, g)
-                            | uu____15304 ->
+                            | uu____15238 ->
                                 let g =
-                                  let uu____15314 =
-                                    let uu____15315 =
+                                  let uu____15248 =
+                                    let uu____15249 =
                                       FStar_TypeChecker_Env.conj_guard ghead1
                                         guard
                                        in
-                                    FStar_All.pipe_right uu____15315
+                                    FStar_All.pipe_right uu____15249
                                       (FStar_TypeChecker_Rel.solve_deferred_constraints
                                          env)
                                      in
                                   FStar_TypeChecker_Env.conj_guard g0
-                                    uu____15314
+                                    uu____15248
                                    in
-                                let uu____15316 =
-                                  let uu____15317 =
+                                let uu____15250 =
+                                  let uu____15251 =
                                     FStar_Syntax_Util.arrow bs cres1  in
-                                  FStar_Syntax_Syntax.mk_Total uu____15317
+                                  FStar_Syntax_Syntax.mk_Total uu____15251
                                    in
-                                (uu____15316, g)
+                                (uu____15250, g)
                              in
-                          (match uu____15287 with
+                          (match uu____15221 with
                            | (cres2,guard1) ->
-                               ((let uu____15327 =
+                               ((let uu____15261 =
                                    FStar_TypeChecker_Env.debug env
                                      FStar_Options.Medium
                                     in
-                                 if uu____15327
+                                 if uu____15261
                                  then
-                                   let uu____15330 =
+                                   let uu____15264 =
                                      FStar_Syntax_Print.comp_to_string cres2
                                       in
                                    FStar_Util.print1
                                      "\t Type of result cres is %s\n"
-                                     uu____15330
+                                     uu____15264
                                  else ());
-                                (let uu____15335 =
-                                   let uu____15340 =
-                                     let uu____15341 =
+                                (let uu____15269 =
+                                   let uu____15274 =
+                                     let uu____15275 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          chead1
                                         in
-                                     FStar_All.pipe_right uu____15341
+                                     FStar_All.pipe_right uu____15275
                                        FStar_TypeChecker_Common.lcomp_of_comp
                                       in
-                                   let uu____15342 =
-                                     let uu____15343 =
+                                   let uu____15276 =
+                                     let uu____15277 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          cres2
                                         in
-                                     FStar_All.pipe_right uu____15343
+                                     FStar_All.pipe_right uu____15277
                                        FStar_TypeChecker_Common.lcomp_of_comp
                                       in
-                                   (uu____15340, uu____15342)  in
-                                 match uu____15335 with
+                                   (uu____15274, uu____15276)  in
+                                 match uu____15269 with
                                  | (chead2,cres3) ->
                                      let cres4 =
                                        let head_is_pure_and_some_arg_is_effectful
@@ -5562,16 +5510,16 @@ and (check_application_args :
                                             chead2)
                                            &&
                                            (FStar_Util.for_some
-                                              (fun uu____15367  ->
-                                                 match uu____15367 with
-                                                 | (uu____15377,uu____15378,lc)
+                                              (fun uu____15301  ->
+                                                 match uu____15301 with
+                                                 | (uu____15311,uu____15312,lc)
                                                      ->
-                                                     (let uu____15386 =
+                                                     (let uu____15320 =
                                                         FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                           lc
                                                          in
                                                       Prims.op_Negation
-                                                        uu____15386)
+                                                        uu____15320)
                                                        ||
                                                        (FStar_TypeChecker_Util.should_not_inline_lc
                                                           lc)) arg_comps_rev)
@@ -5579,64 +5527,63 @@ and (check_application_args :
                                        let term =
                                          FStar_Syntax_Syntax.mk_Tm_app head1
                                            (FStar_List.rev arg_rets_rev)
-                                           FStar_Pervasives_Native.None
                                            head1.FStar_Syntax_Syntax.pos
                                           in
-                                       let uu____15399 =
+                                       let uu____15331 =
                                          (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             cres3)
                                            &&
                                            head_is_pure_and_some_arg_is_effectful
                                           in
-                                       if uu____15399
+                                       if uu____15331
                                        then
-                                         ((let uu____15403 =
+                                         ((let uu____15335 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____15403
+                                           if uu____15335
                                            then
-                                             let uu____15406 =
+                                             let uu____15338 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: Return inserted in monadic application: %s\n"
-                                               uu____15406
+                                               uu____15338
                                            else ());
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                             env term cres3)
                                        else
-                                         ((let uu____15414 =
+                                         ((let uu____15346 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme
                                               in
-                                           if uu____15414
+                                           if uu____15346
                                            then
-                                             let uu____15417 =
+                                             let uu____15349 =
                                                FStar_Syntax_Print.term_to_string
                                                  term
                                                 in
                                              FStar_Util.print1
                                                "(a) Monadic app: No return inserted in monadic application: %s\n"
-                                               uu____15417
+                                               uu____15349
                                            else ());
                                           cres3)
                                         in
                                      let comp =
                                        FStar_List.fold_left
                                          (fun out_c  ->
-                                            fun uu____15448  ->
-                                              match uu____15448 with
+                                            fun uu____15380  ->
+                                              match uu____15380 with
                                               | ((e,q),x,c) ->
-                                                  ((let uu____15490 =
+                                                  ((let uu____15422 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____15490
+                                                    if uu____15422
                                                     then
-                                                      let uu____15493 =
+                                                      let uu____15425 =
                                                         match x with
                                                         | FStar_Pervasives_Native.None
                                                              -> "_"
@@ -5645,25 +5592,25 @@ and (check_application_args :
                                                             FStar_Syntax_Print.bv_to_string
                                                               x1
                                                          in
-                                                      let uu____15498 =
+                                                      let uu____15430 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____15500 =
+                                                      let uu____15432 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print3
                                                         "(b) Monadic app: Binding argument %s : %s of type (%s)\n"
-                                                        uu____15493
-                                                        uu____15498
-                                                        uu____15500
+                                                        uu____15425
+                                                        uu____15430
+                                                        uu____15432
                                                     else ());
-                                                   (let uu____15505 =
+                                                   (let uu____15437 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____15505
+                                                    if uu____15437
                                                     then
                                                       FStar_TypeChecker_Util.bind
                                                         e.FStar_Syntax_Syntax.pos
@@ -5679,25 +5626,25 @@ and (check_application_args :
                                          arg_comps_rev
                                         in
                                      let comp1 =
-                                       (let uu____15516 =
+                                       (let uu____15448 =
                                           FStar_TypeChecker_Env.debug env
                                             FStar_Options.Extreme
                                            in
-                                        if uu____15516
+                                        if uu____15448
                                         then
-                                          let uu____15519 =
+                                          let uu____15451 =
                                             FStar_Syntax_Print.term_to_string
                                               head1
                                              in
                                           FStar_Util.print1
                                             "(c) Monadic app: Binding head %s\n"
-                                            uu____15519
+                                            uu____15451
                                         else ());
-                                       (let uu____15524 =
+                                       (let uu____15456 =
                                           FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             chead2
                                            in
-                                        if uu____15524
+                                        if uu____15456
                                         then
                                           FStar_TypeChecker_Util.bind
                                             head1.FStar_Syntax_Syntax.pos env
@@ -5714,36 +5661,35 @@ and (check_application_args :
                                               comp))
                                         in
                                      let shortcuts_evaluation_order =
-                                       let uu____15535 =
-                                         let uu____15536 =
+                                       let uu____15467 =
+                                         let uu____15468 =
                                            FStar_Syntax_Subst.compress head1
                                             in
-                                         uu____15536.FStar_Syntax_Syntax.n
+                                         uu____15468.FStar_Syntax_Syntax.n
                                           in
-                                       match uu____15535 with
+                                       match uu____15467 with
                                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                                            (FStar_Syntax_Syntax.fv_eq_lid fv
                                               FStar_Parser_Const.op_And)
                                              ||
                                              (FStar_Syntax_Syntax.fv_eq_lid
                                                 fv FStar_Parser_Const.op_Or)
-                                       | uu____15541 -> false  in
+                                       | uu____15473 -> false  in
                                      let app =
                                        if shortcuts_evaluation_order
                                        then
                                          let args1 =
                                            FStar_List.fold_left
                                              (fun args1  ->
-                                                fun uu____15564  ->
-                                                  match uu____15564 with
-                                                  | (arg,uu____15578,uu____15579)
+                                                fun uu____15496  ->
+                                                  match uu____15496 with
+                                                  | (arg,uu____15510,uu____15511)
                                                       -> arg :: args1) []
                                              arg_comps_rev
                                             in
                                          let app =
                                            FStar_Syntax_Syntax.mk_Tm_app
-                                             head1 args1
-                                             FStar_Pervasives_Native.None r
+                                             head1 args1 r
                                             in
                                          let app1 =
                                            FStar_TypeChecker_Util.maybe_lift
@@ -5757,42 +5703,42 @@ and (check_application_args :
                                            comp1.FStar_TypeChecker_Common.eff_name
                                            comp1.FStar_TypeChecker_Common.res_typ
                                        else
-                                         (let uu____15590 =
-                                            let map_fun uu____15656 =
-                                              match uu____15656 with
-                                              | ((e,q),uu____15697,c) ->
-                                                  ((let uu____15720 =
+                                         (let uu____15520 =
+                                            let map_fun uu____15586 =
+                                              match uu____15586 with
+                                              | ((e,q),uu____15627,c) ->
+                                                  ((let uu____15650 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme
                                                        in
-                                                    if uu____15720
+                                                    if uu____15650
                                                     then
-                                                      let uu____15723 =
+                                                      let uu____15653 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e
                                                          in
-                                                      let uu____15725 =
+                                                      let uu____15655 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c
                                                          in
                                                       FStar_Util.print2
                                                         "For arg e=(%s) c=(%s)... "
-                                                        uu____15723
-                                                        uu____15725
+                                                        uu____15653
+                                                        uu____15655
                                                     else ());
-                                                   (let uu____15730 =
+                                                   (let uu____15660 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c
                                                        in
-                                                    if uu____15730
+                                                    if uu____15660
                                                     then
-                                                      ((let uu____15756 =
+                                                      ((let uu____15686 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____15756
+                                                        if uu____15686
                                                         then
                                                           FStar_Util.print_string
                                                             "... not lifting\n"
@@ -5806,72 +5752,72 @@ and (check_application_args :
                                                             env
                                                             chead2.FStar_TypeChecker_Common.res_typ)
                                                            &&
-                                                           (let uu____15797 =
-                                                              let uu____15799
+                                                           (let uu____15727 =
+                                                              let uu____15729
                                                                 =
-                                                                let uu____15800
+                                                                let uu____15730
                                                                   =
                                                                   FStar_Syntax_Util.un_uinst
                                                                     head1
                                                                    in
-                                                                uu____15800.FStar_Syntax_Syntax.n
+                                                                uu____15730.FStar_Syntax_Syntax.n
                                                                  in
-                                                              match uu____15799
+                                                              match uu____15729
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_fvar
                                                                   fv ->
-                                                                  let uu____15805
+                                                                  let uu____15735
                                                                     =
                                                                     FStar_Parser_Const.psconst
                                                                     "ignore"
                                                                      in
                                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                                     fv
-                                                                    uu____15805
-                                                              | uu____15807
+                                                                    uu____15735
+                                                              | uu____15737
                                                                   -> true
                                                                in
                                                             Prims.op_Negation
-                                                              uu____15797)
+                                                              uu____15727)
                                                           in
                                                        if warn_effectful_args
                                                        then
-                                                         (let uu____15811 =
-                                                            let uu____15817 =
-                                                              let uu____15819
+                                                         (let uu____15741 =
+                                                            let uu____15747 =
+                                                              let uu____15749
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   e
                                                                  in
-                                                              let uu____15821
+                                                              let uu____15751
                                                                 =
                                                                 FStar_Ident.string_of_lid
                                                                   c.FStar_TypeChecker_Common.eff_name
                                                                  in
-                                                              let uu____15823
+                                                              let uu____15753
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   head1
                                                                  in
                                                               FStar_Util.format3
                                                                 "Effectful argument %s (%s) to erased function %s, consider let binding it"
-                                                                uu____15819
-                                                                uu____15821
-                                                                uu____15823
+                                                                uu____15749
+                                                                uu____15751
+                                                                uu____15753
                                                                in
                                                             (FStar_Errors.Warning_EffectfulArgumentToErasedFunction,
-                                                              uu____15817)
+                                                              uu____15747)
                                                              in
                                                           FStar_Errors.log_issue
                                                             e.FStar_Syntax_Syntax.pos
-                                                            uu____15811)
+                                                            uu____15741)
                                                        else ();
-                                                       (let uu____15830 =
+                                                       (let uu____15760 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme
                                                            in
-                                                        if uu____15830
+                                                        if uu____15760
                                                         then
                                                           FStar_Util.print_string
                                                             "... lifting!\n"
@@ -5888,68 +5834,66 @@ and (check_application_args :
                                                             comp1.FStar_TypeChecker_Common.eff_name
                                                             c.FStar_TypeChecker_Common.res_typ
                                                            in
-                                                        let uu____15838 =
-                                                          let uu____15847 =
+                                                        let uu____15768 =
+                                                          let uu____15777 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x
                                                              in
-                                                          (uu____15847, q)
+                                                          (uu____15777, q)
                                                            in
                                                         ((FStar_Pervasives_Native.Some
                                                             (x,
                                                               (c.FStar_TypeChecker_Common.eff_name),
                                                               (c.FStar_TypeChecker_Common.res_typ),
                                                               e1)),
-                                                          uu____15838)))))
+                                                          uu____15768)))))
                                                in
-                                            let uu____15876 =
-                                              let uu____15907 =
-                                                let uu____15936 =
-                                                  let uu____15947 =
-                                                    let uu____15956 =
+                                            let uu____15806 =
+                                              let uu____15837 =
+                                                let uu____15866 =
+                                                  let uu____15877 =
+                                                    let uu____15886 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         head1
                                                        in
-                                                    (uu____15956,
+                                                    (uu____15886,
                                                       FStar_Pervasives_Native.None,
                                                       chead2)
                                                      in
-                                                  uu____15947 ::
+                                                  uu____15877 ::
                                                     arg_comps_rev
                                                    in
                                                 FStar_List.map map_fun
-                                                  uu____15936
+                                                  uu____15866
                                                  in
                                               FStar_All.pipe_left
-                                                FStar_List.split uu____15907
+                                                FStar_List.split uu____15837
                                                in
-                                            match uu____15876 with
+                                            match uu____15806 with
                                             | (lifted_args,reverse_args) ->
-                                                let uu____16157 =
-                                                  let uu____16158 =
+                                                let uu____16087 =
+                                                  let uu____16088 =
                                                     FStar_List.hd
                                                       reverse_args
                                                      in
                                                   FStar_Pervasives_Native.fst
-                                                    uu____16158
+                                                    uu____16088
                                                    in
-                                                let uu____16179 =
-                                                  let uu____16180 =
+                                                let uu____16109 =
+                                                  let uu____16110 =
                                                     FStar_List.tl
                                                       reverse_args
                                                      in
-                                                  FStar_List.rev uu____16180
+                                                  FStar_List.rev uu____16110
                                                    in
-                                                (lifted_args, uu____16157,
-                                                  uu____16179)
+                                                (lifted_args, uu____16087,
+                                                  uu____16109)
                                              in
-                                          match uu____15590 with
+                                          match uu____15520 with
                                           | (lifted_args,head2,args1) ->
                                               let app =
                                                 FStar_Syntax_Syntax.mk_Tm_app
-                                                  head2 args1
-                                                  FStar_Pervasives_Native.None
-                                                  r
+                                                  head2 args1 r
                                                  in
                                               let app1 =
                                                 FStar_TypeChecker_Util.maybe_lift
@@ -5965,8 +5909,8 @@ and (check_application_args :
                                                   comp1.FStar_TypeChecker_Common.res_typ
                                                  in
                                               let bind_lifted_args e
-                                                uu___6_16291 =
-                                                match uu___6_16291 with
+                                                uu___6_16219 =
+                                                match uu___6_16219 with
                                                 | FStar_Pervasives_Native.None
                                                      -> e
                                                 | FStar_Pervasives_Native.Some
@@ -5978,33 +5922,28 @@ and (check_application_args :
                                                         e1.FStar_Syntax_Syntax.pos
                                                        in
                                                     let letbinding =
-                                                      let uu____16352 =
-                                                        let uu____16359 =
-                                                          let uu____16360 =
-                                                            let uu____16374 =
-                                                              let uu____16377
+                                                      let uu____16280 =
+                                                        let uu____16281 =
+                                                          let uu____16295 =
+                                                            let uu____16298 =
+                                                              let uu____16299
                                                                 =
-                                                                let uu____16378
-                                                                  =
-                                                                  FStar_Syntax_Syntax.mk_binder
-                                                                    x
-                                                                   in
-                                                                [uu____16378]
+                                                                FStar_Syntax_Syntax.mk_binder
+                                                                  x
                                                                  in
-                                                              FStar_Syntax_Subst.close
-                                                                uu____16377 e
+                                                              [uu____16299]
                                                                in
-                                                            ((false, [lb]),
-                                                              uu____16374)
+                                                            FStar_Syntax_Subst.close
+                                                              uu____16298 e
                                                              in
-                                                          FStar_Syntax_Syntax.Tm_let
-                                                            uu____16360
+                                                          ((false, [lb]),
+                                                            uu____16295)
                                                            in
-                                                        FStar_Syntax_Syntax.mk
-                                                          uu____16359
+                                                        FStar_Syntax_Syntax.Tm_let
+                                                          uu____16281
                                                          in
-                                                      uu____16352
-                                                        FStar_Pervasives_Native.None
+                                                      FStar_Syntax_Syntax.mk
+                                                        uu____16280
                                                         e.FStar_Syntax_Syntax.pos
                                                        in
                                                     FStar_Syntax_Syntax.mk
@@ -6013,264 +5952,263 @@ and (check_application_args :
                                                            (FStar_Syntax_Syntax.Meta_monadic
                                                               (m,
                                                                 (comp1.FStar_TypeChecker_Common.res_typ)))))
-                                                      FStar_Pervasives_Native.None
                                                       e.FStar_Syntax_Syntax.pos
                                                  in
                                               FStar_List.fold_left
                                                 bind_lifted_args app2
                                                 lifted_args)
                                         in
-                                     let uu____16430 =
+                                     let uu____16351 =
                                        FStar_TypeChecker_Util.strengthen_precondition
                                          FStar_Pervasives_Native.None env app
                                          comp1 guard1
                                         in
-                                     (match uu____16430 with
+                                     (match uu____16351 with
                                       | (comp2,g) ->
-                                          ((let uu____16448 =
+                                          ((let uu____16369 =
                                               FStar_TypeChecker_Env.debug env
                                                 FStar_Options.Extreme
                                                in
-                                            if uu____16448
+                                            if uu____16369
                                             then
-                                              let uu____16451 =
+                                              let uu____16372 =
                                                 FStar_Syntax_Print.term_to_string
                                                   app
                                                  in
-                                              let uu____16453 =
+                                              let uu____16374 =
                                                 FStar_TypeChecker_Common.lcomp_to_string
                                                   comp2
                                                  in
                                               FStar_Util.print2
                                                 "(d) Monadic app: type of app\n\t(%s)\n\t: %s\n"
-                                                uu____16451 uu____16453
+                                                uu____16372 uu____16374
                                             else ());
                                            (app, comp2, g)))))))
                   in
-               let rec tc_args head_info uu____16542 bs args1 =
-                 match uu____16542 with
+               let rec tc_args head_info uu____16463 bs args1 =
+                 match uu____16463 with
                  | (subst,outargs,arg_rets,g,fvs) ->
                      (match (bs, args1) with
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____16705))::rest,
-                         (uu____16707,FStar_Pervasives_Native.None )::uu____16708)
+                          (FStar_Syntax_Syntax.Implicit uu____16626))::rest,
+                         (uu____16628,FStar_Pervasives_Native.None )::uu____16629)
                           ->
                           let t =
                             FStar_Syntax_Subst.subst subst
                               x.FStar_Syntax_Syntax.sort
                              in
-                          let uu____16769 =
+                          let uu____16690 =
                             check_no_escape
                               (FStar_Pervasives_Native.Some head) env fvs t
                              in
-                          (match uu____16769 with
+                          (match uu____16690 with
                            | (t1,g_ex) ->
                                let r1 =
                                  match outargs with
                                  | [] -> head.FStar_Syntax_Syntax.pos
-                                 | ((t2,uu____16800),uu____16801,uu____16802)::uu____16803
+                                 | ((t2,uu____16721),uu____16722,uu____16723)::uu____16724
                                      ->
-                                     let uu____16858 =
+                                     let uu____16779 =
                                        FStar_Range.def_range
                                          head.FStar_Syntax_Syntax.pos
                                         in
-                                     let uu____16859 =
-                                       let uu____16860 =
+                                     let uu____16780 =
+                                       let uu____16781 =
                                          FStar_Range.use_range
                                            head.FStar_Syntax_Syntax.pos
                                           in
-                                       let uu____16861 =
+                                       let uu____16782 =
                                          FStar_Range.use_range
                                            t2.FStar_Syntax_Syntax.pos
                                           in
-                                       FStar_Range.union_rng uu____16860
-                                         uu____16861
+                                       FStar_Range.union_rng uu____16781
+                                         uu____16782
                                         in
-                                     FStar_Range.range_of_rng uu____16858
-                                       uu____16859
+                                     FStar_Range.range_of_rng uu____16779
+                                       uu____16780
                                   in
-                               let uu____16862 =
+                               let uu____16783 =
                                  FStar_TypeChecker_Util.new_implicit_var
                                    "Instantiating implicit argument in application"
                                    r1 env t1
                                   in
-                               (match uu____16862 with
-                                | (varg,uu____16883,implicits) ->
+                               (match uu____16783 with
+                                | (varg,uu____16804,implicits) ->
                                     let subst1 =
                                       (FStar_Syntax_Syntax.NT (x, varg)) ::
                                       subst  in
                                     let arg =
-                                      let uu____16911 =
+                                      let uu____16832 =
                                         FStar_Syntax_Syntax.as_implicit true
                                          in
-                                      (varg, uu____16911)  in
+                                      (varg, uu____16832)  in
                                     let guard =
                                       FStar_List.fold_right
                                         FStar_TypeChecker_Env.conj_guard
                                         [g_ex; g] implicits
                                        in
-                                    let uu____16920 =
-                                      let uu____16963 =
-                                        let uu____16982 =
-                                          let uu____16999 =
-                                            let uu____17000 =
+                                    let uu____16841 =
+                                      let uu____16884 =
+                                        let uu____16903 =
+                                          let uu____16920 =
+                                            let uu____16921 =
                                               FStar_Syntax_Syntax.mk_Total t1
                                                in
-                                            FStar_All.pipe_right uu____17000
+                                            FStar_All.pipe_right uu____16921
                                               FStar_TypeChecker_Common.lcomp_of_comp
                                              in
                                           (arg, FStar_Pervasives_Native.None,
-                                            uu____16999)
+                                            uu____16920)
                                            in
-                                        uu____16982 :: outargs  in
-                                      (subst1, uu____16963, (arg ::
+                                        uu____16903 :: outargs  in
+                                      (subst1, uu____16884, (arg ::
                                         arg_rets), guard, fvs)
                                        in
-                                    tc_args head_info uu____16920 rest args1))
+                                    tc_args head_info uu____16841 rest args1))
                       | ((x,FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____17070,FStar_Pervasives_Native.None
-                                                                 )::uu____17071)
+                          (FStar_Syntax_Syntax.Meta tau))::rest,(uu____16991,FStar_Pervasives_Native.None
+                                                                 )::uu____16992)
                           ->
                           let tau1 = FStar_Syntax_Subst.subst subst tau  in
-                          let uu____17133 =
+                          let uu____17054 =
                             tc_tactic FStar_Syntax_Syntax.t_unit
                               FStar_Syntax_Syntax.t_unit env tau1
                              in
-                          (match uu____17133 with
-                           | (tau2,uu____17147,g_tau) ->
+                          (match uu____17054 with
+                           | (tau2,uu____17068,g_tau) ->
                                let t =
                                  FStar_Syntax_Subst.subst subst
                                    x.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____17150 =
+                               let uu____17071 =
                                  check_no_escape
                                    (FStar_Pervasives_Native.Some head) env
                                    fvs t
                                   in
-                               (match uu____17150 with
+                               (match uu____17071 with
                                 | (t1,g_ex) ->
                                     let r1 =
                                       match outargs with
                                       | [] -> head.FStar_Syntax_Syntax.pos
-                                      | ((t2,uu____17181),uu____17182,uu____17183)::uu____17184
+                                      | ((t2,uu____17102),uu____17103,uu____17104)::uu____17105
                                           ->
-                                          let uu____17239 =
+                                          let uu____17160 =
                                             FStar_Range.def_range
                                               head.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____17240 =
-                                            let uu____17241 =
+                                          let uu____17161 =
+                                            let uu____17162 =
                                               FStar_Range.use_range
                                                 head.FStar_Syntax_Syntax.pos
                                                in
-                                            let uu____17242 =
+                                            let uu____17163 =
                                               FStar_Range.use_range
                                                 t2.FStar_Syntax_Syntax.pos
                                                in
-                                            FStar_Range.union_rng uu____17241
-                                              uu____17242
+                                            FStar_Range.union_rng uu____17162
+                                              uu____17163
                                              in
                                           FStar_Range.range_of_rng
-                                            uu____17239 uu____17240
+                                            uu____17160 uu____17161
                                        in
-                                    let uu____17243 =
-                                      let uu____17256 =
-                                        let uu____17263 =
-                                          let uu____17268 =
+                                    let uu____17164 =
+                                      let uu____17177 =
+                                        let uu____17184 =
+                                          let uu____17189 =
                                             FStar_Dyn.mkdyn env  in
-                                          (uu____17268, tau2)  in
+                                          (uu____17189, tau2)  in
                                         FStar_Pervasives_Native.Some
-                                          uu____17263
+                                          uu____17184
                                          in
                                       FStar_TypeChecker_Env.new_implicit_var_aux
                                         "Instantiating meta argument in application"
                                         r1 env t1 FStar_Syntax_Syntax.Strict
-                                        uu____17256
+                                        uu____17177
                                        in
-                                    (match uu____17243 with
-                                     | (varg,uu____17281,implicits) ->
+                                    (match uu____17164 with
+                                     | (varg,uu____17202,implicits) ->
                                          let subst1 =
                                            (FStar_Syntax_Syntax.NT (x, varg))
                                            :: subst  in
                                          let arg =
-                                           let uu____17309 =
+                                           let uu____17230 =
                                              FStar_Syntax_Syntax.as_implicit
                                                true
                                               in
-                                           (varg, uu____17309)  in
+                                           (varg, uu____17230)  in
                                          let guard =
                                            FStar_List.fold_right
                                              FStar_TypeChecker_Env.conj_guard
                                              [g_ex; g; g_tau] implicits
                                             in
-                                         let uu____17318 =
-                                           let uu____17361 =
-                                             let uu____17380 =
-                                               let uu____17397 =
-                                                 let uu____17398 =
+                                         let uu____17239 =
+                                           let uu____17282 =
+                                             let uu____17301 =
+                                               let uu____17318 =
+                                                 let uu____17319 =
                                                    FStar_Syntax_Syntax.mk_Total
                                                      t1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____17398
+                                                   uu____17319
                                                    FStar_TypeChecker_Common.lcomp_of_comp
                                                   in
                                                (arg,
                                                  FStar_Pervasives_Native.None,
-                                                 uu____17397)
+                                                 uu____17318)
                                                 in
-                                             uu____17380 :: outargs  in
-                                           (subst1, uu____17361, (arg ::
+                                             uu____17301 :: outargs  in
+                                           (subst1, uu____17282, (arg ::
                                              arg_rets), guard, fvs)
                                             in
-                                         tc_args head_info uu____17318 rest
+                                         tc_args head_info uu____17239 rest
                                            args1)))
                       | ((x,aqual)::rest,(e,aq)::rest') ->
                           ((match (aqual, aq) with
-                            | (uu____17538,FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____17539)) ->
+                            | (uu____17459,FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Meta uu____17460)) ->
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                     "Inconsistent implicit qualifier; cannot apply meta arguments, just use #")
                                   e.FStar_Syntax_Syntax.pos
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Meta
-                               uu____17550),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____17551)) ->
+                               uu____17471),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____17472)) ->
                                 ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Implicit
-                               uu____17559),FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____17560)) ->
+                               uu____17480),FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu____17481)) ->
                                 ()
                             | (FStar_Pervasives_Native.None
                                ,FStar_Pervasives_Native.None ) -> ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Equality
                                ),FStar_Pervasives_Native.None ) -> ()
-                            | uu____17575 ->
-                                let uu____17584 =
-                                  let uu____17590 =
-                                    let uu____17592 =
+                            | uu____17496 ->
+                                let uu____17505 =
+                                  let uu____17511 =
+                                    let uu____17513 =
                                       FStar_Syntax_Print.aqual_to_string
                                         aqual
                                        in
-                                    let uu____17594 =
+                                    let uu____17515 =
                                       FStar_Syntax_Print.aqual_to_string aq
                                        in
-                                    let uu____17596 =
+                                    let uu____17517 =
                                       FStar_Syntax_Print.bv_to_string x  in
-                                    let uu____17598 =
+                                    let uu____17519 =
                                       FStar_Syntax_Print.term_to_string e  in
                                     FStar_Util.format4
                                       "Inconsistent implicit qualifier; %s vs %s\nfor bvar %s and term %s"
-                                      uu____17592 uu____17594 uu____17596
-                                      uu____17598
+                                      uu____17513 uu____17515 uu____17517
+                                      uu____17519
                                      in
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
-                                    uu____17590)
+                                    uu____17511)
                                    in
-                                FStar_Errors.raise_error uu____17584
+                                FStar_Errors.raise_error uu____17505
                                   e.FStar_Syntax_Syntax.pos);
                            (let targ =
                               FStar_Syntax_Subst.subst subst
@@ -6279,200 +6217,200 @@ and (check_application_args :
                             let aqual1 =
                               FStar_Syntax_Subst.subst_imp subst aqual  in
                             let x1 =
-                              let uu___2341_17605 = x  in
+                              let uu___2341_17526 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___2341_17605.FStar_Syntax_Syntax.ppname);
+                                  (uu___2341_17526.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___2341_17605.FStar_Syntax_Syntax.index);
+                                  (uu___2341_17526.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = targ
                               }  in
-                            (let uu____17607 =
+                            (let uu____17528 =
                                FStar_TypeChecker_Env.debug env
                                  FStar_Options.Extreme
                                 in
-                             if uu____17607
+                             if uu____17528
                              then
-                               let uu____17610 =
+                               let uu____17531 =
                                  FStar_Syntax_Print.bv_to_string x1  in
-                               let uu____17612 =
+                               let uu____17533 =
                                  FStar_Syntax_Print.term_to_string
                                    x1.FStar_Syntax_Syntax.sort
                                   in
-                               let uu____17614 =
+                               let uu____17535 =
                                  FStar_Syntax_Print.term_to_string e  in
-                               let uu____17616 =
+                               let uu____17537 =
                                  FStar_Syntax_Print.subst_to_string subst  in
-                               let uu____17618 =
+                               let uu____17539 =
                                  FStar_Syntax_Print.term_to_string targ  in
                                FStar_Util.print5
                                  "\tFormal is %s : %s\tType of arg %s (after subst %s) = %s\n"
-                                 uu____17610 uu____17612 uu____17614
-                                 uu____17616 uu____17618
+                                 uu____17531 uu____17533 uu____17535
+                                 uu____17537 uu____17539
                              else ());
-                            (let uu____17623 =
+                            (let uu____17544 =
                                check_no_escape
                                  (FStar_Pervasives_Native.Some head) env fvs
                                  targ
                                 in
-                             match uu____17623 with
+                             match uu____17544 with
                              | (targ1,g_ex) ->
                                  let env1 =
                                    FStar_TypeChecker_Env.set_expected_typ env
                                      targ1
                                     in
                                  let env2 =
-                                   let uu___2350_17638 = env1  in
+                                   let uu___2350_17559 = env1  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.solver);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.range);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.curmodule);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.gamma);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.modules);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.sigtab);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.attrtab);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.effects);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.generalize);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.letrecs);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.top_level);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
                                        (is_eq aqual1);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.is_iface);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.admit);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.lax);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.phase1);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.failhard);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.nosynth);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.tc_term);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.type_of);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.universe_of);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.splice);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.postprocess);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.dsenv);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.nbe);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___2350_17559.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___2350_17638.FStar_TypeChecker_Env.erasable_types_tab)
+                                       (uu___2350_17559.FStar_TypeChecker_Env.erasable_types_tab)
                                    }  in
-                                 ((let uu____17640 =
+                                 ((let uu____17561 =
                                      FStar_TypeChecker_Env.debug env2
                                        FStar_Options.High
                                       in
-                                   if uu____17640
+                                   if uu____17561
                                    then
-                                     let uu____17643 =
+                                     let uu____17564 =
                                        FStar_Syntax_Print.tag_of_term e  in
-                                     let uu____17645 =
+                                     let uu____17566 =
                                        FStar_Syntax_Print.term_to_string e
                                         in
-                                     let uu____17647 =
+                                     let uu____17568 =
                                        FStar_Syntax_Print.term_to_string
                                          targ1
                                         in
-                                     let uu____17649 =
+                                     let uu____17570 =
                                        FStar_Util.string_of_bool
                                          env2.FStar_TypeChecker_Env.use_eq
                                         in
                                      FStar_Util.print4
                                        "Checking arg (%s) %s at type %s with use_eq:%s\n"
-                                       uu____17643 uu____17645 uu____17647
-                                       uu____17649
+                                       uu____17564 uu____17566 uu____17568
+                                       uu____17570
                                    else ());
-                                  (let uu____17654 = tc_term env2 e  in
-                                   match uu____17654 with
+                                  (let uu____17575 = tc_term env2 e  in
+                                   match uu____17575 with
                                    | (e1,c,g_e) ->
                                        let g1 =
-                                         let uu____17671 =
+                                         let uu____17592 =
                                            FStar_TypeChecker_Env.conj_guard g
                                              g_e
                                             in
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.conj_guard
-                                              g_ex) uu____17671
+                                              g_ex) uu____17592
                                           in
                                        let arg = (e1, aq)  in
                                        let xterm =
-                                         let uu____17694 =
-                                           let uu____17697 =
-                                             let uu____17706 =
+                                         let uu____17615 =
+                                           let uu____17618 =
+                                             let uu____17627 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  x1
                                                 in
                                              FStar_Syntax_Syntax.as_arg
-                                               uu____17706
+                                               uu____17627
                                               in
                                            FStar_Pervasives_Native.fst
-                                             uu____17697
+                                             uu____17618
                                             in
-                                         (uu____17694, aq)  in
-                                       let uu____17715 =
+                                         (uu____17615, aq)  in
+                                       let uu____17636 =
                                          (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                             c)
                                            ||
@@ -6480,13 +6418,13 @@ and (check_application_args :
                                               env2
                                               c.FStar_TypeChecker_Common.eff_name)
                                           in
-                                       if uu____17715
+                                       if uu____17636
                                        then
                                          let subst1 =
-                                           let uu____17725 = FStar_List.hd bs
+                                           let uu____17646 = FStar_List.hd bs
                                               in
                                            maybe_extend_subst subst
-                                             uu____17725 e1
+                                             uu____17646 e1
                                             in
                                          tc_args head_info
                                            (subst1,
@@ -6503,58 +6441,58 @@ and (check_application_args :
                                                    x1), c) :: outargs),
                                              (xterm :: arg_rets), g1, (x1 ::
                                              fvs)) rest rest')))))
-                      | (uu____17872,[]) ->
+                      | (uu____17793,[]) ->
                           monadic_application head_info subst outargs
                             arg_rets g fvs bs
-                      | ([],arg::uu____17908) ->
-                          let uu____17959 =
+                      | ([],arg::uu____17829) ->
+                          let uu____17880 =
                             monadic_application head_info subst outargs
                               arg_rets g fvs []
                              in
-                          (match uu____17959 with
+                          (match uu____17880 with
                            | (head1,chead1,ghead1) ->
-                               let uu____17981 =
-                                 let uu____17986 =
+                               let uu____17902 =
+                                 let uu____17907 =
                                    FStar_TypeChecker_Common.lcomp_comp chead1
                                     in
-                                 FStar_All.pipe_right uu____17986
-                                   (fun uu____18003  ->
-                                      match uu____18003 with
+                                 FStar_All.pipe_right uu____17907
+                                   (fun uu____17924  ->
+                                      match uu____17924 with
                                       | (c,g1) ->
-                                          let uu____18014 =
+                                          let uu____17935 =
                                             FStar_TypeChecker_Env.conj_guard
                                               ghead1 g1
                                              in
-                                          (c, uu____18014))
+                                          (c, uu____17935))
                                   in
-                               (match uu____17981 with
+                               (match uu____17902 with
                                 | (chead2,ghead2) ->
                                     let rec aux norm1 solve ghead3 tres =
                                       let tres1 =
-                                        let uu____18057 =
+                                        let uu____17978 =
                                           FStar_Syntax_Subst.compress tres
                                            in
-                                        FStar_All.pipe_right uu____18057
+                                        FStar_All.pipe_right uu____17978
                                           FStar_Syntax_Util.unrefine
                                          in
                                       match tres1.FStar_Syntax_Syntax.n with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (bs1,cres') ->
-                                          let uu____18088 =
+                                          let uu____18009 =
                                             FStar_Syntax_Subst.open_comp bs1
                                               cres'
                                              in
-                                          (match uu____18088 with
+                                          (match uu____18009 with
                                            | (bs2,cres'1) ->
                                                let head_info1 =
                                                  (head1, chead2, ghead3,
                                                    cres'1)
                                                   in
-                                               ((let uu____18111 =
+                                               ((let uu____18032 =
                                                    FStar_TypeChecker_Env.debug
                                                      env FStar_Options.Low
                                                     in
-                                                 if uu____18111
+                                                 if uu____18032
                                                  then
                                                    FStar_Errors.log_issue
                                                      tres1.FStar_Syntax_Syntax.pos
@@ -6565,330 +6503,330 @@ and (check_application_args :
                                                   ([], [], [],
                                                     FStar_TypeChecker_Env.trivial_guard,
                                                     []) bs2 args1))
-                                      | uu____18174 when
+                                      | uu____18095 when
                                           Prims.op_Negation norm1 ->
                                           let rec norm_tres tres2 =
                                             let tres3 =
-                                              let uu____18182 =
+                                              let uu____18103 =
                                                 FStar_All.pipe_right tres2
                                                   (FStar_TypeChecker_Normalize.unfold_whnf
                                                      env)
                                                  in
                                               FStar_All.pipe_right
-                                                uu____18182
+                                                uu____18103
                                                 FStar_Syntax_Util.unascribe
                                                in
-                                            let uu____18183 =
-                                              let uu____18184 =
+                                            let uu____18104 =
+                                              let uu____18105 =
                                                 FStar_Syntax_Subst.compress
                                                   tres3
                                                  in
-                                              uu____18184.FStar_Syntax_Syntax.n
+                                              uu____18105.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____18183 with
+                                            match uu____18104 with
                                             | FStar_Syntax_Syntax.Tm_refine
                                                 ({
                                                    FStar_Syntax_Syntax.ppname
-                                                     = uu____18187;
+                                                     = uu____18108;
                                                    FStar_Syntax_Syntax.index
-                                                     = uu____18188;
+                                                     = uu____18109;
                                                    FStar_Syntax_Syntax.sort =
-                                                     tres4;_},uu____18190)
+                                                     tres4;_},uu____18111)
                                                 -> norm_tres tres4
-                                            | uu____18198 -> tres3  in
-                                          let uu____18199 = norm_tres tres1
+                                            | uu____18119 -> tres3  in
+                                          let uu____18120 = norm_tres tres1
                                              in
-                                          aux true solve ghead3 uu____18199
-                                      | uu____18201 when
+                                          aux true solve ghead3 uu____18120
+                                      | uu____18122 when
                                           Prims.op_Negation solve ->
                                           let ghead4 =
                                             FStar_TypeChecker_Rel.solve_deferred_constraints
                                               env ghead3
                                              in
                                           aux norm1 true ghead4 tres1
-                                      | uu____18204 ->
-                                          let uu____18205 =
-                                            let uu____18211 =
-                                              let uu____18213 =
+                                      | uu____18125 ->
+                                          let uu____18126 =
+                                            let uu____18132 =
+                                              let uu____18134 =
                                                 FStar_TypeChecker_Normalize.term_to_string
                                                   env thead
                                                  in
-                                              let uu____18215 =
+                                              let uu____18136 =
                                                 FStar_Util.string_of_int
                                                   n_args
                                                  in
-                                              let uu____18217 =
+                                              let uu____18138 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tres1
                                                  in
                                               FStar_Util.format3
                                                 "Too many arguments to function of type %s; got %s arguments, remaining type is %s"
-                                                uu____18213 uu____18215
-                                                uu____18217
+                                                uu____18134 uu____18136
+                                                uu____18138
                                                in
                                             (FStar_Errors.Fatal_ToManyArgumentToFunction,
-                                              uu____18211)
+                                              uu____18132)
                                              in
-                                          let uu____18221 =
+                                          let uu____18142 =
                                             FStar_Syntax_Syntax.argpos arg
                                              in
                                           FStar_Errors.raise_error
-                                            uu____18205 uu____18221
+                                            uu____18126 uu____18142
                                        in
                                     aux false false ghead2
                                       (FStar_Syntax_Util.comp_result chead2))))
                   in
                let rec check_function_app tf guard =
-                 let uu____18251 =
-                   let uu____18252 =
+                 let uu____18172 =
+                   let uu____18173 =
                      FStar_TypeChecker_Normalize.unfold_whnf env tf  in
-                   uu____18252.FStar_Syntax_Syntax.n  in
-                 match uu____18251 with
-                 | FStar_Syntax_Syntax.Tm_uvar uu____18261 ->
-                     let uu____18274 =
+                   uu____18173.FStar_Syntax_Syntax.n  in
+                 match uu____18172 with
+                 | FStar_Syntax_Syntax.Tm_uvar uu____18182 ->
+                     let uu____18195 =
                        FStar_List.fold_right
-                         (fun uu____18305  ->
-                            fun uu____18306  ->
-                              match uu____18306 with
+                         (fun uu____18226  ->
+                            fun uu____18227  ->
+                              match uu____18227 with
                               | (bs,guard1) ->
-                                  let uu____18333 =
-                                    let uu____18346 =
-                                      let uu____18347 =
+                                  let uu____18254 =
+                                    let uu____18267 =
+                                      let uu____18268 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____18347
+                                      FStar_All.pipe_right uu____18268
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____18346
+                                      uu____18267
                                      in
-                                  (match uu____18333 with
-                                   | (t,uu____18364,g) ->
-                                       let uu____18378 =
-                                         let uu____18381 =
+                                  (match uu____18254 with
+                                   | (t,uu____18285,g) ->
+                                       let uu____18299 =
+                                         let uu____18302 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____18381 :: bs  in
-                                       let uu____18382 =
+                                         uu____18302 :: bs  in
+                                       let uu____18303 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____18378, uu____18382))) args
+                                       (uu____18299, uu____18303))) args
                          ([], guard)
                         in
-                     (match uu____18274 with
+                     (match uu____18195 with
                       | (bs,guard1) ->
-                          let uu____18399 =
-                            let uu____18406 =
-                              let uu____18419 =
-                                let uu____18420 = FStar_Syntax_Util.type_u ()
+                          let uu____18320 =
+                            let uu____18327 =
+                              let uu____18340 =
+                                let uu____18341 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____18420
+                                FStar_All.pipe_right uu____18341
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____18419
+                                uu____18340
                                in
-                            match uu____18406 with
-                            | (t,uu____18437,g) ->
-                                let uu____18451 = FStar_Options.ml_ish ()  in
-                                if uu____18451
+                            match uu____18327 with
+                            | (t,uu____18358,g) ->
+                                let uu____18372 = FStar_Options.ml_ish ()  in
+                                if uu____18372
                                 then
-                                  let uu____18460 =
+                                  let uu____18381 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____18463 =
+                                  let uu____18384 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____18460, uu____18463)
+                                  (uu____18381, uu____18384)
                                 else
-                                  (let uu____18468 =
+                                  (let uu____18389 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____18471 =
+                                   let uu____18392 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____18468, uu____18471))
+                                   (uu____18389, uu____18392))
                              in
-                          (match uu____18399 with
+                          (match uu____18320 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____18490 =
+                               ((let uu____18411 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____18490
+                                 if uu____18411
                                  then
-                                   let uu____18494 =
+                                   let uu____18415 =
                                      FStar_Syntax_Print.term_to_string head
                                       in
-                                   let uu____18496 =
+                                   let uu____18417 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____18498 =
+                                   let uu____18419 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____18494 uu____18496 uu____18498
+                                     uu____18415 uu____18417 uu____18419
                                  else ());
                                 (let g =
-                                   let uu____18504 =
+                                   let uu____18425 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____18504
+                                     env uu____18425
                                     in
-                                 let uu____18505 =
+                                 let uu____18426 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____18505))))
+                                 check_function_app bs_cres uu____18426))))
                  | FStar_Syntax_Syntax.Tm_app
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                          uu____18506;
-                        FStar_Syntax_Syntax.pos = uu____18507;
-                        FStar_Syntax_Syntax.vars = uu____18508;_},uu____18509)
+                          uu____18427;
+                        FStar_Syntax_Syntax.pos = uu____18428;
+                        FStar_Syntax_Syntax.vars = uu____18429;_},uu____18430)
                      ->
-                     let uu____18546 =
+                     let uu____18467 =
                        FStar_List.fold_right
-                         (fun uu____18577  ->
-                            fun uu____18578  ->
-                              match uu____18578 with
+                         (fun uu____18498  ->
+                            fun uu____18499  ->
+                              match uu____18499 with
                               | (bs,guard1) ->
-                                  let uu____18605 =
-                                    let uu____18618 =
-                                      let uu____18619 =
+                                  let uu____18526 =
+                                    let uu____18539 =
+                                      let uu____18540 =
                                         FStar_Syntax_Util.type_u ()  in
-                                      FStar_All.pipe_right uu____18619
+                                      FStar_All.pipe_right uu____18540
                                         FStar_Pervasives_Native.fst
                                        in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____18618
+                                      uu____18539
                                      in
-                                  (match uu____18605 with
-                                   | (t,uu____18636,g) ->
-                                       let uu____18650 =
-                                         let uu____18653 =
+                                  (match uu____18526 with
+                                   | (t,uu____18557,g) ->
+                                       let uu____18571 =
+                                         let uu____18574 =
                                            FStar_Syntax_Syntax.null_binder t
                                             in
-                                         uu____18653 :: bs  in
-                                       let uu____18654 =
+                                         uu____18574 :: bs  in
+                                       let uu____18575 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1
                                           in
-                                       (uu____18650, uu____18654))) args
+                                       (uu____18571, uu____18575))) args
                          ([], guard)
                         in
-                     (match uu____18546 with
+                     (match uu____18467 with
                       | (bs,guard1) ->
-                          let uu____18671 =
-                            let uu____18678 =
-                              let uu____18691 =
-                                let uu____18692 = FStar_Syntax_Util.type_u ()
+                          let uu____18592 =
+                            let uu____18599 =
+                              let uu____18612 =
+                                let uu____18613 = FStar_Syntax_Util.type_u ()
                                    in
-                                FStar_All.pipe_right uu____18692
+                                FStar_All.pipe_right uu____18613
                                   FStar_Pervasives_Native.fst
                                  in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____18691
+                                uu____18612
                                in
-                            match uu____18678 with
-                            | (t,uu____18709,g) ->
-                                let uu____18723 = FStar_Options.ml_ish ()  in
-                                if uu____18723
+                            match uu____18599 with
+                            | (t,uu____18630,g) ->
+                                let uu____18644 = FStar_Options.ml_ish ()  in
+                                if uu____18644
                                 then
-                                  let uu____18732 =
+                                  let uu____18653 =
                                     FStar_Syntax_Util.ml_comp t r  in
-                                  let uu____18735 =
+                                  let uu____18656 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g
                                      in
-                                  (uu____18732, uu____18735)
+                                  (uu____18653, uu____18656)
                                 else
-                                  (let uu____18740 =
+                                  (let uu____18661 =
                                      FStar_Syntax_Syntax.mk_Total t  in
-                                   let uu____18743 =
+                                   let uu____18664 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g
                                       in
-                                   (uu____18740, uu____18743))
+                                   (uu____18661, uu____18664))
                              in
-                          (match uu____18671 with
+                          (match uu____18592 with
                            | (cres,guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres
                                   in
-                               ((let uu____18762 =
+                               ((let uu____18683 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____18762
+                                 if uu____18683
                                  then
-                                   let uu____18766 =
+                                   let uu____18687 =
                                      FStar_Syntax_Print.term_to_string head
                                       in
-                                   let uu____18768 =
+                                   let uu____18689 =
                                      FStar_Syntax_Print.term_to_string tf  in
-                                   let uu____18770 =
+                                   let uu____18691 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres
                                       in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____18766 uu____18768 uu____18770
+                                     uu____18687 uu____18689 uu____18691
                                  else ());
                                 (let g =
-                                   let uu____18776 =
+                                   let uu____18697 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres
                                       in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____18776
+                                     env uu____18697
                                     in
-                                 let uu____18777 =
+                                 let uu____18698 =
                                    FStar_TypeChecker_Env.conj_guard g guard2
                                     in
-                                 check_function_app bs_cres uu____18777))))
+                                 check_function_app bs_cres uu____18698))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                     let uu____18800 = FStar_Syntax_Subst.open_comp bs c  in
-                     (match uu____18800 with
+                     let uu____18721 = FStar_Syntax_Subst.open_comp bs c  in
+                     (match uu____18721 with
                       | (bs1,c1) ->
                           let head_info = (head, chead, ghead, c1)  in
-                          ((let uu____18823 =
+                          ((let uu____18744 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.Extreme
                                in
-                            if uu____18823
+                            if uu____18744
                             then
-                              let uu____18826 =
+                              let uu____18747 =
                                 FStar_Syntax_Print.term_to_string head  in
-                              let uu____18828 =
+                              let uu____18749 =
                                 FStar_Syntax_Print.term_to_string tf  in
-                              let uu____18830 =
+                              let uu____18751 =
                                 FStar_Syntax_Print.binders_to_string ", " bs1
                                  in
-                              let uu____18833 =
+                              let uu____18754 =
                                 FStar_Syntax_Print.comp_to_string c1  in
                               FStar_Util.print4
                                 "######tc_args of head %s @ %s with formals=%s and result type=%s\n"
-                                uu____18826 uu____18828 uu____18830
-                                uu____18833
+                                uu____18747 uu____18749 uu____18751
+                                uu____18754
                             else ());
                            tc_args head_info ([], [], [], guard, []) bs1 args))
-                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____18895) ->
+                 | FStar_Syntax_Syntax.Tm_refine (bv,uu____18816) ->
                      check_function_app bv.FStar_Syntax_Syntax.sort guard
                  | FStar_Syntax_Syntax.Tm_ascribed
-                     (t,uu____18901,uu____18902) ->
+                     (t,uu____18822,uu____18823) ->
                      check_function_app t guard
-                 | uu____18943 ->
-                     let uu____18944 =
+                 | uu____18864 ->
+                     let uu____18865 =
                        FStar_TypeChecker_Err.expected_function_typ env tf  in
-                     FStar_Errors.raise_error uu____18944
+                     FStar_Errors.raise_error uu____18865
                        head.FStar_Syntax_Syntax.pos
                   in
                check_function_app thead FStar_TypeChecker_Env.trivial_guard)
@@ -6922,95 +6860,92 @@ and (check_short_circuit_args :
                     ((FStar_List.length bs) = (FStar_List.length args))
                   ->
                   let res_t = FStar_Syntax_Util.comp_result c  in
-                  let uu____19027 =
+                  let uu____18948 =
                     FStar_List.fold_left2
-                      (fun uu____19096  ->
-                         fun uu____19097  ->
-                           fun uu____19098  ->
-                             match (uu____19096, uu____19097, uu____19098)
+                      (fun uu____19017  ->
+                         fun uu____19018  ->
+                           fun uu____19019  ->
+                             match (uu____19017, uu____19018, uu____19019)
                              with
                              | ((seen,guard,ghost),(e,aq),(b,aq')) ->
-                                 ((let uu____19251 =
-                                     let uu____19253 =
+                                 ((let uu____19172 =
+                                     let uu____19174 =
                                        FStar_Syntax_Util.eq_aqual aq aq'  in
-                                     uu____19253 <> FStar_Syntax_Util.Equal
+                                     uu____19174 <> FStar_Syntax_Util.Equal
                                       in
-                                   if uu____19251
+                                   if uu____19172
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                          "Inconsistent implicit qualifiers")
                                        e.FStar_Syntax_Syntax.pos
                                    else ());
-                                  (let uu____19259 =
+                                  (let uu____19180 =
                                      tc_check_tot_or_gtot_term env e
                                        b.FStar_Syntax_Syntax.sort
                                        "arguments to short circuiting operators must be pure or ghost"
                                       in
-                                   match uu____19259 with
+                                   match uu____19180 with
                                    | (e1,c1,g) ->
                                        let short =
                                          FStar_TypeChecker_Util.short_circuit
                                            head seen
                                           in
                                        let g1 =
-                                         let uu____19289 =
+                                         let uu____19210 =
                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                              short
                                             in
                                          FStar_TypeChecker_Env.imp_guard
-                                           uu____19289 g
+                                           uu____19210 g
                                           in
                                        let ghost1 =
                                          ghost ||
-                                           ((let uu____19294 =
+                                           ((let uu____19215 =
                                                FStar_TypeChecker_Common.is_total_lcomp
                                                  c1
                                                 in
-                                             Prims.op_Negation uu____19294)
+                                             Prims.op_Negation uu____19215)
                                               &&
-                                              (let uu____19297 =
+                                              (let uu____19218 =
                                                  FStar_TypeChecker_Util.is_pure_effect
                                                    env
                                                    c1.FStar_TypeChecker_Common.eff_name
                                                   in
-                                               Prims.op_Negation uu____19297))
+                                               Prims.op_Negation uu____19218))
                                           in
-                                       let uu____19299 =
-                                         let uu____19310 =
-                                           let uu____19321 =
+                                       let uu____19220 =
+                                         let uu____19231 =
+                                           let uu____19242 =
                                              FStar_Syntax_Syntax.as_arg e1
                                               in
-                                           [uu____19321]  in
-                                         FStar_List.append seen uu____19310
+                                           [uu____19242]  in
+                                         FStar_List.append seen uu____19231
                                           in
-                                       let uu____19354 =
+                                       let uu____19275 =
                                          FStar_TypeChecker_Env.conj_guard
                                            guard g1
                                           in
-                                       (uu____19299, uu____19354, ghost1))))
+                                       (uu____19220, uu____19275, ghost1))))
                       ([], g_head, false) args bs
                      in
-                  (match uu____19027 with
+                  (match uu____18948 with
                    | (args1,guard,ghost) ->
-                       let e =
-                         FStar_Syntax_Syntax.mk_Tm_app head args1
-                           FStar_Pervasives_Native.None r
-                          in
+                       let e = FStar_Syntax_Syntax.mk_Tm_app head args1 r  in
                        let c1 =
                          if ghost
                          then
-                           let uu____19422 =
+                           let uu____19341 =
                              FStar_Syntax_Syntax.mk_GTotal res_t  in
-                           FStar_All.pipe_right uu____19422
+                           FStar_All.pipe_right uu____19341
                              FStar_TypeChecker_Common.lcomp_of_comp
                          else FStar_TypeChecker_Common.lcomp_of_comp c  in
-                       let uu____19425 =
+                       let uu____19344 =
                          FStar_TypeChecker_Util.strengthen_precondition
                            FStar_Pervasives_Native.None env e c1 guard
                           in
-                       (match uu____19425 with | (c2,g) -> (e, c2, g)))
-              | uu____19442 ->
+                       (match uu____19344 with | (c2,g) -> (e, c2, g)))
+              | uu____19361 ->
                   check_application_args env head chead g_head args
                     expected_topt
 
@@ -7034,25 +6969,25 @@ and (tc_pat :
         let expected_pat_typ env1 pos scrutinee_t =
           let rec aux norm1 t =
             let t1 = FStar_Syntax_Util.unrefine t  in
-            let uu____19540 = FStar_Syntax_Util.head_and_args t1  in
-            match uu____19540 with
+            let uu____19459 = FStar_Syntax_Util.head_and_args t1  in
+            match uu____19459 with
             | (head,args) ->
-                let uu____19583 =
-                  let uu____19584 = FStar_Syntax_Subst.compress head  in
-                  uu____19584.FStar_Syntax_Syntax.n  in
-                (match uu____19583 with
+                let uu____19502 =
+                  let uu____19503 = FStar_Syntax_Subst.compress head  in
+                  uu____19503.FStar_Syntax_Syntax.n  in
+                (match uu____19502 with
                  | FStar_Syntax_Syntax.Tm_uinst
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                        FStar_Syntax_Syntax.pos = uu____19588;
-                        FStar_Syntax_Syntax.vars = uu____19589;_},us)
+                        FStar_Syntax_Syntax.pos = uu____19507;
+                        FStar_Syntax_Syntax.vars = uu____19508;_},us)
                      -> unfold_once t1 f us args
                  | FStar_Syntax_Syntax.Tm_fvar f -> unfold_once t1 f [] args
-                 | uu____19596 ->
+                 | uu____19515 ->
                      if norm1
                      then t1
                      else
-                       (let uu____19600 =
+                       (let uu____19519 =
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.HNF;
                             FStar_TypeChecker_Env.Unmeta;
@@ -7060,33 +6995,32 @@ and (tc_pat :
                             FStar_TypeChecker_Env.UnfoldUntil
                               FStar_Syntax_Syntax.delta_constant] env1 t1
                            in
-                        aux true uu____19600))
+                        aux true uu____19519))
           
           and unfold_once t f us args =
-            let uu____19618 =
+            let uu____19537 =
               FStar_TypeChecker_Env.is_type_constructor env1
                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                in
-            if uu____19618
+            if uu____19537
             then t
             else
-              (let uu____19623 =
+              (let uu____19542 =
                  FStar_TypeChecker_Env.lookup_definition
                    [FStar_TypeChecker_Env.Unfold
                       FStar_Syntax_Syntax.delta_constant] env1
                    (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   in
-               match uu____19623 with
+               match uu____19542 with
                | FStar_Pervasives_Native.None  -> t
                | FStar_Pervasives_Native.Some head_def_ts ->
-                   let uu____19643 =
+                   let uu____19562 =
                      FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us
                       in
-                   (match uu____19643 with
-                    | (uu____19648,head_def) ->
+                   (match uu____19562 with
+                    | (uu____19567,head_def) ->
                         let t' =
                           FStar_Syntax_Syntax.mk_Tm_app head_def args
-                            FStar_Pervasives_Native.None
                             t.FStar_Syntax_Syntax.pos
                            in
                         let t'1 =
@@ -7096,79 +7030,79 @@ and (tc_pat :
                            in
                         aux false t'1))
            in
-          let uu____19655 =
+          let uu____19572 =
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota] env1
               scrutinee_t
              in
-          aux false uu____19655  in
+          aux false uu____19572  in
         let pat_typ_ok env1 pat_t1 scrutinee_t =
-          (let uu____19674 =
+          (let uu____19591 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____19674
+           if uu____19591
            then
-             let uu____19679 = FStar_Syntax_Print.term_to_string pat_t1  in
-             let uu____19681 = FStar_Syntax_Print.term_to_string scrutinee_t
+             let uu____19596 = FStar_Syntax_Print.term_to_string pat_t1  in
+             let uu____19598 = FStar_Syntax_Print.term_to_string scrutinee_t
                 in
              FStar_Util.print2 "$$$$$$$$$$$$pat_typ_ok? %s vs. %s\n"
-               uu____19679 uu____19681
+               uu____19596 uu____19598
            else ());
           (let fail1 msg =
              let msg1 =
-               let uu____19701 = FStar_Syntax_Print.term_to_string pat_t1  in
-               let uu____19703 =
+               let uu____19618 = FStar_Syntax_Print.term_to_string pat_t1  in
+               let uu____19620 =
                  FStar_Syntax_Print.term_to_string scrutinee_t  in
                FStar_Util.format3
                  "Type of pattern (%s) does not match type of scrutinee (%s)%s"
-                 uu____19701 uu____19703 msg
+                 uu____19618 uu____19620 msg
                 in
              FStar_Errors.raise_error
                (FStar_Errors.Fatal_MismatchedPatternType, msg1)
                p0.FStar_Syntax_Syntax.p
               in
-           let uu____19707 = FStar_Syntax_Util.head_and_args scrutinee_t  in
-           match uu____19707 with
+           let uu____19624 = FStar_Syntax_Util.head_and_args scrutinee_t  in
+           match uu____19624 with
            | (head_s,args_s) ->
                let pat_t2 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env1 pat_t1
                   in
-               let uu____19751 = FStar_Syntax_Util.un_uinst head_s  in
-               (match uu____19751 with
+               let uu____19668 = FStar_Syntax_Util.un_uinst head_s  in
+               (match uu____19668 with
                 | {
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                      uu____19752;
-                    FStar_Syntax_Syntax.pos = uu____19753;
-                    FStar_Syntax_Syntax.vars = uu____19754;_} ->
-                    let uu____19757 = FStar_Syntax_Util.head_and_args pat_t2
+                      uu____19669;
+                    FStar_Syntax_Syntax.pos = uu____19670;
+                    FStar_Syntax_Syntax.vars = uu____19671;_} ->
+                    let uu____19674 = FStar_Syntax_Util.head_and_args pat_t2
                        in
-                    (match uu____19757 with
+                    (match uu____19674 with
                      | (head_p,args_p) ->
-                         let uu____19800 =
+                         let uu____19717 =
                            FStar_TypeChecker_Rel.teq_nosmt_force env1 head_p
                              head_s
                             in
-                         if uu____19800
+                         if uu____19717
                          then
-                           let uu____19803 =
-                             let uu____19804 =
+                           let uu____19720 =
+                             let uu____19721 =
                                FStar_Syntax_Util.un_uinst head_p  in
-                             uu____19804.FStar_Syntax_Syntax.n  in
-                           (match uu____19803 with
+                             uu____19721.FStar_Syntax_Syntax.n  in
+                           (match uu____19720 with
                             | FStar_Syntax_Syntax.Tm_fvar f ->
-                                ((let uu____19809 =
-                                    let uu____19811 =
-                                      let uu____19813 =
+                                ((let uu____19726 =
+                                    let uu____19728 =
+                                      let uu____19730 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.is_type_constructor
-                                        env1 uu____19813
+                                        env1 uu____19730
                                        in
                                     FStar_All.pipe_left Prims.op_Negation
-                                      uu____19811
+                                      uu____19728
                                      in
-                                  if uu____19809
+                                  if uu____19726
                                   then
                                     fail1
                                       "Pattern matching a non-inductive type"
@@ -7178,61 +7112,61 @@ and (tc_pat :
                                      (FStar_List.length args_s)
                                  then fail1 ""
                                  else ();
-                                 (let uu____19841 =
-                                    let uu____19866 =
-                                      let uu____19870 =
+                                 (let uu____19758 =
+                                    let uu____19783 =
+                                      let uu____19787 =
                                         FStar_Syntax_Syntax.lid_of_fv f  in
                                       FStar_TypeChecker_Env.num_inductive_ty_params
-                                        env1 uu____19870
+                                        env1 uu____19787
                                        in
-                                    match uu____19866 with
+                                    match uu____19783 with
                                     | FStar_Pervasives_Native.None  ->
                                         (args_p, args_s)
                                     | FStar_Pervasives_Native.Some n ->
-                                        let uu____19919 =
+                                        let uu____19836 =
                                           FStar_Util.first_N n args_p  in
-                                        (match uu____19919 with
-                                         | (params_p,uu____19977) ->
-                                             let uu____20018 =
+                                        (match uu____19836 with
+                                         | (params_p,uu____19894) ->
+                                             let uu____19935 =
                                                FStar_Util.first_N n args_s
                                                 in
-                                             (match uu____20018 with
-                                              | (params_s,uu____20076) ->
+                                             (match uu____19935 with
+                                              | (params_s,uu____19993) ->
                                                   (params_p, params_s)))
                                      in
-                                  match uu____19841 with
+                                  match uu____19758 with
                                   | (params_p,params_s) ->
                                       FStar_List.fold_left2
                                         (fun out  ->
-                                           fun uu____20205  ->
-                                             fun uu____20206  ->
-                                               match (uu____20205,
-                                                       uu____20206)
+                                           fun uu____20122  ->
+                                             fun uu____20123  ->
+                                               match (uu____20122,
+                                                       uu____20123)
                                                with
-                                               | ((p,uu____20240),(s,uu____20242))
+                                               | ((p,uu____20157),(s,uu____20159))
                                                    ->
-                                                   let uu____20275 =
+                                                   let uu____20192 =
                                                      FStar_TypeChecker_Rel.teq_nosmt
                                                        env1 p s
                                                       in
-                                                   (match uu____20275 with
+                                                   (match uu____20192 with
                                                     | FStar_Pervasives_Native.None
                                                          ->
-                                                        let uu____20278 =
-                                                          let uu____20280 =
+                                                        let uu____20195 =
+                                                          let uu____20197 =
                                                             FStar_Syntax_Print.term_to_string
                                                               p
                                                              in
-                                                          let uu____20282 =
+                                                          let uu____20199 =
                                                             FStar_Syntax_Print.term_to_string
                                                               s
                                                              in
                                                           FStar_Util.format2
                                                             "; parameter %s <> parameter %s"
-                                                            uu____20280
-                                                            uu____20282
+                                                            uu____20197
+                                                            uu____20199
                                                            in
-                                                        fail1 uu____20278
+                                                        fail1 uu____20195
                                                     | FStar_Pervasives_Native.Some
                                                         g ->
                                                         let g1 =
@@ -7243,23 +7177,23 @@ and (tc_pat :
                                                           g1 out))
                                         FStar_TypeChecker_Env.trivial_guard
                                         params_p params_s))
-                            | uu____20287 ->
+                            | uu____20204 ->
                                 fail1 "Pattern matching a non-inductive type")
                          else
-                           (let uu____20291 =
-                              let uu____20293 =
+                           (let uu____20208 =
+                              let uu____20210 =
                                 FStar_Syntax_Print.term_to_string head_p  in
-                              let uu____20295 =
+                              let uu____20212 =
                                 FStar_Syntax_Print.term_to_string head_s  in
                               FStar_Util.format2 "; head mismatch %s vs %s"
-                                uu____20293 uu____20295
+                                uu____20210 uu____20212
                                in
-                            fail1 uu____20291))
-                | uu____20298 ->
-                    let uu____20299 =
+                            fail1 uu____20208))
+                | uu____20215 ->
+                    let uu____20216 =
                       FStar_TypeChecker_Rel.teq_nosmt env1 pat_t2 scrutinee_t
                        in
-                    (match uu____20299 with
+                    (match uu____20216 with
                      | FStar_Pervasives_Native.None  -> fail1 ""
                      | FStar_Pervasives_Native.Some g ->
                          let g1 =
@@ -7269,20 +7203,20 @@ and (tc_pat :
                          g1)))
            in
         let type_of_simple_pat env1 e =
-          let uu____20342 = FStar_Syntax_Util.head_and_args e  in
-          match uu____20342 with
+          let uu____20259 = FStar_Syntax_Util.head_and_args e  in
+          match uu____20259 with
           | (head,args) ->
               (match head.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_fvar f ->
-                   let uu____20412 =
+                   let uu____20329 =
                      FStar_TypeChecker_Env.lookup_datacon env1
                        (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                       in
-                   (match uu____20412 with
+                   (match uu____20329 with
                     | (us,t_f) ->
-                        let uu____20432 = FStar_Syntax_Util.arrow_formals t_f
+                        let uu____20349 = FStar_Syntax_Util.arrow_formals t_f
                            in
-                        (match uu____20432 with
+                        (match uu____20349 with
                          | (formals,t) ->
                              let erasable =
                                FStar_TypeChecker_Env.non_informative env1 t
@@ -7294,8 +7228,8 @@ and (tc_pat :
                                 fail
                                   "Pattern is not a fully-applied data constructor"
                               else ();
-                              (let rec aux uu____20545 formals1 args1 =
-                                 match uu____20545 with
+                              (let rec aux uu____20460 formals1 args1 =
+                                 match uu____20460 with
                                  | (subst,args_out,bvs,guard) ->
                                      (match (formals1, args1) with
                                       | ([],[]) ->
@@ -7306,39 +7240,38 @@ and (tc_pat :
                                           let pat_e =
                                             FStar_Syntax_Syntax.mk_Tm_app
                                               head1 args_out
-                                              FStar_Pervasives_Native.None
                                               e.FStar_Syntax_Syntax.pos
                                              in
-                                          let uu____20696 =
+                                          let uu____20605 =
                                             FStar_Syntax_Subst.subst subst t
                                              in
-                                          (pat_e, uu____20696, bvs, guard,
+                                          (pat_e, uu____20605, bvs, guard,
                                             erasable)
-                                      | ((f1,uu____20703)::formals2,(a,imp_a)::args2)
+                                      | ((f1,uu____20610)::formals2,(a,imp_a)::args2)
                                           ->
                                           let t_f1 =
                                             FStar_Syntax_Subst.subst subst
                                               f1.FStar_Syntax_Syntax.sort
                                              in
-                                          let uu____20761 =
-                                            let uu____20782 =
-                                              let uu____20783 =
+                                          let uu____20668 =
+                                            let uu____20689 =
+                                              let uu____20690 =
                                                 FStar_Syntax_Subst.compress a
                                                  in
-                                              uu____20783.FStar_Syntax_Syntax.n
+                                              uu____20690.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____20782 with
+                                            match uu____20689 with
                                             | FStar_Syntax_Syntax.Tm_name x
                                                 ->
                                                 let x1 =
-                                                  let uu___2657_20808 = x  in
+                                                  let uu___2657_20715 = x  in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___2657_20808.FStar_Syntax_Syntax.ppname);
+                                                      (uu___2657_20715.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       =
-                                                      (uu___2657_20808.FStar_Syntax_Syntax.index);
+                                                      (uu___2657_20715.FStar_Syntax_Syntax.index);
                                                     FStar_Syntax_Syntax.sort
                                                       = t_f1
                                                   }  in
@@ -7354,16 +7287,16 @@ and (tc_pat :
                                                   (FStar_List.append bvs [x1]),
                                                   FStar_TypeChecker_Env.trivial_guard)
                                             | FStar_Syntax_Syntax.Tm_uvar
-                                                uu____20831 ->
+                                                uu____20738 ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ
                                                     env1 t_f1
                                                    in
-                                                let uu____20845 =
+                                                let uu____20752 =
                                                   tc_tot_or_gtot_term env2 a
                                                    in
-                                                (match uu____20845 with
-                                                 | (a1,uu____20873,g) ->
+                                                (match uu____20752 with
+                                                 | (a1,uu____20780,g) ->
                                                      let g1 =
                                                        FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                          env2 g
@@ -7374,42 +7307,42 @@ and (tc_pat :
                                                        :: subst  in
                                                      ((a1, imp_a), subst1,
                                                        bvs, g1))
-                                            | uu____20897 ->
+                                            | uu____20804 ->
                                                 fail "Not a simple pattern"
                                              in
-                                          (match uu____20761 with
+                                          (match uu____20668 with
                                            | (a1,subst1,bvs1,g) ->
-                                               let uu____20962 =
-                                                 let uu____20985 =
+                                               let uu____20867 =
+                                                 let uu____20890 =
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g guard
                                                     in
                                                  (subst1,
                                                    (FStar_List.append
                                                       args_out [a1]), bvs1,
-                                                   uu____20985)
+                                                   uu____20890)
                                                   in
-                                               aux uu____20962 formals2 args2)
-                                      | uu____21024 ->
+                                               aux uu____20867 formals2 args2)
+                                      | uu____20929 ->
                                           fail "Not a fully applued pattern")
                                   in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
                                  formals args))))
-               | uu____21083 -> fail "Not a simple pattern")
+               | uu____20986 -> fail "Not a simple pattern")
            in
         let rec check_nested_pattern env1 p t =
-          (let uu____21149 =
+          (let uu____21052 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns")
               in
-           if uu____21149
+           if uu____21052
            then
-             let uu____21154 = FStar_Syntax_Print.pat_to_string p  in
-             let uu____21156 = FStar_Syntax_Print.term_to_string t  in
-             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____21154
-               uu____21156
+             let uu____21057 = FStar_Syntax_Print.pat_to_string p  in
+             let uu____21059 = FStar_Syntax_Print.term_to_string t  in
+             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____21057
+               uu____21059
            else ());
           (let id =
              FStar_Syntax_Syntax.fvar FStar_Parser_Const.id_lid
@@ -7418,122 +7351,118 @@ and (tc_pat :
               in
            let mk_disc_t disc inner_t =
              let x_b =
-               let uu____21181 =
+               let uu____21084 =
                  FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
                    t
                   in
-               FStar_All.pipe_right uu____21181 FStar_Syntax_Syntax.mk_binder
+               FStar_All.pipe_right uu____21084 FStar_Syntax_Syntax.mk_binder
                 in
              let tm =
-               let uu____21192 =
-                 let uu____21197 =
-                   let uu____21198 =
-                     let uu____21207 =
-                       let uu____21208 =
-                         FStar_All.pipe_right x_b FStar_Pervasives_Native.fst
-                          in
-                       FStar_All.pipe_right uu____21208
-                         FStar_Syntax_Syntax.bv_to_name
+               let uu____21093 =
+                 let uu____21094 =
+                   let uu____21103 =
+                     let uu____21104 =
+                       FStar_All.pipe_right x_b FStar_Pervasives_Native.fst
                         in
-                     FStar_All.pipe_right uu____21207
-                       FStar_Syntax_Syntax.as_arg
+                     FStar_All.pipe_right uu____21104
+                       FStar_Syntax_Syntax.bv_to_name
                       in
-                   [uu____21198]  in
-                 FStar_Syntax_Syntax.mk_Tm_app disc uu____21197  in
-               uu____21192 FStar_Pervasives_Native.None
+                   FStar_All.pipe_right uu____21103
+                     FStar_Syntax_Syntax.as_arg
+                    in
+                 [uu____21094]  in
+               FStar_Syntax_Syntax.mk_Tm_app disc uu____21093
                  FStar_Range.dummyRange
                 in
              let tm1 =
-               let uu____21244 =
-                 let uu____21249 =
-                   let uu____21250 =
-                     FStar_All.pipe_right tm FStar_Syntax_Syntax.as_arg  in
-                   [uu____21250]  in
-                 FStar_Syntax_Syntax.mk_Tm_app inner_t uu____21249  in
-               uu____21244 FStar_Pervasives_Native.None
+               let uu____21138 =
+                 let uu____21139 =
+                   FStar_All.pipe_right tm FStar_Syntax_Syntax.as_arg  in
+                 [uu____21139]  in
+               FStar_Syntax_Syntax.mk_Tm_app inner_t uu____21138
                  FStar_Range.dummyRange
                 in
              FStar_Syntax_Util.abs [x_b] tm1 FStar_Pervasives_Native.None  in
            match p.FStar_Syntax_Syntax.v with
-           | FStar_Syntax_Syntax.Pat_dot_term uu____21312 ->
-               let uu____21319 =
-                 let uu____21321 = FStar_Syntax_Print.pat_to_string p  in
+           | FStar_Syntax_Syntax.Pat_dot_term uu____21201 ->
+               let uu____21208 =
+                 let uu____21210 = FStar_Syntax_Print.pat_to_string p  in
                  FStar_Util.format1
                    "Impossible: Expected an undecorated pattern, got %s"
-                   uu____21321
+                   uu____21210
                   in
-               failwith uu____21319
+               failwith uu____21208
            | FStar_Syntax_Syntax.Pat_wild x ->
                let x1 =
-                 let uu___2696_21343 = x  in
+                 let uu___2696_21232 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2696_21343.FStar_Syntax_Syntax.ppname);
+                     (uu___2696_21232.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2696_21343.FStar_Syntax_Syntax.index);
+                     (uu___2696_21232.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____21344 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], [id], uu____21344,
-                 (let uu___2699_21351 = p  in
+               let uu____21233 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], [id], uu____21233,
+                 (let uu___2699_21240 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2699_21351.FStar_Syntax_Syntax.p)
+                      (uu___2699_21240.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_var x ->
                let x1 =
-                 let uu___2703_21355 = x  in
+                 let uu___2703_21244 = x  in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2703_21355.FStar_Syntax_Syntax.ppname);
+                     (uu___2703_21244.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2703_21355.FStar_Syntax_Syntax.index);
+                     (uu___2703_21244.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  }  in
-               let uu____21356 = FStar_Syntax_Syntax.bv_to_name x1  in
-               ([x1], [id], uu____21356,
-                 (let uu___2706_21363 = p  in
+               let uu____21245 = FStar_Syntax_Syntax.bv_to_name x1  in
+               ([x1], [id], uu____21245,
+                 (let uu___2706_21252 = p  in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2706_21363.FStar_Syntax_Syntax.p)
+                      (uu___2706_21252.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
-           | FStar_Syntax_Syntax.Pat_constant uu____21365 ->
-               let uu____21366 =
+           | FStar_Syntax_Syntax.Pat_constant uu____21254 ->
+               let uu____21255 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1 p  in
-               (match uu____21366 with
-                | (uu____21395,e_c,uu____21397,uu____21398) ->
-                    let uu____21403 = tc_tot_or_gtot_term env1 e_c  in
-                    (match uu____21403 with
+               (match uu____21255 with
+                | (uu____21284,e_c,uu____21286,uu____21287) ->
+                    let uu____21292 = tc_tot_or_gtot_term env1 e_c  in
+                    (match uu____21292 with
                      | (e_c1,lc,g) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env1 g;
                           (let expected_t =
                              expected_pat_typ env1 p0.FStar_Syntax_Syntax.p t
                               in
-                           (let uu____21433 =
-                              let uu____21435 =
+                           (let uu____21322 =
+                              let uu____21324 =
                                 FStar_TypeChecker_Rel.teq_nosmt_force env1
                                   lc.FStar_TypeChecker_Common.res_typ
                                   expected_t
                                  in
-                              Prims.op_Negation uu____21435  in
-                            if uu____21433
+                              Prims.op_Negation uu____21324  in
+                            if uu____21322
                             then
-                              let uu____21438 =
-                                let uu____21440 =
+                              let uu____21327 =
+                                let uu____21329 =
                                   FStar_Syntax_Print.term_to_string
                                     lc.FStar_TypeChecker_Common.res_typ
                                    in
-                                let uu____21442 =
+                                let uu____21331 =
                                   FStar_Syntax_Print.term_to_string
                                     expected_t
                                    in
                                 FStar_Util.format2
                                   "Type of pattern (%s) does not match type of scrutinee (%s)"
-                                  uu____21440 uu____21442
+                                  uu____21329 uu____21331
                                  in
-                              fail uu____21438
+                              fail uu____21327
                             else ());
                            ([], [], e_c1, p,
                              FStar_TypeChecker_Env.trivial_guard, false)))))
@@ -7541,165 +7470,165 @@ and (tc_pat :
                let simple_pat =
                  let simple_sub_pats =
                    FStar_List.map
-                     (fun uu____21504  ->
-                        match uu____21504 with
+                     (fun uu____21393  ->
+                        match uu____21393 with
                         | (p1,b) ->
                             (match p1.FStar_Syntax_Syntax.v with
-                             | FStar_Syntax_Syntax.Pat_dot_term uu____21534
+                             | FStar_Syntax_Syntax.Pat_dot_term uu____21423
                                  -> (p1, b)
-                             | uu____21544 ->
-                                 let uu____21545 =
-                                   let uu____21548 =
-                                     let uu____21549 =
+                             | uu____21433 ->
+                                 let uu____21434 =
+                                   let uu____21437 =
+                                     let uu____21438 =
                                        FStar_Syntax_Syntax.new_bv
                                          (FStar_Pervasives_Native.Some
                                             (p1.FStar_Syntax_Syntax.p))
                                          FStar_Syntax_Syntax.tun
                                         in
-                                     FStar_Syntax_Syntax.Pat_var uu____21549
+                                     FStar_Syntax_Syntax.Pat_var uu____21438
                                       in
-                                   FStar_Syntax_Syntax.withinfo uu____21548
+                                   FStar_Syntax_Syntax.withinfo uu____21437
                                      p1.FStar_Syntax_Syntax.p
                                     in
-                                 (uu____21545, b))) sub_pats
+                                 (uu____21434, b))) sub_pats
                     in
-                 let uu___2734_21553 = p  in
+                 let uu___2734_21442 = p  in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons (fv, simple_sub_pats));
                    FStar_Syntax_Syntax.p =
-                     (uu___2734_21553.FStar_Syntax_Syntax.p)
+                     (uu___2734_21442.FStar_Syntax_Syntax.p)
                  }  in
                let sub_pats1 =
                  FStar_All.pipe_right sub_pats
                    (FStar_List.filter
-                      (fun uu____21598  ->
-                         match uu____21598 with
-                         | (x,uu____21608) ->
+                      (fun uu____21487  ->
+                         match uu____21487 with
+                         | (x,uu____21497) ->
                              (match x.FStar_Syntax_Syntax.v with
-                              | FStar_Syntax_Syntax.Pat_dot_term uu____21616
+                              | FStar_Syntax_Syntax.Pat_dot_term uu____21505
                                   -> false
-                              | uu____21624 -> true)))
+                              | uu____21513 -> true)))
                   in
-               let uu____21626 =
+               let uu____21515 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1
                    simple_pat
                   in
-               (match uu____21626 with
+               (match uu____21515 with
                 | (simple_bvs,simple_pat_e,g0,simple_pat_elab) ->
                     (if
                        (FStar_List.length simple_bvs) <>
                          (FStar_List.length sub_pats1)
                      then
-                       (let uu____21670 =
-                          let uu____21672 =
+                       (let uu____21559 =
+                          let uu____21561 =
                             FStar_Range.string_of_range
                               p.FStar_Syntax_Syntax.p
                              in
-                          let uu____21674 =
+                          let uu____21563 =
                             FStar_Syntax_Print.pat_to_string simple_pat  in
-                          let uu____21676 =
+                          let uu____21565 =
                             FStar_Util.string_of_int
                               (FStar_List.length sub_pats1)
                              in
-                          let uu____21683 =
+                          let uu____21572 =
                             FStar_Util.string_of_int
                               (FStar_List.length simple_bvs)
                              in
                           FStar_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
-                            uu____21672 uu____21674 uu____21676 uu____21683
+                            uu____21561 uu____21563 uu____21565 uu____21572
                            in
-                        failwith uu____21670)
+                        failwith uu____21559)
                      else ();
-                     (let uu____21688 =
-                        let uu____21700 =
+                     (let uu____21577 =
+                        let uu____21589 =
                           type_of_simple_pat env1 simple_pat_e  in
-                        match uu____21700 with
+                        match uu____21589 with
                         | (simple_pat_e1,simple_pat_t,simple_bvs1,guard,erasable)
                             ->
                             let g' =
-                              let uu____21737 =
+                              let uu____21626 =
                                 expected_pat_typ env1
                                   p0.FStar_Syntax_Syntax.p t
                                  in
-                              pat_typ_ok env1 simple_pat_t uu____21737  in
+                              pat_typ_ok env1 simple_pat_t uu____21626  in
                             let guard1 =
                               FStar_TypeChecker_Env.conj_guard guard g'  in
-                            ((let uu____21740 =
+                            ((let uu____21629 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env1)
                                   (FStar_Options.Other "Patterns")
                                  in
-                              if uu____21740
+                              if uu____21629
                               then
-                                let uu____21745 =
+                                let uu____21634 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_e1
                                    in
-                                let uu____21747 =
+                                let uu____21636 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_t
                                    in
-                                let uu____21749 =
-                                  let uu____21751 =
+                                let uu____21638 =
+                                  let uu____21640 =
                                     FStar_List.map
                                       (fun x  ->
-                                         let uu____21759 =
-                                           let uu____21761 =
+                                         let uu____21648 =
+                                           let uu____21650 =
                                              FStar_Syntax_Print.bv_to_string
                                                x
                                               in
-                                           let uu____21763 =
-                                             let uu____21765 =
-                                               let uu____21767 =
+                                           let uu____21652 =
+                                             let uu____21654 =
+                                               let uu____21656 =
                                                  FStar_Syntax_Print.term_to_string
                                                    x.FStar_Syntax_Syntax.sort
                                                   in
-                                               Prims.op_Hat uu____21767 ")"
+                                               Prims.op_Hat uu____21656 ")"
                                                 in
-                                             Prims.op_Hat " : " uu____21765
+                                             Prims.op_Hat " : " uu____21654
                                               in
-                                           Prims.op_Hat uu____21761
-                                             uu____21763
+                                           Prims.op_Hat uu____21650
+                                             uu____21652
                                             in
-                                         Prims.op_Hat "(" uu____21759)
+                                         Prims.op_Hat "(" uu____21648)
                                       simple_bvs1
                                      in
-                                  FStar_All.pipe_right uu____21751
+                                  FStar_All.pipe_right uu____21640
                                     (FStar_String.concat " ")
                                    in
                                 FStar_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
-                                  uu____21745 uu____21747 uu____21749
+                                  uu____21634 uu____21636 uu____21638
                               else ());
                              (simple_pat_e1, simple_bvs1, guard1, erasable))
                          in
-                      match uu____21688 with
+                      match uu____21577 with
                       | (simple_pat_e1,simple_bvs1,g1,erasable) ->
-                          let uu____21810 =
-                            let uu____21842 =
-                              let uu____21874 =
+                          let uu____21699 =
+                            let uu____21731 =
+                              let uu____21763 =
                                 FStar_TypeChecker_Env.conj_guard g0 g1  in
-                              (env1, [], [], [], [], uu____21874, erasable,
+                              (env1, [], [], [], [], uu____21763, erasable,
                                 Prims.int_zero)
                                in
                             FStar_List.fold_left2
-                              (fun uu____21956  ->
-                                 fun uu____21957  ->
+                              (fun uu____21845  ->
+                                 fun uu____21846  ->
                                    fun x  ->
-                                     match (uu____21956, uu____21957) with
+                                     match (uu____21845, uu____21846) with
                                      | ((env2,bvs,tms,pats,subst,g,erasable1,i),
                                         (p1,b)) ->
                                          let expected_t =
                                            FStar_Syntax_Subst.subst subst
                                              x.FStar_Syntax_Syntax.sort
                                             in
-                                         let uu____22141 =
+                                         let uu____22030 =
                                            check_nested_pattern env2 p1
                                              expected_t
                                             in
-                                         (match uu____22141 with
+                                         (match uu____22030 with
                                           | (bvs_p,tms_p,e_p,p2,g',erasable_p)
                                               ->
                                               let env3 =
@@ -7708,29 +7637,29 @@ and (tc_pat :
                                                  in
                                               let tms_p1 =
                                                 let disc_tm =
-                                                  let uu____22211 =
+                                                  let uu____22100 =
                                                     FStar_Syntax_Syntax.lid_of_fv
                                                       fv
                                                      in
                                                   FStar_TypeChecker_Util.get_field_projector_name
-                                                    env3 uu____22211 i
+                                                    env3 uu____22100 i
                                                    in
-                                                let uu____22212 =
-                                                  let uu____22221 =
-                                                    let uu____22226 =
+                                                let uu____22101 =
+                                                  let uu____22110 =
+                                                    let uu____22115 =
                                                       FStar_Syntax_Syntax.fvar
                                                         disc_tm
                                                         (FStar_Syntax_Syntax.Delta_constant_at_level
                                                            Prims.int_one)
                                                         FStar_Pervasives_Native.None
                                                        in
-                                                    mk_disc_t uu____22226  in
-                                                  FStar_List.map uu____22221
+                                                    mk_disc_t uu____22115  in
+                                                  FStar_List.map uu____22110
                                                    in
                                                 FStar_All.pipe_right tms_p
-                                                  uu____22212
+                                                  uu____22101
                                                  in
-                                              let uu____22232 =
+                                              let uu____22121 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g'
                                                  in
@@ -7741,13 +7670,13 @@ and (tc_pat :
                                                    [(p2, b)]),
                                                 ((FStar_Syntax_Syntax.NT
                                                     (x, e_p)) :: subst),
-                                                uu____22232,
+                                                uu____22121,
                                                 (erasable1 || erasable_p),
                                                 (i + Prims.int_one))))
-                              uu____21842 sub_pats1 simple_bvs1
+                              uu____21731 sub_pats1 simple_bvs1
                              in
-                          (match uu____21810 with
-                           | (_env,bvs,tms,checked_sub_pats,subst,g,erasable1,uu____22291)
+                          (match uu____21699 with
+                           | (_env,bvs,tms,checked_sub_pats,subst,g,erasable1,uu____22180)
                                ->
                                let pat_e =
                                  FStar_Syntax_Subst.subst subst simple_pat_e1
@@ -7765,34 +7694,34 @@ and (tc_pat :
                                                 e
                                                in
                                             let hd1 =
-                                              let uu___2818_22467 = hd  in
+                                              let uu___2818_22356 = hd  in
                                               {
                                                 FStar_Syntax_Syntax.v =
                                                   (FStar_Syntax_Syntax.Pat_dot_term
                                                      (x, e1));
                                                 FStar_Syntax_Syntax.p =
-                                                  (uu___2818_22467.FStar_Syntax_Syntax.p)
+                                                  (uu___2818_22356.FStar_Syntax_Syntax.p)
                                               }  in
-                                            let uu____22472 =
+                                            let uu____22361 =
                                               aux simple_pats1 bvs1 sub_pats2
                                                in
-                                            (hd1, b) :: uu____22472
+                                            (hd1, b) :: uu____22361
                                         | FStar_Syntax_Syntax.Pat_var x ->
                                             (match (bvs1, sub_pats2) with
-                                             | (x'::bvs2,(hd1,uu____22516)::sub_pats3)
+                                             | (x'::bvs2,(hd1,uu____22405)::sub_pats3)
                                                  when
                                                  FStar_Syntax_Syntax.bv_eq x
                                                    x'
                                                  ->
-                                                 let uu____22553 =
+                                                 let uu____22442 =
                                                    aux simple_pats1 bvs2
                                                      sub_pats3
                                                     in
-                                                 (hd1, b) :: uu____22553
-                                             | uu____22573 ->
+                                                 (hd1, b) :: uu____22442
+                                             | uu____22462 ->
                                                  failwith
                                                    "Impossible: simple pat variable mismatch")
-                                        | uu____22599 ->
+                                        | uu____22488 ->
                                             failwith
                                               "Impossible: expected a simple pattern")
                                     in
@@ -7803,152 +7732,152 @@ and (tc_pat :
                                        aux simple_pats simple_bvs1
                                          checked_sub_pats
                                         in
-                                     let uu___2839_22642 = pat  in
+                                     let uu___2839_22531 = pat  in
                                      {
                                        FStar_Syntax_Syntax.v =
                                          (FStar_Syntax_Syntax.Pat_cons
                                             (fv1, nested_pats));
                                        FStar_Syntax_Syntax.p =
-                                         (uu___2839_22642.FStar_Syntax_Syntax.p)
+                                         (uu___2839_22531.FStar_Syntax_Syntax.p)
                                      }
-                                 | uu____22654 -> failwith "Impossible"  in
-                               let uu____22658 =
+                                 | uu____22543 -> failwith "Impossible"  in
+                               let uu____22547 =
                                  reconstruct_nested_pat simple_pat_elab  in
-                               (bvs, tms, pat_e, uu____22658, g, erasable1))))))
+                               (bvs, tms, pat_e, uu____22547, g, erasable1))))))
            in
-        (let uu____22665 =
+        (let uu____22554 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Patterns")
             in
-         if uu____22665
+         if uu____22554
          then
-           let uu____22670 = FStar_Syntax_Print.pat_to_string p0  in
-           FStar_Util.print1 "Checking pattern: %s\n" uu____22670
+           let uu____22559 = FStar_Syntax_Print.pat_to_string p0  in
+           FStar_Util.print1 "Checking pattern: %s\n" uu____22559
          else ());
-        (let uu____22675 =
-           let uu____22693 =
-             let uu___2844_22694 =
-               let uu____22695 = FStar_TypeChecker_Env.clear_expected_typ env
+        (let uu____22564 =
+           let uu____22582 =
+             let uu___2844_22583 =
+               let uu____22584 = FStar_TypeChecker_Env.clear_expected_typ env
                   in
-               FStar_All.pipe_right uu____22695 FStar_Pervasives_Native.fst
+               FStar_All.pipe_right uu____22584 FStar_Pervasives_Native.fst
                 in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___2844_22694.FStar_TypeChecker_Env.solver);
+                 (uu___2844_22583.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___2844_22694.FStar_TypeChecker_Env.range);
+                 (uu___2844_22583.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___2844_22694.FStar_TypeChecker_Env.curmodule);
+                 (uu___2844_22583.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___2844_22694.FStar_TypeChecker_Env.gamma);
+                 (uu___2844_22583.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___2844_22694.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___2844_22583.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___2844_22694.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___2844_22583.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___2844_22694.FStar_TypeChecker_Env.modules);
+                 (uu___2844_22583.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___2844_22694.FStar_TypeChecker_Env.expected_typ);
+                 (uu___2844_22583.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___2844_22694.FStar_TypeChecker_Env.sigtab);
+                 (uu___2844_22583.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___2844_22694.FStar_TypeChecker_Env.attrtab);
+                 (uu___2844_22583.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___2844_22694.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___2844_22583.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___2844_22694.FStar_TypeChecker_Env.effects);
+                 (uu___2844_22583.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___2844_22694.FStar_TypeChecker_Env.generalize);
+                 (uu___2844_22583.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___2844_22694.FStar_TypeChecker_Env.letrecs);
+                 (uu___2844_22583.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___2844_22694.FStar_TypeChecker_Env.top_level);
+                 (uu___2844_22583.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___2844_22694.FStar_TypeChecker_Env.check_uvars);
+                 (uu___2844_22583.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq = true;
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___2844_22694.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___2844_22583.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___2844_22694.FStar_TypeChecker_Env.is_iface);
+                 (uu___2844_22583.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___2844_22694.FStar_TypeChecker_Env.admit);
+                 (uu___2844_22583.FStar_TypeChecker_Env.admit);
                FStar_TypeChecker_Env.lax =
-                 (uu___2844_22694.FStar_TypeChecker_Env.lax);
+                 (uu___2844_22583.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___2844_22694.FStar_TypeChecker_Env.lax_universes);
+                 (uu___2844_22583.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___2844_22694.FStar_TypeChecker_Env.phase1);
+                 (uu___2844_22583.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___2844_22694.FStar_TypeChecker_Env.failhard);
+                 (uu___2844_22583.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___2844_22694.FStar_TypeChecker_Env.nosynth);
+                 (uu___2844_22583.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___2844_22694.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___2844_22583.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___2844_22694.FStar_TypeChecker_Env.tc_term);
+                 (uu___2844_22583.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___2844_22694.FStar_TypeChecker_Env.type_of);
+                 (uu___2844_22583.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___2844_22694.FStar_TypeChecker_Env.universe_of);
+                 (uu___2844_22583.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___2844_22694.FStar_TypeChecker_Env.check_type_of);
+                 (uu___2844_22583.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___2844_22694.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___2844_22583.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___2844_22694.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___2844_22583.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___2844_22694.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___2844_22583.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___2844_22694.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___2844_22583.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___2844_22694.FStar_TypeChecker_Env.proof_ns);
+                 (uu___2844_22583.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___2844_22694.FStar_TypeChecker_Env.synth_hook);
+                 (uu___2844_22583.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___2844_22694.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___2844_22583.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___2844_22694.FStar_TypeChecker_Env.splice);
+                 (uu___2844_22583.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___2844_22694.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___2844_22583.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___2844_22694.FStar_TypeChecker_Env.postprocess);
+                 (uu___2844_22583.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___2844_22694.FStar_TypeChecker_Env.identifier_info);
+                 (uu___2844_22583.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___2844_22694.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___2844_22583.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___2844_22694.FStar_TypeChecker_Env.dsenv);
+                 (uu___2844_22583.FStar_TypeChecker_Env.dsenv);
                FStar_TypeChecker_Env.nbe =
-                 (uu___2844_22694.FStar_TypeChecker_Env.nbe);
+                 (uu___2844_22583.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___2844_22694.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___2844_22583.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___2844_22694.FStar_TypeChecker_Env.erasable_types_tab)
+                 (uu___2844_22583.FStar_TypeChecker_Env.erasable_types_tab)
              }  in
-           let uu____22711 =
+           let uu____22600 =
              FStar_TypeChecker_PatternUtils.elaborate_pat env p0  in
-           check_nested_pattern uu____22693 uu____22711 pat_t  in
-         match uu____22675 with
+           check_nested_pattern uu____22582 uu____22600 pat_t  in
+         match uu____22564 with
          | (bvs,tms,pat_e,pat,g,erasable) ->
-             ((let uu____22750 =
+             ((let uu____22639 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Patterns")
                   in
-               if uu____22750
+               if uu____22639
                then
-                 let uu____22755 = FStar_Syntax_Print.pat_to_string pat  in
-                 let uu____22757 = FStar_Syntax_Print.term_to_string pat_e
+                 let uu____22644 = FStar_Syntax_Print.pat_to_string pat  in
+                 let uu____22646 = FStar_Syntax_Print.term_to_string pat_e
                     in
                  FStar_Util.print2
-                   "Done checking pattern %s as expression %s\n" uu____22755
-                   uu____22757
+                   "Done checking pattern %s as expression %s\n" uu____22644
+                   uu____22646
                else ());
-              (let uu____22762 = FStar_TypeChecker_Env.push_bvs env bvs  in
-               let uu____22763 =
+              (let uu____22651 = FStar_TypeChecker_Env.push_bvs env bvs  in
+               let uu____22652 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env pat_e
                   in
-               (pat, bvs, tms, uu____22762, pat_e, uu____22763, g, erasable))))
+               (pat, bvs, tms, uu____22651, pat_e, uu____22652, g, erasable))))
 
 and (tc_eqn :
   FStar_Syntax_Syntax.bv ->
@@ -7964,89 +7893,89 @@ and (tc_eqn :
   fun scrutinee  ->
     fun env  ->
       fun branch  ->
-        let uu____22801 = FStar_Syntax_Subst.open_branch branch  in
-        match uu____22801 with
+        let uu____22690 = FStar_Syntax_Subst.open_branch branch  in
+        match uu____22690 with
         | (pattern,when_clause,branch_exp) ->
-            let uu____22850 = branch  in
-            (match uu____22850 with
-             | (cpat,uu____22881,cbr) ->
+            let uu____22739 = branch  in
+            (match uu____22739 with
+             | (cpat,uu____22770,cbr) ->
                  let pat_t = scrutinee.FStar_Syntax_Syntax.sort  in
                  let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee
                     in
-                 let uu____22903 =
-                   let uu____22910 =
+                 let uu____22792 =
+                   let uu____22799 =
                      FStar_TypeChecker_Env.push_bv env scrutinee  in
-                   FStar_All.pipe_right uu____22910
+                   FStar_All.pipe_right uu____22799
                      FStar_TypeChecker_Env.clear_expected_typ
                     in
-                 (match uu____22903 with
-                  | (scrutinee_env,uu____22947) ->
-                      let uu____22952 = tc_pat env pat_t pattern  in
-                      (match uu____22952 with
+                 (match uu____22792 with
+                  | (scrutinee_env,uu____22836) ->
+                      let uu____22841 = tc_pat env pat_t pattern  in
+                      (match uu____22841 with
                        | (pattern1,pat_bvs,pat_bv_tms,pat_env,pat_exp,norm_pat_exp,guard_pat,erasable)
                            ->
-                           ((let uu____23022 =
+                           ((let uu____22911 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
                                  FStar_Options.Extreme
                                 in
-                             if uu____23022
+                             if uu____22911
                              then
-                               let uu____23026 =
+                               let uu____22915 =
                                  FStar_Syntax_Print.pat_to_string pattern1
                                   in
-                               let uu____23028 =
+                               let uu____22917 =
                                  FStar_Syntax_Print.bvs_to_string ";" pat_bvs
                                   in
-                               let uu____23031 =
+                               let uu____22920 =
                                  FStar_List.fold_left
                                    (fun s  ->
                                       fun t  ->
-                                        let uu____23040 =
-                                          let uu____23042 =
+                                        let uu____22929 =
+                                          let uu____22931 =
                                             FStar_Syntax_Print.term_to_string
                                               t
                                              in
-                                          Prims.op_Hat ";" uu____23042  in
-                                        Prims.op_Hat s uu____23040) ""
+                                          Prims.op_Hat ";" uu____22931  in
+                                        Prims.op_Hat s uu____22929) ""
                                    pat_bv_tms
                                   in
                                FStar_Util.print3
                                  "tc_eqn: typechecked pattern %s with bvs %s and pat_bv_tms %s"
-                                 uu____23026 uu____23028 uu____23031
+                                 uu____22915 uu____22917 uu____22920
                              else ());
-                            (let uu____23049 =
+                            (let uu____22938 =
                                match when_clause with
                                | FStar_Pervasives_Native.None  ->
                                    (FStar_Pervasives_Native.None,
                                      FStar_TypeChecker_Env.trivial_guard)
                                | FStar_Pervasives_Native.Some e ->
-                                   let uu____23079 =
+                                   let uu____22968 =
                                      FStar_TypeChecker_Env.should_verify env
                                       in
-                                   if uu____23079
+                                   if uu____22968
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_WhenClauseNotSupported,
                                          "When clauses are not yet supported in --verify mode; they will be some day")
                                        e.FStar_Syntax_Syntax.pos
                                    else
-                                     (let uu____23102 =
-                                        let uu____23109 =
+                                     (let uu____22991 =
+                                        let uu____22998 =
                                           FStar_TypeChecker_Env.set_expected_typ
                                             pat_env FStar_Syntax_Util.t_bool
                                            in
-                                        tc_term uu____23109 e  in
-                                      match uu____23102 with
+                                        tc_term uu____22998 e  in
+                                      match uu____22991 with
                                       | (e1,c,g) ->
                                           ((FStar_Pervasives_Native.Some e1),
                                             g))
                                 in
-                             match uu____23049 with
+                             match uu____22938 with
                              | (when_clause1,g_when) ->
-                                 let uu____23166 = tc_term pat_env branch_exp
+                                 let uu____23055 = tc_term pat_env branch_exp
                                     in
-                                 (match uu____23166 with
+                                 (match uu____23055 with
                                   | (branch_exp1,c,g_branch) ->
                                       (FStar_TypeChecker_Env.def_check_guard_wf
                                          cbr.FStar_Syntax_Syntax.pos
@@ -8056,25 +7985,25 @@ and (tc_eqn :
                                           | FStar_Pervasives_Native.None  ->
                                               FStar_Pervasives_Native.None
                                           | FStar_Pervasives_Native.Some w ->
-                                              let uu____23225 =
+                                              let uu____23114 =
                                                 FStar_Syntax_Util.mk_eq2
                                                   FStar_Syntax_Syntax.U_zero
                                                   FStar_Syntax_Util.t_bool w
                                                   FStar_Syntax_Util.exp_true_bool
                                                  in
                                               FStar_All.pipe_left
-                                                (fun uu____23236  ->
+                                                (fun uu____23125  ->
                                                    FStar_Pervasives_Native.Some
-                                                     uu____23236) uu____23225
+                                                     uu____23125) uu____23114
                                            in
                                         let branch_guard =
-                                          let uu____23240 =
-                                            let uu____23242 =
+                                          let uu____23129 =
+                                            let uu____23131 =
                                               FStar_TypeChecker_Env.should_verify
                                                 env
                                                in
-                                            Prims.op_Negation uu____23242  in
-                                          if uu____23240
+                                            Prims.op_Negation uu____23131  in
+                                          if uu____23129
                                           then FStar_Syntax_Util.t_true
                                           else
                                             (let rec build_branch_guard
@@ -8082,16 +8011,16 @@ and (tc_eqn :
                                                pat_exp1 =
                                                let discriminate scrutinee_tm2
                                                  f =
-                                                 let uu____23298 =
-                                                   let uu____23306 =
+                                                 let uu____23187 =
+                                                   let uu____23195 =
                                                      FStar_TypeChecker_Env.typ_of_datacon
                                                        env
                                                        f.FStar_Syntax_Syntax.v
                                                       in
                                                    FStar_TypeChecker_Env.datacons_of_typ
-                                                     env uu____23306
+                                                     env uu____23195
                                                     in
-                                                 match uu____23298 with
+                                                 match uu____23187 with
                                                  | (is_induc,datacons) ->
                                                      if
                                                        (Prims.op_Negation
@@ -8105,15 +8034,15 @@ and (tc_eqn :
                                                          FStar_Syntax_Util.mk_discriminator
                                                            f.FStar_Syntax_Syntax.v
                                                           in
-                                                       let uu____23322 =
+                                                       let uu____23211 =
                                                          FStar_TypeChecker_Env.try_lookup_lid
                                                            env discriminator
                                                           in
-                                                       (match uu____23322
+                                                       (match uu____23211
                                                         with
                                                         | FStar_Pervasives_Native.None
                                                              -> []
-                                                        | uu____23343 ->
+                                                        | uu____23232 ->
                                                             let disc =
                                                               FStar_Syntax_Syntax.fvar
                                                                 discriminator
@@ -8122,55 +8051,50 @@ and (tc_eqn :
                                                                 FStar_Pervasives_Native.None
                                                                in
                                                             let disc1 =
-                                                              let uu____23359
+                                                              let uu____23246
                                                                 =
-                                                                let uu____23364
+                                                                let uu____23247
                                                                   =
-                                                                  let uu____23365
-                                                                    =
-                                                                    FStar_Syntax_Syntax.as_arg
+                                                                  FStar_Syntax_Syntax.as_arg
                                                                     scrutinee_tm2
-                                                                     in
-                                                                  [uu____23365]
                                                                    in
-                                                                FStar_Syntax_Syntax.mk_Tm_app
-                                                                  disc
-                                                                  uu____23364
+                                                                [uu____23247]
                                                                  in
-                                                              uu____23359
-                                                                FStar_Pervasives_Native.None
+                                                              FStar_Syntax_Syntax.mk_Tm_app
+                                                                disc
+                                                                uu____23246
                                                                 scrutinee_tm2.FStar_Syntax_Syntax.pos
                                                                in
-                                                            let uu____23390 =
+                                                            let uu____23272 =
                                                               FStar_Syntax_Util.mk_eq2
                                                                 FStar_Syntax_Syntax.U_zero
                                                                 FStar_Syntax_Util.t_bool
                                                                 disc1
                                                                 FStar_Syntax_Util.exp_true_bool
                                                                in
-                                                            [uu____23390])
+                                                            [uu____23272])
                                                      else []
                                                   in
-                                               let fail uu____23398 =
-                                                 let uu____23399 =
-                                                   let uu____23401 =
+                                               let fail uu____23280 =
+                                                 let uu____23281 =
+                                                   let uu____23283 =
                                                      FStar_Range.string_of_range
                                                        pat_exp1.FStar_Syntax_Syntax.pos
                                                       in
-                                                   let uu____23403 =
+                                                   let uu____23285 =
                                                      FStar_Syntax_Print.term_to_string
                                                        pat_exp1
                                                       in
-                                                   let uu____23405 =
+                                                   let uu____23287 =
                                                      FStar_Syntax_Print.tag_of_term
                                                        pat_exp1
                                                       in
                                                    FStar_Util.format3
                                                      "tc_eqn: Impossible (%s) %s (%s)"
-                                                     uu____23401 uu____23403
-                                                     uu____23405
+                                                     uu____23283 uu____23285
+                                                     uu____23287
                                                     in
-                                                 failwith uu____23399  in
+                                                 failwith uu____23281  in
                                                let rec head_constructor t =
                                                  match t.FStar_Syntax_Syntax.n
                                                  with
@@ -8178,171 +8102,171 @@ and (tc_eqn :
                                                      fv ->
                                                      fv.FStar_Syntax_Syntax.fv_name
                                                  | FStar_Syntax_Syntax.Tm_uinst
-                                                     (t1,uu____23420) ->
+                                                     (t1,uu____23302) ->
                                                      head_constructor t1
-                                                 | uu____23425 -> fail ()  in
+                                                 | uu____23307 -> fail ()  in
                                                let force_scrutinee
-                                                 uu____23431 =
+                                                 uu____23313 =
                                                  match scrutinee_tm1 with
                                                  | FStar_Pervasives_Native.None
                                                       ->
-                                                     let uu____23432 =
-                                                       let uu____23434 =
+                                                     let uu____23314 =
+                                                       let uu____23316 =
                                                          FStar_Range.string_of_range
                                                            pattern2.FStar_Syntax_Syntax.p
                                                           in
-                                                       let uu____23436 =
+                                                       let uu____23318 =
                                                          FStar_Syntax_Print.pat_to_string
                                                            pattern2
                                                           in
                                                        FStar_Util.format2
                                                          "Impossible (%s): scrutinee of match is not defined %s"
-                                                         uu____23434
-                                                         uu____23436
+                                                         uu____23316
+                                                         uu____23318
                                                         in
-                                                     failwith uu____23432
+                                                     failwith uu____23314
                                                  | FStar_Pervasives_Native.Some
                                                      t -> t
                                                   in
                                                let pat_exp2 =
-                                                 let uu____23443 =
+                                                 let uu____23325 =
                                                    FStar_Syntax_Subst.compress
                                                      pat_exp1
                                                     in
                                                  FStar_All.pipe_right
-                                                   uu____23443
+                                                   uu____23325
                                                    FStar_Syntax_Util.unmeta
                                                   in
                                                match ((pattern2.FStar_Syntax_Syntax.v),
                                                        (pat_exp2.FStar_Syntax_Syntax.n))
                                                with
-                                               | (uu____23448,FStar_Syntax_Syntax.Tm_name
-                                                  uu____23449) -> []
-                                               | (uu____23450,FStar_Syntax_Syntax.Tm_constant
+                                               | (uu____23330,FStar_Syntax_Syntax.Tm_name
+                                                  uu____23331) -> []
+                                               | (uu____23332,FStar_Syntax_Syntax.Tm_constant
                                                   (FStar_Const.Const_unit ))
                                                    -> []
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   _c,FStar_Syntax_Syntax.Tm_constant
                                                   c1) ->
-                                                   let uu____23453 =
-                                                     let uu____23454 =
+                                                   let uu____23335 =
+                                                     let uu____23336 =
                                                        tc_constant env
                                                          pat_exp2.FStar_Syntax_Syntax.pos
                                                          c1
                                                         in
-                                                     let uu____23455 =
+                                                     let uu____23337 =
                                                        force_scrutinee ()  in
                                                      FStar_Syntax_Util.mk_eq2
                                                        FStar_Syntax_Syntax.U_zero
-                                                       uu____23454
-                                                       uu____23455 pat_exp2
+                                                       uu____23336
+                                                       uu____23337 pat_exp2
                                                       in
-                                                   [uu____23453]
+                                                   [uu____23335]
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   (FStar_Const.Const_int
-                                                  (uu____23456,FStar_Pervasives_Native.Some
-                                                   uu____23457)),uu____23458)
+                                                  (uu____23338,FStar_Pervasives_Native.Some
+                                                   uu____23339)),uu____23340)
                                                    ->
-                                                   let uu____23475 =
-                                                     let uu____23482 =
+                                                   let uu____23357 =
+                                                     let uu____23364 =
                                                        FStar_TypeChecker_Env.clear_expected_typ
                                                          env
                                                         in
-                                                     match uu____23482 with
-                                                     | (env1,uu____23496) ->
+                                                     match uu____23364 with
+                                                     | (env1,uu____23378) ->
                                                          env1.FStar_TypeChecker_Env.type_of
                                                            env1 pat_exp2
                                                       in
-                                                   (match uu____23475 with
-                                                    | (uu____23503,t,uu____23505)
+                                                   (match uu____23357 with
+                                                    | (uu____23385,t,uu____23387)
                                                         ->
-                                                        let uu____23506 =
-                                                          let uu____23507 =
+                                                        let uu____23388 =
+                                                          let uu____23389 =
                                                             force_scrutinee
                                                               ()
                                                              in
                                                           FStar_Syntax_Util.mk_eq2
                                                             FStar_Syntax_Syntax.U_zero
-                                                            t uu____23507
+                                                            t uu____23389
                                                             pat_exp2
                                                            in
-                                                        [uu____23506])
+                                                        [uu____23388])
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____23508,[]),FStar_Syntax_Syntax.Tm_uinst
-                                                  uu____23509) ->
+                                                  (uu____23390,[]),FStar_Syntax_Syntax.Tm_uinst
+                                                  uu____23391) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2
                                                       in
-                                                   let uu____23533 =
-                                                     let uu____23535 =
+                                                   let uu____23415 =
+                                                     let uu____23417 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v
                                                         in
                                                      Prims.op_Negation
-                                                       uu____23535
+                                                       uu____23417
                                                       in
-                                                   if uu____23533
+                                                   if uu____23415
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____23545 =
+                                                     (let uu____23427 =
                                                         force_scrutinee ()
                                                          in
-                                                      let uu____23548 =
+                                                      let uu____23430 =
                                                         head_constructor
                                                           pat_exp2
                                                          in
                                                       discriminate
-                                                        uu____23545
-                                                        uu____23548)
+                                                        uu____23427
+                                                        uu____23430)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____23551,[]),FStar_Syntax_Syntax.Tm_fvar
-                                                  uu____23552) ->
+                                                  (uu____23433,[]),FStar_Syntax_Syntax.Tm_fvar
+                                                  uu____23434) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2
                                                       in
-                                                   let uu____23570 =
-                                                     let uu____23572 =
+                                                   let uu____23452 =
+                                                     let uu____23454 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v
                                                         in
                                                      Prims.op_Negation
-                                                       uu____23572
+                                                       uu____23454
                                                       in
-                                                   if uu____23570
+                                                   if uu____23452
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____23582 =
+                                                     (let uu____23464 =
                                                         force_scrutinee ()
                                                          in
-                                                      let uu____23585 =
+                                                      let uu____23467 =
                                                         head_constructor
                                                           pat_exp2
                                                          in
                                                       discriminate
-                                                        uu____23582
-                                                        uu____23585)
+                                                        uu____23464
+                                                        uu____23467)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____23588,pat_args),FStar_Syntax_Syntax.Tm_app
+                                                  (uu____23470,pat_args),FStar_Syntax_Syntax.Tm_app
                                                   (head,args)) ->
                                                    let f =
                                                      head_constructor head
                                                       in
-                                                   let uu____23635 =
-                                                     (let uu____23639 =
+                                                   let uu____23517 =
+                                                     (let uu____23521 =
                                                         FStar_TypeChecker_Env.is_datacon
                                                           env
                                                           f.FStar_Syntax_Syntax.v
                                                          in
                                                       Prims.op_Negation
-                                                        uu____23639)
+                                                        uu____23521)
                                                        ||
                                                        ((FStar_List.length
                                                            pat_args)
@@ -8350,29 +8274,29 @@ and (tc_eqn :
                                                           (FStar_List.length
                                                              args))
                                                       in
-                                                   if uu____23635
+                                                   if uu____23517
                                                    then
                                                      failwith
                                                        "Impossible: application patterns must be fully-applied data constructors"
                                                    else
                                                      (let sub_term_guards =
-                                                        let uu____23667 =
-                                                          let uu____23672 =
+                                                        let uu____23549 =
+                                                          let uu____23554 =
                                                             FStar_List.zip
                                                               pat_args args
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____23672
+                                                            uu____23554
                                                             (FStar_List.mapi
                                                                (fun i  ->
                                                                   fun
-                                                                    uu____23758
+                                                                    uu____23640
                                                                      ->
-                                                                    match uu____23758
+                                                                    match uu____23640
                                                                     with
                                                                     | 
-                                                                    ((pi,uu____23780),
-                                                                    (ei,uu____23782))
+                                                                    ((pi,uu____23662),
+                                                                    (ei,uu____23664))
                                                                     ->
                                                                     let projector
                                                                     =
@@ -8382,140 +8306,135 @@ and (tc_eqn :
                                                                     i  in
                                                                     let scrutinee_tm2
                                                                     =
-                                                                    let uu____23810
+                                                                    let uu____23692
                                                                     =
                                                                     FStar_TypeChecker_Env.try_lookup_lid
                                                                     env
                                                                     projector
                                                                      in
-                                                                    match uu____23810
+                                                                    match uu____23692
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                      ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu____23831
+                                                                    uu____23713
                                                                     ->
                                                                     let proj
                                                                     =
-                                                                    let uu____23843
+                                                                    let uu____23725
                                                                     =
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Syntax_Syntax.fvar
-                                                                    uu____23843
+                                                                    uu____23725
                                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)
                                                                     FStar_Pervasives_Native.None
                                                                      in
-                                                                    let uu____23845
+                                                                    let uu____23727
                                                                     =
-                                                                    let uu____23846
+                                                                    let uu____23728
                                                                     =
-                                                                    let uu____23851
+                                                                    let uu____23729
                                                                     =
-                                                                    let uu____23852
-                                                                    =
-                                                                    let uu____23861
+                                                                    let uu____23738
                                                                     =
                                                                     force_scrutinee
                                                                     ()  in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____23861
+                                                                    uu____23738
                                                                      in
-                                                                    [uu____23852]
+                                                                    [uu____23729]
                                                                      in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     proj
-                                                                    uu____23851
-                                                                     in
-                                                                    uu____23846
-                                                                    FStar_Pervasives_Native.None
+                                                                    uu____23728
                                                                     f.FStar_Syntax_Syntax.p
                                                                      in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____23845
+                                                                    uu____23727
                                                                      in
                                                                     build_branch_guard
                                                                     scrutinee_tm2
                                                                     pi ei))
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____23667
+                                                          uu____23549
                                                           FStar_List.flatten
                                                          in
-                                                      let uu____23884 =
-                                                        let uu____23887 =
+                                                      let uu____23761 =
+                                                        let uu____23764 =
                                                           force_scrutinee ()
                                                            in
                                                         discriminate
-                                                          uu____23887 f
+                                                          uu____23764 f
                                                          in
                                                       FStar_List.append
-                                                        uu____23884
+                                                        uu____23761
                                                         sub_term_guards)
                                                | (FStar_Syntax_Syntax.Pat_dot_term
-                                                  uu____23890,uu____23891) ->
+                                                  uu____23767,uu____23768) ->
                                                    []
-                                               | uu____23898 ->
-                                                   let uu____23903 =
-                                                     let uu____23905 =
+                                               | uu____23775 ->
+                                                   let uu____23780 =
+                                                     let uu____23782 =
                                                        FStar_Syntax_Print.pat_to_string
                                                          pattern2
                                                         in
-                                                     let uu____23907 =
+                                                     let uu____23784 =
                                                        FStar_Syntax_Print.term_to_string
                                                          pat_exp2
                                                         in
                                                      FStar_Util.format2
                                                        "Internal error: unexpected elaborated pattern: %s and pattern expression %s"
-                                                       uu____23905
-                                                       uu____23907
+                                                       uu____23782
+                                                       uu____23784
                                                       in
-                                                   failwith uu____23903
+                                                   failwith uu____23780
                                                 in
                                              let build_and_check_branch_guard
                                                scrutinee_tm1 pattern2 pat =
-                                               let uu____23936 =
-                                                 let uu____23938 =
+                                               let uu____23813 =
+                                                 let uu____23815 =
                                                    FStar_TypeChecker_Env.should_verify
                                                      env
                                                     in
                                                  Prims.op_Negation
-                                                   uu____23938
+                                                   uu____23815
                                                   in
-                                               if uu____23936
+                                               if uu____23813
                                                then
                                                  FStar_TypeChecker_Util.fvar_const
                                                    env
                                                    FStar_Parser_Const.true_lid
                                                else
                                                  (let t =
-                                                    let uu____23944 =
+                                                    let uu____23821 =
                                                       build_branch_guard
                                                         scrutinee_tm1
                                                         pattern2 pat
                                                        in
                                                     FStar_All.pipe_left
                                                       FStar_Syntax_Util.mk_conj_l
-                                                      uu____23944
+                                                      uu____23821
                                                      in
-                                                  let uu____23953 =
+                                                  let uu____23830 =
                                                     FStar_Syntax_Util.type_u
                                                       ()
                                                      in
-                                                  match uu____23953 with
-                                                  | (k,uu____23959) ->
-                                                      let uu____23960 =
+                                                  match uu____23830 with
+                                                  | (k,uu____23836) ->
+                                                      let uu____23837 =
                                                         tc_check_tot_or_gtot_term
                                                           scrutinee_env t k
                                                           ""
                                                          in
-                                                      (match uu____23960 with
-                                                       | (t1,uu____23969,uu____23970)
+                                                      (match uu____23837 with
+                                                       | (t1,uu____23846,uu____23847)
                                                            -> t1))
                                                 in
                                              let branch_guard =
@@ -8535,16 +8454,16 @@ and (tc_eqn :
                                                 in
                                              branch_guard1)
                                            in
-                                        let uu____23984 =
+                                        let uu____23861 =
                                           let eqs =
-                                            let uu____24004 =
-                                              let uu____24006 =
+                                            let uu____23881 =
+                                              let uu____23883 =
                                                 FStar_TypeChecker_Env.should_verify
                                                   env
                                                  in
-                                              Prims.op_Negation uu____24006
+                                              Prims.op_Negation uu____23883
                                                in
-                                            if uu____24004
+                                            if uu____23881
                                             then FStar_Pervasives_Native.None
                                             else
                                               (let e =
@@ -8554,56 +8473,56 @@ and (tc_eqn :
                                                match e.FStar_Syntax_Syntax.n
                                                with
                                                | FStar_Syntax_Syntax.Tm_uvar
-                                                   uu____24016 ->
+                                                   uu____23893 ->
                                                    FStar_Pervasives_Native.None
                                                | FStar_Syntax_Syntax.Tm_constant
-                                                   uu____24029 ->
+                                                   uu____23906 ->
                                                    FStar_Pervasives_Native.None
                                                | FStar_Syntax_Syntax.Tm_fvar
-                                                   uu____24030 ->
+                                                   uu____23907 ->
                                                    FStar_Pervasives_Native.None
-                                               | uu____24031 ->
-                                                   let uu____24032 =
-                                                     let uu____24033 =
+                                               | uu____23908 ->
+                                                   let uu____23909 =
+                                                     let uu____23910 =
                                                        env.FStar_TypeChecker_Env.universe_of
                                                          env pat_t
                                                         in
                                                      FStar_Syntax_Util.mk_eq2
-                                                       uu____24033 pat_t
+                                                       uu____23910 pat_t
                                                        scrutinee_tm e
                                                       in
                                                    FStar_Pervasives_Native.Some
-                                                     uu____24032)
+                                                     uu____23909)
                                              in
-                                          let uu____24034 =
+                                          let uu____23911 =
                                             FStar_TypeChecker_Util.strengthen_precondition
                                               FStar_Pervasives_Native.None
                                               env branch_exp1 c g_branch
                                              in
-                                          match uu____24034 with
+                                          match uu____23911 with
                                           | (c1,g_branch1) ->
                                               let branch_has_layered_effect =
-                                                let uu____24063 =
+                                                let uu____23940 =
                                                   FStar_All.pipe_right
                                                     c1.FStar_TypeChecker_Common.eff_name
                                                     (FStar_TypeChecker_Env.norm_eff_name
                                                        env)
                                                    in
                                                 FStar_All.pipe_right
-                                                  uu____24063
+                                                  uu____23940
                                                   (FStar_TypeChecker_Env.is_layered_effect
                                                      env)
                                                  in
-                                              let uu____24065 =
+                                              let uu____23942 =
                                                 let env1 =
-                                                  let uu____24071 =
+                                                  let uu____23948 =
                                                     FStar_All.pipe_right
                                                       pat_bvs
                                                       (FStar_List.map
                                                          FStar_Syntax_Syntax.mk_binder)
                                                      in
                                                   FStar_TypeChecker_Env.push_binders
-                                                    scrutinee_env uu____24071
+                                                    scrutinee_env uu____23948
                                                    in
                                                 if branch_has_layered_effect
                                                 then
@@ -8619,13 +8538,13 @@ and (tc_eqn :
                                                   (match (eqs,
                                                            when_condition)
                                                    with
-                                                   | uu____24092 when
-                                                       let uu____24103 =
+                                                   | uu____23969 when
+                                                       let uu____23980 =
                                                          FStar_TypeChecker_Env.should_verify
                                                            env1
                                                           in
                                                        Prims.op_Negation
-                                                         uu____24103
+                                                         uu____23980
                                                        -> (c1, g_when)
                                                    | (FStar_Pervasives_Native.None
                                                       ,FStar_Pervasives_Native.None
@@ -8641,16 +8560,16 @@ and (tc_eqn :
                                                          FStar_TypeChecker_Env.guard_of_guard_formula
                                                            gf
                                                           in
-                                                       let uu____24124 =
+                                                       let uu____24001 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 gf
                                                           in
-                                                       let uu____24125 =
+                                                       let uu____24002 =
                                                          FStar_TypeChecker_Env.imp_guard
                                                            g g_when
                                                           in
-                                                       (uu____24124,
-                                                         uu____24125)
+                                                       (uu____24001,
+                                                         uu____24002)
                                                    | (FStar_Pervasives_Native.Some
                                                       f,FStar_Pervasives_Native.Some
                                                       w) ->
@@ -8659,27 +8578,27 @@ and (tc_eqn :
                                                            f
                                                           in
                                                        let g_fw =
-                                                         let uu____24140 =
+                                                         let uu____24017 =
                                                            FStar_Syntax_Util.mk_conj
                                                              f w
                                                             in
                                                          FStar_TypeChecker_Common.NonTrivial
-                                                           uu____24140
+                                                           uu____24017
                                                           in
-                                                       let uu____24141 =
+                                                       let uu____24018 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 g_fw
                                                           in
-                                                       let uu____24142 =
-                                                         let uu____24143 =
+                                                       let uu____24019 =
+                                                         let uu____24020 =
                                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                                              g_f
                                                             in
                                                          FStar_TypeChecker_Env.imp_guard
-                                                           uu____24143 g_when
+                                                           uu____24020 g_when
                                                           in
-                                                       (uu____24141,
-                                                         uu____24142)
+                                                       (uu____24018,
+                                                         uu____24019)
                                                    | (FStar_Pervasives_Native.None
                                                       ,FStar_Pervasives_Native.Some
                                                       w) ->
@@ -8691,13 +8610,13 @@ and (tc_eqn :
                                                          FStar_TypeChecker_Env.guard_of_guard_formula
                                                            g_w
                                                           in
-                                                       let uu____24157 =
+                                                       let uu____24034 =
                                                          FStar_TypeChecker_Util.weaken_precondition
                                                            env1 c1 g_w
                                                           in
-                                                       (uu____24157, g_when))
+                                                       (uu____24034, g_when))
                                                  in
-                                              (match uu____24065 with
+                                              (match uu____23942 with
                                                | (c_weak,g_when_weak) ->
                                                    let binders =
                                                      FStar_List.map
@@ -8707,12 +8626,12 @@ and (tc_eqn :
                                                    let maybe_return_c_weak
                                                      should_return =
                                                      let c_weak1 =
-                                                       let uu____24200 =
+                                                       let uu____24077 =
                                                          should_return &&
                                                            (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                               c_weak)
                                                           in
-                                                       if uu____24200
+                                                       if uu____24077
                                                        then
                                                          FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                                            env branch_exp1
@@ -8721,14 +8640,14 @@ and (tc_eqn :
                                                      if
                                                        branch_has_layered_effect
                                                      then
-                                                       ((let uu____24207 =
+                                                       ((let uu____24084 =
                                                            FStar_All.pipe_left
                                                              (FStar_TypeChecker_Env.debug
                                                                 env)
                                                              (FStar_Options.Other
                                                                 "LayeredEffects")
                                                             in
-                                                         if uu____24207
+                                                         if uu____24084
                                                          then
                                                            FStar_Util.print_string
                                                              "Typechecking pat_bv_tms ...\n"
@@ -8740,29 +8659,24 @@ and (tc_eqn :
                                                                 (fun
                                                                    pat_bv_tm 
                                                                    ->
-                                                                   let uu____24227
+                                                                   let uu____24102
                                                                     =
-                                                                    let uu____24232
-                                                                    =
-                                                                    let uu____24233
+                                                                    let uu____24103
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     scrutinee_tm
                                                                     FStar_Syntax_Syntax.as_arg
                                                                      in
-                                                                    [uu____24233]
+                                                                    [uu____24103]
                                                                      in
-                                                                    FStar_Syntax_Syntax.mk_Tm_app
+                                                                   FStar_Syntax_Syntax.mk_Tm_app
                                                                     pat_bv_tm
-                                                                    uu____24232
-                                                                     in
-                                                                   uu____24227
-                                                                    FStar_Pervasives_Native.None
+                                                                    uu____24102
                                                                     FStar_Range.dummyRange))
                                                             in
                                                          let pat_bv_tms2 =
                                                            let env1 =
-                                                             let uu___3084_24270
+                                                             let uu___3084_24140
                                                                =
                                                                FStar_TypeChecker_Env.push_bv
                                                                  env
@@ -8771,155 +8685,155 @@ and (tc_eqn :
                                                              {
                                                                FStar_TypeChecker_Env.solver
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.solver);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.solver);
                                                                FStar_TypeChecker_Env.range
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.range);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.range);
                                                                FStar_TypeChecker_Env.curmodule
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.curmodule);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.curmodule);
                                                                FStar_TypeChecker_Env.gamma
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.gamma);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.gamma);
                                                                FStar_TypeChecker_Env.gamma_sig
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.gamma_sig);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.gamma_sig);
                                                                FStar_TypeChecker_Env.gamma_cache
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.gamma_cache);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.gamma_cache);
                                                                FStar_TypeChecker_Env.modules
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.modules);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.modules);
                                                                FStar_TypeChecker_Env.expected_typ
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.expected_typ);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.expected_typ);
                                                                FStar_TypeChecker_Env.sigtab
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.sigtab);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.sigtab);
                                                                FStar_TypeChecker_Env.attrtab
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.attrtab);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.attrtab);
                                                                FStar_TypeChecker_Env.instantiate_imp
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.instantiate_imp);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.instantiate_imp);
                                                                FStar_TypeChecker_Env.effects
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.effects);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.effects);
                                                                FStar_TypeChecker_Env.generalize
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.generalize);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.generalize);
                                                                FStar_TypeChecker_Env.letrecs
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.letrecs);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.letrecs);
                                                                FStar_TypeChecker_Env.top_level
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.top_level);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.top_level);
                                                                FStar_TypeChecker_Env.check_uvars
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.check_uvars);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.check_uvars);
                                                                FStar_TypeChecker_Env.use_eq
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.use_eq);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.use_eq);
                                                                FStar_TypeChecker_Env.use_eq_strict
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.use_eq_strict);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.use_eq_strict);
                                                                FStar_TypeChecker_Env.is_iface
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.is_iface);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.is_iface);
                                                                FStar_TypeChecker_Env.admit
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.admit);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.admit);
                                                                FStar_TypeChecker_Env.lax
                                                                  = true;
                                                                FStar_TypeChecker_Env.lax_universes
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.lax_universes);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.lax_universes);
                                                                FStar_TypeChecker_Env.phase1
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.phase1);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.phase1);
                                                                FStar_TypeChecker_Env.failhard
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.failhard);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.failhard);
                                                                FStar_TypeChecker_Env.nosynth
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.nosynth);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.nosynth);
                                                                FStar_TypeChecker_Env.uvar_subtyping
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.uvar_subtyping);
                                                                FStar_TypeChecker_Env.tc_term
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.tc_term);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.tc_term);
                                                                FStar_TypeChecker_Env.type_of
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.type_of);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.type_of);
                                                                FStar_TypeChecker_Env.universe_of
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.universe_of);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.universe_of);
                                                                FStar_TypeChecker_Env.check_type_of
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.check_type_of);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.check_type_of);
                                                                FStar_TypeChecker_Env.use_bv_sorts
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.use_bv_sorts);
                                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                FStar_TypeChecker_Env.normalized_eff_names
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.normalized_eff_names);
                                                                FStar_TypeChecker_Env.fv_delta_depths
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.fv_delta_depths);
                                                                FStar_TypeChecker_Env.proof_ns
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.proof_ns);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.proof_ns);
                                                                FStar_TypeChecker_Env.synth_hook
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.synth_hook);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.synth_hook);
                                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                FStar_TypeChecker_Env.splice
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.splice);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.splice);
                                                                FStar_TypeChecker_Env.mpreprocess
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.mpreprocess);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.mpreprocess);
                                                                FStar_TypeChecker_Env.postprocess
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.postprocess);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.postprocess);
                                                                FStar_TypeChecker_Env.identifier_info
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.identifier_info);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.identifier_info);
                                                                FStar_TypeChecker_Env.tc_hooks
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.tc_hooks);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.tc_hooks);
                                                                FStar_TypeChecker_Env.dsenv
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.dsenv);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.dsenv);
                                                                FStar_TypeChecker_Env.nbe
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.nbe);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.nbe);
                                                                FStar_TypeChecker_Env.strict_args_tab
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.strict_args_tab);
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.strict_args_tab);
                                                                FStar_TypeChecker_Env.erasable_types_tab
                                                                  =
-                                                                 (uu___3084_24270.FStar_TypeChecker_Env.erasable_types_tab)
+                                                                 (uu___3084_24140.FStar_TypeChecker_Env.erasable_types_tab)
                                                              }  in
-                                                           let uu____24272 =
-                                                             let uu____24275
+                                                           let uu____24142 =
+                                                             let uu____24145
                                                                =
                                                                FStar_List.fold_left2
                                                                  (fun
-                                                                    uu____24303
+                                                                    uu____24173
                                                                      ->
                                                                     fun
                                                                     pat_bv_tm
                                                                      ->
                                                                     fun bv 
                                                                     ->
-                                                                    match uu____24303
+                                                                    match uu____24173
                                                                     with
                                                                     | 
                                                                     (substs,acc)
@@ -8932,32 +8846,32 @@ and (tc_eqn :
                                                                      in
                                                                     let pat_bv_tm1
                                                                     =
-                                                                    let uu____24344
+                                                                    let uu____24214
                                                                     =
-                                                                    let uu____24351
+                                                                    let uu____24221
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     pat_bv_tm
                                                                     (FStar_Syntax_Subst.subst
                                                                     substs)
                                                                      in
-                                                                    let uu____24352
+                                                                    let uu____24222
                                                                     =
-                                                                    let uu____24363
+                                                                    let uu____24233
                                                                     =
                                                                     FStar_TypeChecker_Env.set_expected_typ
                                                                     env1
                                                                     expected_t
                                                                      in
                                                                     tc_trivial_guard
-                                                                    uu____24363
+                                                                    uu____24233
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____24351
-                                                                    uu____24352
+                                                                    uu____24221
+                                                                    uu____24222
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____24344
+                                                                    uu____24214
                                                                     FStar_Pervasives_Native.fst
                                                                      in
                                                                     ((FStar_List.append
@@ -8974,70 +8888,70 @@ and (tc_eqn :
                                                                  pat_bvs
                                                                 in
                                                              FStar_All.pipe_right
-                                                               uu____24275
+                                                               uu____24145
                                                                FStar_Pervasives_Native.snd
                                                               in
                                                            FStar_All.pipe_right
-                                                             uu____24272
+                                                             uu____24142
                                                              (FStar_List.map
                                                                 (FStar_TypeChecker_Normalize.normalize
                                                                    [FStar_TypeChecker_Env.Beta]
                                                                    env1))
                                                             in
-                                                         (let uu____24425 =
+                                                         (let uu____24295 =
                                                             FStar_All.pipe_left
                                                               (FStar_TypeChecker_Env.debug
                                                                  env)
                                                               (FStar_Options.Other
                                                                  "LayeredEffects")
                                                              in
-                                                          if uu____24425
+                                                          if uu____24295
                                                           then
-                                                            let uu____24430 =
+                                                            let uu____24300 =
                                                               FStar_List.fold_left
                                                                 (fun s  ->
                                                                    fun t  ->
-                                                                    let uu____24439
+                                                                    let uu____24309
                                                                     =
-                                                                    let uu____24441
+                                                                    let uu____24311
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t  in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____24441
+                                                                    uu____24311
                                                                      in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____24439)
+                                                                    uu____24309)
                                                                 ""
                                                                 pat_bv_tms2
                                                                in
-                                                            let uu____24445 =
+                                                            let uu____24315 =
                                                               FStar_List.fold_left
                                                                 (fun s  ->
                                                                    fun t  ->
-                                                                    let uu____24454
+                                                                    let uu____24324
                                                                     =
-                                                                    let uu____24456
+                                                                    let uu____24326
                                                                     =
                                                                     FStar_Syntax_Print.bv_to_string
                                                                     t  in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____24456
+                                                                    uu____24326
                                                                      in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____24454)
+                                                                    uu____24324)
                                                                 "" pat_bvs
                                                                in
                                                             FStar_Util.print2
                                                               "tc_eqn: typechecked pat_bv_tms %s (pat_bvs : %s)\n"
-                                                              uu____24430
-                                                              uu____24445
+                                                              uu____24300
+                                                              uu____24315
                                                           else ());
-                                                         (let uu____24463 =
+                                                         (let uu____24333 =
                                                             FStar_All.pipe_right
                                                               c_weak1
                                                               (FStar_TypeChecker_Common.apply_lcomp
@@ -9055,77 +8969,77 @@ and (tc_eqn :
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g eqs1))
                                                              in
-                                                          let uu____24470 =
-                                                            let uu____24475 =
+                                                          let uu____24340 =
+                                                            let uu____24345 =
                                                               FStar_TypeChecker_Env.push_bv
                                                                 env scrutinee
                                                                in
                                                             FStar_TypeChecker_Util.close_layered_lcomp
-                                                              uu____24475
+                                                              uu____24345
                                                               pat_bvs
                                                               pat_bv_tms2
                                                              in
                                                           FStar_All.pipe_right
-                                                            uu____24463
-                                                            uu____24470)))
+                                                            uu____24333
+                                                            uu____24340)))
                                                      else
                                                        FStar_TypeChecker_Util.close_wp_lcomp
                                                          env pat_bvs c_weak1
                                                       in
-                                                   let uu____24478 =
+                                                   let uu____24348 =
                                                      FStar_TypeChecker_Env.close_guard
                                                        env binders
                                                        g_when_weak
                                                       in
-                                                   let uu____24479 =
+                                                   let uu____24349 =
                                                      FStar_TypeChecker_Env.conj_guard
                                                        guard_pat g_branch1
                                                       in
                                                    ((c_weak.FStar_TypeChecker_Common.eff_name),
                                                      (c_weak.FStar_TypeChecker_Common.cflags),
                                                      maybe_return_c_weak,
-                                                     uu____24478,
-                                                     uu____24479))
+                                                     uu____24348,
+                                                     uu____24349))
                                            in
-                                        match uu____23984 with
+                                        match uu____23861 with
                                         | (effect_label,cflags,maybe_return_c,g_when1,g_branch1)
                                             ->
                                             let guard =
                                               FStar_TypeChecker_Env.conj_guard
                                                 g_when1 g_branch1
                                                in
-                                            ((let uu____24534 =
+                                            ((let uu____24404 =
                                                 FStar_TypeChecker_Env.debug
                                                   env FStar_Options.High
                                                  in
-                                              if uu____24534
+                                              if uu____24404
                                               then
-                                                let uu____24537 =
+                                                let uu____24407 =
                                                   FStar_TypeChecker_Rel.guard_to_string
                                                     env guard
                                                    in
                                                 FStar_All.pipe_left
                                                   (FStar_Util.print1
                                                      "Carrying guard from match: %s\n")
-                                                  uu____24537
+                                                  uu____24407
                                               else ());
-                                             (let uu____24543 =
+                                             (let uu____24413 =
                                                 FStar_Syntax_Subst.close_branch
                                                   (pattern1, when_clause1,
                                                     branch_exp1)
                                                  in
-                                              let uu____24560 =
-                                                let uu____24561 =
+                                              let uu____24430 =
+                                                let uu____24431 =
                                                   FStar_List.map
                                                     FStar_Syntax_Syntax.mk_binder
                                                     pat_bvs
                                                    in
                                                 FStar_TypeChecker_Util.close_guard_implicits
-                                                  env false uu____24561 guard
+                                                  env false uu____24431 guard
                                                  in
-                                              (uu____24543, branch_guard,
+                                              (uu____24413, branch_guard,
                                                 effect_label, cflags,
-                                                maybe_return_c, uu____24560,
+                                                maybe_return_c, uu____24430,
                                                 erasable)))))))))))
 
 and (check_top_level_let :
@@ -9139,42 +9053,42 @@ and (check_top_level_let :
       let env1 = instantiate_both env  in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
-          let uu____24610 = check_let_bound_def true env1 lb  in
-          (match uu____24610 with
+          let uu____24480 = check_let_bound_def true env1 lb  in
+          (match uu____24480 with
            | (e1,univ_vars,c1,g1,annotated) ->
-               let uu____24636 =
+               let uu____24506 =
                  if
                    annotated &&
                      (Prims.op_Negation env1.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____24658 =
+                   let uu____24528 =
                      FStar_TypeChecker_Normalize.reduce_uvar_solutions env1
                        e1
                       in
-                   (g1, uu____24658, univ_vars, c1)
+                   (g1, uu____24528, univ_vars, c1)
                  else
                    (let g11 =
-                      let uu____24664 =
+                      let uu____24534 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
                           g1
                          in
-                      FStar_All.pipe_right uu____24664
+                      FStar_All.pipe_right uu____24534
                         (FStar_TypeChecker_Rel.resolve_implicits env1)
                        in
-                    let uu____24665 = FStar_TypeChecker_Common.lcomp_comp c1
+                    let uu____24535 = FStar_TypeChecker_Common.lcomp_comp c1
                        in
-                    match uu____24665 with
+                    match uu____24535 with
                     | (comp1,g_comp1) ->
                         let g12 =
                           FStar_TypeChecker_Env.conj_guard g11 g_comp1  in
-                        let uu____24683 =
-                          let uu____24696 =
+                        let uu____24553 =
+                          let uu____24566 =
                             FStar_TypeChecker_Util.generalize env1 false
                               [((lb.FStar_Syntax_Syntax.lbname), e1, comp1)]
                              in
-                          FStar_List.hd uu____24696  in
-                        (match uu____24683 with
-                         | (uu____24746,univs,e11,c11,gvs) ->
+                          FStar_List.hd uu____24566  in
+                        (match uu____24553 with
+                         | (uu____24616,univs,e11,c11,gvs) ->
                              let g13 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.map_guard g12)
@@ -9189,44 +9103,43 @@ and (check_top_level_let :
                              let g14 =
                                FStar_TypeChecker_Env.abstract_guard_n gvs g13
                                 in
-                             let uu____24760 =
+                             let uu____24630 =
                                FStar_TypeChecker_Common.lcomp_of_comp c11  in
-                             (g14, e11, univs, uu____24760)))
+                             (g14, e11, univs, uu____24630)))
                   in
-               (match uu____24636 with
+               (match uu____24506 with
                 | (g11,e11,univ_vars1,c11) ->
-                    let uu____24777 =
-                      let uu____24786 =
+                    let uu____24647 =
+                      let uu____24656 =
                         FStar_TypeChecker_Env.should_verify env1  in
-                      if uu____24786
+                      if uu____24656
                       then
-                        let uu____24797 =
+                        let uu____24667 =
                           FStar_TypeChecker_Util.check_top_level env1 g11 c11
                            in
-                        match uu____24797 with
+                        match uu____24667 with
                         | (ok,c12) ->
                             (if ok
                              then (e2, c12)
                              else
-                               ((let uu____24831 =
+                               ((let uu____24701 =
                                    FStar_TypeChecker_Env.get_range env1  in
-                                 FStar_Errors.log_issue uu____24831
+                                 FStar_Errors.log_issue uu____24701
                                    FStar_TypeChecker_Err.top_level_effect);
-                                (let uu____24832 =
+                                (let uu____24702 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_meta
                                         (e2,
                                           (FStar_Syntax_Syntax.Meta_desugared
                                              FStar_Syntax_Syntax.Masked_effect)))
-                                     FStar_Pervasives_Native.None
                                      e2.FStar_Syntax_Syntax.pos
                                     in
-                                 (uu____24832, c12))))
+                                 (uu____24702, c12))))
                       else
                         (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
-                         (let uu____24844 =
+                         (let uu____24714 =
                             FStar_TypeChecker_Common.lcomp_comp c11  in
-                          match uu____24844 with
+                          match uu____24714 with
                           | (comp1,g_comp1) ->
                               (FStar_TypeChecker_Rel.force_trivial_guard env1
                                  g_comp1;
@@ -9239,42 +9152,41 @@ and (check_top_level_let :
                                        env1)
                                    in
                                 let e21 =
-                                  let uu____24868 =
+                                  let uu____24738 =
                                     FStar_Syntax_Util.is_pure_comp c  in
-                                  if uu____24868
+                                  if uu____24738
                                   then e2
                                   else
-                                    ((let uu____24876 =
+                                    ((let uu____24746 =
                                         FStar_TypeChecker_Env.get_range env1
                                          in
-                                      FStar_Errors.log_issue uu____24876
+                                      FStar_Errors.log_issue uu____24746
                                         FStar_TypeChecker_Err.top_level_effect);
                                      FStar_Syntax_Syntax.mk
                                        (FStar_Syntax_Syntax.Tm_meta
                                           (e2,
                                             (FStar_Syntax_Syntax.Meta_desugared
                                                FStar_Syntax_Syntax.Masked_effect)))
-                                       FStar_Pervasives_Native.None
                                        e2.FStar_Syntax_Syntax.pos)
                                    in
                                 (e21, c)))))
                        in
-                    (match uu____24777 with
+                    (match uu____24647 with
                      | (e21,c12) ->
-                         ((let uu____24900 =
+                         ((let uu____24770 =
                              FStar_TypeChecker_Env.debug env1
                                FStar_Options.Medium
                               in
-                           if uu____24900
+                           if uu____24770
                            then
-                             let uu____24903 =
+                             let uu____24773 =
                                FStar_Syntax_Print.term_to_string e11  in
                              FStar_Util.print1
-                               "Let binding BEFORE tcnorm: %s\n" uu____24903
+                               "Let binding BEFORE tcnorm: %s\n" uu____24773
                            else ());
                           (let e12 =
-                             let uu____24909 = FStar_Options.tcnorm ()  in
-                             if uu____24909
+                             let uu____24779 = FStar_Options.tcnorm ()  in
+                             if uu____24779
                              then
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.UnfoldAttr
@@ -9287,22 +9199,22 @@ and (check_top_level_let :
                                  FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                  env1 e11
                              else e11  in
-                           (let uu____24915 =
+                           (let uu____24785 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Medium
                                in
-                            if uu____24915
+                            if uu____24785
                             then
-                              let uu____24918 =
+                              let uu____24788 =
                                 FStar_Syntax_Print.term_to_string e12  in
                               FStar_Util.print1
-                                "Let binding AFTER tcnorm: %s\n" uu____24918
+                                "Let binding AFTER tcnorm: %s\n" uu____24788
                             else ());
                            (let cres =
-                              let uu____24924 =
+                              let uu____24794 =
                                 FStar_Syntax_Util.is_pure_or_ghost_comp c12
                                  in
-                              if uu____24924
+                              if uu____24794
                               then
                                 FStar_Syntax_Syntax.mk_Total'
                                   FStar_Syntax_Syntax.t_unit
@@ -9317,8 +9229,8 @@ and (check_top_level_let :
                                  let c1_wp =
                                    match c1_comp_typ.FStar_Syntax_Syntax.effect_args
                                    with
-                                   | (wp,uu____24932)::[] -> wp
-                                   | uu____24957 ->
+                                   | (wp,uu____24802)::[] -> wp
+                                   | uu____24827 ->
                                        failwith
                                          "Impossible! check_top_level_let: got unexpected effect args"
                                     in
@@ -9331,110 +9243,100 @@ and (check_top_level_let :
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_return_vc_combinator
                                       in
-                                   let uu____24974 =
-                                     let uu____24979 =
-                                       FStar_TypeChecker_Env.inst_effect_fun_with
-                                         [FStar_Syntax_Syntax.U_zero] env1
-                                         c1_eff_decl ret
-                                        in
-                                     let uu____24980 =
-                                       let uu____24981 =
-                                         FStar_Syntax_Syntax.as_arg
-                                           FStar_Syntax_Syntax.t_unit
-                                          in
-                                       let uu____24990 =
-                                         let uu____25001 =
-                                           FStar_Syntax_Syntax.as_arg
-                                             FStar_Syntax_Syntax.unit_const
-                                            in
-                                         [uu____25001]  in
-                                       uu____24981 :: uu____24990  in
-                                     FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____24979 uu____24980
+                                   let uu____24842 =
+                                     FStar_TypeChecker_Env.inst_effect_fun_with
+                                       [FStar_Syntax_Syntax.U_zero] env1
+                                       c1_eff_decl ret
                                       in
-                                   uu____24974 FStar_Pervasives_Native.None
-                                     e21.FStar_Syntax_Syntax.pos
+                                   let uu____24843 =
+                                     let uu____24844 =
+                                       FStar_Syntax_Syntax.as_arg
+                                         FStar_Syntax_Syntax.t_unit
+                                        in
+                                     let uu____24853 =
+                                       let uu____24864 =
+                                         FStar_Syntax_Syntax.as_arg
+                                           FStar_Syntax_Syntax.unit_const
+                                          in
+                                       [uu____24864]  in
+                                     uu____24844 :: uu____24853  in
+                                   FStar_Syntax_Syntax.mk_Tm_app uu____24842
+                                     uu____24843 e21.FStar_Syntax_Syntax.pos
                                     in
                                  let wp =
                                    let bind =
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_bind_vc_combinator
                                       in
-                                   let uu____25038 =
-                                     let uu____25043 =
-                                       FStar_TypeChecker_Env.inst_effect_fun_with
-                                         (FStar_List.append
-                                            c1_comp_typ.FStar_Syntax_Syntax.comp_univs
-                                            [FStar_Syntax_Syntax.U_zero])
-                                         env1 c1_eff_decl bind
+                                   let uu____24899 =
+                                     FStar_TypeChecker_Env.inst_effect_fun_with
+                                       (FStar_List.append
+                                          c1_comp_typ.FStar_Syntax_Syntax.comp_univs
+                                          [FStar_Syntax_Syntax.U_zero]) env1
+                                       c1_eff_decl bind
+                                      in
+                                   let uu____24900 =
+                                     let uu____24901 =
+                                       let uu____24910 =
+                                         FStar_Syntax_Syntax.mk
+                                           (FStar_Syntax_Syntax.Tm_constant
+                                              (FStar_Const.Const_range
+                                                 (lb.FStar_Syntax_Syntax.lbpos)))
+                                           lb.FStar_Syntax_Syntax.lbpos
+                                          in
+                                       FStar_All.pipe_left
+                                         FStar_Syntax_Syntax.as_arg
+                                         uu____24910
                                         in
-                                     let uu____25044 =
-                                       let uu____25045 =
-                                         let uu____25054 =
-                                           FStar_Syntax_Syntax.mk
-                                             (FStar_Syntax_Syntax.Tm_constant
-                                                (FStar_Const.Const_range
-                                                   (lb.FStar_Syntax_Syntax.lbpos)))
-                                             FStar_Pervasives_Native.None
-                                             lb.FStar_Syntax_Syntax.lbpos
-                                            in
+                                     let uu____24919 =
+                                       let uu____24930 =
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
-                                           uu____25054
+                                           c1_comp_typ.FStar_Syntax_Syntax.result_typ
                                           in
-                                       let uu____25063 =
-                                         let uu____25074 =
-                                           FStar_All.pipe_left
-                                             FStar_Syntax_Syntax.as_arg
-                                             c1_comp_typ.FStar_Syntax_Syntax.result_typ
+                                       let uu____24947 =
+                                         let uu____24958 =
+                                           FStar_Syntax_Syntax.as_arg
+                                             FStar_Syntax_Syntax.t_unit
                                             in
-                                         let uu____25091 =
-                                           let uu____25102 =
-                                             FStar_Syntax_Syntax.as_arg
-                                               FStar_Syntax_Syntax.t_unit
+                                         let uu____24967 =
+                                           let uu____24978 =
+                                             FStar_Syntax_Syntax.as_arg c1_wp
                                               in
-                                           let uu____25111 =
-                                             let uu____25122 =
-                                               FStar_Syntax_Syntax.as_arg
-                                                 c1_wp
-                                                in
-                                             let uu____25131 =
-                                               let uu____25142 =
-                                                 let uu____25151 =
-                                                   let uu____25152 =
-                                                     let uu____25153 =
-                                                       FStar_Syntax_Syntax.null_binder
-                                                         c1_comp_typ.FStar_Syntax_Syntax.result_typ
-                                                        in
-                                                     [uu____25153]  in
-                                                   FStar_Syntax_Util.abs
-                                                     uu____25152 wp2
-                                                     (FStar_Pervasives_Native.Some
-                                                        (FStar_Syntax_Util.mk_residual_comp
-                                                           FStar_Parser_Const.effect_Tot_lid
-                                                           FStar_Pervasives_Native.None
-                                                           [FStar_Syntax_Syntax.TOTAL]))
-                                                    in
-                                                 FStar_All.pipe_left
-                                                   FStar_Syntax_Syntax.as_arg
-                                                   uu____25151
+                                           let uu____24987 =
+                                             let uu____24998 =
+                                               let uu____25007 =
+                                                 let uu____25008 =
+                                                   let uu____25009 =
+                                                     FStar_Syntax_Syntax.null_binder
+                                                       c1_comp_typ.FStar_Syntax_Syntax.result_typ
+                                                      in
+                                                   [uu____25009]  in
+                                                 FStar_Syntax_Util.abs
+                                                   uu____25008 wp2
+                                                   (FStar_Pervasives_Native.Some
+                                                      (FStar_Syntax_Util.mk_residual_comp
+                                                         FStar_Parser_Const.effect_Tot_lid
+                                                         FStar_Pervasives_Native.None
+                                                         [FStar_Syntax_Syntax.TOTAL]))
                                                   in
-                                               [uu____25142]  in
-                                             uu____25122 :: uu____25131  in
-                                           uu____25102 :: uu____25111  in
-                                         uu____25074 :: uu____25091  in
-                                       uu____25045 :: uu____25063  in
-                                     FStar_Syntax_Syntax.mk_Tm_app
-                                       uu____25043 uu____25044
-                                      in
-                                   uu____25038 FStar_Pervasives_Native.None
-                                     lb.FStar_Syntax_Syntax.lbpos
+                                               FStar_All.pipe_left
+                                                 FStar_Syntax_Syntax.as_arg
+                                                 uu____25007
+                                                in
+                                             [uu____24998]  in
+                                           uu____24978 :: uu____24987  in
+                                         uu____24958 :: uu____24967  in
+                                       uu____24930 :: uu____24947  in
+                                     uu____24901 :: uu____24919  in
+                                   FStar_Syntax_Syntax.mk_Tm_app uu____24899
+                                     uu____24900 lb.FStar_Syntax_Syntax.lbpos
                                     in
-                                 let uu____25230 =
-                                   let uu____25231 =
-                                     let uu____25242 =
+                                 let uu____25086 =
+                                   let uu____25087 =
+                                     let uu____25098 =
                                        FStar_Syntax_Syntax.as_arg wp  in
-                                     [uu____25242]  in
+                                     [uu____25098]  in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
                                        [FStar_Syntax_Syntax.U_zero];
@@ -9443,10 +9345,10 @@ and (check_top_level_let :
                                      FStar_Syntax_Syntax.result_typ =
                                        FStar_Syntax_Syntax.t_unit;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____25231;
+                                       uu____25087;
                                      FStar_Syntax_Syntax.flags = []
                                    }  in
-                                 FStar_Syntax_Syntax.mk_Comp uu____25230)
+                                 FStar_Syntax_Syntax.mk_Comp uu____25086)
                                in
                             let lb1 =
                               FStar_Syntax_Util.close_univs_and_mk_letbinding
@@ -9457,18 +9359,17 @@ and (check_top_level_let :
                                 lb.FStar_Syntax_Syntax.lbattrs
                                 lb.FStar_Syntax_Syntax.lbpos
                                in
-                            let uu____25270 =
+                            let uu____25126 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_let
                                    ((false, [lb1]), e21))
-                                FStar_Pervasives_Native.None
                                 e.FStar_Syntax_Syntax.pos
                                in
-                            let uu____25284 =
+                            let uu____25140 =
                               FStar_TypeChecker_Common.lcomp_of_comp cres  in
-                            (uu____25270, uu____25284,
+                            (uu____25126, uu____25140,
                               FStar_TypeChecker_Env.trivial_guard)))))))
-      | uu____25285 -> failwith "Impossible"
+      | uu____25141 -> failwith "Impossible"
 
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
@@ -9478,15 +9379,15 @@ and (maybe_intro_smt_lemma :
   fun env  ->
     fun lem_typ  ->
       fun c2  ->
-        let uu____25296 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
-        if uu____25296
+        let uu____25152 = FStar_Syntax_Util.is_smt_lemma lem_typ  in
+        if uu____25152
         then
           let universe_of_binders bs =
-            let uu____25323 =
+            let uu____25179 =
               FStar_List.fold_left
-                (fun uu____25348  ->
+                (fun uu____25204  ->
                    fun b  ->
-                     match uu____25348 with
+                     match uu____25204 with
                      | (env1,us) ->
                          let u =
                            env1.FStar_TypeChecker_Env.universe_of env1
@@ -9496,7 +9397,7 @@ and (maybe_intro_smt_lemma :
                            FStar_TypeChecker_Env.push_binders env1 [b]  in
                          (env2, (u :: us))) (env, []) bs
                in
-            match uu____25323 with | (uu____25396,us) -> FStar_List.rev us
+            match uu____25179 with | (uu____25252,us) -> FStar_List.rev us
              in
           let quant =
             FStar_Syntax_Util.smt_lemma_as_forall lem_typ universe_of_binders
@@ -9517,109 +9418,109 @@ and (check_inner_let :
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false ,lb::[]),e2) ->
           let env2 =
-            let uu___3216_25432 = env1  in
+            let uu___3216_25288 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___3216_25432.FStar_TypeChecker_Env.solver);
+                (uu___3216_25288.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___3216_25432.FStar_TypeChecker_Env.range);
+                (uu___3216_25288.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___3216_25432.FStar_TypeChecker_Env.curmodule);
+                (uu___3216_25288.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___3216_25432.FStar_TypeChecker_Env.gamma);
+                (uu___3216_25288.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___3216_25432.FStar_TypeChecker_Env.gamma_sig);
+                (uu___3216_25288.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___3216_25432.FStar_TypeChecker_Env.gamma_cache);
+                (uu___3216_25288.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___3216_25432.FStar_TypeChecker_Env.modules);
+                (uu___3216_25288.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___3216_25432.FStar_TypeChecker_Env.expected_typ);
+                (uu___3216_25288.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___3216_25432.FStar_TypeChecker_Env.sigtab);
+                (uu___3216_25288.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___3216_25432.FStar_TypeChecker_Env.attrtab);
+                (uu___3216_25288.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___3216_25432.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___3216_25288.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___3216_25432.FStar_TypeChecker_Env.effects);
+                (uu___3216_25288.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___3216_25432.FStar_TypeChecker_Env.generalize);
+                (uu___3216_25288.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___3216_25432.FStar_TypeChecker_Env.letrecs);
+                (uu___3216_25288.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level = false;
               FStar_TypeChecker_Env.check_uvars =
-                (uu___3216_25432.FStar_TypeChecker_Env.check_uvars);
+                (uu___3216_25288.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___3216_25432.FStar_TypeChecker_Env.use_eq);
+                (uu___3216_25288.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___3216_25432.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___3216_25288.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___3216_25432.FStar_TypeChecker_Env.is_iface);
+                (uu___3216_25288.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___3216_25432.FStar_TypeChecker_Env.admit);
+                (uu___3216_25288.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___3216_25432.FStar_TypeChecker_Env.lax);
+                (uu___3216_25288.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___3216_25432.FStar_TypeChecker_Env.lax_universes);
+                (uu___3216_25288.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___3216_25432.FStar_TypeChecker_Env.phase1);
+                (uu___3216_25288.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___3216_25432.FStar_TypeChecker_Env.failhard);
+                (uu___3216_25288.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___3216_25432.FStar_TypeChecker_Env.nosynth);
+                (uu___3216_25288.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___3216_25432.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___3216_25288.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___3216_25432.FStar_TypeChecker_Env.tc_term);
+                (uu___3216_25288.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___3216_25432.FStar_TypeChecker_Env.type_of);
+                (uu___3216_25288.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___3216_25432.FStar_TypeChecker_Env.universe_of);
+                (uu___3216_25288.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___3216_25432.FStar_TypeChecker_Env.check_type_of);
+                (uu___3216_25288.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___3216_25432.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___3216_25288.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___3216_25432.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___3216_25288.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___3216_25432.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___3216_25288.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___3216_25432.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___3216_25288.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___3216_25432.FStar_TypeChecker_Env.proof_ns);
+                (uu___3216_25288.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___3216_25432.FStar_TypeChecker_Env.synth_hook);
+                (uu___3216_25288.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___3216_25432.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___3216_25288.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___3216_25432.FStar_TypeChecker_Env.splice);
+                (uu___3216_25288.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___3216_25432.FStar_TypeChecker_Env.mpreprocess);
+                (uu___3216_25288.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___3216_25432.FStar_TypeChecker_Env.postprocess);
+                (uu___3216_25288.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___3216_25432.FStar_TypeChecker_Env.identifier_info);
+                (uu___3216_25288.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___3216_25432.FStar_TypeChecker_Env.tc_hooks);
+                (uu___3216_25288.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___3216_25432.FStar_TypeChecker_Env.dsenv);
+                (uu___3216_25288.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___3216_25432.FStar_TypeChecker_Env.nbe);
+                (uu___3216_25288.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___3216_25432.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___3216_25288.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___3216_25432.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___3216_25288.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let uu____25434 =
-            let uu____25446 =
-              let uu____25447 = FStar_TypeChecker_Env.clear_expected_typ env2
+          let uu____25290 =
+            let uu____25302 =
+              let uu____25303 = FStar_TypeChecker_Env.clear_expected_typ env2
                  in
-              FStar_All.pipe_right uu____25447 FStar_Pervasives_Native.fst
+              FStar_All.pipe_right uu____25303 FStar_Pervasives_Native.fst
                in
-            check_let_bound_def false uu____25446 lb  in
-          (match uu____25434 with
-           | (e1,uu____25470,c1,g1,annotated) ->
+            check_let_bound_def false uu____25302 lb  in
+          (match uu____25290 with
+           | (e1,uu____25326,c1,g1,annotated) ->
                let pure_or_ghost =
                  FStar_TypeChecker_Common.is_pure_or_ghost_lcomp c1  in
                let is_inline_let =
@@ -9630,76 +9531,76 @@ and (check_inner_let :
                   in
                (if is_inline_let && (Prims.op_Negation pure_or_ghost)
                 then
-                  (let uu____25484 =
-                     let uu____25490 =
-                       let uu____25492 = FStar_Syntax_Print.term_to_string e1
+                  (let uu____25340 =
+                     let uu____25346 =
+                       let uu____25348 = FStar_Syntax_Print.term_to_string e1
                           in
-                       let uu____25494 =
+                       let uu____25350 =
                          FStar_Syntax_Print.lid_to_string
                            c1.FStar_TypeChecker_Common.eff_name
                           in
                        FStar_Util.format2
                          "Definitions marked @inline_let are expected to be pure or ghost; got an expression \"%s\" with effect \"%s\""
-                         uu____25492 uu____25494
+                         uu____25348 uu____25350
                         in
-                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____25490)
+                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____25346)
                       in
-                   FStar_Errors.raise_error uu____25484
+                   FStar_Errors.raise_error uu____25340
                      e1.FStar_Syntax_Syntax.pos)
                 else ();
                 (let attrs =
-                   let uu____25505 =
+                   let uu____25361 =
                      (pure_or_ghost && (Prims.op_Negation is_inline_let)) &&
                        (FStar_Syntax_Util.is_unit
                           c1.FStar_TypeChecker_Common.res_typ)
                       in
-                   if uu____25505
+                   if uu____25361
                    then FStar_Syntax_Util.inline_let_attr ::
                      (lb.FStar_Syntax_Syntax.lbattrs)
                    else lb.FStar_Syntax_Syntax.lbattrs  in
                  let x =
-                   let uu___3231_25517 =
+                   let uu___3231_25373 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname  in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___3231_25517.FStar_Syntax_Syntax.ppname);
+                       (uu___3231_25373.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___3231_25517.FStar_Syntax_Syntax.index);
+                       (uu___3231_25373.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort =
                        (c1.FStar_TypeChecker_Common.res_typ)
                    }  in
-                 let uu____25518 =
-                   let uu____25523 =
-                     let uu____25524 = FStar_Syntax_Syntax.mk_binder x  in
-                     [uu____25524]  in
-                   FStar_Syntax_Subst.open_term uu____25523 e2  in
-                 match uu____25518 with
+                 let uu____25374 =
+                   let uu____25379 =
+                     let uu____25380 = FStar_Syntax_Syntax.mk_binder x  in
+                     [uu____25380]  in
+                   FStar_Syntax_Subst.open_term uu____25379 e2  in
+                 match uu____25374 with
                  | (xb,e21) ->
                      let xbinder = FStar_List.hd xb  in
                      let x1 = FStar_Pervasives_Native.fst xbinder  in
                      let env_x = FStar_TypeChecker_Env.push_bv env2 x1  in
-                     let uu____25568 =
-                       let uu____25575 = tc_term env_x e21  in
-                       FStar_All.pipe_right uu____25575
-                         (fun uu____25601  ->
-                            match uu____25601 with
+                     let uu____25424 =
+                       let uu____25431 = tc_term env_x e21  in
+                       FStar_All.pipe_right uu____25431
+                         (fun uu____25457  ->
+                            match uu____25457 with
                             | (e22,c2,g2) ->
-                                let uu____25617 =
-                                  let uu____25622 =
+                                let uu____25473 =
+                                  let uu____25478 =
                                     FStar_All.pipe_right
-                                      (fun uu____25640  ->
+                                      (fun uu____25496  ->
                                          "folding guard g2 of e2 in the lcomp")
-                                      (fun uu____25646  ->
+                                      (fun uu____25502  ->
                                          FStar_Pervasives_Native.Some
-                                           uu____25646)
+                                           uu____25502)
                                      in
                                   FStar_TypeChecker_Util.strengthen_precondition
-                                    uu____25622 env_x e22 c2 g2
+                                    uu____25478 env_x e22 c2 g2
                                    in
-                                (match uu____25617 with
+                                (match uu____25473 with
                                  | (c21,g21) -> (e22, c21, g21)))
                         in
-                     (match uu____25568 with
+                     (match uu____25424 with
                       | (e22,c2,g2) ->
                           let c21 =
                             maybe_intro_smt_lemma env_x
@@ -9731,15 +9632,13 @@ and (check_inner_let :
                               attrs lb.FStar_Syntax_Syntax.lbpos
                              in
                           let e3 =
-                            let uu____25674 =
-                              let uu____25681 =
-                                let uu____25682 =
-                                  let uu____25696 =
-                                    FStar_Syntax_Subst.close xb e23  in
-                                  ((false, [lb1]), uu____25696)  in
-                                FStar_Syntax_Syntax.Tm_let uu____25682  in
-                              FStar_Syntax_Syntax.mk uu____25681  in
-                            uu____25674 FStar_Pervasives_Native.None
+                            let uu____25530 =
+                              let uu____25531 =
+                                let uu____25545 =
+                                  FStar_Syntax_Subst.close xb e23  in
+                                ((false, [lb1]), uu____25545)  in
+                              FStar_Syntax_Syntax.Tm_let uu____25531  in
+                            FStar_Syntax_Syntax.mk uu____25530
                               e.FStar_Syntax_Syntax.pos
                              in
                           let e4 =
@@ -9748,92 +9647,92 @@ and (check_inner_let :
                               cres.FStar_TypeChecker_Common.res_typ
                              in
                           let g21 =
-                            let uu____25714 =
-                              let uu____25716 =
+                            let uu____25563 =
+                              let uu____25565 =
                                 FStar_All.pipe_right
                                   cres.FStar_TypeChecker_Common.eff_name
                                   (FStar_TypeChecker_Env.norm_eff_name env2)
                                  in
-                              FStar_All.pipe_right uu____25716
+                              FStar_All.pipe_right uu____25565
                                 (FStar_TypeChecker_Env.is_layered_effect env2)
                                in
                             FStar_TypeChecker_Util.close_guard_implicits env2
-                              uu____25714 xb g2
+                              uu____25563 xb g2
                              in
                           let guard = FStar_TypeChecker_Env.conj_guard g1 g21
                              in
-                          let uu____25719 =
-                            let uu____25721 =
+                          let uu____25568 =
+                            let uu____25570 =
                               FStar_TypeChecker_Env.expected_typ env2  in
-                            FStar_Option.isSome uu____25721  in
-                          if uu____25719
+                            FStar_Option.isSome uu____25570  in
+                          if uu____25568
                           then
                             let tt =
-                              let uu____25732 =
+                              let uu____25581 =
                                 FStar_TypeChecker_Env.expected_typ env2  in
-                              FStar_All.pipe_right uu____25732
+                              FStar_All.pipe_right uu____25581
                                 FStar_Option.get
                                in
-                            ((let uu____25738 =
+                            ((let uu____25587 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
                                   (FStar_Options.Other "Exports")
                                  in
-                              if uu____25738
+                              if uu____25587
                               then
-                                let uu____25743 =
+                                let uu____25592 =
                                   FStar_Syntax_Print.term_to_string tt  in
-                                let uu____25745 =
+                                let uu____25594 =
                                   FStar_Syntax_Print.term_to_string
                                     cres.FStar_TypeChecker_Common.res_typ
                                    in
                                 FStar_Util.print2
                                   "Got expected type from env %s\ncres.res_typ=%s\n"
-                                  uu____25743 uu____25745
+                                  uu____25592 uu____25594
                               else ());
                              (e4, cres, guard))
                           else
-                            (let uu____25752 =
+                            (let uu____25601 =
                                check_no_escape FStar_Pervasives_Native.None
                                  env2 [x1]
                                  cres.FStar_TypeChecker_Common.res_typ
                                 in
-                             match uu____25752 with
+                             match uu____25601 with
                              | (t,g_ex) ->
-                                 ((let uu____25766 =
+                                 ((let uu____25615 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Exports")
                                       in
-                                   if uu____25766
+                                   if uu____25615
                                    then
-                                     let uu____25771 =
+                                     let uu____25620 =
                                        FStar_Syntax_Print.term_to_string
                                          cres.FStar_TypeChecker_Common.res_typ
                                         in
-                                     let uu____25773 =
+                                     let uu____25622 =
                                        FStar_Syntax_Print.term_to_string t
                                         in
                                      FStar_Util.print2
                                        "Checked %s has no escaping types; normalized to %s\n"
-                                       uu____25771 uu____25773
+                                       uu____25620 uu____25622
                                    else ());
-                                  (let uu____25778 =
+                                  (let uu____25627 =
                                      FStar_TypeChecker_Env.conj_guard g_ex
                                        guard
                                       in
                                    (e4,
-                                     (let uu___3270_25780 = cres  in
+                                     (let uu___3270_25629 = cres  in
                                       {
                                         FStar_TypeChecker_Common.eff_name =
-                                          (uu___3270_25780.FStar_TypeChecker_Common.eff_name);
+                                          (uu___3270_25629.FStar_TypeChecker_Common.eff_name);
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          (uu___3270_25780.FStar_TypeChecker_Common.cflags);
+                                          (uu___3270_25629.FStar_TypeChecker_Common.cflags);
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          (uu___3270_25780.FStar_TypeChecker_Common.comp_thunk)
-                                      }), uu____25778))))))))
-      | uu____25781 ->
+                                          (uu___3270_25629.FStar_TypeChecker_Common.comp_thunk)
+                                      }), uu____25627))))))))
+      | uu____25630 ->
           failwith "Impossible (inner let with more than one lb)"
 
 and (check_top_level_let_rec :
@@ -9847,44 +9746,44 @@ and (check_top_level_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____25817 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____25817 with
+          let uu____25666 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____25666 with
            | (lbs1,e21) ->
-               let uu____25836 =
+               let uu____25685 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____25836 with
+               (match uu____25685 with
                 | (env0,topt) ->
-                    let uu____25855 = build_let_rec_env true env0 lbs1  in
-                    (match uu____25855 with
+                    let uu____25704 = build_let_rec_env true env0 lbs1  in
+                    (match uu____25704 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____25878 = check_let_recs rec_env lbs2  in
-                         (match uu____25878 with
+                         let uu____25727 = check_let_recs rec_env lbs2  in
+                         (match uu____25727 with
                           | (lbs3,g_lbs) ->
                               let g_lbs1 =
-                                let uu____25898 =
-                                  let uu____25899 =
+                                let uu____25747 =
+                                  let uu____25748 =
                                     FStar_TypeChecker_Env.conj_guard g_t
                                       g_lbs
                                      in
-                                  FStar_All.pipe_right uu____25899
+                                  FStar_All.pipe_right uu____25748
                                     (FStar_TypeChecker_Rel.solve_deferred_constraints
                                        env1)
                                    in
-                                FStar_All.pipe_right uu____25898
+                                FStar_All.pipe_right uu____25747
                                   (FStar_TypeChecker_Rel.resolve_implicits
                                      env1)
                                  in
                               let all_lb_names =
-                                let uu____25905 =
+                                let uu____25754 =
                                   FStar_All.pipe_right lbs3
                                     (FStar_List.map
                                        (fun lb  ->
                                           FStar_Util.right
                                             lb.FStar_Syntax_Syntax.lbname))
                                    in
-                                FStar_All.pipe_right uu____25905
-                                  (fun uu____25922  ->
-                                     FStar_Pervasives_Native.Some uu____25922)
+                                FStar_All.pipe_right uu____25754
+                                  (fun uu____25771  ->
+                                     FStar_Pervasives_Native.Some uu____25771)
                                  in
                               let lbs4 =
                                 if
@@ -9915,25 +9814,25 @@ and (check_top_level_let_rec :
                                               lb.FStar_Syntax_Syntax.lbpos))
                                 else
                                   (let ecs =
-                                     let uu____25959 =
+                                     let uu____25808 =
                                        FStar_All.pipe_right lbs3
                                          (FStar_List.map
                                             (fun lb  ->
-                                               let uu____25993 =
+                                               let uu____25842 =
                                                  FStar_Syntax_Syntax.mk_Total
                                                    lb.FStar_Syntax_Syntax.lbtyp
                                                   in
                                                ((lb.FStar_Syntax_Syntax.lbname),
                                                  (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____25993)))
+                                                 uu____25842)))
                                         in
                                      FStar_TypeChecker_Util.generalize env1
-                                       true uu____25959
+                                       true uu____25808
                                       in
                                    FStar_List.map2
-                                     (fun uu____26028  ->
+                                     (fun uu____25877  ->
                                         fun lb  ->
-                                          match uu____26028 with
+                                          match uu____25877 with
                                           | (x,uvs,e,c,gvs) ->
                                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                                 all_lb_names x uvs
@@ -9946,35 +9845,34 @@ and (check_top_level_let_rec :
                                      ecs lbs3)
                                  in
                               let cres =
-                                let uu____26076 =
+                                let uu____25925 =
                                   FStar_Syntax_Syntax.mk_Total
                                     FStar_Syntax_Syntax.t_unit
                                    in
                                 FStar_All.pipe_left
                                   FStar_TypeChecker_Common.lcomp_of_comp
-                                  uu____26076
+                                  uu____25925
                                  in
-                              let uu____26077 =
+                              let uu____25926 =
                                 FStar_Syntax_Subst.close_let_rec lbs4 e21  in
-                              (match uu____26077 with
+                              (match uu____25926 with
                                | (lbs5,e22) ->
-                                   ((let uu____26097 =
+                                   ((let uu____25946 =
                                        FStar_TypeChecker_Rel.discharge_guard
                                          env1 g_lbs1
                                         in
-                                     FStar_All.pipe_right uu____26097
+                                     FStar_All.pipe_right uu____25946
                                        (FStar_TypeChecker_Rel.force_trivial_guard
                                           env1));
-                                    (let uu____26098 =
+                                    (let uu____25947 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((true, lbs5), e22))
-                                         FStar_Pervasives_Native.None
                                          top.FStar_Syntax_Syntax.pos
                                         in
-                                     (uu____26098, cres,
+                                     (uu____25947, cres,
                                        FStar_TypeChecker_Env.trivial_guard))))))))
-      | uu____26112 -> failwith "Impossible"
+      | uu____25961 -> failwith "Impossible"
 
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
@@ -9987,64 +9885,64 @@ and (check_inner_let_rec :
       let env1 = instantiate_both env  in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true ,lbs),e2) ->
-          let uu____26148 = FStar_Syntax_Subst.open_let_rec lbs e2  in
-          (match uu____26148 with
+          let uu____25997 = FStar_Syntax_Subst.open_let_rec lbs e2  in
+          (match uu____25997 with
            | (lbs1,e21) ->
-               let uu____26167 =
+               let uu____26016 =
                  FStar_TypeChecker_Env.clear_expected_typ env1  in
-               (match uu____26167 with
+               (match uu____26016 with
                 | (env0,topt) ->
-                    let uu____26186 = build_let_rec_env false env0 lbs1  in
-                    (match uu____26186 with
+                    let uu____26035 = build_let_rec_env false env0 lbs1  in
+                    (match uu____26035 with
                      | (lbs2,rec_env,g_t) ->
-                         let uu____26209 =
-                           let uu____26216 = check_let_recs rec_env lbs2  in
-                           FStar_All.pipe_right uu____26216
-                             (fun uu____26239  ->
-                                match uu____26239 with
+                         let uu____26058 =
+                           let uu____26065 = check_let_recs rec_env lbs2  in
+                           FStar_All.pipe_right uu____26065
+                             (fun uu____26088  ->
+                                match uu____26088 with
                                 | (lbs3,g) ->
-                                    let uu____26258 =
+                                    let uu____26107 =
                                       FStar_TypeChecker_Env.conj_guard g_t g
                                        in
-                                    (lbs3, uu____26258))
+                                    (lbs3, uu____26107))
                             in
-                         (match uu____26209 with
+                         (match uu____26058 with
                           | (lbs3,g_lbs) ->
-                              let uu____26273 =
+                              let uu____26122 =
                                 FStar_All.pipe_right lbs3
                                   (FStar_Util.fold_map
                                      (fun env2  ->
                                         fun lb  ->
                                           let x =
-                                            let uu___3345_26296 =
+                                            let uu___3345_26145 =
                                               FStar_Util.left
                                                 lb.FStar_Syntax_Syntax.lbname
                                                in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___3345_26296.FStar_Syntax_Syntax.ppname);
+                                                (uu___3345_26145.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___3345_26296.FStar_Syntax_Syntax.index);
+                                                (uu___3345_26145.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort =
                                                 (lb.FStar_Syntax_Syntax.lbtyp)
                                             }  in
                                           let lb1 =
-                                            let uu___3348_26298 = lb  in
+                                            let uu___3348_26147 = lb  in
                                             {
                                               FStar_Syntax_Syntax.lbname =
                                                 (FStar_Util.Inl x);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___3348_26298.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___3348_26147.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___3348_26298.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___3348_26147.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
-                                                (uu___3348_26298.FStar_Syntax_Syntax.lbeff);
+                                                (uu___3348_26147.FStar_Syntax_Syntax.lbeff);
                                               FStar_Syntax_Syntax.lbdef =
-                                                (uu___3348_26298.FStar_Syntax_Syntax.lbdef);
+                                                (uu___3348_26147.FStar_Syntax_Syntax.lbdef);
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___3348_26298.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___3348_26147.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___3348_26298.FStar_Syntax_Syntax.lbpos)
+                                                (uu___3348_26147.FStar_Syntax_Syntax.lbpos)
                                             }  in
                                           let env3 =
                                             FStar_TypeChecker_Env.push_let_binding
@@ -10055,7 +9953,7 @@ and (check_inner_let_rec :
                                              in
                                           (env3, lb1)) env1)
                                  in
-                              (match uu____26273 with
+                              (match uu____26122 with
                                | (env2,lbs4) ->
                                    let bvs =
                                      FStar_All.pipe_right lbs4
@@ -10064,8 +9962,8 @@ and (check_inner_let_rec :
                                              FStar_Util.left
                                                lb.FStar_Syntax_Syntax.lbname))
                                       in
-                                   let uu____26325 = tc_term env2 e21  in
-                                   (match uu____26325 with
+                                   let uu____26174 = tc_term env2 e21  in
+                                   (match uu____26174 with
                                     | (e22,cres,g2) ->
                                         let cres1 =
                                           FStar_List.fold_right
@@ -10085,17 +9983,17 @@ and (check_inner_let_rec :
                                             [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
                                            in
                                         let guard =
-                                          let uu____26349 =
-                                            let uu____26350 =
+                                          let uu____26198 =
+                                            let uu____26199 =
                                               FStar_List.map
                                                 FStar_Syntax_Syntax.mk_binder
                                                 bvs
                                                in
                                             FStar_TypeChecker_Env.close_guard
-                                              env2 uu____26350 g2
+                                              env2 uu____26199 g2
                                              in
                                           FStar_TypeChecker_Env.conj_guard
-                                            g_lbs uu____26349
+                                            g_lbs uu____26198
                                            in
                                         let cres4 =
                                           FStar_TypeChecker_Util.close_wp_lcomp
@@ -10106,83 +10004,82 @@ and (check_inner_let_rec :
                                             cres4.FStar_TypeChecker_Common.res_typ
                                            in
                                         let cres5 =
-                                          let uu___3369_26360 = cres4  in
+                                          let uu___3369_26209 = cres4  in
                                           {
                                             FStar_TypeChecker_Common.eff_name
                                               =
-                                              (uu___3369_26360.FStar_TypeChecker_Common.eff_name);
+                                              (uu___3369_26209.FStar_TypeChecker_Common.eff_name);
                                             FStar_TypeChecker_Common.res_typ
                                               = tres;
                                             FStar_TypeChecker_Common.cflags =
-                                              (uu___3369_26360.FStar_TypeChecker_Common.cflags);
+                                              (uu___3369_26209.FStar_TypeChecker_Common.cflags);
                                             FStar_TypeChecker_Common.comp_thunk
                                               =
-                                              (uu___3369_26360.FStar_TypeChecker_Common.comp_thunk)
+                                              (uu___3369_26209.FStar_TypeChecker_Common.comp_thunk)
                                           }  in
                                         let guard1 =
                                           let bs =
                                             FStar_All.pipe_right lbs4
                                               (FStar_List.map
                                                  (fun lb  ->
-                                                    let uu____26368 =
+                                                    let uu____26217 =
                                                       FStar_Util.left
                                                         lb.FStar_Syntax_Syntax.lbname
                                                        in
                                                     FStar_Syntax_Syntax.mk_binder
-                                                      uu____26368))
+                                                      uu____26217))
                                              in
                                           FStar_TypeChecker_Util.close_guard_implicits
                                             env2 false bs guard
                                            in
-                                        let uu____26370 =
+                                        let uu____26219 =
                                           FStar_Syntax_Subst.close_let_rec
                                             lbs4 e22
                                            in
-                                        (match uu____26370 with
+                                        (match uu____26219 with
                                          | (lbs5,e23) ->
                                              let e =
                                                FStar_Syntax_Syntax.mk
                                                  (FStar_Syntax_Syntax.Tm_let
                                                     ((true, lbs5), e23))
-                                                 FStar_Pervasives_Native.None
                                                  top.FStar_Syntax_Syntax.pos
                                                 in
                                              (match topt with
                                               | FStar_Pervasives_Native.Some
-                                                  uu____26411 ->
+                                                  uu____26260 ->
                                                   (e, cres5, guard1)
                                               | FStar_Pervasives_Native.None 
                                                   ->
-                                                  let uu____26412 =
+                                                  let uu____26261 =
                                                     check_no_escape
                                                       FStar_Pervasives_Native.None
                                                       env2 bvs tres
                                                      in
-                                                  (match uu____26412 with
+                                                  (match uu____26261 with
                                                    | (tres1,g_ex) ->
                                                        let cres6 =
-                                                         let uu___3385_26426
+                                                         let uu___3385_26275
                                                            = cres5  in
                                                          {
                                                            FStar_TypeChecker_Common.eff_name
                                                              =
-                                                             (uu___3385_26426.FStar_TypeChecker_Common.eff_name);
+                                                             (uu___3385_26275.FStar_TypeChecker_Common.eff_name);
                                                            FStar_TypeChecker_Common.res_typ
                                                              = tres1;
                                                            FStar_TypeChecker_Common.cflags
                                                              =
-                                                             (uu___3385_26426.FStar_TypeChecker_Common.cflags);
+                                                             (uu___3385_26275.FStar_TypeChecker_Common.cflags);
                                                            FStar_TypeChecker_Common.comp_thunk
                                                              =
-                                                             (uu___3385_26426.FStar_TypeChecker_Common.comp_thunk)
+                                                             (uu___3385_26275.FStar_TypeChecker_Common.comp_thunk)
                                                          }  in
-                                                       let uu____26427 =
+                                                       let uu____26276 =
                                                          FStar_TypeChecker_Env.conj_guard
                                                            g_ex guard1
                                                           in
                                                        (e, cres6,
-                                                         uu____26427))))))))))
-      | uu____26428 -> failwith "Impossible"
+                                                         uu____26276))))))))))
+      | uu____26277 -> failwith "Impossible"
 
 and (build_let_rec_env :
   Prims.bool ->
@@ -10196,43 +10093,43 @@ and (build_let_rec_env :
       fun lbs  ->
         let env0 = env  in
         let termination_check_enabled lbname lbdef lbtyp =
-          let uu____26476 = FStar_Options.ml_ish ()  in
-          if uu____26476
+          let uu____26325 = FStar_Options.ml_ish ()  in
+          if uu____26325
           then false
           else
             (let t = FStar_TypeChecker_Normalize.unfold_whnf env lbtyp  in
-             let uu____26484 = FStar_Syntax_Util.arrow_formals_comp t  in
-             match uu____26484 with
+             let uu____26333 = FStar_Syntax_Util.arrow_formals_comp t  in
+             match uu____26333 with
              | (formals,c) ->
-                 let uu____26492 = FStar_Syntax_Util.abs_formals lbdef  in
-                 (match uu____26492 with
-                  | (actuals,uu____26503,uu____26504) ->
+                 let uu____26341 = FStar_Syntax_Util.abs_formals lbdef  in
+                 (match uu____26341 with
+                  | (actuals,uu____26352,uu____26353) ->
                       if
                         ((FStar_List.length formals) < Prims.int_one) ||
                           ((FStar_List.length actuals) < Prims.int_one)
                       then
-                        let uu____26525 =
-                          let uu____26531 =
-                            let uu____26533 =
+                        let uu____26374 =
+                          let uu____26380 =
+                            let uu____26382 =
                               FStar_Syntax_Print.term_to_string lbdef  in
-                            let uu____26535 =
+                            let uu____26384 =
                               FStar_Syntax_Print.term_to_string lbtyp  in
                             FStar_Util.format2
                               "Only function literals with arrow types can be defined recursively; got %s : %s"
-                              uu____26533 uu____26535
+                              uu____26382 uu____26384
                              in
                           (FStar_Errors.Fatal_RecursiveFunctionLiteral,
-                            uu____26531)
+                            uu____26380)
                            in
-                        FStar_Errors.raise_error uu____26525
+                        FStar_Errors.raise_error uu____26374
                           lbtyp.FStar_Syntax_Syntax.pos
                       else
                         (let actuals1 =
-                           let uu____26543 =
+                           let uu____26392 =
                              FStar_TypeChecker_Env.set_expected_typ env lbtyp
                               in
                            FStar_TypeChecker_Util.maybe_add_implicit_binders
-                             uu____26543 actuals
+                             uu____26392 actuals
                             in
                          if
                            (FStar_List.length formals) <>
@@ -10243,30 +10140,30 @@ and (build_let_rec_env :
                               if n = Prims.int_one
                               then "1 argument was found"
                               else
-                                (let uu____26574 = FStar_Util.string_of_int n
+                                (let uu____26423 = FStar_Util.string_of_int n
                                     in
                                  FStar_Util.format1 "%s arguments were found"
-                                   uu____26574)
+                                   uu____26423)
                                in
                             let formals_msg =
                               let n = FStar_List.length formals  in
                               if n = Prims.int_one
                               then "1 argument"
                               else
-                                (let uu____26593 = FStar_Util.string_of_int n
+                                (let uu____26442 = FStar_Util.string_of_int n
                                     in
                                  FStar_Util.format1 "%s arguments"
-                                   uu____26593)
+                                   uu____26442)
                                in
                             let msg =
-                              let uu____26598 =
+                              let uu____26447 =
                                 FStar_Syntax_Print.term_to_string lbtyp  in
-                              let uu____26600 =
+                              let uu____26449 =
                                 FStar_Syntax_Print.lbname_to_string lbname
                                  in
                               FStar_Util.format4
                                 "From its type %s, the definition of `let rec %s` expects a function with %s, but %s"
-                                uu____26598 uu____26600 formals_msg
+                                uu____26447 uu____26449 formals_msg
                                 actuals_msg
                                in
                             FStar_Errors.raise_error
@@ -10281,17 +10178,17 @@ and (build_let_rec_env :
                             (FStar_List.contains
                                FStar_Syntax_Syntax.TotalEffect)))))
            in
-        let uu____26612 =
+        let uu____26461 =
           FStar_List.fold_left
-            (fun uu____26645  ->
+            (fun uu____26494  ->
                fun lb  ->
-                 match uu____26645 with
+                 match uu____26494 with
                  | (lbs1,env1,g_acc) ->
-                     let uu____26670 =
+                     let uu____26519 =
                        FStar_TypeChecker_Util.extract_let_rec_annotation env1
                          lb
                         in
-                     (match uu____26670 with
+                     (match uu____26519 with
                       | (univ_vars,t,check_t) ->
                           let env2 =
                             FStar_TypeChecker_Env.push_univ_vars env1
@@ -10301,7 +10198,7 @@ and (build_let_rec_env :
                             FStar_Syntax_Util.unascribe
                               lb.FStar_Syntax_Syntax.lbdef
                              in
-                          let uu____26693 =
+                          let uu____26542 =
                             if Prims.op_Negation check_t
                             then (g_acc, t)
                             else
@@ -10309,242 +10206,242 @@ and (build_let_rec_env :
                                  FStar_TypeChecker_Env.push_univ_vars env0
                                    univ_vars
                                   in
-                               let uu____26712 =
-                                 let uu____26719 =
-                                   let uu____26720 =
+                               let uu____26561 =
+                                 let uu____26568 =
+                                   let uu____26569 =
                                      FStar_Syntax_Util.type_u ()  in
                                    FStar_All.pipe_left
-                                     FStar_Pervasives_Native.fst uu____26720
+                                     FStar_Pervasives_Native.fst uu____26569
                                     in
                                  tc_check_tot_or_gtot_term
-                                   (let uu___3431_26731 = env01  in
+                                   (let uu___3431_26580 = env01  in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.solver);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.range);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.curmodule);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.gamma);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.modules);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.sigtab);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.attrtab);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.effects);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.generalize);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.letrecs);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.top_level);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
                                         true;
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.use_eq);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.is_iface);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.admit);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.lax);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.phase1);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.failhard);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.nosynth);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.tc_term);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.type_of);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.universe_of);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.splice);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.postprocess);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.dsenv);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.nbe);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___3431_26580.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___3431_26731.FStar_TypeChecker_Env.erasable_types_tab)
-                                    }) t uu____26719 ""
+                                        (uu___3431_26580.FStar_TypeChecker_Env.erasable_types_tab)
+                                    }) t uu____26568 ""
                                   in
-                               match uu____26712 with
-                               | (t1,uu____26741,g) ->
-                                   let uu____26743 =
-                                     let uu____26744 =
-                                       let uu____26745 =
+                               match uu____26561 with
+                               | (t1,uu____26590,g) ->
+                                   let uu____26592 =
+                                     let uu____26593 =
+                                       let uu____26594 =
                                          FStar_All.pipe_right g
                                            (FStar_TypeChecker_Rel.resolve_implicits
                                               env2)
                                           in
-                                       FStar_All.pipe_right uu____26745
+                                       FStar_All.pipe_right uu____26594
                                          (FStar_TypeChecker_Rel.discharge_guard
                                             env2)
                                         in
                                      FStar_TypeChecker_Env.conj_guard g_acc
-                                       uu____26744
+                                       uu____26593
                                       in
-                                   let uu____26746 = norm env01 t1  in
-                                   (uu____26743, uu____26746))
+                                   let uu____26595 = norm env01 t1  in
+                                   (uu____26592, uu____26595))
                              in
-                          (match uu____26693 with
+                          (match uu____26542 with
                            | (g,t1) ->
                                let env3 =
-                                 let uu____26766 =
+                                 let uu____26615 =
                                    termination_check_enabled
                                      lb.FStar_Syntax_Syntax.lbname e t1
                                     in
-                                 if uu____26766
+                                 if uu____26615
                                  then
-                                   let uu___3441_26769 = env2  in
+                                   let uu___3441_26618 = env2  in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.solver);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.range);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.curmodule);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.gamma);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.modules);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.sigtab);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.attrtab);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.effects);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.generalize);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
                                        (((lb.FStar_Syntax_Syntax.lbname), t1,
                                           univ_vars) ::
                                        (env2.FStar_TypeChecker_Env.letrecs));
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.top_level);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.use_eq);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.use_eq);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.is_iface);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.admit);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.lax);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.phase1);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.failhard);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.nosynth);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.tc_term);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.type_of);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.universe_of);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.splice);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.postprocess);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.dsenv);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.nbe);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___3441_26618.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___3441_26769.FStar_TypeChecker_Env.erasable_types_tab)
+                                       (uu___3441_26618.FStar_TypeChecker_Env.erasable_types_tab)
                                    }
                                  else
                                    FStar_TypeChecker_Env.push_let_binding
@@ -10552,24 +10449,24 @@ and (build_let_rec_env :
                                      (univ_vars, t1)
                                   in
                                let lb1 =
-                                 let uu___3444_26783 = lb  in
+                                 let uu___3444_26632 = lb  in
                                  {
                                    FStar_Syntax_Syntax.lbname =
-                                     (uu___3444_26783.FStar_Syntax_Syntax.lbname);
+                                     (uu___3444_26632.FStar_Syntax_Syntax.lbname);
                                    FStar_Syntax_Syntax.lbunivs = univ_vars;
                                    FStar_Syntax_Syntax.lbtyp = t1;
                                    FStar_Syntax_Syntax.lbeff =
-                                     (uu___3444_26783.FStar_Syntax_Syntax.lbeff);
+                                     (uu___3444_26632.FStar_Syntax_Syntax.lbeff);
                                    FStar_Syntax_Syntax.lbdef = e;
                                    FStar_Syntax_Syntax.lbattrs =
-                                     (uu___3444_26783.FStar_Syntax_Syntax.lbattrs);
+                                     (uu___3444_26632.FStar_Syntax_Syntax.lbattrs);
                                    FStar_Syntax_Syntax.lbpos =
-                                     (uu___3444_26783.FStar_Syntax_Syntax.lbpos)
+                                     (uu___3444_26632.FStar_Syntax_Syntax.lbpos)
                                  }  in
                                ((lb1 :: lbs1), env3, g))))
             ([], env, FStar_TypeChecker_Env.trivial_guard) lbs
            in
-        match uu____26612 with
+        match uu____26461 with
         | (lbs1,env1,g) -> ((FStar_List.rev lbs1), env1, g)
 
 and (check_let_recs :
@@ -10580,64 +10477,64 @@ and (check_let_recs :
   =
   fun env  ->
     fun lbs  ->
-      let uu____26809 =
-        let uu____26818 =
+      let uu____26658 =
+        let uu____26667 =
           FStar_All.pipe_right lbs
             (FStar_List.map
                (fun lb  ->
-                  let uu____26844 =
+                  let uu____26693 =
                     FStar_Syntax_Util.abs_formals
                       lb.FStar_Syntax_Syntax.lbdef
                      in
-                  match uu____26844 with
+                  match uu____26693 with
                   | (bs,t,lcomp) ->
                       (match bs with
                        | [] ->
-                           let uu____26874 =
+                           let uu____26723 =
                              FStar_Syntax_Syntax.range_of_lbname
                                lb.FStar_Syntax_Syntax.lbname
                               in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_RecursiveFunctionLiteral,
                                "Only function literals may be defined recursively")
-                             uu____26874
-                       | uu____26881 ->
+                             uu____26723
+                       | uu____26730 ->
                            let lb1 =
-                             let uu___3461_26884 = lb  in
-                             let uu____26885 =
+                             let uu___3461_26733 = lb  in
+                             let uu____26734 =
                                FStar_Syntax_Util.abs bs t lcomp  in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___3461_26884.FStar_Syntax_Syntax.lbname);
+                                 (uu___3461_26733.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___3461_26884.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___3461_26733.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___3461_26884.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___3461_26733.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___3461_26884.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____26885;
+                                 (uu___3461_26733.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____26734;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___3461_26884.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___3461_26733.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___3461_26884.FStar_Syntax_Syntax.lbpos)
+                                 (uu___3461_26733.FStar_Syntax_Syntax.lbpos)
                              }  in
-                           let uu____26888 =
-                             let uu____26895 =
+                           let uu____26737 =
+                             let uu____26744 =
                                FStar_TypeChecker_Env.set_expected_typ env
                                  lb1.FStar_Syntax_Syntax.lbtyp
                                 in
-                             tc_tot_or_gtot_term uu____26895
+                             tc_tot_or_gtot_term uu____26744
                                lb1.FStar_Syntax_Syntax.lbdef
                               in
-                           (match uu____26888 with
+                           (match uu____26737 with
                             | (e,c,g) ->
-                                ((let uu____26904 =
-                                    let uu____26906 =
+                                ((let uu____26753 =
+                                    let uu____26755 =
                                       FStar_TypeChecker_Common.is_total_lcomp
                                         c
                                        in
-                                    Prims.op_Negation uu____26906  in
-                                  if uu____26904
+                                    Prims.op_Negation uu____26755  in
+                                  if uu____26753
                                   then
                                     FStar_Errors.raise_error
                                       (FStar_Errors.Fatal_UnexpectedGTotForLetRec,
@@ -10655,8 +10552,8 @@ and (check_let_recs :
                                      in
                                   (lb2, g)))))))
            in
-        FStar_All.pipe_right uu____26818 FStar_List.unzip  in
-      match uu____26809 with
+        FStar_All.pipe_right uu____26667 FStar_List.unzip  in
+      match uu____26658 with
       | (lbs1,gs) ->
           let g_lbs =
             FStar_List.fold_right FStar_TypeChecker_Env.conj_guard gs
@@ -10675,12 +10572,12 @@ and (check_let_bound_def :
   fun top_level  ->
     fun env  ->
       fun lb  ->
-        let uu____26962 = FStar_TypeChecker_Env.clear_expected_typ env  in
-        match uu____26962 with
-        | (env1,uu____26981) ->
+        let uu____26811 = FStar_TypeChecker_Env.clear_expected_typ env  in
+        match uu____26811 with
+        | (env1,uu____26830) ->
             let e1 = lb.FStar_Syntax_Syntax.lbdef  in
-            let uu____26989 = check_lbtyp top_level env lb  in
-            (match uu____26989 with
+            let uu____26838 = check_lbtyp top_level env lb  in
+            (match uu____26838 with
              | (topt,wf_annot,univ_vars,univ_opening,env11) ->
                  (if (Prims.op_Negation top_level) && (univ_vars <> [])
                   then
@@ -10690,142 +10587,142 @@ and (check_let_bound_def :
                       e1.FStar_Syntax_Syntax.pos
                   else ();
                   (let e11 = FStar_Syntax_Subst.subst univ_opening e1  in
-                   let uu____27038 =
+                   let uu____26887 =
                      tc_maybe_toplevel_term
-                       (let uu___3492_27047 = env11  in
+                       (let uu___3492_26896 = env11  in
                         {
                           FStar_TypeChecker_Env.solver =
-                            (uu___3492_27047.FStar_TypeChecker_Env.solver);
+                            (uu___3492_26896.FStar_TypeChecker_Env.solver);
                           FStar_TypeChecker_Env.range =
-                            (uu___3492_27047.FStar_TypeChecker_Env.range);
+                            (uu___3492_26896.FStar_TypeChecker_Env.range);
                           FStar_TypeChecker_Env.curmodule =
-                            (uu___3492_27047.FStar_TypeChecker_Env.curmodule);
+                            (uu___3492_26896.FStar_TypeChecker_Env.curmodule);
                           FStar_TypeChecker_Env.gamma =
-                            (uu___3492_27047.FStar_TypeChecker_Env.gamma);
+                            (uu___3492_26896.FStar_TypeChecker_Env.gamma);
                           FStar_TypeChecker_Env.gamma_sig =
-                            (uu___3492_27047.FStar_TypeChecker_Env.gamma_sig);
+                            (uu___3492_26896.FStar_TypeChecker_Env.gamma_sig);
                           FStar_TypeChecker_Env.gamma_cache =
-                            (uu___3492_27047.FStar_TypeChecker_Env.gamma_cache);
+                            (uu___3492_26896.FStar_TypeChecker_Env.gamma_cache);
                           FStar_TypeChecker_Env.modules =
-                            (uu___3492_27047.FStar_TypeChecker_Env.modules);
+                            (uu___3492_26896.FStar_TypeChecker_Env.modules);
                           FStar_TypeChecker_Env.expected_typ =
-                            (uu___3492_27047.FStar_TypeChecker_Env.expected_typ);
+                            (uu___3492_26896.FStar_TypeChecker_Env.expected_typ);
                           FStar_TypeChecker_Env.sigtab =
-                            (uu___3492_27047.FStar_TypeChecker_Env.sigtab);
+                            (uu___3492_26896.FStar_TypeChecker_Env.sigtab);
                           FStar_TypeChecker_Env.attrtab =
-                            (uu___3492_27047.FStar_TypeChecker_Env.attrtab);
+                            (uu___3492_26896.FStar_TypeChecker_Env.attrtab);
                           FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___3492_27047.FStar_TypeChecker_Env.instantiate_imp);
+                            (uu___3492_26896.FStar_TypeChecker_Env.instantiate_imp);
                           FStar_TypeChecker_Env.effects =
-                            (uu___3492_27047.FStar_TypeChecker_Env.effects);
+                            (uu___3492_26896.FStar_TypeChecker_Env.effects);
                           FStar_TypeChecker_Env.generalize =
-                            (uu___3492_27047.FStar_TypeChecker_Env.generalize);
+                            (uu___3492_26896.FStar_TypeChecker_Env.generalize);
                           FStar_TypeChecker_Env.letrecs =
-                            (uu___3492_27047.FStar_TypeChecker_Env.letrecs);
+                            (uu___3492_26896.FStar_TypeChecker_Env.letrecs);
                           FStar_TypeChecker_Env.top_level = top_level;
                           FStar_TypeChecker_Env.check_uvars =
-                            (uu___3492_27047.FStar_TypeChecker_Env.check_uvars);
+                            (uu___3492_26896.FStar_TypeChecker_Env.check_uvars);
                           FStar_TypeChecker_Env.use_eq =
-                            (uu___3492_27047.FStar_TypeChecker_Env.use_eq);
+                            (uu___3492_26896.FStar_TypeChecker_Env.use_eq);
                           FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___3492_27047.FStar_TypeChecker_Env.use_eq_strict);
+                            (uu___3492_26896.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
-                            (uu___3492_27047.FStar_TypeChecker_Env.is_iface);
+                            (uu___3492_26896.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
-                            (uu___3492_27047.FStar_TypeChecker_Env.admit);
+                            (uu___3492_26896.FStar_TypeChecker_Env.admit);
                           FStar_TypeChecker_Env.lax =
-                            (uu___3492_27047.FStar_TypeChecker_Env.lax);
+                            (uu___3492_26896.FStar_TypeChecker_Env.lax);
                           FStar_TypeChecker_Env.lax_universes =
-                            (uu___3492_27047.FStar_TypeChecker_Env.lax_universes);
+                            (uu___3492_26896.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
-                            (uu___3492_27047.FStar_TypeChecker_Env.phase1);
+                            (uu___3492_26896.FStar_TypeChecker_Env.phase1);
                           FStar_TypeChecker_Env.failhard =
-                            (uu___3492_27047.FStar_TypeChecker_Env.failhard);
+                            (uu___3492_26896.FStar_TypeChecker_Env.failhard);
                           FStar_TypeChecker_Env.nosynth =
-                            (uu___3492_27047.FStar_TypeChecker_Env.nosynth);
+                            (uu___3492_26896.FStar_TypeChecker_Env.nosynth);
                           FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___3492_27047.FStar_TypeChecker_Env.uvar_subtyping);
+                            (uu___3492_26896.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.tc_term =
-                            (uu___3492_27047.FStar_TypeChecker_Env.tc_term);
+                            (uu___3492_26896.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.type_of =
-                            (uu___3492_27047.FStar_TypeChecker_Env.type_of);
+                            (uu___3492_26896.FStar_TypeChecker_Env.type_of);
                           FStar_TypeChecker_Env.universe_of =
-                            (uu___3492_27047.FStar_TypeChecker_Env.universe_of);
+                            (uu___3492_26896.FStar_TypeChecker_Env.universe_of);
                           FStar_TypeChecker_Env.check_type_of =
-                            (uu___3492_27047.FStar_TypeChecker_Env.check_type_of);
+                            (uu___3492_26896.FStar_TypeChecker_Env.check_type_of);
                           FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___3492_27047.FStar_TypeChecker_Env.use_bv_sorts);
+                            (uu___3492_26896.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___3492_27047.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            (uu___3492_26896.FStar_TypeChecker_Env.qtbl_name_and_index);
                           FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___3492_27047.FStar_TypeChecker_Env.normalized_eff_names);
+                            (uu___3492_26896.FStar_TypeChecker_Env.normalized_eff_names);
                           FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___3492_27047.FStar_TypeChecker_Env.fv_delta_depths);
+                            (uu___3492_26896.FStar_TypeChecker_Env.fv_delta_depths);
                           FStar_TypeChecker_Env.proof_ns =
-                            (uu___3492_27047.FStar_TypeChecker_Env.proof_ns);
+                            (uu___3492_26896.FStar_TypeChecker_Env.proof_ns);
                           FStar_TypeChecker_Env.synth_hook =
-                            (uu___3492_27047.FStar_TypeChecker_Env.synth_hook);
+                            (uu___3492_26896.FStar_TypeChecker_Env.synth_hook);
                           FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___3492_27047.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                            (uu___3492_26896.FStar_TypeChecker_Env.try_solve_implicits_hook);
                           FStar_TypeChecker_Env.splice =
-                            (uu___3492_27047.FStar_TypeChecker_Env.splice);
+                            (uu___3492_26896.FStar_TypeChecker_Env.splice);
                           FStar_TypeChecker_Env.mpreprocess =
-                            (uu___3492_27047.FStar_TypeChecker_Env.mpreprocess);
+                            (uu___3492_26896.FStar_TypeChecker_Env.mpreprocess);
                           FStar_TypeChecker_Env.postprocess =
-                            (uu___3492_27047.FStar_TypeChecker_Env.postprocess);
+                            (uu___3492_26896.FStar_TypeChecker_Env.postprocess);
                           FStar_TypeChecker_Env.identifier_info =
-                            (uu___3492_27047.FStar_TypeChecker_Env.identifier_info);
+                            (uu___3492_26896.FStar_TypeChecker_Env.identifier_info);
                           FStar_TypeChecker_Env.tc_hooks =
-                            (uu___3492_27047.FStar_TypeChecker_Env.tc_hooks);
+                            (uu___3492_26896.FStar_TypeChecker_Env.tc_hooks);
                           FStar_TypeChecker_Env.dsenv =
-                            (uu___3492_27047.FStar_TypeChecker_Env.dsenv);
+                            (uu___3492_26896.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.nbe =
-                            (uu___3492_27047.FStar_TypeChecker_Env.nbe);
+                            (uu___3492_26896.FStar_TypeChecker_Env.nbe);
                           FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___3492_27047.FStar_TypeChecker_Env.strict_args_tab);
+                            (uu___3492_26896.FStar_TypeChecker_Env.strict_args_tab);
                           FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___3492_27047.FStar_TypeChecker_Env.erasable_types_tab)
+                            (uu___3492_26896.FStar_TypeChecker_Env.erasable_types_tab)
                         }) e11
                       in
-                   match uu____27038 with
+                   match uu____26887 with
                    | (e12,c1,g1) ->
-                       let uu____27062 =
-                         let uu____27067 =
+                       let uu____26911 =
+                         let uu____26916 =
                            FStar_TypeChecker_Env.set_range env11
                              e12.FStar_Syntax_Syntax.pos
                             in
                          FStar_TypeChecker_Util.strengthen_precondition
                            (FStar_Pervasives_Native.Some
-                              (fun uu____27073  ->
+                              (fun uu____26922  ->
                                  FStar_Util.return_all
                                    FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____27067 e12 c1 wf_annot
+                           uu____26916 e12 c1 wf_annot
                           in
-                       (match uu____27062 with
+                       (match uu____26911 with
                         | (c11,guard_f) ->
                             let g11 =
                               FStar_TypeChecker_Env.conj_guard g1 guard_f  in
-                            ((let uu____27090 =
+                            ((let uu____26939 =
                                 FStar_TypeChecker_Env.debug env
                                   FStar_Options.Extreme
                                  in
-                              if uu____27090
+                              if uu____26939
                               then
-                                let uu____27093 =
+                                let uu____26942 =
                                   FStar_Syntax_Print.lbname_to_string
                                     lb.FStar_Syntax_Syntax.lbname
                                    in
-                                let uu____27095 =
+                                let uu____26944 =
                                   FStar_TypeChecker_Common.lcomp_to_string
                                     c11
                                    in
-                                let uu____27097 =
+                                let uu____26946 =
                                   FStar_TypeChecker_Rel.guard_to_string env
                                     g11
                                    in
                                 FStar_Util.print3
                                   "checked let-bound def %s : %s guard is %s\n"
-                                  uu____27093 uu____27095 uu____27097
+                                  uu____26942 uu____26944 uu____26946
                               else ());
                              (e12, univ_vars, c11, g11,
                                (FStar_Option.isSome topt)))))))
@@ -10845,23 +10742,23 @@ and (check_lbtyp :
         let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp  in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_unknown  ->
-            let uu____27136 =
+            let uu____26985 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____27136 with
+            (match uu____26985 with
              | (univ_opening,univ_vars) ->
-                 let uu____27169 =
+                 let uu____27018 =
                    FStar_TypeChecker_Env.push_univ_vars env univ_vars  in
                  (FStar_Pervasives_Native.None,
                    FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                   univ_opening, uu____27169))
-        | uu____27174 ->
-            let uu____27175 =
+                   univ_opening, uu____27018))
+        | uu____27023 ->
+            let uu____27024 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs
                in
-            (match uu____27175 with
+            (match uu____27024 with
              | (univ_opening,univ_vars) ->
                  let t1 = FStar_Syntax_Subst.subst univ_opening t  in
                  let env1 =
@@ -10870,45 +10767,45 @@ and (check_lbtyp :
                    top_level &&
                      (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____27225 =
+                   let uu____27074 =
                      FStar_TypeChecker_Env.set_expected_typ env1 t1  in
                    ((FStar_Pervasives_Native.Some t1),
                      FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                     univ_opening, uu____27225)
+                     univ_opening, uu____27074)
                  else
-                   (let uu____27232 = FStar_Syntax_Util.type_u ()  in
-                    match uu____27232 with
-                    | (k,uu____27252) ->
-                        let uu____27253 =
+                   (let uu____27081 = FStar_Syntax_Util.type_u ()  in
+                    match uu____27081 with
+                    | (k,uu____27101) ->
+                        let uu____27102 =
                           tc_check_tot_or_gtot_term env1 t1 k ""  in
-                        (match uu____27253 with
-                         | (t2,uu____27276,g) ->
-                             ((let uu____27279 =
+                        (match uu____27102 with
+                         | (t2,uu____27125,g) ->
+                             ((let uu____27128 =
                                  FStar_TypeChecker_Env.debug env
                                    FStar_Options.Medium
                                   in
-                               if uu____27279
+                               if uu____27128
                                then
-                                 let uu____27282 =
-                                   let uu____27284 =
+                                 let uu____27131 =
+                                   let uu____27133 =
                                      FStar_Syntax_Util.range_of_lbname
                                        lb.FStar_Syntax_Syntax.lbname
                                       in
-                                   FStar_Range.string_of_range uu____27284
+                                   FStar_Range.string_of_range uu____27133
                                     in
-                                 let uu____27285 =
+                                 let uu____27134 =
                                    FStar_Syntax_Print.term_to_string t2  in
                                  FStar_Util.print2
                                    "(%s) Checked type annotation %s\n"
-                                   uu____27282 uu____27285
+                                   uu____27131 uu____27134
                                else ());
                               (let t3 = norm env1 t2  in
-                               let uu____27291 =
+                               let uu____27140 =
                                  FStar_TypeChecker_Env.set_expected_typ env1
                                    t3
                                   in
                                ((FStar_Pervasives_Native.Some t3), g,
-                                 univ_vars, univ_opening, uu____27291))))))
+                                 univ_vars, univ_opening, uu____27140))))))
 
 and (tc_binder :
   FStar_TypeChecker_Env.env ->
@@ -10919,76 +10816,76 @@ and (tc_binder :
         FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universe))
   =
   fun env  ->
-    fun uu____27297  ->
-      match uu____27297 with
+    fun uu____27146  ->
+      match uu____27146 with
       | (x,imp) ->
-          let uu____27324 = FStar_Syntax_Util.type_u ()  in
-          (match uu____27324 with
+          let uu____27173 = FStar_Syntax_Util.type_u ()  in
+          (match uu____27173 with
            | (tu,u) ->
-               ((let uu____27346 =
+               ((let uu____27195 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-                 if uu____27346
+                 if uu____27195
                  then
-                   let uu____27349 = FStar_Syntax_Print.bv_to_string x  in
-                   let uu____27351 =
+                   let uu____27198 = FStar_Syntax_Print.bv_to_string x  in
+                   let uu____27200 =
                      FStar_Syntax_Print.term_to_string
                        x.FStar_Syntax_Syntax.sort
                       in
-                   let uu____27353 = FStar_Syntax_Print.term_to_string tu  in
+                   let uu____27202 = FStar_Syntax_Print.term_to_string tu  in
                    FStar_Util.print3 "Checking binder %s:%s at type %s\n"
-                     uu____27349 uu____27351 uu____27353
+                     uu____27198 uu____27200 uu____27202
                  else ());
-                (let uu____27358 =
+                (let uu____27207 =
                    tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
                      tu ""
                     in
-                 match uu____27358 with
-                 | (t,uu____27381,g) ->
-                     let uu____27383 =
+                 match uu____27207 with
+                 | (t,uu____27230,g) ->
+                     let uu____27232 =
                        match imp with
                        | FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Meta tau) ->
-                           let uu____27399 =
+                           let uu____27248 =
                              tc_tactic FStar_Syntax_Syntax.t_unit
                                FStar_Syntax_Syntax.t_unit env tau
                               in
-                           (match uu____27399 with
-                            | (tau1,uu____27413,g1) ->
+                           (match uu____27248 with
+                            | (tau1,uu____27262,g1) ->
                                 ((FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Meta tau1)), g1))
-                       | uu____27417 ->
+                       | uu____27266 ->
                            (imp, FStar_TypeChecker_Env.trivial_guard)
                         in
-                     (match uu____27383 with
+                     (match uu____27232 with
                       | (imp1,g') ->
                           let x1 =
-                            ((let uu___3554_27452 = x  in
+                            ((let uu___3554_27301 = x  in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___3554_27452.FStar_Syntax_Syntax.ppname);
+                                  (uu___3554_27301.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___3554_27452.FStar_Syntax_Syntax.index);
+                                  (uu___3554_27301.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               }), imp1)
                              in
-                          ((let uu____27454 =
+                          ((let uu____27303 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.High
                                in
-                            if uu____27454
+                            if uu____27303
                             then
-                              let uu____27457 =
+                              let uu____27306 =
                                 FStar_Syntax_Print.bv_to_string
                                   (FStar_Pervasives_Native.fst x1)
                                  in
-                              let uu____27461 =
+                              let uu____27310 =
                                 FStar_Syntax_Print.term_to_string t  in
                               FStar_Util.print2
-                                "Pushing binder %s at type %s\n" uu____27457
-                                uu____27461
+                                "Pushing binder %s at type %s\n" uu____27306
+                                uu____27310
                             else ());
-                           (let uu____27466 = push_binding env x1  in
-                            (x1, uu____27466, g, u)))))))
+                           (let uu____27315 = push_binding env x1  in
+                            (x1, uu____27315, g, u)))))))
 
 and (tc_binders :
   FStar_TypeChecker_Env.env ->
@@ -10998,30 +10895,30 @@ and (tc_binders :
   =
   fun env  ->
     fun bs  ->
-      (let uu____27478 =
+      (let uu____27327 =
          FStar_TypeChecker_Env.debug env FStar_Options.Extreme  in
-       if uu____27478
+       if uu____27327
        then
-         let uu____27481 = FStar_Syntax_Print.binders_to_string ", " bs  in
-         FStar_Util.print1 "Checking binders %s\n" uu____27481
+         let uu____27330 = FStar_Syntax_Print.binders_to_string ", " bs  in
+         FStar_Util.print1 "Checking binders %s\n" uu____27330
        else ());
       (let rec aux env1 bs1 =
          match bs1 with
          | [] -> ([], env1, FStar_TypeChecker_Env.trivial_guard, [])
          | b::bs2 ->
-             let uu____27594 = tc_binder env1 b  in
-             (match uu____27594 with
+             let uu____27443 = tc_binder env1 b  in
+             (match uu____27443 with
               | (b1,env',g,u) ->
-                  let uu____27643 = aux env' bs2  in
-                  (match uu____27643 with
+                  let uu____27492 = aux env' bs2  in
+                  (match uu____27492 with
                    | (bs3,env'1,g',us) ->
-                       let uu____27704 =
-                         let uu____27705 =
+                       let uu____27553 =
+                         let uu____27554 =
                            FStar_TypeChecker_Env.close_guard_univs [u] 
                              [b1] g'
                             in
-                         FStar_TypeChecker_Env.conj_guard g uu____27705  in
-                       ((b1 :: bs3), env'1, uu____27704, (u :: us))))
+                         FStar_TypeChecker_Env.conj_guard g uu____27554  in
+                       ((b1 :: bs3), env'1, uu____27553, (u :: us))))
           in
        aux env bs)
 
@@ -11038,30 +10935,30 @@ and (tc_smt_pats :
     fun pats  ->
       let tc_args en1 args =
         FStar_List.fold_right
-          (fun uu____27813  ->
-             fun uu____27814  ->
-               match (uu____27813, uu____27814) with
+          (fun uu____27662  ->
+             fun uu____27663  ->
+               match (uu____27662, uu____27663) with
                | ((t,imp),(args1,g)) ->
                    (FStar_All.pipe_right t (check_no_smt_theory_symbols en1);
-                    (let uu____27906 = tc_term en1 t  in
-                     match uu____27906 with
-                     | (t1,uu____27926,g') ->
-                         let uu____27928 =
+                    (let uu____27755 = tc_term en1 t  in
+                     match uu____27755 with
+                     | (t1,uu____27775,g') ->
+                         let uu____27777 =
                            FStar_TypeChecker_Env.conj_guard g g'  in
-                         (((t1, imp) :: args1), uu____27928)))) args
+                         (((t1, imp) :: args1), uu____27777)))) args
           ([], FStar_TypeChecker_Env.trivial_guard)
          in
       FStar_List.fold_right
         (fun p  ->
-           fun uu____27982  ->
-             match uu____27982 with
+           fun uu____27831  ->
+             match uu____27831 with
              | (pats1,g) ->
-                 let uu____28009 = tc_args en p  in
-                 (match uu____28009 with
+                 let uu____27858 = tc_args en p  in
+                 (match uu____27858 with
                   | (args,g') ->
-                      let uu____28022 = FStar_TypeChecker_Env.conj_guard g g'
+                      let uu____27871 = FStar_TypeChecker_Env.conj_guard g g'
                          in
-                      ((args :: pats1), uu____28022))) pats
+                      ((args :: pats1), uu____27871))) pats
         ([], FStar_TypeChecker_Env.trivial_guard)
 
 and (tc_tot_or_gtot_term' :
@@ -11074,72 +10971,72 @@ and (tc_tot_or_gtot_term' :
   fun env  ->
     fun e  ->
       fun msg  ->
-        let uu____28037 = tc_maybe_toplevel_term env e  in
-        match uu____28037 with
+        let uu____27886 = tc_maybe_toplevel_term env e  in
+        match uu____27886 with
         | (e1,c,g) ->
-            let uu____28053 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c
+            let uu____27902 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c
                in
-            if uu____28053
+            if uu____27902
             then (e1, c, g)
             else
               (let g1 =
                  FStar_TypeChecker_Rel.solve_deferred_constraints env g  in
-               let uu____28065 = FStar_TypeChecker_Common.lcomp_comp c  in
-               match uu____28065 with
+               let uu____27914 = FStar_TypeChecker_Common.lcomp_comp c  in
+               match uu____27914 with
                | (c1,g_c) ->
                    let c2 = norm_c env c1  in
-                   let uu____28079 =
-                     let uu____28085 =
+                   let uu____27928 =
+                     let uu____27934 =
                        FStar_TypeChecker_Util.is_pure_effect env
                          (FStar_Syntax_Util.comp_effect_name c2)
                         in
-                     if uu____28085
+                     if uu____27934
                      then
-                       let uu____28093 =
+                       let uu____27942 =
                          FStar_Syntax_Syntax.mk_Total
                            (FStar_Syntax_Util.comp_result c2)
                           in
-                       (uu____28093, false)
+                       (uu____27942, false)
                      else
-                       (let uu____28098 =
+                       (let uu____27947 =
                           FStar_Syntax_Syntax.mk_GTotal
                             (FStar_Syntax_Util.comp_result c2)
                            in
-                        (uu____28098, true))
+                        (uu____27947, true))
                       in
-                   (match uu____28079 with
+                   (match uu____27928 with
                     | (target_comp,allow_ghost) ->
-                        let uu____28111 =
+                        let uu____27960 =
                           FStar_TypeChecker_Rel.sub_comp env c2 target_comp
                            in
-                        (match uu____28111 with
+                        (match uu____27960 with
                          | FStar_Pervasives_Native.Some g' ->
-                             let uu____28121 =
+                             let uu____27970 =
                                FStar_TypeChecker_Common.lcomp_of_comp
                                  target_comp
                                 in
-                             let uu____28122 =
-                               let uu____28123 =
+                             let uu____27971 =
+                               let uu____27972 =
                                  FStar_TypeChecker_Env.conj_guard g_c g'  in
                                FStar_TypeChecker_Env.conj_guard g1
-                                 uu____28123
+                                 uu____27972
                                 in
-                             (e1, uu____28121, uu____28122)
-                         | uu____28124 ->
+                             (e1, uu____27970, uu____27971)
+                         | uu____27973 ->
                              if allow_ghost
                              then
-                               let uu____28134 =
+                               let uu____27983 =
                                  FStar_TypeChecker_Err.expected_ghost_expression
                                    e1 c2 msg
                                   in
-                               FStar_Errors.raise_error uu____28134
+                               FStar_Errors.raise_error uu____27983
                                  e1.FStar_Syntax_Syntax.pos
                              else
-                               (let uu____28148 =
+                               (let uu____27997 =
                                   FStar_TypeChecker_Err.expected_pure_expression
                                     e1 c2 msg
                                    in
-                                FStar_Errors.raise_error uu____28148
+                                FStar_Errors.raise_error uu____27997
                                   e1.FStar_Syntax_Syntax.pos))))
 
 and (tc_tot_or_gtot_term :
@@ -11171,8 +11068,8 @@ and (tc_trivial_guard :
   =
   fun env  ->
     fun t  ->
-      let uu____28177 = tc_tot_or_gtot_term env t  in
-      match uu____28177 with
+      let uu____28026 = tc_tot_or_gtot_term env t  in
+      match uu____28026 with
       | (t1,c,g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
 
@@ -11184,9 +11081,9 @@ let (tc_check_trivial_guard :
   fun env  ->
     fun t  ->
       fun k  ->
-        let uu____28208 = tc_check_tot_or_gtot_term env t k ""  in
-        match uu____28208 with
-        | (t1,uu____28217,g) ->
+        let uu____28057 = tc_check_tot_or_gtot_term env t k ""  in
+        match uu____28057 with
+        | (t1,uu____28066,g) ->
             (FStar_TypeChecker_Rel.force_trivial_guard env g; t1)
   
 let (type_of_tot_term :
@@ -11197,155 +11094,155 @@ let (type_of_tot_term :
   =
   fun env  ->
     fun e  ->
-      (let uu____28238 =
+      (let uu____28087 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "RelCheck")
           in
-       if uu____28238
+       if uu____28087
        then
-         let uu____28243 = FStar_Syntax_Print.term_to_string e  in
-         FStar_Util.print1 "Checking term %s\n" uu____28243
+         let uu____28092 = FStar_Syntax_Print.term_to_string e  in
+         FStar_Util.print1 "Checking term %s\n" uu____28092
        else ());
       (let env1 =
-         let uu___3650_28249 = env  in
+         let uu___3650_28098 = env  in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___3650_28249.FStar_TypeChecker_Env.solver);
+             (uu___3650_28098.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___3650_28249.FStar_TypeChecker_Env.range);
+             (uu___3650_28098.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___3650_28249.FStar_TypeChecker_Env.curmodule);
+             (uu___3650_28098.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___3650_28249.FStar_TypeChecker_Env.gamma);
+             (uu___3650_28098.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___3650_28249.FStar_TypeChecker_Env.gamma_sig);
+             (uu___3650_28098.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___3650_28249.FStar_TypeChecker_Env.gamma_cache);
+             (uu___3650_28098.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___3650_28249.FStar_TypeChecker_Env.modules);
+             (uu___3650_28098.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___3650_28249.FStar_TypeChecker_Env.expected_typ);
+             (uu___3650_28098.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___3650_28249.FStar_TypeChecker_Env.sigtab);
+             (uu___3650_28098.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___3650_28249.FStar_TypeChecker_Env.attrtab);
+             (uu___3650_28098.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___3650_28249.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___3650_28098.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___3650_28249.FStar_TypeChecker_Env.effects);
+             (uu___3650_28098.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___3650_28249.FStar_TypeChecker_Env.generalize);
+             (uu___3650_28098.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs = [];
            FStar_TypeChecker_Env.top_level = false;
            FStar_TypeChecker_Env.check_uvars =
-             (uu___3650_28249.FStar_TypeChecker_Env.check_uvars);
+             (uu___3650_28098.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___3650_28249.FStar_TypeChecker_Env.use_eq);
+             (uu___3650_28098.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___3650_28249.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___3650_28098.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___3650_28249.FStar_TypeChecker_Env.is_iface);
+             (uu___3650_28098.FStar_TypeChecker_Env.is_iface);
            FStar_TypeChecker_Env.admit =
-             (uu___3650_28249.FStar_TypeChecker_Env.admit);
+             (uu___3650_28098.FStar_TypeChecker_Env.admit);
            FStar_TypeChecker_Env.lax =
-             (uu___3650_28249.FStar_TypeChecker_Env.lax);
+             (uu___3650_28098.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___3650_28249.FStar_TypeChecker_Env.lax_universes);
+             (uu___3650_28098.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___3650_28249.FStar_TypeChecker_Env.phase1);
+             (uu___3650_28098.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___3650_28249.FStar_TypeChecker_Env.failhard);
+             (uu___3650_28098.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___3650_28249.FStar_TypeChecker_Env.nosynth);
+             (uu___3650_28098.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___3650_28249.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___3650_28098.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___3650_28249.FStar_TypeChecker_Env.tc_term);
+             (uu___3650_28098.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___3650_28249.FStar_TypeChecker_Env.type_of);
+             (uu___3650_28098.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___3650_28249.FStar_TypeChecker_Env.universe_of);
+             (uu___3650_28098.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___3650_28249.FStar_TypeChecker_Env.check_type_of);
+             (uu___3650_28098.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___3650_28249.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___3650_28098.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___3650_28249.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___3650_28098.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___3650_28249.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___3650_28098.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___3650_28249.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___3650_28098.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___3650_28249.FStar_TypeChecker_Env.proof_ns);
+             (uu___3650_28098.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___3650_28249.FStar_TypeChecker_Env.synth_hook);
+             (uu___3650_28098.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___3650_28249.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___3650_28098.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___3650_28249.FStar_TypeChecker_Env.splice);
+             (uu___3650_28098.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___3650_28249.FStar_TypeChecker_Env.mpreprocess);
+             (uu___3650_28098.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___3650_28249.FStar_TypeChecker_Env.postprocess);
+             (uu___3650_28098.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___3650_28249.FStar_TypeChecker_Env.identifier_info);
+             (uu___3650_28098.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___3650_28249.FStar_TypeChecker_Env.tc_hooks);
+             (uu___3650_28098.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___3650_28249.FStar_TypeChecker_Env.dsenv);
+             (uu___3650_28098.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___3650_28249.FStar_TypeChecker_Env.nbe);
+             (uu___3650_28098.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___3650_28249.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___3650_28098.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___3650_28249.FStar_TypeChecker_Env.erasable_types_tab)
+             (uu___3650_28098.FStar_TypeChecker_Env.erasable_types_tab)
          }  in
-       let uu____28257 =
+       let uu____28106 =
          try
-           (fun uu___3654_28271  ->
+           (fun uu___3654_28120  ->
               match () with | () -> tc_tot_or_gtot_term env1 e) ()
          with
-         | FStar_Errors.Error (e1,msg,uu____28292) ->
-             let uu____28295 = FStar_TypeChecker_Env.get_range env1  in
-             FStar_Errors.raise_error (e1, msg) uu____28295
+         | FStar_Errors.Error (e1,msg,uu____28141) ->
+             let uu____28144 = FStar_TypeChecker_Env.get_range env1  in
+             FStar_Errors.raise_error (e1, msg) uu____28144
           in
-       match uu____28257 with
+       match uu____28106 with
        | (t,c,g) ->
            let c1 = FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env1 c
               in
-           let uu____28313 = FStar_TypeChecker_Common.is_total_lcomp c1  in
-           if uu____28313
+           let uu____28162 = FStar_TypeChecker_Common.is_total_lcomp c1  in
+           if uu____28162
            then (t, (c1.FStar_TypeChecker_Common.res_typ), g)
            else
-             (let uu____28324 =
-                let uu____28330 =
-                  let uu____28332 = FStar_Syntax_Print.term_to_string e  in
+             (let uu____28173 =
+                let uu____28179 =
+                  let uu____28181 = FStar_Syntax_Print.term_to_string e  in
                   FStar_Util.format1
                     "Implicit argument: Expected a total term; got a ghost term: %s"
-                    uu____28332
+                    uu____28181
                    in
-                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____28330)
+                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____28179)
                  in
-              let uu____28336 = FStar_TypeChecker_Env.get_range env1  in
-              FStar_Errors.raise_error uu____28324 uu____28336))
+              let uu____28185 = FStar_TypeChecker_Env.get_range env1  in
+              FStar_Errors.raise_error uu____28173 uu____28185))
   
 let level_of_type_fail :
-  'uuuuuu28352 .
+  'uuuuuu28201 .
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu28352
+      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu28201
   =
   fun env  ->
     fun e  ->
       fun t  ->
-        let uu____28370 =
-          let uu____28376 =
-            let uu____28378 = FStar_Syntax_Print.term_to_string e  in
+        let uu____28219 =
+          let uu____28225 =
+            let uu____28227 = FStar_Syntax_Print.term_to_string e  in
             FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-              uu____28378 t
+              uu____28227 t
              in
-          (FStar_Errors.Fatal_UnexpectedTermType, uu____28376)  in
-        let uu____28382 = FStar_TypeChecker_Env.get_range env  in
-        FStar_Errors.raise_error uu____28370 uu____28382
+          (FStar_Errors.Fatal_UnexpectedTermType, uu____28225)  in
+        let uu____28231 = FStar_TypeChecker_Env.get_range env  in
+        FStar_Errors.raise_error uu____28219 uu____28231
   
 let (level_of_type :
   FStar_TypeChecker_Env.env ->
@@ -11356,12 +11253,12 @@ let (level_of_type :
     fun e  ->
       fun t  ->
         let rec aux retry t1 =
-          let uu____28416 =
-            let uu____28417 = FStar_Syntax_Util.unrefine t1  in
-            uu____28417.FStar_Syntax_Syntax.n  in
-          match uu____28416 with
+          let uu____28265 =
+            let uu____28266 = FStar_Syntax_Util.unrefine t1  in
+            uu____28266.FStar_Syntax_Syntax.n  in
+          match uu____28265 with
           | FStar_Syntax_Syntax.Tm_type u -> u
-          | uu____28421 ->
+          | uu____28270 ->
               if retry
               then
                 let t2 =
@@ -11371,111 +11268,111 @@ let (level_of_type :
                    in
                 aux false t2
               else
-                (let uu____28427 = FStar_Syntax_Util.type_u ()  in
-                 match uu____28427 with
+                (let uu____28276 = FStar_Syntax_Util.type_u ()  in
+                 match uu____28276 with
                  | (t_u,u) ->
                      let env1 =
-                       let uu___3686_28435 = env  in
+                       let uu___3686_28284 = env  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3686_28435.FStar_TypeChecker_Env.solver);
+                           (uu___3686_28284.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3686_28435.FStar_TypeChecker_Env.range);
+                           (uu___3686_28284.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3686_28435.FStar_TypeChecker_Env.curmodule);
+                           (uu___3686_28284.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3686_28435.FStar_TypeChecker_Env.gamma);
+                           (uu___3686_28284.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3686_28435.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3686_28284.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3686_28435.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3686_28284.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3686_28435.FStar_TypeChecker_Env.modules);
+                           (uu___3686_28284.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3686_28435.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3686_28284.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3686_28435.FStar_TypeChecker_Env.sigtab);
+                           (uu___3686_28284.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3686_28435.FStar_TypeChecker_Env.attrtab);
+                           (uu___3686_28284.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3686_28435.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3686_28284.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3686_28435.FStar_TypeChecker_Env.effects);
+                           (uu___3686_28284.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3686_28435.FStar_TypeChecker_Env.generalize);
+                           (uu___3686_28284.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3686_28435.FStar_TypeChecker_Env.letrecs);
+                           (uu___3686_28284.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level =
-                           (uu___3686_28435.FStar_TypeChecker_Env.top_level);
+                           (uu___3686_28284.FStar_TypeChecker_Env.top_level);
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3686_28435.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3686_28284.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3686_28435.FStar_TypeChecker_Env.use_eq);
+                           (uu___3686_28284.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3686_28435.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3686_28284.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3686_28435.FStar_TypeChecker_Env.is_iface);
+                           (uu___3686_28284.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3686_28435.FStar_TypeChecker_Env.admit);
+                           (uu___3686_28284.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3686_28435.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3686_28284.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3686_28435.FStar_TypeChecker_Env.phase1);
+                           (uu___3686_28284.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3686_28435.FStar_TypeChecker_Env.failhard);
+                           (uu___3686_28284.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3686_28435.FStar_TypeChecker_Env.nosynth);
+                           (uu___3686_28284.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3686_28435.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3686_28284.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3686_28435.FStar_TypeChecker_Env.tc_term);
+                           (uu___3686_28284.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3686_28435.FStar_TypeChecker_Env.type_of);
+                           (uu___3686_28284.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3686_28435.FStar_TypeChecker_Env.universe_of);
+                           (uu___3686_28284.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3686_28435.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3686_28284.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___3686_28435.FStar_TypeChecker_Env.use_bv_sorts);
+                           (uu___3686_28284.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3686_28435.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3686_28284.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3686_28435.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3686_28284.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3686_28435.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3686_28284.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3686_28435.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3686_28284.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3686_28435.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3686_28284.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3686_28435.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3686_28284.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3686_28435.FStar_TypeChecker_Env.splice);
+                           (uu___3686_28284.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3686_28435.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3686_28284.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3686_28435.FStar_TypeChecker_Env.postprocess);
+                           (uu___3686_28284.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3686_28435.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3686_28284.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3686_28435.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3686_28284.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3686_28435.FStar_TypeChecker_Env.dsenv);
+                           (uu___3686_28284.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3686_28435.FStar_TypeChecker_Env.nbe);
+                           (uu___3686_28284.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3686_28435.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3686_28284.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3686_28435.FStar_TypeChecker_Env.erasable_types_tab)
+                           (uu___3686_28284.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
                      let g = FStar_TypeChecker_Rel.teq env1 t1 t_u  in
                      ((match g.FStar_TypeChecker_Common.guard_f with
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____28440 =
+                           let uu____28289 =
                              FStar_Syntax_Print.term_to_string t1  in
-                           level_of_type_fail env1 e uu____28440
-                       | uu____28442 ->
+                           level_of_type_fail env1 e uu____28289
+                       | uu____28291 ->
                            FStar_TypeChecker_Rel.force_trivial_guard env1 g);
                       u))
            in
@@ -11488,61 +11385,61 @@ let rec (universe_of_aux :
   =
   fun env  ->
     fun e  ->
-      let uu____28459 =
-        let uu____28460 = FStar_Syntax_Subst.compress e  in
-        uu____28460.FStar_Syntax_Syntax.n  in
-      match uu____28459 with
-      | FStar_Syntax_Syntax.Tm_bvar uu____28463 -> failwith "Impossible"
+      let uu____28308 =
+        let uu____28309 = FStar_Syntax_Subst.compress e  in
+        uu____28309.FStar_Syntax_Syntax.n  in
+      match uu____28308 with
+      | FStar_Syntax_Syntax.Tm_bvar uu____28312 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____28466 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_let uu____28482 ->
+      | FStar_Syntax_Syntax.Tm_delayed uu____28315 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_let uu____28331 ->
           let e1 = FStar_TypeChecker_Normalize.normalize [] env e  in
           universe_of_aux env e1
-      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____28499) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs,t,uu____28348) ->
           level_of_type_fail env e "arrow type"
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
           FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
-      | FStar_Syntax_Syntax.Tm_meta (t,uu____28544) -> universe_of_aux env t
+      | FStar_Syntax_Syntax.Tm_meta (t,uu____28393) -> universe_of_aux env t
       | FStar_Syntax_Syntax.Tm_name n -> n.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____28551 =
+          let uu____28400 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____28551 with | ((uu____28560,t),uu____28562) -> t)
+          (match uu____28400 with | ((uu____28409,t),uu____28411) -> t)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____28568 = FStar_Syntax_Util.unfold_lazy i  in
-          universe_of_aux env uu____28568
+          let uu____28417 = FStar_Syntax_Util.unfold_lazy i  in
+          universe_of_aux env uu____28417
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____28571,(FStar_Util.Inl t,uu____28573),uu____28574) -> t
+          (uu____28420,(FStar_Util.Inl t,uu____28422),uu____28423) -> t
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____28621,(FStar_Util.Inr c,uu____28623),uu____28624) ->
+          (uu____28470,(FStar_Util.Inr c,uu____28472),uu____28473) ->
           FStar_Syntax_Util.comp_result c
       | FStar_Syntax_Syntax.Tm_type u ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u))
-            FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_quoted uu____28672 -> FStar_Syntax_Util.ktype0
+            e.FStar_Syntax_Syntax.pos
+      | FStar_Syntax_Syntax.Tm_quoted uu____28521 -> FStar_Syntax_Util.ktype0
       | FStar_Syntax_Syntax.Tm_constant sc ->
           tc_constant env e.FStar_Syntax_Syntax.pos sc
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____28681;
-             FStar_Syntax_Syntax.vars = uu____28682;_},us)
+             FStar_Syntax_Syntax.pos = uu____28530;
+             FStar_Syntax_Syntax.vars = uu____28531;_},us)
           ->
-          let uu____28688 =
+          let uu____28537 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          (match uu____28688 with
-           | ((us',t),uu____28699) ->
+          (match uu____28537 with
+           | ((us',t),uu____28548) ->
                (if (FStar_List.length us) <> (FStar_List.length us')
                 then
-                  (let uu____28706 = FStar_TypeChecker_Env.get_range env  in
+                  (let uu____28555 = FStar_TypeChecker_Env.get_range env  in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
                        "Unexpected number of universe instantiations")
-                     uu____28706)
+                     uu____28555)
                 else
                   FStar_List.iter2
                     (fun u'  ->
@@ -11550,31 +11447,31 @@ let rec (universe_of_aux :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____28727 -> failwith "Impossible") us' us;
+                         | uu____28576 -> failwith "Impossible") us' us;
                 t))
-      | FStar_Syntax_Syntax.Tm_uinst uu____28729 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____28578 ->
           failwith "Impossible: Tm_uinst's head must be an fvar"
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____28738) ->
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____28587) ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____28765 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____28765 with
+          let uu____28614 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____28614 with
            | (bs1,c1) ->
                let us =
                  FStar_List.map
-                   (fun uu____28785  ->
-                      match uu____28785 with
-                      | (b,uu____28793) ->
-                          let uu____28798 =
+                   (fun uu____28634  ->
+                      match uu____28634 with
+                      | (b,uu____28642) ->
+                          let uu____28647 =
                             universe_of_aux env b.FStar_Syntax_Syntax.sort
                              in
                           level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____28798) bs1
+                            uu____28647) bs1
                   in
                let u_res =
                  let res = FStar_Syntax_Util.comp_result c1  in
-                 let uu____28803 = universe_of_aux env res  in
-                 level_of_type env res uu____28803  in
+                 let uu____28652 = universe_of_aux env res  in
+                 level_of_type env res uu____28652  in
                let u_c =
                  FStar_All.pipe_right c1
                    (FStar_TypeChecker_Util.universe_of_comp env u_res)
@@ -11584,208 +11481,208 @@ let rec (universe_of_aux :
                    (FStar_Syntax_Syntax.U_max (u_c :: us))
                   in
                FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
-                 FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos)
+                 e.FStar_Syntax_Syntax.pos)
       | FStar_Syntax_Syntax.Tm_app (hd,args) ->
           let rec type_of_head retry hd1 args1 =
             let hd2 = FStar_Syntax_Subst.compress hd1  in
             match hd2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown  -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_bvar uu____28914 ->
+            | FStar_Syntax_Syntax.Tm_bvar uu____28763 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_delayed uu____28930 ->
+            | FStar_Syntax_Syntax.Tm_delayed uu____28779 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_fvar uu____28960 ->
-                let uu____28961 = universe_of_aux env hd2  in
-                (uu____28961, args1)
-            | FStar_Syntax_Syntax.Tm_name uu____28972 ->
-                let uu____28973 = universe_of_aux env hd2  in
-                (uu____28973, args1)
-            | FStar_Syntax_Syntax.Tm_uvar uu____28984 ->
-                let uu____28997 = universe_of_aux env hd2  in
-                (uu____28997, args1)
-            | FStar_Syntax_Syntax.Tm_uinst uu____29008 ->
-                let uu____29015 = universe_of_aux env hd2  in
-                (uu____29015, args1)
-            | FStar_Syntax_Syntax.Tm_ascribed uu____29026 ->
-                let uu____29053 = universe_of_aux env hd2  in
-                (uu____29053, args1)
-            | FStar_Syntax_Syntax.Tm_refine uu____29064 ->
-                let uu____29071 = universe_of_aux env hd2  in
-                (uu____29071, args1)
-            | FStar_Syntax_Syntax.Tm_constant uu____29082 ->
-                let uu____29083 = universe_of_aux env hd2  in
-                (uu____29083, args1)
-            | FStar_Syntax_Syntax.Tm_arrow uu____29094 ->
-                let uu____29109 = universe_of_aux env hd2  in
-                (uu____29109, args1)
-            | FStar_Syntax_Syntax.Tm_meta uu____29120 ->
-                let uu____29127 = universe_of_aux env hd2  in
-                (uu____29127, args1)
-            | FStar_Syntax_Syntax.Tm_type uu____29138 ->
-                let uu____29139 = universe_of_aux env hd2  in
-                (uu____29139, args1)
-            | FStar_Syntax_Syntax.Tm_match (uu____29150,hd3::uu____29152) ->
-                let uu____29217 = FStar_Syntax_Subst.open_branch hd3  in
-                (match uu____29217 with
-                 | (uu____29232,uu____29233,hd4) ->
-                     let uu____29251 = FStar_Syntax_Util.head_and_args hd4
+            | FStar_Syntax_Syntax.Tm_fvar uu____28809 ->
+                let uu____28810 = universe_of_aux env hd2  in
+                (uu____28810, args1)
+            | FStar_Syntax_Syntax.Tm_name uu____28821 ->
+                let uu____28822 = universe_of_aux env hd2  in
+                (uu____28822, args1)
+            | FStar_Syntax_Syntax.Tm_uvar uu____28833 ->
+                let uu____28846 = universe_of_aux env hd2  in
+                (uu____28846, args1)
+            | FStar_Syntax_Syntax.Tm_uinst uu____28857 ->
+                let uu____28864 = universe_of_aux env hd2  in
+                (uu____28864, args1)
+            | FStar_Syntax_Syntax.Tm_ascribed uu____28875 ->
+                let uu____28902 = universe_of_aux env hd2  in
+                (uu____28902, args1)
+            | FStar_Syntax_Syntax.Tm_refine uu____28913 ->
+                let uu____28920 = universe_of_aux env hd2  in
+                (uu____28920, args1)
+            | FStar_Syntax_Syntax.Tm_constant uu____28931 ->
+                let uu____28932 = universe_of_aux env hd2  in
+                (uu____28932, args1)
+            | FStar_Syntax_Syntax.Tm_arrow uu____28943 ->
+                let uu____28958 = universe_of_aux env hd2  in
+                (uu____28958, args1)
+            | FStar_Syntax_Syntax.Tm_meta uu____28969 ->
+                let uu____28976 = universe_of_aux env hd2  in
+                (uu____28976, args1)
+            | FStar_Syntax_Syntax.Tm_type uu____28987 ->
+                let uu____28988 = universe_of_aux env hd2  in
+                (uu____28988, args1)
+            | FStar_Syntax_Syntax.Tm_match (uu____28999,hd3::uu____29001) ->
+                let uu____29066 = FStar_Syntax_Subst.open_branch hd3  in
+                (match uu____29066 with
+                 | (uu____29081,uu____29082,hd4) ->
+                     let uu____29100 = FStar_Syntax_Util.head_and_args hd4
                         in
-                     (match uu____29251 with
+                     (match uu____29100 with
                       | (hd5,args') ->
                           type_of_head retry hd5
                             (FStar_List.append args' args1)))
-            | uu____29316 when retry ->
+            | uu____29165 when retry ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
                     FStar_TypeChecker_Env.DoNotUnfoldPureLets] env e
                    in
-                let uu____29318 = FStar_Syntax_Util.head_and_args e1  in
-                (match uu____29318 with
+                let uu____29167 = FStar_Syntax_Util.head_and_args e1  in
+                (match uu____29167 with
                  | (hd3,args2) -> type_of_head false hd3 args2)
-            | uu____29376 ->
-                let uu____29377 =
+            | uu____29225 ->
+                let uu____29226 =
                   FStar_TypeChecker_Env.clear_expected_typ env  in
-                (match uu____29377 with
-                 | (env1,uu____29399) ->
+                (match uu____29226 with
+                 | (env1,uu____29248) ->
                      let env2 =
-                       let uu___3847_29405 = env1  in
+                       let uu___3847_29254 = env1  in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3847_29405.FStar_TypeChecker_Env.solver);
+                           (uu___3847_29254.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3847_29405.FStar_TypeChecker_Env.range);
+                           (uu___3847_29254.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3847_29405.FStar_TypeChecker_Env.curmodule);
+                           (uu___3847_29254.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3847_29405.FStar_TypeChecker_Env.gamma);
+                           (uu___3847_29254.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3847_29405.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3847_29254.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3847_29405.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3847_29254.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3847_29405.FStar_TypeChecker_Env.modules);
+                           (uu___3847_29254.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3847_29405.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3847_29254.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3847_29405.FStar_TypeChecker_Env.sigtab);
+                           (uu___3847_29254.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3847_29405.FStar_TypeChecker_Env.attrtab);
+                           (uu___3847_29254.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3847_29405.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3847_29254.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3847_29405.FStar_TypeChecker_Env.effects);
+                           (uu___3847_29254.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3847_29405.FStar_TypeChecker_Env.generalize);
+                           (uu___3847_29254.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3847_29405.FStar_TypeChecker_Env.letrecs);
+                           (uu___3847_29254.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level = false;
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3847_29405.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3847_29254.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3847_29405.FStar_TypeChecker_Env.use_eq);
+                           (uu___3847_29254.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3847_29405.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3847_29254.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3847_29405.FStar_TypeChecker_Env.is_iface);
+                           (uu___3847_29254.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3847_29405.FStar_TypeChecker_Env.admit);
+                           (uu___3847_29254.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3847_29405.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3847_29254.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3847_29405.FStar_TypeChecker_Env.phase1);
+                           (uu___3847_29254.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3847_29405.FStar_TypeChecker_Env.failhard);
+                           (uu___3847_29254.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3847_29405.FStar_TypeChecker_Env.nosynth);
+                           (uu___3847_29254.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3847_29405.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3847_29254.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3847_29405.FStar_TypeChecker_Env.tc_term);
+                           (uu___3847_29254.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3847_29405.FStar_TypeChecker_Env.type_of);
+                           (uu___3847_29254.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3847_29405.FStar_TypeChecker_Env.universe_of);
+                           (uu___3847_29254.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3847_29405.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3847_29254.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts = true;
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3847_29405.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3847_29254.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3847_29405.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3847_29254.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3847_29405.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3847_29254.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3847_29405.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3847_29254.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3847_29405.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3847_29254.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3847_29405.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3847_29254.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3847_29405.FStar_TypeChecker_Env.splice);
+                           (uu___3847_29254.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3847_29405.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3847_29254.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3847_29405.FStar_TypeChecker_Env.postprocess);
+                           (uu___3847_29254.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3847_29405.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3847_29254.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3847_29405.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3847_29254.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3847_29405.FStar_TypeChecker_Env.dsenv);
+                           (uu___3847_29254.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3847_29405.FStar_TypeChecker_Env.nbe);
+                           (uu___3847_29254.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3847_29405.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3847_29254.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3847_29405.FStar_TypeChecker_Env.erasable_types_tab)
+                           (uu___3847_29254.FStar_TypeChecker_Env.erasable_types_tab)
                        }  in
-                     ((let uu____29410 =
+                     ((let uu____29259 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env2)
                            (FStar_Options.Other "UniverseOf")
                           in
-                       if uu____29410
+                       if uu____29259
                        then
-                         let uu____29415 =
-                           let uu____29417 =
+                         let uu____29264 =
+                           let uu____29266 =
                              FStar_TypeChecker_Env.get_range env2  in
-                           FStar_Range.string_of_range uu____29417  in
-                         let uu____29418 =
+                           FStar_Range.string_of_range uu____29266  in
+                         let uu____29267 =
                            FStar_Syntax_Print.term_to_string hd2  in
                          FStar_Util.print2 "%s: About to type-check %s\n"
-                           uu____29415 uu____29418
+                           uu____29264 uu____29267
                        else ());
-                      (let uu____29423 = tc_term env2 hd2  in
-                       match uu____29423 with
-                       | (uu____29444,{
+                      (let uu____29272 = tc_term env2 hd2  in
+                       match uu____29272 with
+                       | (uu____29293,{
                                         FStar_TypeChecker_Common.eff_name =
-                                          uu____29445;
+                                          uu____29294;
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          uu____29447;
+                                          uu____29296;
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          uu____29448;_},g)
+                                          uu____29297;_},g)
                            ->
-                           ((let uu____29466 =
+                           ((let uu____29315 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env2 g
                                 in
-                             FStar_All.pipe_right uu____29466
-                               (fun uu____29467  -> ()));
+                             FStar_All.pipe_right uu____29315
+                               (fun uu____29316  -> ()));
                             (t, args1)))))
              in
-          let uu____29478 = type_of_head true hd args  in
-          (match uu____29478 with
+          let uu____29327 = type_of_head true hd args  in
+          (match uu____29327 with
            | (t,args1) ->
                let t1 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.UnfoldUntil
                       FStar_Syntax_Syntax.delta_constant] env t
                   in
-               let uu____29517 = FStar_Syntax_Util.arrow_formals_comp t1  in
-               (match uu____29517 with
+               let uu____29366 = FStar_Syntax_Util.arrow_formals_comp t1  in
+               (match uu____29366 with
                 | (bs,res) ->
                     let res1 = FStar_Syntax_Util.comp_result res  in
                     if (FStar_List.length bs) = (FStar_List.length args1)
@@ -11794,14 +11691,14 @@ let rec (universe_of_aux :
                          in
                       FStar_Syntax_Subst.subst subst res1
                     else
-                      (let uu____29545 =
+                      (let uu____29394 =
                          FStar_Syntax_Print.term_to_string res1  in
-                       level_of_type_fail env e uu____29545)))
-      | FStar_Syntax_Syntax.Tm_match (uu____29547,hd::uu____29549) ->
-          let uu____29614 = FStar_Syntax_Subst.open_branch hd  in
-          (match uu____29614 with
-           | (uu____29615,uu____29616,hd1) -> universe_of_aux env hd1)
-      | FStar_Syntax_Syntax.Tm_match (uu____29634,[]) ->
+                       level_of_type_fail env e uu____29394)))
+      | FStar_Syntax_Syntax.Tm_match (uu____29396,hd::uu____29398) ->
+          let uu____29463 = FStar_Syntax_Subst.open_branch hd  in
+          (match uu____29463 with
+           | (uu____29464,uu____29465,hd1) -> universe_of_aux env hd1)
+      | FStar_Syntax_Syntax.Tm_match (uu____29483,[]) ->
           level_of_type_fail env e "empty match cases"
   
 let (universe_of :
@@ -11810,8 +11707,8 @@ let (universe_of :
   =
   fun env  ->
     fun e  ->
-      let uu____29681 = universe_of_aux env e  in
-      level_of_type env e uu____29681
+      let uu____29530 = universe_of_aux env e  in
+      level_of_type env e uu____29530
   
 let (tc_tparams :
   FStar_TypeChecker_Env.env_t ->
@@ -11821,8 +11718,8 @@ let (tc_tparams :
   =
   fun env0  ->
     fun tps  ->
-      let uu____29705 = tc_binders env0 tps  in
-      match uu____29705 with
+      let uu____29554 = tc_binders env0 tps  in
+      match uu____29554 with
       | (tps1,env,g,us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env0 g; (tps1, env, us))
   
@@ -11835,234 +11732,230 @@ let rec (type_of_well_typed_term :
     fun t  ->
       let mk_tm_type u =
         FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
-          FStar_Pervasives_Native.None t.FStar_Syntax_Syntax.pos
+          t.FStar_Syntax_Syntax.pos
          in
       let t1 = FStar_Syntax_Subst.compress t  in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____29763 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_bvar uu____29781 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____29612 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_bvar uu____29630 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x ->
           FStar_Pervasives_Native.Some (x.FStar_Syntax_Syntax.sort)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____29787 = FStar_Syntax_Util.unfold_lazy i  in
-          type_of_well_typed_term env uu____29787
+          let uu____29636 = FStar_Syntax_Util.unfold_lazy i  in
+          type_of_well_typed_term env uu____29636
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____29789 =
+          let uu____29638 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env []
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____29789
-            (fun uu____29803  ->
-               match uu____29803 with
-               | (t2,uu____29811) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____29638
+            (fun uu____29652  ->
+               match uu____29652 with
+               | (t2,uu____29660) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____29813;
-             FStar_Syntax_Syntax.vars = uu____29814;_},us)
+             FStar_Syntax_Syntax.pos = uu____29662;
+             FStar_Syntax_Syntax.vars = uu____29663;_},us)
           ->
-          let uu____29820 =
+          let uu____29669 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          FStar_Util.bind_opt uu____29820
-            (fun uu____29834  ->
-               match uu____29834 with
-               | (t2,uu____29842) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____29669
+            (fun uu____29683  ->
+               match uu____29683 with
+               | (t2,uu____29691) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect
-          uu____29843) -> FStar_Pervasives_Native.None
+          uu____29692) -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant sc ->
-          let uu____29845 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
-          FStar_Pervasives_Native.Some uu____29845
+          let uu____29694 = tc_constant env t1.FStar_Syntax_Syntax.pos sc  in
+          FStar_Pervasives_Native.Some uu____29694
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____29847 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
-          FStar_Pervasives_Native.Some uu____29847
+          let uu____29696 = mk_tm_type (FStar_Syntax_Syntax.U_succ u)  in
+          FStar_Pervasives_Native.Some uu____29696
       | FStar_Syntax_Syntax.Tm_abs
           (bs,body,FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.residual_effect = eff;
              FStar_Syntax_Syntax.residual_typ = FStar_Pervasives_Native.Some
                tbody;
-             FStar_Syntax_Syntax.residual_flags = uu____29852;_})
+             FStar_Syntax_Syntax.residual_flags = uu____29701;_})
           ->
           let mk_comp =
-            let uu____29896 =
+            let uu____29745 =
               FStar_Ident.lid_equals eff FStar_Parser_Const.effect_Tot_lid
                in
-            if uu____29896
+            if uu____29745
             then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_Total'
             else
-              (let uu____29927 =
+              (let uu____29776 =
                  FStar_Ident.lid_equals eff
                    FStar_Parser_Const.effect_GTot_lid
                   in
-               if uu____29927
+               if uu____29776
                then
                  FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_GTotal'
                else FStar_Pervasives_Native.None)
              in
           FStar_Util.bind_opt mk_comp
             (fun f  ->
-               let uu____29997 = universe_of_well_typed_term env tbody  in
-               FStar_Util.bind_opt uu____29997
+               let uu____29846 = universe_of_well_typed_term env tbody  in
+               FStar_Util.bind_opt uu____29846
                  (fun u  ->
-                    let uu____30005 =
-                      let uu____30008 =
-                        let uu____30015 =
-                          let uu____30016 =
-                            let uu____30031 =
-                              f tbody (FStar_Pervasives_Native.Some u)  in
-                            (bs, uu____30031)  in
-                          FStar_Syntax_Syntax.Tm_arrow uu____30016  in
-                        FStar_Syntax_Syntax.mk uu____30015  in
-                      uu____30008 FStar_Pervasives_Native.None
+                    let uu____29854 =
+                      let uu____29857 =
+                        let uu____29858 =
+                          let uu____29873 =
+                            f tbody (FStar_Pervasives_Native.Some u)  in
+                          (bs, uu____29873)  in
+                        FStar_Syntax_Syntax.Tm_arrow uu____29858  in
+                      FStar_Syntax_Syntax.mk uu____29857
                         t1.FStar_Syntax_Syntax.pos
                        in
-                    FStar_Pervasives_Native.Some uu____30005))
+                    FStar_Pervasives_Native.Some uu____29854))
       | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-          let uu____30068 = FStar_Syntax_Subst.open_comp bs c  in
-          (match uu____30068 with
+          let uu____29910 = FStar_Syntax_Subst.open_comp bs c  in
+          (match uu____29910 with
            | (bs1,c1) ->
                let rec aux env1 us bs2 =
                  match bs2 with
                  | [] ->
-                     let uu____30127 =
+                     let uu____29969 =
                        universe_of_well_typed_term env1
                          (FStar_Syntax_Util.comp_result c1)
                         in
-                     FStar_Util.bind_opt uu____30127
+                     FStar_Util.bind_opt uu____29969
                        (fun uc  ->
-                          let uu____30135 =
+                          let uu____29977 =
                             mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us))
                              in
-                          FStar_Pervasives_Native.Some uu____30135)
+                          FStar_Pervasives_Native.Some uu____29977)
                  | (x,imp)::bs3 ->
-                     let uu____30161 =
+                     let uu____30003 =
                        universe_of_well_typed_term env1
                          x.FStar_Syntax_Syntax.sort
                         in
-                     FStar_Util.bind_opt uu____30161
+                     FStar_Util.bind_opt uu____30003
                        (fun u_x  ->
                           let env2 = FStar_TypeChecker_Env.push_bv env1 x  in
                           aux env2 (u_x :: us) bs3)
                   in
                aux env [] bs1)
-      | FStar_Syntax_Syntax.Tm_abs uu____30170 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____30012 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_refine (x,uu____30190) ->
-          let uu____30195 =
+      | FStar_Syntax_Syntax.Tm_refine (x,uu____30032) ->
+          let uu____30037 =
             universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort  in
-          FStar_Util.bind_opt uu____30195
+          FStar_Util.bind_opt uu____30037
             (fun u_x  ->
-               let uu____30203 = mk_tm_type u_x  in
-               FStar_Pervasives_Native.Some uu____30203)
+               let uu____30045 = mk_tm_type u_x  in
+               FStar_Pervasives_Native.Some uu____30045)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____30208;
-             FStar_Syntax_Syntax.vars = uu____30209;_},a::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____30050;
+             FStar_Syntax_Syntax.vars = uu____30051;_},a::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____30288 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____30288 with
-           | (unary_op,uu____30308) ->
+          let uu____30130 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____30130 with
+           | (unary_op,uu____30150) ->
                let head =
-                 let uu____30336 =
+                 let uu____30178 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a]))
-                   FStar_Pervasives_Native.None uu____30336
+                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____30178
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                   FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
+                   t1.FStar_Syntax_Syntax.pos
                   in
                type_of_well_typed_term env t2)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____30384;
-             FStar_Syntax_Syntax.vars = uu____30385;_},a1::a2::hd::rest)
+             FStar_Syntax_Syntax.pos = uu____30226;
+             FStar_Syntax_Syntax.vars = uu____30227;_},a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest  in
-          let uu____30481 = FStar_Syntax_Util.head_and_args t1  in
-          (match uu____30481 with
-           | (unary_op,uu____30501) ->
+          let uu____30323 = FStar_Syntax_Util.head_and_args t1  in
+          (match uu____30323 with
+           | (unary_op,uu____30343) ->
                let head =
-                 let uu____30529 =
+                 let uu____30371 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos
                     in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                   FStar_Pervasives_Native.None uu____30529
+                   uu____30371
                   in
                let t2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                   FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
+                   t1.FStar_Syntax_Syntax.pos
                   in
                type_of_well_typed_term env t2)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of );
-             FStar_Syntax_Syntax.pos = uu____30585;
-             FStar_Syntax_Syntax.vars = uu____30586;_},uu____30587::[])
+             FStar_Syntax_Syntax.pos = uu____30427;
+             FStar_Syntax_Syntax.vars = uu____30428;_},uu____30429::[])
           -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_range
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of );
-             FStar_Syntax_Syntax.pos = uu____30626;
-             FStar_Syntax_Syntax.vars = uu____30627;_},(t2,uu____30629)::uu____30630::[])
+             FStar_Syntax_Syntax.pos = uu____30468;
+             FStar_Syntax_Syntax.vars = uu____30469;_},(t2,uu____30471)::uu____30472::[])
           -> type_of_well_typed_term env t2
       | FStar_Syntax_Syntax.Tm_app (hd,args) ->
           let t_hd = type_of_well_typed_term env hd  in
           let rec aux t_hd1 =
-            let uu____30726 =
-              let uu____30727 =
+            let uu____30568 =
+              let uu____30569 =
                 FStar_TypeChecker_Normalize.unfold_whnf env t_hd1  in
-              uu____30727.FStar_Syntax_Syntax.n  in
-            match uu____30726 with
+              uu____30569.FStar_Syntax_Syntax.n  in
+            match uu____30568 with
             | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
                 let n_args = FStar_List.length args  in
                 let n_bs = FStar_List.length bs  in
                 let bs_t_opt =
                   if n_args < n_bs
                   then
-                    let uu____30800 = FStar_Util.first_N n_args bs  in
-                    match uu____30800 with
+                    let uu____30642 = FStar_Util.first_N n_args bs  in
+                    match uu____30642 with
                     | (bs1,rest) ->
                         let t2 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (rest, c))
-                            FStar_Pervasives_Native.None
                             t_hd1.FStar_Syntax_Syntax.pos
                            in
-                        let uu____30888 =
-                          let uu____30893 = FStar_Syntax_Syntax.mk_Total t2
+                        let uu____30730 =
+                          let uu____30735 = FStar_Syntax_Syntax.mk_Total t2
                              in
-                          FStar_Syntax_Subst.open_comp bs1 uu____30893  in
-                        (match uu____30888 with
+                          FStar_Syntax_Subst.open_comp bs1 uu____30735  in
+                        (match uu____30730 with
                          | (bs2,c1) ->
                              FStar_Pervasives_Native.Some
                                (bs2, (FStar_Syntax_Util.comp_result c1)))
                   else
                     if n_args = n_bs
                     then
-                      (let uu____30947 = FStar_Syntax_Subst.open_comp bs c
+                      (let uu____30789 = FStar_Syntax_Subst.open_comp bs c
                           in
-                       match uu____30947 with
+                       match uu____30789 with
                        | (bs1,c1) ->
-                           let uu____30968 =
+                           let uu____30810 =
                              FStar_Syntax_Util.is_tot_or_gtot_comp c1  in
-                           if uu____30968
+                           if uu____30810
                            then
                              FStar_Pervasives_Native.Some
                                (bs1, (FStar_Syntax_Util.comp_result c1))
@@ -12070,8 +11963,8 @@ let rec (type_of_well_typed_term :
                     else FStar_Pervasives_Native.None
                    in
                 FStar_Util.bind_opt bs_t_opt
-                  (fun uu____31050  ->
-                     match uu____31050 with
+                  (fun uu____30892  ->
+                     match uu____30892 with
                      | (bs1,t2) ->
                          let subst =
                            FStar_List.map2
@@ -12082,36 +11975,36 @@ let rec (type_of_well_typed_term :
                                       (FStar_Pervasives_Native.fst a))) bs1
                              args
                             in
-                         let uu____31126 = FStar_Syntax_Subst.subst subst t2
+                         let uu____30968 = FStar_Syntax_Subst.subst subst t2
                             in
-                         FStar_Pervasives_Native.Some uu____31126)
-            | FStar_Syntax_Syntax.Tm_refine (x,uu____31128) ->
+                         FStar_Pervasives_Native.Some uu____30968)
+            | FStar_Syntax_Syntax.Tm_refine (x,uu____30970) ->
                 aux x.FStar_Syntax_Syntax.sort
-            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____31134,uu____31135) ->
+            | FStar_Syntax_Syntax.Tm_ascribed (t2,uu____30976,uu____30977) ->
                 aux t2
-            | uu____31176 -> FStar_Pervasives_Native.None  in
+            | uu____31018 -> FStar_Pervasives_Native.None  in
           FStar_Util.bind_opt t_hd aux
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____31177,(FStar_Util.Inl t2,uu____31179),uu____31180) ->
+          (uu____31019,(FStar_Util.Inl t2,uu____31021),uu____31022) ->
           FStar_Pervasives_Native.Some t2
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____31227,(FStar_Util.Inr c,uu____31229),uu____31230) ->
+          (uu____31069,(FStar_Util.Inr c,uu____31071),uu____31072) ->
           FStar_Pervasives_Native.Some (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_uvar (u,s) ->
-          let uu____31295 =
+          let uu____31137 =
             FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
              in
-          FStar_Pervasives_Native.Some uu____31295
+          FStar_Pervasives_Native.Some uu____31137
       | FStar_Syntax_Syntax.Tm_quoted (tm,qi) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_term
-      | FStar_Syntax_Syntax.Tm_meta (t2,uu____31303) ->
+      | FStar_Syntax_Syntax.Tm_meta (t2,uu____31145) ->
           type_of_well_typed_term env t2
-      | FStar_Syntax_Syntax.Tm_match uu____31308 ->
+      | FStar_Syntax_Syntax.Tm_match uu____31150 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____31331 ->
+      | FStar_Syntax_Syntax.Tm_let uu____31173 ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_unknown  -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst uu____31345 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____31187 ->
           FStar_Pervasives_Native.None
 
 and (universe_of_well_typed_term :
@@ -12121,14 +12014,14 @@ and (universe_of_well_typed_term :
   =
   fun env  ->
     fun t  ->
-      let uu____31356 = type_of_well_typed_term env t  in
-      match uu____31356 with
+      let uu____31198 = type_of_well_typed_term env t  in
+      match uu____31198 with
       | FStar_Pervasives_Native.Some
           { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_type u;
-            FStar_Syntax_Syntax.pos = uu____31362;
-            FStar_Syntax_Syntax.vars = uu____31363;_}
+            FStar_Syntax_Syntax.pos = uu____31204;
+            FStar_Syntax_Syntax.vars = uu____31205;_}
           -> FStar_Pervasives_Native.Some u
-      | uu____31366 -> FStar_Pervasives_Native.None
+      | uu____31208 -> FStar_Pervasives_Native.None
 
 let (check_type_of_well_typed_term' :
   Prims.bool ->
@@ -12142,146 +12035,146 @@ let (check_type_of_well_typed_term' :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___4126_31394 = env1  in
+            let uu___4126_31236 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4126_31394.FStar_TypeChecker_Env.solver);
+                (uu___4126_31236.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4126_31394.FStar_TypeChecker_Env.range);
+                (uu___4126_31236.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4126_31394.FStar_TypeChecker_Env.curmodule);
+                (uu___4126_31236.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4126_31394.FStar_TypeChecker_Env.gamma);
+                (uu___4126_31236.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4126_31394.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4126_31236.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4126_31394.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4126_31236.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4126_31394.FStar_TypeChecker_Env.modules);
+                (uu___4126_31236.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4126_31394.FStar_TypeChecker_Env.expected_typ);
+                (uu___4126_31236.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4126_31394.FStar_TypeChecker_Env.sigtab);
+                (uu___4126_31236.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4126_31394.FStar_TypeChecker_Env.attrtab);
+                (uu___4126_31236.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4126_31394.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4126_31236.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4126_31394.FStar_TypeChecker_Env.effects);
+                (uu___4126_31236.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4126_31394.FStar_TypeChecker_Env.generalize);
+                (uu___4126_31236.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4126_31394.FStar_TypeChecker_Env.letrecs);
+                (uu___4126_31236.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4126_31394.FStar_TypeChecker_Env.top_level);
+                (uu___4126_31236.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4126_31394.FStar_TypeChecker_Env.check_uvars);
+                (uu___4126_31236.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4126_31394.FStar_TypeChecker_Env.use_eq);
+                (uu___4126_31236.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4126_31394.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4126_31236.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4126_31394.FStar_TypeChecker_Env.is_iface);
+                (uu___4126_31236.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4126_31394.FStar_TypeChecker_Env.admit);
+                (uu___4126_31236.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4126_31394.FStar_TypeChecker_Env.lax);
+                (uu___4126_31236.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4126_31394.FStar_TypeChecker_Env.lax_universes);
+                (uu___4126_31236.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4126_31394.FStar_TypeChecker_Env.phase1);
+                (uu___4126_31236.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4126_31394.FStar_TypeChecker_Env.failhard);
+                (uu___4126_31236.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4126_31394.FStar_TypeChecker_Env.nosynth);
+                (uu___4126_31236.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4126_31394.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4126_31236.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4126_31394.FStar_TypeChecker_Env.tc_term);
+                (uu___4126_31236.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4126_31394.FStar_TypeChecker_Env.type_of);
+                (uu___4126_31236.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4126_31394.FStar_TypeChecker_Env.universe_of);
+                (uu___4126_31236.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4126_31394.FStar_TypeChecker_Env.check_type_of);
+                (uu___4126_31236.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4126_31394.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4126_31236.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4126_31394.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4126_31236.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4126_31394.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4126_31236.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4126_31394.FStar_TypeChecker_Env.proof_ns);
+                (uu___4126_31236.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4126_31394.FStar_TypeChecker_Env.synth_hook);
+                (uu___4126_31236.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4126_31394.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4126_31236.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4126_31394.FStar_TypeChecker_Env.splice);
+                (uu___4126_31236.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4126_31394.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4126_31236.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4126_31394.FStar_TypeChecker_Env.postprocess);
+                (uu___4126_31236.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4126_31394.FStar_TypeChecker_Env.identifier_info);
+                (uu___4126_31236.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4126_31394.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4126_31236.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4126_31394.FStar_TypeChecker_Env.dsenv);
+                (uu___4126_31236.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4126_31394.FStar_TypeChecker_Env.nbe);
+                (uu___4126_31236.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4126_31394.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4126_31236.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4126_31394.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___4126_31236.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____31401 =
+          let slow_check uu____31243 =
             if must_total
             then
-              let uu____31403 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____31403 with | (uu____31410,uu____31411,g) -> g
+              let uu____31245 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____31245 with | (uu____31252,uu____31253,g) -> g
             else
-              (let uu____31415 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____31257 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____31415 with | (uu____31422,uu____31423,g) -> g)
+               match uu____31257 with | (uu____31264,uu____31265,g) -> g)
              in
-          let uu____31425 = type_of_well_typed_term env2 t  in
-          match uu____31425 with
+          let uu____31267 = type_of_well_typed_term env2 t  in
+          match uu____31267 with
           | FStar_Pervasives_Native.None  -> slow_check ()
           | FStar_Pervasives_Native.Some k' ->
-              ((let uu____31430 =
+              ((let uu____31272 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                     (FStar_Options.Other "FastImplicits")
                    in
-                if uu____31430
+                if uu____31272
                 then
-                  let uu____31435 =
+                  let uu____31277 =
                     FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos  in
-                  let uu____31437 = FStar_Syntax_Print.term_to_string t  in
-                  let uu____31439 = FStar_Syntax_Print.term_to_string k'  in
-                  let uu____31441 = FStar_Syntax_Print.term_to_string k  in
+                  let uu____31279 = FStar_Syntax_Print.term_to_string t  in
+                  let uu____31281 = FStar_Syntax_Print.term_to_string k'  in
+                  let uu____31283 = FStar_Syntax_Print.term_to_string k  in
                   FStar_Util.print4 "(%s) Fast check  %s : %s <:? %s\n"
-                    uu____31435 uu____31437 uu____31439 uu____31441
+                    uu____31277 uu____31279 uu____31281 uu____31283
                 else ());
                (let g = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k  in
-                (let uu____31450 =
+                (let uu____31292 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                      (FStar_Options.Other "FastImplicits")
                     in
-                 if uu____31450
+                 if uu____31292
                  then
-                   let uu____31455 =
+                   let uu____31297 =
                      FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos
                       in
-                   let uu____31457 = FStar_Syntax_Print.term_to_string t  in
-                   let uu____31459 = FStar_Syntax_Print.term_to_string k'  in
-                   let uu____31461 = FStar_Syntax_Print.term_to_string k  in
+                   let uu____31299 = FStar_Syntax_Print.term_to_string t  in
+                   let uu____31301 = FStar_Syntax_Print.term_to_string k'  in
+                   let uu____31303 = FStar_Syntax_Print.term_to_string k  in
                    FStar_Util.print5 "(%s) Fast check %s: %s : %s <: %s\n"
-                     uu____31455
+                     uu____31297
                      (if FStar_Option.isSome g
                       then "succeeded with guard"
-                      else "failed") uu____31457 uu____31459 uu____31461
+                      else "failed") uu____31299 uu____31301 uu____31303
                  else ());
                 (match g with
                  | FStar_Pervasives_Native.None  -> slow_check ()
@@ -12299,114 +12192,114 @@ let (check_type_of_well_typed_term :
         fun k  ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k  in
           let env2 =
-            let uu___4157_31498 = env1  in
+            let uu___4157_31340 = env1  in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4157_31498.FStar_TypeChecker_Env.solver);
+                (uu___4157_31340.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4157_31498.FStar_TypeChecker_Env.range);
+                (uu___4157_31340.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4157_31498.FStar_TypeChecker_Env.curmodule);
+                (uu___4157_31340.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4157_31498.FStar_TypeChecker_Env.gamma);
+                (uu___4157_31340.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4157_31498.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4157_31340.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4157_31498.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4157_31340.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4157_31498.FStar_TypeChecker_Env.modules);
+                (uu___4157_31340.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4157_31498.FStar_TypeChecker_Env.expected_typ);
+                (uu___4157_31340.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4157_31498.FStar_TypeChecker_Env.sigtab);
+                (uu___4157_31340.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4157_31498.FStar_TypeChecker_Env.attrtab);
+                (uu___4157_31340.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4157_31498.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4157_31340.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4157_31498.FStar_TypeChecker_Env.effects);
+                (uu___4157_31340.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4157_31498.FStar_TypeChecker_Env.generalize);
+                (uu___4157_31340.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4157_31498.FStar_TypeChecker_Env.letrecs);
+                (uu___4157_31340.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4157_31498.FStar_TypeChecker_Env.top_level);
+                (uu___4157_31340.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4157_31498.FStar_TypeChecker_Env.check_uvars);
+                (uu___4157_31340.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4157_31498.FStar_TypeChecker_Env.use_eq);
+                (uu___4157_31340.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4157_31498.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4157_31340.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4157_31498.FStar_TypeChecker_Env.is_iface);
+                (uu___4157_31340.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4157_31498.FStar_TypeChecker_Env.admit);
+                (uu___4157_31340.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4157_31498.FStar_TypeChecker_Env.lax);
+                (uu___4157_31340.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4157_31498.FStar_TypeChecker_Env.lax_universes);
+                (uu___4157_31340.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4157_31498.FStar_TypeChecker_Env.phase1);
+                (uu___4157_31340.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4157_31498.FStar_TypeChecker_Env.failhard);
+                (uu___4157_31340.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4157_31498.FStar_TypeChecker_Env.nosynth);
+                (uu___4157_31340.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4157_31498.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4157_31340.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4157_31498.FStar_TypeChecker_Env.tc_term);
+                (uu___4157_31340.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4157_31498.FStar_TypeChecker_Env.type_of);
+                (uu___4157_31340.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4157_31498.FStar_TypeChecker_Env.universe_of);
+                (uu___4157_31340.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4157_31498.FStar_TypeChecker_Env.check_type_of);
+                (uu___4157_31340.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4157_31498.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4157_31340.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4157_31498.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4157_31340.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4157_31498.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4157_31340.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4157_31498.FStar_TypeChecker_Env.proof_ns);
+                (uu___4157_31340.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4157_31498.FStar_TypeChecker_Env.synth_hook);
+                (uu___4157_31340.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4157_31498.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4157_31340.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4157_31498.FStar_TypeChecker_Env.splice);
+                (uu___4157_31340.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4157_31498.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4157_31340.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4157_31498.FStar_TypeChecker_Env.postprocess);
+                (uu___4157_31340.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4157_31498.FStar_TypeChecker_Env.identifier_info);
+                (uu___4157_31340.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4157_31498.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4157_31340.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4157_31498.FStar_TypeChecker_Env.dsenv);
+                (uu___4157_31340.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4157_31498.FStar_TypeChecker_Env.nbe);
+                (uu___4157_31340.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4157_31498.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4157_31340.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4157_31498.FStar_TypeChecker_Env.erasable_types_tab)
+                (uu___4157_31340.FStar_TypeChecker_Env.erasable_types_tab)
             }  in
-          let slow_check uu____31505 =
+          let slow_check uu____31347 =
             if must_total
             then
-              let uu____31507 = env2.FStar_TypeChecker_Env.type_of env2 t  in
-              match uu____31507 with | (uu____31514,uu____31515,g) -> g
+              let uu____31349 = env2.FStar_TypeChecker_Env.type_of env2 t  in
+              match uu____31349 with | (uu____31356,uu____31357,g) -> g
             else
-              (let uu____31519 = env2.FStar_TypeChecker_Env.tc_term env2 t
+              (let uu____31361 = env2.FStar_TypeChecker_Env.tc_term env2 t
                   in
-               match uu____31519 with | (uu____31526,uu____31527,g) -> g)
+               match uu____31361 with | (uu____31368,uu____31369,g) -> g)
              in
-          let uu____31529 =
-            let uu____31531 = FStar_Options.__temp_fast_implicits ()  in
-            FStar_All.pipe_left Prims.op_Negation uu____31531  in
-          if uu____31529
+          let uu____31371 =
+            let uu____31373 = FStar_Options.__temp_fast_implicits ()  in
+            FStar_All.pipe_left Prims.op_Negation uu____31373  in
+          if uu____31371
           then slow_check ()
           else check_type_of_well_typed_term' must_total env2 t k
   

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -181,7 +181,6 @@ let (extract_let_rec_annotation :
                           let t2 =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_arrow (bs, c))
-                              FStar_Pervasives_Native.None
                               c.FStar_Syntax_Syntax.pos
                              in
                           ((let uu____535 =
@@ -234,10 +233,7 @@ let rec (decorated_pattern_as_term :
     (FStar_Syntax_Syntax.bv Prims.list * FStar_Syntax_Syntax.term))
   =
   fun pat  ->
-    let mk f =
-      FStar_Syntax_Syntax.mk f FStar_Pervasives_Native.None
-        pat.FStar_Syntax_Syntax.p
-       in
+    let mk f = FStar_Syntax_Syntax.mk f pat.FStar_Syntax_Syntax.p  in
     let pat_as_arg uu____640 =
       match uu____640 with
       | (p,i) ->
@@ -396,19 +392,17 @@ let (mk_wp_return :
                   FStar_Syntax_Util.get_return_vc_combinator
                  in
               let wp =
-                let uu____1374 =
-                  let uu____1379 =
-                    FStar_TypeChecker_Env.inst_effect_fun_with [u_a] env ed
-                      ret_wp
-                     in
-                  let uu____1380 =
-                    let uu____1381 = FStar_Syntax_Syntax.as_arg a  in
-                    let uu____1390 =
-                      let uu____1401 = FStar_Syntax_Syntax.as_arg e  in
-                      [uu____1401]  in
-                    uu____1381 :: uu____1390  in
-                  FStar_Syntax_Syntax.mk_Tm_app uu____1379 uu____1380  in
-                uu____1374 FStar_Pervasives_Native.None r  in
+                let uu____1372 =
+                  FStar_TypeChecker_Env.inst_effect_fun_with [u_a] env ed
+                    ret_wp
+                   in
+                let uu____1373 =
+                  let uu____1374 = FStar_Syntax_Syntax.as_arg a  in
+                  let uu____1383 =
+                    let uu____1394 = FStar_Syntax_Syntax.as_arg e  in
+                    [uu____1394]  in
+                  uu____1374 :: uu____1383  in
+                FStar_Syntax_Syntax.mk_Tm_app uu____1372 uu____1373 r  in
               mk_comp ed u_a a wp [FStar_Syntax_Syntax.RETURN]
   
 let (mk_indexed_return :
@@ -426,138 +420,138 @@ let (mk_indexed_return :
         fun a  ->
           fun e  ->
             fun r  ->
-              (let uu____1474 =
+              (let uu____1467 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "LayeredEffects")
                   in
-               if uu____1474
+               if uu____1467
                then
-                 let uu____1479 =
+                 let uu____1472 =
                    FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname  in
-                 let uu____1481 = FStar_Syntax_Print.univ_to_string u_a  in
-                 let uu____1483 = FStar_Syntax_Print.term_to_string a  in
-                 let uu____1485 = FStar_Syntax_Print.term_to_string e  in
+                 let uu____1474 = FStar_Syntax_Print.univ_to_string u_a  in
+                 let uu____1476 = FStar_Syntax_Print.term_to_string a  in
+                 let uu____1478 = FStar_Syntax_Print.term_to_string e  in
                  FStar_Util.print4
                    "Computing %s.return for u_a:%s, a:%s, and e:%s{\n"
-                   uu____1479 uu____1481 uu____1483 uu____1485
+                   uu____1472 uu____1474 uu____1476 uu____1478
                else ());
-              (let uu____1490 =
-                 let uu____1495 =
+              (let uu____1483 =
+                 let uu____1488 =
                    FStar_All.pipe_right ed
                      FStar_Syntax_Util.get_return_vc_combinator
                     in
-                 FStar_TypeChecker_Env.inst_tscheme_with uu____1495 [u_a]  in
-               match uu____1490 with
-               | (uu____1500,return_t) ->
+                 FStar_TypeChecker_Env.inst_tscheme_with uu____1488 [u_a]  in
+               match uu____1483 with
+               | (uu____1493,return_t) ->
                    let return_t_shape_error s =
-                     let uu____1515 =
-                       let uu____1517 =
+                     let uu____1508 =
+                       let uu____1510 =
                          FStar_Ident.string_of_lid
                            ed.FStar_Syntax_Syntax.mname
                           in
-                       let uu____1519 =
+                       let uu____1512 =
                          FStar_Syntax_Print.term_to_string return_t  in
                        FStar_Util.format3
                          "%s.return %s does not have proper shape (reason:%s)"
-                         uu____1517 uu____1519 s
+                         uu____1510 uu____1512 s
                         in
-                     (FStar_Errors.Fatal_UnexpectedEffect, uu____1515)  in
-                   let uu____1523 =
-                     let uu____1552 =
-                       let uu____1553 = FStar_Syntax_Subst.compress return_t
+                     (FStar_Errors.Fatal_UnexpectedEffect, uu____1508)  in
+                   let uu____1516 =
+                     let uu____1545 =
+                       let uu____1546 = FStar_Syntax_Subst.compress return_t
                           in
-                       uu____1553.FStar_Syntax_Syntax.n  in
-                     match uu____1552 with
+                       uu____1546.FStar_Syntax_Syntax.n  in
+                     match uu____1545 with
                      | FStar_Syntax_Syntax.Tm_arrow (bs,c) when
                          (FStar_List.length bs) >= (Prims.of_int (2)) ->
-                         let uu____1613 = FStar_Syntax_Subst.open_comp bs c
+                         let uu____1606 = FStar_Syntax_Subst.open_comp bs c
                             in
-                         (match uu____1613 with
+                         (match uu____1606 with
                           | (a_b::x_b::bs1,c1) ->
-                              let uu____1682 =
+                              let uu____1675 =
                                 FStar_Syntax_Util.comp_to_comp_typ c1  in
-                              (a_b, x_b, bs1, uu____1682))
-                     | uu____1703 ->
-                         let uu____1704 =
+                              (a_b, x_b, bs1, uu____1675))
+                     | uu____1696 ->
+                         let uu____1697 =
                            return_t_shape_error
                              "Either not an arrow or not enough binders"
                             in
-                         FStar_Errors.raise_error uu____1704 r
+                         FStar_Errors.raise_error uu____1697 r
                       in
-                   (match uu____1523 with
+                   (match uu____1516 with
                     | (a_b,x_b,rest_bs,return_ct) ->
-                        let uu____1787 =
-                          let uu____1794 =
-                            let uu____1795 =
-                              let uu____1796 =
-                                let uu____1803 =
+                        let uu____1780 =
+                          let uu____1787 =
+                            let uu____1788 =
+                              let uu____1789 =
+                                let uu____1796 =
                                   FStar_All.pipe_right a_b
                                     FStar_Pervasives_Native.fst
                                    in
-                                (uu____1803, a)  in
-                              FStar_Syntax_Syntax.NT uu____1796  in
-                            let uu____1814 =
-                              let uu____1817 =
-                                let uu____1818 =
-                                  let uu____1825 =
+                                (uu____1796, a)  in
+                              FStar_Syntax_Syntax.NT uu____1789  in
+                            let uu____1807 =
+                              let uu____1810 =
+                                let uu____1811 =
+                                  let uu____1818 =
                                     FStar_All.pipe_right x_b
                                       FStar_Pervasives_Native.fst
                                      in
-                                  (uu____1825, e)  in
-                                FStar_Syntax_Syntax.NT uu____1818  in
-                              [uu____1817]  in
-                            uu____1795 :: uu____1814  in
+                                  (uu____1818, e)  in
+                                FStar_Syntax_Syntax.NT uu____1811  in
+                              [uu____1810]  in
+                            uu____1788 :: uu____1807  in
                           FStar_TypeChecker_Env.uvars_for_binders env rest_bs
-                            uu____1794
+                            uu____1787
                             (fun b  ->
-                               let uu____1841 =
+                               let uu____1834 =
                                  FStar_Syntax_Print.binder_to_string b  in
-                               let uu____1843 =
-                                 let uu____1845 =
+                               let uu____1836 =
+                                 let uu____1838 =
                                    FStar_Ident.string_of_lid
                                      ed.FStar_Syntax_Syntax.mname
                                     in
-                                 FStar_Util.format1 "%s.return" uu____1845
+                                 FStar_Util.format1 "%s.return" uu____1838
                                   in
-                               let uu____1848 = FStar_Range.string_of_range r
+                               let uu____1841 = FStar_Range.string_of_range r
                                   in
                                FStar_Util.format3
                                  "implicit var for binder %s of %s at %s"
-                                 uu____1841 uu____1843 uu____1848) r
+                                 uu____1834 uu____1836 uu____1841) r
                            in
-                        (match uu____1787 with
+                        (match uu____1780 with
                          | (rest_bs_uvars,g_uvars) ->
                              let subst =
                                FStar_List.map2
                                  (fun b  ->
                                     fun t  ->
-                                      let uu____1885 =
-                                        let uu____1892 =
+                                      let uu____1878 =
+                                        let uu____1885 =
                                           FStar_All.pipe_right b
                                             FStar_Pervasives_Native.fst
                                            in
-                                        (uu____1892, t)  in
-                                      FStar_Syntax_Syntax.NT uu____1885) (a_b
+                                        (uu____1885, t)  in
+                                      FStar_Syntax_Syntax.NT uu____1878) (a_b
                                  :: x_b :: rest_bs) (a :: e :: rest_bs_uvars)
                                 in
                              let is =
-                               let uu____1918 =
-                                 let uu____1921 =
+                               let uu____1911 =
+                                 let uu____1914 =
                                    FStar_Syntax_Subst.compress
                                      return_ct.FStar_Syntax_Syntax.result_typ
                                     in
-                                 let uu____1922 =
+                                 let uu____1915 =
                                    FStar_Syntax_Util.is_layered ed  in
-                                 effect_args_from_repr uu____1921 uu____1922
+                                 effect_args_from_repr uu____1914 uu____1915
                                    r
                                   in
-                               FStar_All.pipe_right uu____1918
+                               FStar_All.pipe_right uu____1911
                                  (FStar_List.map
                                     (FStar_Syntax_Subst.subst subst))
                                 in
                              let c =
-                               let uu____1929 =
-                                 let uu____1930 =
+                               let uu____1922 =
+                                 let uu____1923 =
                                    FStar_All.pipe_right is
                                      (FStar_List.map
                                         FStar_Syntax_Syntax.as_arg)
@@ -568,21 +562,21 @@ let (mk_indexed_return :
                                      (ed.FStar_Syntax_Syntax.mname);
                                    FStar_Syntax_Syntax.result_typ = a;
                                    FStar_Syntax_Syntax.effect_args =
-                                     uu____1930;
+                                     uu____1923;
                                    FStar_Syntax_Syntax.flags = []
                                  }  in
-                               FStar_Syntax_Syntax.mk_Comp uu____1929  in
-                             ((let uu____1954 =
+                               FStar_Syntax_Syntax.mk_Comp uu____1922  in
+                             ((let uu____1947 =
                                  FStar_All.pipe_left
                                    (FStar_TypeChecker_Env.debug env)
                                    (FStar_Options.Other "LayeredEffects")
                                   in
-                               if uu____1954
+                               if uu____1947
                                then
-                                 let uu____1959 =
+                                 let uu____1952 =
                                    FStar_Syntax_Print.comp_to_string c  in
                                  FStar_Util.print1 "} c after return %s\n"
-                                   uu____1959
+                                   uu____1952
                                else ());
                               (c, g_uvars)))))
   
@@ -601,13 +595,13 @@ let (mk_return :
         fun a  ->
           fun e  ->
             fun r  ->
-              let uu____2003 =
+              let uu____1996 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.is_layered  in
-              if uu____2003
+              if uu____1996
               then mk_indexed_return env ed u_a a e r
               else
-                (let uu____2013 = mk_wp_return env ed u_a a e r  in
-                 (uu____2013, FStar_TypeChecker_Env.trivial_guard))
+                (let uu____2006 = mk_wp_return env ed u_a a e r  in
+                 (uu____2006, FStar_TypeChecker_Env.trivial_guard))
   
 let (lift_comp :
   FStar_TypeChecker_Env.env ->
@@ -618,22 +612,22 @@ let (lift_comp :
   fun env  ->
     fun c  ->
       fun lift  ->
-        let uu____2038 =
+        let uu____2031 =
           FStar_All.pipe_right
-            (let uu___251_2040 = c  in
+            (let uu___251_2033 = c  in
              {
                FStar_Syntax_Syntax.comp_univs =
-                 (uu___251_2040.FStar_Syntax_Syntax.comp_univs);
+                 (uu___251_2033.FStar_Syntax_Syntax.comp_univs);
                FStar_Syntax_Syntax.effect_name =
-                 (uu___251_2040.FStar_Syntax_Syntax.effect_name);
+                 (uu___251_2033.FStar_Syntax_Syntax.effect_name);
                FStar_Syntax_Syntax.result_typ =
-                 (uu___251_2040.FStar_Syntax_Syntax.result_typ);
+                 (uu___251_2033.FStar_Syntax_Syntax.result_typ);
                FStar_Syntax_Syntax.effect_args =
-                 (uu___251_2040.FStar_Syntax_Syntax.effect_args);
+                 (uu___251_2033.FStar_Syntax_Syntax.effect_args);
                FStar_Syntax_Syntax.flags = []
              }) FStar_Syntax_Syntax.mk_Comp
            in
-        FStar_All.pipe_right uu____2038
+        FStar_All.pipe_right uu____2031
           (lift.FStar_TypeChecker_Env.mlift_wp env)
   
 let (join_effects :
@@ -643,36 +637,36 @@ let (join_effects :
   fun env  ->
     fun l1_in  ->
       fun l2_in  ->
-        let uu____2061 =
-          let uu____2066 = FStar_TypeChecker_Env.norm_eff_name env l1_in  in
-          let uu____2067 = FStar_TypeChecker_Env.norm_eff_name env l2_in  in
-          (uu____2066, uu____2067)  in
-        match uu____2061 with
+        let uu____2054 =
+          let uu____2059 = FStar_TypeChecker_Env.norm_eff_name env l1_in  in
+          let uu____2060 = FStar_TypeChecker_Env.norm_eff_name env l2_in  in
+          (uu____2059, uu____2060)  in
+        match uu____2054 with
         | (l1,l2) ->
-            let uu____2070 = FStar_TypeChecker_Env.join_opt env l1 l2  in
-            (match uu____2070 with
-             | FStar_Pervasives_Native.Some (m,uu____2080,uu____2081) -> m
+            let uu____2063 = FStar_TypeChecker_Env.join_opt env l1 l2  in
+            (match uu____2063 with
+             | FStar_Pervasives_Native.Some (m,uu____2073,uu____2074) -> m
              | FStar_Pervasives_Native.None  ->
-                 let uu____2094 =
+                 let uu____2087 =
                    FStar_TypeChecker_Env.exists_polymonadic_bind env l1 l2
                     in
-                 (match uu____2094 with
-                  | FStar_Pervasives_Native.Some (m,uu____2108) -> m
+                 (match uu____2087 with
+                  | FStar_Pervasives_Native.Some (m,uu____2101) -> m
                   | FStar_Pervasives_Native.None  ->
-                      let uu____2141 =
-                        let uu____2147 =
-                          let uu____2149 =
+                      let uu____2134 =
+                        let uu____2140 =
+                          let uu____2142 =
                             FStar_Syntax_Print.lid_to_string l1_in  in
-                          let uu____2151 =
+                          let uu____2144 =
                             FStar_Syntax_Print.lid_to_string l2_in  in
                           FStar_Util.format2
-                            "Effects %s and %s cannot be composed" uu____2149
-                            uu____2151
+                            "Effects %s and %s cannot be composed" uu____2142
+                            uu____2144
                            in
                         (FStar_Errors.Fatal_EffectsCannotBeComposed,
-                          uu____2147)
+                          uu____2140)
                          in
-                      FStar_Errors.raise_error uu____2141
+                      FStar_Errors.raise_error uu____2134
                         env.FStar_TypeChecker_Env.range))
   
 let (join_lcomp :
@@ -683,11 +677,11 @@ let (join_lcomp :
   fun env  ->
     fun c1  ->
       fun c2  ->
-        let uu____2171 =
+        let uu____2164 =
           (FStar_TypeChecker_Common.is_total_lcomp c1) &&
             (FStar_TypeChecker_Common.is_total_lcomp c2)
            in
-        if uu____2171
+        if uu____2164
         then FStar_Parser_Const.effect_Tot_lid
         else
           join_effects env c1.FStar_TypeChecker_Common.eff_name
@@ -710,17 +704,17 @@ let (lift_comps_sep_guards :
           fun for_bind  ->
             let c11 = FStar_TypeChecker_Env.unfold_effect_abbrev env c1  in
             let c21 = FStar_TypeChecker_Env.unfold_effect_abbrev env c2  in
-            let uu____2230 =
+            let uu____2223 =
               FStar_TypeChecker_Env.join_opt env
                 c11.FStar_Syntax_Syntax.effect_name
                 c21.FStar_Syntax_Syntax.effect_name
                in
-            match uu____2230 with
+            match uu____2223 with
             | FStar_Pervasives_Native.Some (m,lift1,lift2) ->
-                let uu____2258 = lift_comp env c11 lift1  in
-                (match uu____2258 with
+                let uu____2251 = lift_comp env c11 lift1  in
+                (match uu____2251 with
                  | (c12,g1) ->
-                     let uu____2275 =
+                     let uu____2268 =
                        if Prims.op_Negation for_bind
                        then lift_comp env c21 lift2
                        else
@@ -734,61 +728,61 @@ let (lift_comps_sep_guards :
                              in
                           let env_x =
                             FStar_TypeChecker_Env.push_binders env [x_a]  in
-                          let uu____2314 = lift_comp env_x c21 lift2  in
-                          match uu____2314 with
+                          let uu____2307 = lift_comp env_x c21 lift2  in
+                          match uu____2307 with
                           | (c22,g2) ->
-                              let uu____2325 =
+                              let uu____2318 =
                                 FStar_TypeChecker_Env.close_guard env 
                                   [x_a] g2
                                  in
-                              (c22, uu____2325))
+                              (c22, uu____2318))
                         in
-                     (match uu____2275 with
+                     (match uu____2268 with
                       | (c22,g2) -> (m, c12, c22, g1, g2)))
             | FStar_Pervasives_Native.None  ->
                 let rng = env.FStar_TypeChecker_Env.range  in
-                let err uu____2372 =
-                  let uu____2373 =
-                    let uu____2379 =
-                      let uu____2381 =
+                let err uu____2365 =
+                  let uu____2366 =
+                    let uu____2372 =
+                      let uu____2374 =
                         FStar_Syntax_Print.lid_to_string
                           c11.FStar_Syntax_Syntax.effect_name
                          in
-                      let uu____2383 =
+                      let uu____2376 =
                         FStar_Syntax_Print.lid_to_string
                           c21.FStar_Syntax_Syntax.effect_name
                          in
                       FStar_Util.format2
-                        "Effects %s and %s cannot be composed" uu____2381
-                        uu____2383
+                        "Effects %s and %s cannot be composed" uu____2374
+                        uu____2376
                        in
-                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____2379)
+                    (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____2372)
                      in
-                  FStar_Errors.raise_error uu____2373 rng  in
-                ((let uu____2398 =
+                  FStar_Errors.raise_error uu____2366 rng  in
+                ((let uu____2391 =
                     FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                       (FStar_Options.Other "LayeredEffects")
                      in
-                  if uu____2398
+                  if uu____2391
                   then
-                    let uu____2403 =
-                      let uu____2405 =
+                    let uu____2396 =
+                      let uu____2398 =
                         FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp
                          in
-                      FStar_All.pipe_right uu____2405
+                      FStar_All.pipe_right uu____2398
                         FStar_Syntax_Print.comp_to_string
                        in
-                    let uu____2407 =
-                      let uu____2409 =
+                    let uu____2400 =
+                      let uu____2402 =
                         FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp
                          in
-                      FStar_All.pipe_right uu____2409
+                      FStar_All.pipe_right uu____2402
                         FStar_Syntax_Print.comp_to_string
                        in
-                    let uu____2411 = FStar_Util.string_of_bool for_bind  in
+                    let uu____2404 = FStar_Util.string_of_bool for_bind  in
                     FStar_Util.print3
                       "Lifting comps %s and %s with for_bind %s{\n"
-                      uu____2403 uu____2407 uu____2411
+                      uu____2396 uu____2400 uu____2404
                   else ());
                  if for_bind
                  then err ()
@@ -799,34 +793,34 @@ let (lift_comps_sep_guards :
                           FStar_Pervasives_Native.None
                           ct.FStar_Syntax_Syntax.result_typ
                          in
-                      let uu____2467 =
-                        let uu____2472 =
+                      let uu____2460 =
+                        let uu____2465 =
                           FStar_TypeChecker_Env.push_bv env x_bv  in
-                        let uu____2473 =
+                        let uu____2466 =
                           FStar_TypeChecker_Env.get_effect_decl env ret_eff
                            in
-                        let uu____2474 =
+                        let uu____2467 =
                           FStar_List.hd ct.FStar_Syntax_Syntax.comp_univs  in
-                        let uu____2475 = FStar_Syntax_Syntax.bv_to_name x_bv
+                        let uu____2468 = FStar_Syntax_Syntax.bv_to_name x_bv
                            in
-                        mk_return uu____2472 uu____2473 uu____2474
-                          ct.FStar_Syntax_Syntax.result_typ uu____2475 rng
+                        mk_return uu____2465 uu____2466 uu____2467
+                          ct.FStar_Syntax_Syntax.result_typ uu____2468 rng
                          in
-                      match uu____2467 with
+                      match uu____2460 with
                       | (c_ret,g_ret) ->
-                          let uu____2482 =
-                            let uu____2487 =
+                          let uu____2475 =
+                            let uu____2480 =
                               FStar_Syntax_Util.comp_to_comp_typ c_ret  in
                             f_bind env ct (FStar_Pervasives_Native.Some x_bv)
-                              uu____2487 [] rng
+                              uu____2480 [] rng
                              in
-                          (match uu____2482 with
+                          (match uu____2475 with
                            | (c,g_bind) ->
-                               let uu____2494 =
+                               let uu____2487 =
                                  FStar_TypeChecker_Env.conj_guard g_ret
                                    g_bind
                                   in
-                               (c, uu____2494))
+                               (c, uu____2487))
                        in
                     let try_lift c12 c22 =
                       let p_bind_opt =
@@ -834,65 +828,65 @@ let (lift_comps_sep_guards :
                           c12.FStar_Syntax_Syntax.effect_name
                           c22.FStar_Syntax_Syntax.effect_name
                          in
-                      let uu____2539 =
+                      let uu____2532 =
                         FStar_All.pipe_right p_bind_opt FStar_Util.is_some
                          in
-                      if uu____2539
+                      if uu____2532
                       then
-                        let uu____2575 =
+                        let uu____2568 =
                           FStar_All.pipe_right p_bind_opt FStar_Util.must  in
-                        match uu____2575 with
+                        match uu____2568 with
                         | (p,f_bind) ->
-                            let uu____2642 =
+                            let uu____2635 =
                               FStar_Ident.lid_equals p
                                 c22.FStar_Syntax_Syntax.effect_name
                                in
-                            (if uu____2642
+                            (if uu____2635
                              then
-                               let uu____2655 = bind_with_return c12 p f_bind
+                               let uu____2648 = bind_with_return c12 p f_bind
                                   in
-                               match uu____2655 with
+                               match uu____2648 with
                                | (c13,g) ->
-                                   let uu____2672 =
-                                     let uu____2681 =
+                                   let uu____2665 =
+                                     let uu____2674 =
                                        FStar_Syntax_Syntax.mk_Comp c22  in
                                      ((c22.FStar_Syntax_Syntax.effect_name),
-                                       c13, uu____2681, g)
+                                       c13, uu____2674, g)
                                       in
-                                   FStar_Pervasives_Native.Some uu____2672
+                                   FStar_Pervasives_Native.Some uu____2665
                              else FStar_Pervasives_Native.None)
                       else FStar_Pervasives_Native.None  in
-                    let uu____2710 =
-                      let uu____2721 = try_lift c11 c21  in
-                      match uu____2721 with
+                    let uu____2703 =
+                      let uu____2714 = try_lift c11 c21  in
+                      match uu____2714 with
                       | FStar_Pervasives_Native.Some (p,c12,c22,g) ->
                           (p, c12, c22, g,
                             FStar_TypeChecker_Env.trivial_guard)
                       | FStar_Pervasives_Native.None  ->
-                          let uu____2762 = try_lift c21 c11  in
-                          (match uu____2762 with
+                          let uu____2755 = try_lift c21 c11  in
+                          (match uu____2755 with
                            | FStar_Pervasives_Native.Some (p,c22,c12,g) ->
                                (p, c12, c22,
                                  FStar_TypeChecker_Env.trivial_guard, g)
                            | FStar_Pervasives_Native.None  -> err ())
                        in
-                    match uu____2710 with
+                    match uu____2703 with
                     | (p,c12,c22,g1,g2) ->
-                        ((let uu____2819 =
+                        ((let uu____2812 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "LayeredEffects")
                              in
-                          if uu____2819
+                          if uu____2812
                           then
-                            let uu____2824 = FStar_Ident.string_of_lid p  in
-                            let uu____2826 =
+                            let uu____2817 = FStar_Ident.string_of_lid p  in
+                            let uu____2819 =
                               FStar_Syntax_Print.comp_to_string c12  in
-                            let uu____2828 =
+                            let uu____2821 =
                               FStar_Syntax_Print.comp_to_string c22  in
                             FStar_Util.print3
                               "} Returning p %s, c1 %s, and c2 %s\n"
-                              uu____2824 uu____2826 uu____2828
+                              uu____2817 uu____2819 uu____2821
                           else ());
                          (p, c12, c22, g1, g2))))
   
@@ -910,11 +904,11 @@ let (lift_comps :
       fun c2  ->
         fun b  ->
           fun for_bind  ->
-            let uu____2881 = lift_comps_sep_guards env c1 c2 b for_bind  in
-            match uu____2881 with
+            let uu____2874 = lift_comps_sep_guards env c1 c2 b for_bind  in
+            match uu____2874 with
             | (l,c11,c21,g1,g2) ->
-                let uu____2905 = FStar_TypeChecker_Env.conj_guard g1 g2  in
-                (l, c11, c21, uu____2905)
+                let uu____2898 = FStar_TypeChecker_Env.conj_guard g1 g2  in
+                (l, c11, c21, uu____2898)
   
 let (is_pure_effect :
   FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool) =
@@ -941,10 +935,10 @@ let (lax_mk_tot_or_comp_l :
     fun u_result  ->
       fun result  ->
         fun flags  ->
-          let uu____2961 =
+          let uu____2954 =
             FStar_Ident.lid_equals mname FStar_Parser_Const.effect_Tot_lid
              in
-          if uu____2961
+          if uu____2954
           then
             FStar_Syntax_Syntax.mk_Total' result
               (FStar_Pervasives_Native.Some u_result)
@@ -952,12 +946,12 @@ let (lax_mk_tot_or_comp_l :
   
 let (is_function : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t  ->
-    let uu____2973 =
-      let uu____2974 = FStar_Syntax_Subst.compress t  in
-      uu____2974.FStar_Syntax_Syntax.n  in
-    match uu____2973 with
-    | FStar_Syntax_Syntax.Tm_arrow uu____2978 -> true
-    | uu____2994 -> false
+    let uu____2966 =
+      let uu____2967 = FStar_Syntax_Subst.compress t  in
+      uu____2967.FStar_Syntax_Syntax.n  in
+    match uu____2966 with
+    | FStar_Syntax_Syntax.Tm_arrow uu____2971 -> true
+    | uu____2987 -> false
   
 let (label :
   Prims.string ->
@@ -969,7 +963,7 @@ let (label :
         FStar_Syntax_Syntax.mk
           (FStar_Syntax_Syntax.Tm_meta
              (f, (FStar_Syntax_Syntax.Meta_labeled (reason, r, false))))
-          FStar_Pervasives_Native.None f.FStar_Syntax_Syntax.pos
+          f.FStar_Syntax_Syntax.pos
   
 let (label_opt :
   FStar_TypeChecker_Env.env ->
@@ -983,12 +977,12 @@ let (label_opt :
           match reason with
           | FStar_Pervasives_Native.None  -> f
           | FStar_Pervasives_Native.Some reason1 ->
-              let uu____3064 =
-                let uu____3066 = FStar_TypeChecker_Env.should_verify env  in
-                FStar_All.pipe_left Prims.op_Negation uu____3066  in
-              if uu____3064
+              let uu____3057 =
+                let uu____3059 = FStar_TypeChecker_Env.should_verify env  in
+                FStar_All.pipe_left Prims.op_Negation uu____3059  in
+              if uu____3057
               then f
-              else (let uu____3073 = reason1 ()  in label uu____3073 r f)
+              else (let uu____3066 = reason1 ()  in label uu____3066 r f)
   
 let (label_guard :
   FStar_Range.range ->
@@ -1001,18 +995,18 @@ let (label_guard :
         match g.FStar_TypeChecker_Common.guard_f with
         | FStar_TypeChecker_Common.Trivial  -> g
         | FStar_TypeChecker_Common.NonTrivial f ->
-            let uu___396_3094 = g  in
-            let uu____3095 =
-              let uu____3096 = label reason r f  in
-              FStar_TypeChecker_Common.NonTrivial uu____3096  in
+            let uu___396_3087 = g  in
+            let uu____3088 =
+              let uu____3089 = label reason r f  in
+              FStar_TypeChecker_Common.NonTrivial uu____3089  in
             {
-              FStar_TypeChecker_Common.guard_f = uu____3095;
+              FStar_TypeChecker_Common.guard_f = uu____3088;
               FStar_TypeChecker_Common.deferred =
-                (uu___396_3094.FStar_TypeChecker_Common.deferred);
+                (uu___396_3087.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___396_3094.FStar_TypeChecker_Common.univ_ineqs);
+                (uu___396_3087.FStar_TypeChecker_Common.univ_ineqs);
               FStar_TypeChecker_Common.implicits =
-                (uu___396_3094.FStar_TypeChecker_Common.implicits)
+                (uu___396_3087.FStar_TypeChecker_Common.implicits)
             }
   
 let (close_wp_comp :
@@ -1023,36 +1017,36 @@ let (close_wp_comp :
   fun env  ->
     fun bvs  ->
       fun c  ->
-        let uu____3117 = FStar_Syntax_Util.is_ml_comp c  in
-        if uu____3117
+        let uu____3110 = FStar_Syntax_Util.is_ml_comp c  in
+        if uu____3110
         then c
         else
-          (let uu____3122 =
+          (let uu____3115 =
              env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ())  in
-           if uu____3122
+           if uu____3115
            then c
            else
              (let close_wp u_res md res_t bvs1 wp0 =
                 let close =
-                  let uu____3164 =
+                  let uu____3157 =
                     FStar_All.pipe_right md
                       FStar_Syntax_Util.get_wp_close_combinator
                      in
-                  FStar_All.pipe_right uu____3164 FStar_Util.must  in
+                  FStar_All.pipe_right uu____3157 FStar_Util.must  in
                 FStar_List.fold_right
                   (fun x  ->
                      fun wp  ->
                        let bs =
-                         let uu____3192 = FStar_Syntax_Syntax.mk_binder x  in
-                         [uu____3192]  in
+                         let uu____3186 = FStar_Syntax_Syntax.mk_binder x  in
+                         [uu____3186]  in
                        let us =
-                         let uu____3214 =
-                           let uu____3217 =
+                         let uu____3208 =
+                           let uu____3211 =
                              env.FStar_TypeChecker_Env.universe_of env
                                x.FStar_Syntax_Syntax.sort
                               in
-                           [uu____3217]  in
-                         u_res :: uu____3214  in
+                           [uu____3211]  in
+                         u_res :: uu____3208  in
                        let wp1 =
                          FStar_Syntax_Util.abs bs wp
                            (FStar_Pervasives_Native.Some
@@ -1061,33 +1055,30 @@ let (close_wp_comp :
                                  FStar_Pervasives_Native.None
                                  [FStar_Syntax_Syntax.TOTAL]))
                           in
-                       let uu____3223 =
-                         let uu____3228 =
-                           FStar_TypeChecker_Env.inst_effect_fun_with us env
-                             md close
-                            in
-                         let uu____3229 =
-                           let uu____3230 = FStar_Syntax_Syntax.as_arg res_t
-                              in
-                           let uu____3239 =
-                             let uu____3250 =
-                               FStar_Syntax_Syntax.as_arg
-                                 x.FStar_Syntax_Syntax.sort
-                                in
-                             let uu____3259 =
-                               let uu____3270 =
-                                 FStar_Syntax_Syntax.as_arg wp1  in
-                               [uu____3270]  in
-                             uu____3250 :: uu____3259  in
-                           uu____3230 :: uu____3239  in
-                         FStar_Syntax_Syntax.mk_Tm_app uu____3228 uu____3229
+                       let uu____3217 =
+                         FStar_TypeChecker_Env.inst_effect_fun_with us env md
+                           close
                           in
-                       uu____3223 FStar_Pervasives_Native.None
+                       let uu____3218 =
+                         let uu____3219 = FStar_Syntax_Syntax.as_arg res_t
+                            in
+                         let uu____3228 =
+                           let uu____3239 =
+                             FStar_Syntax_Syntax.as_arg
+                               x.FStar_Syntax_Syntax.sort
+                              in
+                           let uu____3248 =
+                             let uu____3259 = FStar_Syntax_Syntax.as_arg wp1
+                                in
+                             [uu____3259]  in
+                           uu____3239 :: uu____3248  in
+                         uu____3219 :: uu____3228  in
+                       FStar_Syntax_Syntax.mk_Tm_app uu____3217 uu____3218
                          wp0.FStar_Syntax_Syntax.pos) bvs1 wp0
                  in
               let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
-              let uu____3312 = destruct_wp_comp c1  in
-              match uu____3312 with
+              let uu____3301 = destruct_wp_comp c1  in
+              match uu____3301 with
               | (u_res_t,res_t,wp) ->
                   let md =
                     FStar_TypeChecker_Env.get_effect_decl env
@@ -1112,11 +1103,11 @@ let (close_wp_lcomp :
         FStar_All.pipe_right lc
           (FStar_TypeChecker_Common.apply_lcomp (close_wp_comp env bvs)
              (fun g  ->
-                let uu____3352 =
+                let uu____3341 =
                   FStar_All.pipe_right g
                     (FStar_TypeChecker_Env.close_guard env bs)
                    in
-                FStar_All.pipe_right uu____3352
+                FStar_All.pipe_right uu____3341
                   (close_guard_implicits env false bs)))
   
 let (close_layered_lcomp :
@@ -1141,21 +1132,21 @@ let (close_layered_lcomp :
             (FStar_TypeChecker_Common.apply_lcomp
                (FStar_Syntax_Subst.subst_comp substs)
                (fun g  ->
-                  let uu____3402 =
+                  let uu____3391 =
                     FStar_All.pipe_right g
                       (FStar_TypeChecker_Env.close_guard env bs)
                      in
-                  FStar_All.pipe_right uu____3402
+                  FStar_All.pipe_right uu____3391
                     (close_guard_implicits env false bs)))
   
 let (should_not_inline_lc : FStar_TypeChecker_Common.lcomp -> Prims.bool) =
   fun lc  ->
     FStar_All.pipe_right lc.FStar_TypeChecker_Common.cflags
       (FStar_Util.for_some
-         (fun uu___0_3415  ->
-            match uu___0_3415 with
+         (fun uu___0_3404  ->
+            match uu___0_3404 with
             | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  -> true
-            | uu____3418 -> false))
+            | uu____3407 -> false))
   
 let (should_return :
   FStar_TypeChecker_Env.env ->
@@ -1166,23 +1157,23 @@ let (should_return :
     fun eopt  ->
       fun lc  ->
         let lc_is_unit_or_effectful =
-          let uu____3443 =
-            let uu____3446 =
+          let uu____3432 =
+            let uu____3435 =
               FStar_All.pipe_right lc.FStar_TypeChecker_Common.res_typ
                 FStar_Syntax_Util.arrow_formals_comp
                in
-            FStar_All.pipe_right uu____3446 FStar_Pervasives_Native.snd  in
-          FStar_All.pipe_right uu____3443
+            FStar_All.pipe_right uu____3435 FStar_Pervasives_Native.snd  in
+          FStar_All.pipe_right uu____3432
             (fun c  ->
-               (let uu____3470 =
+               (let uu____3459 =
                   FStar_TypeChecker_Env.is_reifiable_comp env c  in
-                Prims.op_Negation uu____3470) &&
+                Prims.op_Negation uu____3459) &&
                  ((FStar_All.pipe_right (FStar_Syntax_Util.comp_result c)
                      FStar_Syntax_Util.is_unit)
                     ||
-                    (let uu____3474 =
+                    (let uu____3463 =
                        FStar_Syntax_Util.is_pure_or_ghost_comp c  in
-                     Prims.op_Negation uu____3474)))
+                     Prims.op_Negation uu____3463)))
            in
         match eopt with
         | FStar_Pervasives_Native.None  -> false
@@ -1190,25 +1181,25 @@ let (should_return :
             (((FStar_TypeChecker_Common.is_pure_or_ghost_lcomp lc) &&
                 (Prims.op_Negation lc_is_unit_or_effectful))
                &&
-               (let uu____3485 = FStar_Syntax_Util.head_and_args' e  in
-                match uu____3485 with
-                | (head,uu____3502) ->
-                    let uu____3523 =
-                      let uu____3524 = FStar_Syntax_Util.un_uinst head  in
-                      uu____3524.FStar_Syntax_Syntax.n  in
-                    (match uu____3523 with
+               (let uu____3474 = FStar_Syntax_Util.head_and_args' e  in
+                match uu____3474 with
+                | (head,uu____3491) ->
+                    let uu____3512 =
+                      let uu____3513 = FStar_Syntax_Util.un_uinst head  in
+                      uu____3513.FStar_Syntax_Syntax.n  in
+                    (match uu____3512 with
                      | FStar_Syntax_Syntax.Tm_fvar fv ->
-                         let uu____3529 =
-                           let uu____3531 = FStar_Syntax_Syntax.lid_of_fv fv
+                         let uu____3518 =
+                           let uu____3520 = FStar_Syntax_Syntax.lid_of_fv fv
                               in
                            FStar_TypeChecker_Env.is_irreducible env
-                             uu____3531
+                             uu____3520
                             in
-                         Prims.op_Negation uu____3529
-                     | uu____3532 -> true)))
+                         Prims.op_Negation uu____3518
+                     | uu____3521 -> true)))
               &&
-              (let uu____3535 = should_not_inline_lc lc  in
-               Prims.op_Negation uu____3535)
+              (let uu____3524 = should_not_inline_lc lc  in
+               Prims.op_Negation uu____3524)
   
 let (return_value :
   FStar_TypeChecker_Env.env ->
@@ -1221,17 +1212,17 @@ let (return_value :
       fun t  ->
         fun v  ->
           let c =
-            let uu____3563 =
-              let uu____3565 =
+            let uu____3552 =
+              let uu____3554 =
                 FStar_TypeChecker_Env.lid_exists env
                   FStar_Parser_Const.effect_GTot_lid
                  in
-              FStar_All.pipe_left Prims.op_Negation uu____3565  in
-            if uu____3563
+              FStar_All.pipe_left Prims.op_Negation uu____3554  in
+            if uu____3552
             then FStar_Syntax_Syntax.mk_Total t
             else
-              (let uu____3572 = FStar_Syntax_Util.is_unit t  in
-               if uu____3572
+              (let uu____3561 = FStar_Syntax_Util.is_unit t  in
+               if uu____3561
                then
                  FStar_Syntax_Syntax.mk_Total' t
                    (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.U_zero)
@@ -1246,56 +1237,51 @@ let (return_value :
                         env.FStar_TypeChecker_Env.universe_of env t
                     | FStar_Pervasives_Native.Some u_t -> u_t  in
                   let wp =
-                    let uu____3581 =
+                    let uu____3570 =
                       env.FStar_TypeChecker_Env.lax &&
                         (FStar_Options.ml_ish ())
                        in
-                    if uu____3581
+                    if uu____3570
                     then FStar_Syntax_Syntax.tun
                     else
                       (let ret_wp =
                          FStar_All.pipe_right m
                            FStar_Syntax_Util.get_return_vc_combinator
                           in
-                       let uu____3587 =
-                         let uu____3588 =
-                           let uu____3593 =
-                             FStar_TypeChecker_Env.inst_effect_fun_with 
-                               [u_t] env m ret_wp
-                              in
-                           let uu____3594 =
-                             let uu____3595 = FStar_Syntax_Syntax.as_arg t
-                                in
-                             let uu____3604 =
-                               let uu____3615 = FStar_Syntax_Syntax.as_arg v
-                                  in
-                               [uu____3615]  in
-                             uu____3595 :: uu____3604  in
-                           FStar_Syntax_Syntax.mk_Tm_app uu____3593
-                             uu____3594
+                       let uu____3576 =
+                         let uu____3577 =
+                           FStar_TypeChecker_Env.inst_effect_fun_with 
+                             [u_t] env m ret_wp
                             in
-                         uu____3588 FStar_Pervasives_Native.None
+                         let uu____3578 =
+                           let uu____3579 = FStar_Syntax_Syntax.as_arg t  in
+                           let uu____3588 =
+                             let uu____3599 = FStar_Syntax_Syntax.as_arg v
+                                in
+                             [uu____3599]  in
+                           uu____3579 :: uu____3588  in
+                         FStar_Syntax_Syntax.mk_Tm_app uu____3577 uu____3578
                            v.FStar_Syntax_Syntax.pos
                           in
                        FStar_TypeChecker_Normalize.normalize
                          [FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.NoFullNorm] env uu____3587)
+                         FStar_TypeChecker_Env.NoFullNorm] env uu____3576)
                      in
                   mk_comp m u_t t wp [FStar_Syntax_Syntax.RETURN]))
              in
-          (let uu____3649 =
+          (let uu____3633 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Return")
               in
-           if uu____3649
+           if uu____3633
            then
-             let uu____3654 =
+             let uu____3638 =
                FStar_Range.string_of_range v.FStar_Syntax_Syntax.pos  in
-             let uu____3656 = FStar_Syntax_Print.term_to_string v  in
-             let uu____3658 =
+             let uu____3640 = FStar_Syntax_Print.term_to_string v  in
+             let uu____3642 =
                FStar_TypeChecker_Normalize.comp_to_string env c  in
              FStar_Util.print3 "(%s) returning %s at comp type %s\n"
-               uu____3654 uu____3656 uu____3658
+               uu____3638 uu____3640 uu____3642
            else ());
           c
   
@@ -1323,106 +1309,106 @@ let (mk_indexed_bind :
                 fun ct2  ->
                   fun flags  ->
                     fun r1  ->
-                      (let uu____3731 =
+                      (let uu____3715 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env)
                            (FStar_Options.Other "LayeredEffects")
                           in
-                       if uu____3731
+                       if uu____3715
                        then
-                         let uu____3736 =
-                           let uu____3738 = FStar_Syntax_Syntax.mk_Comp ct1
+                         let uu____3720 =
+                           let uu____3722 = FStar_Syntax_Syntax.mk_Comp ct1
                               in
-                           FStar_Syntax_Print.comp_to_string uu____3738  in
-                         let uu____3739 =
-                           let uu____3741 = FStar_Syntax_Syntax.mk_Comp ct2
+                           FStar_Syntax_Print.comp_to_string uu____3722  in
+                         let uu____3723 =
+                           let uu____3725 = FStar_Syntax_Syntax.mk_Comp ct2
                               in
-                           FStar_Syntax_Print.comp_to_string uu____3741  in
+                           FStar_Syntax_Print.comp_to_string uu____3725  in
                          FStar_Util.print2 "Binding c1:%s and c2:%s {\n"
-                           uu____3736 uu____3739
+                           uu____3720 uu____3723
                        else ());
-                      (let uu____3745 =
-                         let uu____3752 =
+                      (let uu____3729 =
+                         let uu____3736 =
                            FStar_TypeChecker_Env.get_effect_decl env m  in
-                         let uu____3753 =
+                         let uu____3737 =
                            FStar_TypeChecker_Env.get_effect_decl env n  in
-                         let uu____3754 =
+                         let uu____3738 =
                            FStar_TypeChecker_Env.get_effect_decl env p  in
-                         (uu____3752, uu____3753, uu____3754)  in
-                       match uu____3745 with
+                         (uu____3736, uu____3737, uu____3738)  in
+                       match uu____3729 with
                        | (m_ed,n_ed,p_ed) ->
-                           let uu____3762 =
-                             let uu____3773 =
+                           let uu____3746 =
+                             let uu____3757 =
                                FStar_List.hd
                                  ct1.FStar_Syntax_Syntax.comp_univs
                                 in
-                             let uu____3774 =
+                             let uu____3758 =
                                FStar_List.map FStar_Pervasives_Native.fst
                                  ct1.FStar_Syntax_Syntax.effect_args
                                 in
-                             (uu____3773,
+                             (uu____3757,
                                (ct1.FStar_Syntax_Syntax.result_typ),
-                               uu____3774)
+                               uu____3758)
                               in
-                           (match uu____3762 with
+                           (match uu____3746 with
                             | (u1,t1,is1) ->
-                                let uu____3808 =
-                                  let uu____3819 =
+                                let uu____3792 =
+                                  let uu____3803 =
                                     FStar_List.hd
                                       ct2.FStar_Syntax_Syntax.comp_univs
                                      in
-                                  let uu____3820 =
+                                  let uu____3804 =
                                     FStar_List.map
                                       FStar_Pervasives_Native.fst
                                       ct2.FStar_Syntax_Syntax.effect_args
                                      in
-                                  (uu____3819,
+                                  (uu____3803,
                                     (ct2.FStar_Syntax_Syntax.result_typ),
-                                    uu____3820)
+                                    uu____3804)
                                    in
-                                (match uu____3808 with
+                                (match uu____3792 with
                                  | (u2,t2,is2) ->
-                                     let uu____3854 =
+                                     let uu____3838 =
                                        FStar_TypeChecker_Env.inst_tscheme_with
                                          bind_t [u1; u2]
                                         in
-                                     (match uu____3854 with
-                                      | (uu____3863,bind_t1) ->
+                                     (match uu____3838 with
+                                      | (uu____3847,bind_t1) ->
                                           let bind_t_shape_error s =
-                                            let uu____3878 =
-                                              let uu____3880 =
+                                            let uu____3862 =
+                                              let uu____3864 =
                                                 FStar_Syntax_Print.term_to_string
                                                   bind_t1
                                                  in
                                               FStar_Util.format2
                                                 "bind %s does not have proper shape (reason:%s)"
-                                                uu____3880 s
+                                                uu____3864 s
                                                in
                                             (FStar_Errors.Fatal_UnexpectedEffect,
-                                              uu____3878)
+                                              uu____3862)
                                              in
-                                          let uu____3884 =
-                                            let uu____3929 =
-                                              let uu____3930 =
+                                          let uu____3868 =
+                                            let uu____3913 =
+                                              let uu____3914 =
                                                 FStar_Syntax_Subst.compress
                                                   bind_t1
                                                  in
-                                              uu____3930.FStar_Syntax_Syntax.n
+                                              uu____3914.FStar_Syntax_Syntax.n
                                                in
-                                            match uu____3929 with
+                                            match uu____3913 with
                                             | FStar_Syntax_Syntax.Tm_arrow
                                                 (bs,c) when
                                                 (FStar_List.length bs) >=
                                                   (Prims.of_int (4))
                                                 ->
-                                                let uu____4006 =
+                                                let uu____3990 =
                                                   FStar_Syntax_Subst.open_comp
                                                     bs c
                                                    in
-                                                (match uu____4006 with
+                                                (match uu____3990 with
                                                  | (a_b::b_b::bs1,c1) ->
-                                                     let uu____4091 =
-                                                       let uu____4118 =
+                                                     let uu____4075 =
+                                                       let uu____4102 =
                                                          FStar_List.splitAt
                                                            ((FStar_List.length
                                                                bs1)
@@ -1431,155 +1417,155 @@ let (mk_indexed_bind :
                                                            bs1
                                                           in
                                                        FStar_All.pipe_right
-                                                         uu____4118
-                                                         (fun uu____4203  ->
-                                                            match uu____4203
+                                                         uu____4102
+                                                         (fun uu____4187  ->
+                                                            match uu____4187
                                                             with
                                                             | (l1,l2) ->
-                                                                let uu____4284
+                                                                let uu____4268
                                                                   =
                                                                   FStar_List.hd
                                                                     l2
                                                                    in
-                                                                let uu____4297
+                                                                let uu____4281
                                                                   =
-                                                                  let uu____4304
+                                                                  let uu____4288
                                                                     =
                                                                     FStar_List.tl
                                                                     l2  in
                                                                   FStar_List.hd
-                                                                    uu____4304
+                                                                    uu____4288
                                                                    in
                                                                 (l1,
-                                                                  uu____4284,
-                                                                  uu____4297))
+                                                                  uu____4268,
+                                                                  uu____4281))
                                                         in
-                                                     (match uu____4091 with
+                                                     (match uu____4075 with
                                                       | (rest_bs,f_b,g_b) ->
                                                           (a_b, b_b, rest_bs,
                                                             f_b, g_b, c1)))
-                                            | uu____4464 ->
-                                                let uu____4465 =
+                                            | uu____4448 ->
+                                                let uu____4449 =
                                                   bind_t_shape_error
                                                     "Either not an arrow or not enough binders"
                                                    in
                                                 FStar_Errors.raise_error
-                                                  uu____4465 r1
+                                                  uu____4449 r1
                                              in
-                                          (match uu____3884 with
+                                          (match uu____3868 with
                                            | (a_b,b_b,rest_bs,f_b,g_b,bind_c)
                                                ->
-                                               let uu____4590 =
-                                                 let uu____4597 =
-                                                   let uu____4598 =
-                                                     let uu____4599 =
-                                                       let uu____4606 =
+                                               let uu____4574 =
+                                                 let uu____4581 =
+                                                   let uu____4582 =
+                                                     let uu____4583 =
+                                                       let uu____4590 =
                                                          FStar_All.pipe_right
                                                            a_b
                                                            FStar_Pervasives_Native.fst
                                                           in
-                                                       (uu____4606, t1)  in
+                                                       (uu____4590, t1)  in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____4599
+                                                       uu____4583
                                                       in
-                                                   let uu____4617 =
-                                                     let uu____4620 =
-                                                       let uu____4621 =
-                                                         let uu____4628 =
+                                                   let uu____4601 =
+                                                     let uu____4604 =
+                                                       let uu____4605 =
+                                                         let uu____4612 =
                                                            FStar_All.pipe_right
                                                              b_b
                                                              FStar_Pervasives_Native.fst
                                                             in
-                                                         (uu____4628, t2)  in
+                                                         (uu____4612, t2)  in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____4621
+                                                         uu____4605
                                                         in
-                                                     [uu____4620]  in
-                                                   uu____4598 :: uu____4617
+                                                     [uu____4604]  in
+                                                   uu____4582 :: uu____4601
                                                     in
                                                  FStar_TypeChecker_Env.uvars_for_binders
-                                                   env rest_bs uu____4597
+                                                   env rest_bs uu____4581
                                                    (fun b1  ->
-                                                      let uu____4644 =
+                                                      let uu____4628 =
                                                         FStar_Syntax_Print.binder_to_string
                                                           b1
                                                          in
-                                                      let uu____4646 =
-                                                        let uu____4648 =
+                                                      let uu____4630 =
+                                                        let uu____4632 =
                                                           FStar_Ident.string_of_lid
                                                             m
                                                            in
-                                                        let uu____4650 =
+                                                        let uu____4634 =
                                                           FStar_Ident.string_of_lid
                                                             n
                                                            in
-                                                        let uu____4652 =
+                                                        let uu____4636 =
                                                           FStar_Ident.string_of_lid
                                                             p
                                                            in
                                                         FStar_Util.format3
                                                           "(%s, %s) |> %s"
-                                                          uu____4648
-                                                          uu____4650
-                                                          uu____4652
+                                                          uu____4632
+                                                          uu____4634
+                                                          uu____4636
                                                          in
-                                                      let uu____4655 =
+                                                      let uu____4639 =
                                                         FStar_Range.string_of_range
                                                           r1
                                                          in
                                                       FStar_Util.format3
                                                         "implicit var for binder %s of %s at %s"
-                                                        uu____4644 uu____4646
-                                                        uu____4655) r1
+                                                        uu____4628 uu____4630
+                                                        uu____4639) r1
                                                   in
-                                               (match uu____4590 with
+                                               (match uu____4574 with
                                                 | (rest_bs_uvars,g_uvars) ->
                                                     let subst =
                                                       FStar_List.map2
                                                         (fun b1  ->
                                                            fun t  ->
-                                                             let uu____4692 =
-                                                               let uu____4699
+                                                             let uu____4676 =
+                                                               let uu____4683
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    b1
                                                                    FStar_Pervasives_Native.fst
                                                                   in
-                                                               (uu____4699,
+                                                               (uu____4683,
                                                                  t)
                                                                 in
                                                              FStar_Syntax_Syntax.NT
-                                                               uu____4692)
+                                                               uu____4676)
                                                         (a_b :: b_b ::
                                                         rest_bs) (t1 :: t2 ::
                                                         rest_bs_uvars)
                                                        in
                                                     let f_guard =
                                                       let f_sort_is =
-                                                        let uu____4726 =
-                                                          let uu____4729 =
-                                                            let uu____4730 =
-                                                              let uu____4731
+                                                        let uu____4710 =
+                                                          let uu____4713 =
+                                                            let uu____4714 =
+                                                              let uu____4715
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   f_b
                                                                   FStar_Pervasives_Native.fst
                                                                  in
-                                                              uu____4731.FStar_Syntax_Syntax.sort
+                                                              uu____4715.FStar_Syntax_Syntax.sort
                                                                in
                                                             FStar_Syntax_Subst.compress
-                                                              uu____4730
+                                                              uu____4714
                                                              in
-                                                          let uu____4740 =
+                                                          let uu____4724 =
                                                             FStar_Syntax_Util.is_layered
                                                               m_ed
                                                              in
                                                           effect_args_from_repr
-                                                            uu____4729
-                                                            uu____4740 r1
+                                                            uu____4713
+                                                            uu____4724 r1
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____4726
+                                                          uu____4710
                                                           (FStar_List.map
                                                              (FStar_Syntax_Subst.subst
                                                                 subst))
@@ -1588,14 +1574,14 @@ let (mk_indexed_bind :
                                                         (fun g  ->
                                                            fun i1  ->
                                                              fun f_i1  ->
-                                                               let uu____4753
+                                                               let uu____4737
                                                                  =
                                                                  FStar_TypeChecker_Rel.teq
                                                                    env i1
                                                                    f_i1
                                                                   in
                                                                FStar_TypeChecker_Env.conj_guard
-                                                                 g uu____4753)
+                                                                 g uu____4737)
                                                         FStar_TypeChecker_Env.trivial_guard
                                                         is1 f_sort_is
                                                        in
@@ -1612,91 +1598,91 @@ let (mk_indexed_bind :
                                                               x
                                                          in
                                                       let g_sort_is =
-                                                        let uu____4772 =
-                                                          let uu____4773 =
-                                                            let uu____4776 =
-                                                              let uu____4777
+                                                        let uu____4756 =
+                                                          let uu____4757 =
+                                                            let uu____4760 =
+                                                              let uu____4761
                                                                 =
                                                                 FStar_All.pipe_right
                                                                   g_b
                                                                   FStar_Pervasives_Native.fst
                                                                  in
-                                                              uu____4777.FStar_Syntax_Syntax.sort
+                                                              uu____4761.FStar_Syntax_Syntax.sort
                                                                in
                                                             FStar_Syntax_Subst.compress
-                                                              uu____4776
+                                                              uu____4760
                                                              in
-                                                          uu____4773.FStar_Syntax_Syntax.n
+                                                          uu____4757.FStar_Syntax_Syntax.n
                                                            in
-                                                        match uu____4772 with
+                                                        match uu____4756 with
                                                         | FStar_Syntax_Syntax.Tm_arrow
                                                             (bs,c) ->
-                                                            let uu____4810 =
+                                                            let uu____4794 =
                                                               FStar_Syntax_Subst.open_comp
                                                                 bs c
                                                                in
-                                                            (match uu____4810
+                                                            (match uu____4794
                                                              with
                                                              | (bs1,c1) ->
                                                                  let bs_subst
                                                                    =
-                                                                   let uu____4820
+                                                                   let uu____4804
                                                                     =
-                                                                    let uu____4827
+                                                                    let uu____4811
                                                                     =
-                                                                    let uu____4828
+                                                                    let uu____4812
                                                                     =
                                                                     FStar_List.hd
                                                                     bs1  in
                                                                     FStar_All.pipe_right
-                                                                    uu____4828
+                                                                    uu____4812
                                                                     FStar_Pervasives_Native.fst
                                                                      in
-                                                                    let uu____4849
+                                                                    let uu____4833
                                                                     =
-                                                                    let uu____4852
+                                                                    let uu____4836
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     x_a
                                                                     FStar_Pervasives_Native.fst
                                                                      in
                                                                     FStar_All.pipe_right
-                                                                    uu____4852
+                                                                    uu____4836
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                      in
-                                                                    (uu____4827,
-                                                                    uu____4849)
+                                                                    (uu____4811,
+                                                                    uu____4833)
                                                                      in
                                                                    FStar_Syntax_Syntax.NT
-                                                                    uu____4820
+                                                                    uu____4804
                                                                     in
                                                                  let c2 =
                                                                    FStar_Syntax_Subst.subst_comp
                                                                     [bs_subst]
                                                                     c1
                                                                     in
-                                                                 let uu____4866
+                                                                 let uu____4850
                                                                    =
-                                                                   let uu____4869
+                                                                   let uu____4853
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c2)  in
-                                                                   let uu____4870
+                                                                   let uu____4854
                                                                     =
                                                                     FStar_Syntax_Util.is_layered
                                                                     n_ed  in
                                                                    effect_args_from_repr
-                                                                    uu____4869
-                                                                    uu____4870
+                                                                    uu____4853
+                                                                    uu____4854
                                                                     r1
                                                                     in
                                                                  FStar_All.pipe_right
-                                                                   uu____4866
+                                                                   uu____4850
                                                                    (FStar_List.map
                                                                     (FStar_Syntax_Subst.subst
                                                                     subst)))
-                                                        | uu____4876 ->
+                                                        | uu____4860 ->
                                                             failwith
                                                               "imspossible: mk_indexed_bind"
                                                          in
@@ -1704,12 +1690,12 @@ let (mk_indexed_bind :
                                                         FStar_TypeChecker_Env.push_binders
                                                           env [x_a]
                                                          in
-                                                      let uu____4893 =
+                                                      let uu____4877 =
                                                         FStar_List.fold_left2
                                                           (fun g  ->
                                                              fun i1  ->
                                                                fun g_i1  ->
-                                                                 let uu____4901
+                                                                 let uu____4885
                                                                    =
                                                                    FStar_TypeChecker_Rel.teq
                                                                     env_g i1
@@ -1717,44 +1703,44 @@ let (mk_indexed_bind :
                                                                     in
                                                                  FStar_TypeChecker_Env.conj_guard
                                                                    g
-                                                                   uu____4901)
+                                                                   uu____4885)
                                                           FStar_TypeChecker_Env.trivial_guard
                                                           is2 g_sort_is
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____4893
+                                                        uu____4877
                                                         (FStar_TypeChecker_Env.close_guard
                                                            env [x_a])
                                                        in
                                                     let bind_ct =
-                                                      let uu____4915 =
+                                                      let uu____4899 =
                                                         FStar_All.pipe_right
                                                           bind_c
                                                           (FStar_Syntax_Subst.subst_comp
                                                              subst)
                                                          in
                                                       FStar_All.pipe_right
-                                                        uu____4915
+                                                        uu____4899
                                                         FStar_Syntax_Util.comp_to_comp_typ
                                                        in
                                                     let fml =
-                                                      let uu____4917 =
-                                                        let uu____4922 =
+                                                      let uu____4901 =
+                                                        let uu____4906 =
                                                           FStar_List.hd
                                                             bind_ct.FStar_Syntax_Syntax.comp_univs
                                                            in
-                                                        let uu____4923 =
-                                                          let uu____4924 =
+                                                        let uu____4907 =
+                                                          let uu____4908 =
                                                             FStar_List.hd
                                                               bind_ct.FStar_Syntax_Syntax.effect_args
                                                              in
                                                           FStar_Pervasives_Native.fst
-                                                            uu____4924
+                                                            uu____4908
                                                            in
-                                                        (uu____4922,
-                                                          uu____4923)
+                                                        (uu____4906,
+                                                          uu____4907)
                                                          in
-                                                      match uu____4917 with
+                                                      match uu____4901 with
                                                       | (u,wp) ->
                                                           FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                                             env u
@@ -1763,21 +1749,21 @@ let (mk_indexed_bind :
                                                             FStar_Range.dummyRange
                                                        in
                                                     let is =
-                                                      let uu____4950 =
+                                                      let uu____4934 =
                                                         FStar_Syntax_Subst.compress
                                                           bind_ct.FStar_Syntax_Syntax.result_typ
                                                          in
-                                                      let uu____4951 =
+                                                      let uu____4935 =
                                                         FStar_Syntax_Util.is_layered
                                                           p_ed
                                                          in
                                                       effect_args_from_repr
-                                                        uu____4950 uu____4951
+                                                        uu____4934 uu____4935
                                                         r1
                                                        in
                                                     let c =
-                                                      let uu____4954 =
-                                                        let uu____4955 =
+                                                      let uu____4938 =
+                                                        let uu____4939 =
                                                           FStar_List.map
                                                             FStar_Syntax_Syntax.as_arg
                                                             is
@@ -1792,58 +1778,58 @@ let (mk_indexed_bind :
                                                           FStar_Syntax_Syntax.result_typ
                                                             = t2;
                                                           FStar_Syntax_Syntax.effect_args
-                                                            = uu____4955;
+                                                            = uu____4939;
                                                           FStar_Syntax_Syntax.flags
                                                             = flags
                                                         }  in
                                                       FStar_Syntax_Syntax.mk_Comp
-                                                        uu____4954
+                                                        uu____4938
                                                        in
-                                                    ((let uu____4975 =
+                                                    ((let uu____4959 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env)
                                                           (FStar_Options.Other
                                                              "LayeredEffects")
                                                          in
-                                                      if uu____4975
+                                                      if uu____4959
                                                       then
-                                                        let uu____4980 =
+                                                        let uu____4964 =
                                                           FStar_Syntax_Print.comp_to_string
                                                             c
                                                            in
                                                         FStar_Util.print1
                                                           "} c after bind: %s\n"
-                                                          uu____4980
+                                                          uu____4964
                                                       else ());
-                                                     (let uu____4985 =
-                                                        let uu____4986 =
-                                                          let uu____4989 =
-                                                            let uu____4992 =
-                                                              let uu____4995
+                                                     (let uu____4969 =
+                                                        let uu____4970 =
+                                                          let uu____4973 =
+                                                            let uu____4976 =
+                                                              let uu____4979
                                                                 =
-                                                                let uu____4998
+                                                                let uu____4982
                                                                   =
                                                                   FStar_TypeChecker_Env.guard_of_guard_formula
                                                                     (
                                                                     FStar_TypeChecker_Common.NonTrivial
                                                                     fml)
                                                                    in
-                                                                [uu____4998]
+                                                                [uu____4982]
                                                                  in
                                                               g_guard ::
-                                                                uu____4995
+                                                                uu____4979
                                                                in
                                                             f_guard ::
-                                                              uu____4992
+                                                              uu____4976
                                                              in
                                                           g_uvars ::
-                                                            uu____4989
+                                                            uu____4973
                                                            in
                                                         FStar_TypeChecker_Env.conj_guards
-                                                          uu____4986
+                                                          uu____4970
                                                          in
-                                                      (c, uu____4985)))))))))
+                                                      (c, uu____4969)))))))))
   
 let (mk_wp_bind :
   FStar_TypeChecker_Env.env ->
@@ -1861,28 +1847,28 @@ let (mk_wp_bind :
           fun ct2  ->
             fun flags  ->
               fun r1  ->
-                let uu____5043 =
+                let uu____5027 =
                   let md = FStar_TypeChecker_Env.get_effect_decl env m  in
-                  let uu____5069 = FStar_TypeChecker_Env.wp_signature env m
+                  let uu____5053 = FStar_TypeChecker_Env.wp_signature env m
                      in
-                  match uu____5069 with
+                  match uu____5053 with
                   | (a,kwp) ->
-                      let uu____5100 = destruct_wp_comp ct1  in
-                      let uu____5107 = destruct_wp_comp ct2  in
-                      ((md, a, kwp), uu____5100, uu____5107)
+                      let uu____5084 = destruct_wp_comp ct1  in
+                      let uu____5091 = destruct_wp_comp ct2  in
+                      ((md, a, kwp), uu____5084, uu____5091)
                    in
-                match uu____5043 with
+                match uu____5027 with
                 | ((md,a,kwp),(u_t1,t1,wp1),(u_t2,t2,wp2)) ->
                     let bs =
                       match b with
                       | FStar_Pervasives_Native.None  ->
-                          let uu____5160 = FStar_Syntax_Syntax.null_binder t1
+                          let uu____5144 = FStar_Syntax_Syntax.null_binder t1
                              in
-                          [uu____5160]
+                          [uu____5144]
                       | FStar_Pervasives_Native.Some x ->
-                          let uu____5180 = FStar_Syntax_Syntax.mk_binder x
+                          let uu____5164 = FStar_Syntax_Syntax.mk_binder x
                              in
-                          [uu____5180]
+                          [uu____5164]
                        in
                     let mk_lam wp =
                       FStar_Syntax_Util.abs bs wp
@@ -1895,39 +1881,36 @@ let (mk_wp_bind :
                     let r11 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_range r1))
-                        FStar_Pervasives_Native.None r1
+                           (FStar_Const.Const_range r1)) r1
                        in
                     let wp_args =
-                      let uu____5227 = FStar_Syntax_Syntax.as_arg r11  in
-                      let uu____5236 =
-                        let uu____5247 = FStar_Syntax_Syntax.as_arg t1  in
-                        let uu____5256 =
-                          let uu____5267 = FStar_Syntax_Syntax.as_arg t2  in
-                          let uu____5276 =
-                            let uu____5287 = FStar_Syntax_Syntax.as_arg wp1
+                      let uu____5211 = FStar_Syntax_Syntax.as_arg r11  in
+                      let uu____5220 =
+                        let uu____5231 = FStar_Syntax_Syntax.as_arg t1  in
+                        let uu____5240 =
+                          let uu____5251 = FStar_Syntax_Syntax.as_arg t2  in
+                          let uu____5260 =
+                            let uu____5271 = FStar_Syntax_Syntax.as_arg wp1
                                in
-                            let uu____5296 =
-                              let uu____5307 =
-                                let uu____5316 = mk_lam wp2  in
-                                FStar_Syntax_Syntax.as_arg uu____5316  in
-                              [uu____5307]  in
-                            uu____5287 :: uu____5296  in
-                          uu____5267 :: uu____5276  in
-                        uu____5247 :: uu____5256  in
-                      uu____5227 :: uu____5236  in
+                            let uu____5280 =
+                              let uu____5291 =
+                                let uu____5300 = mk_lam wp2  in
+                                FStar_Syntax_Syntax.as_arg uu____5300  in
+                              [uu____5291]  in
+                            uu____5271 :: uu____5280  in
+                          uu____5251 :: uu____5260  in
+                        uu____5231 :: uu____5240  in
+                      uu____5211 :: uu____5220  in
                     let bind_wp =
                       FStar_All.pipe_right md
                         FStar_Syntax_Util.get_bind_vc_combinator
                        in
                     let wp =
-                      let uu____5369 =
-                        let uu____5374 =
-                          FStar_TypeChecker_Env.inst_effect_fun_with
-                            [u_t1; u_t2] env md bind_wp
-                           in
-                        FStar_Syntax_Syntax.mk_Tm_app uu____5374 wp_args  in
-                      uu____5369 FStar_Pervasives_Native.None
+                      let uu____5351 =
+                        FStar_TypeChecker_Env.inst_effect_fun_with
+                          [u_t1; u_t2] env md bind_wp
+                         in
+                      FStar_Syntax_Syntax.mk_Tm_app uu____5351 wp_args
                         t2.FStar_Syntax_Syntax.pos
                        in
                     mk_comp md u_t2 t2 wp flags
@@ -1947,66 +1930,66 @@ let (mk_bind :
         fun c2  ->
           fun flags  ->
             fun r1  ->
-              let uu____5422 =
-                let uu____5427 =
+              let uu____5399 =
+                let uu____5404 =
                   FStar_TypeChecker_Env.unfold_effect_abbrev env c1  in
-                let uu____5428 =
+                let uu____5405 =
                   FStar_TypeChecker_Env.unfold_effect_abbrev env c2  in
-                (uu____5427, uu____5428)  in
-              match uu____5422 with
+                (uu____5404, uu____5405)  in
+              match uu____5399 with
               | (ct1,ct2) ->
-                  let uu____5435 =
+                  let uu____5412 =
                     FStar_TypeChecker_Env.exists_polymonadic_bind env
                       ct1.FStar_Syntax_Syntax.effect_name
                       ct2.FStar_Syntax_Syntax.effect_name
                      in
-                  (match uu____5435 with
+                  (match uu____5412 with
                    | FStar_Pervasives_Native.Some (p,f_bind) ->
                        f_bind env ct1 b ct2 flags r1
                    | FStar_Pervasives_Native.None  ->
-                       let uu____5486 = lift_comps env c1 c2 b true  in
-                       (match uu____5486 with
+                       let uu____5463 = lift_comps env c1 c2 b true  in
+                       (match uu____5463 with
                         | (m,c11,c21,g_lift) ->
-                            let uu____5504 =
-                              let uu____5509 =
+                            let uu____5481 =
+                              let uu____5486 =
                                 FStar_Syntax_Util.comp_to_comp_typ c11  in
-                              let uu____5510 =
+                              let uu____5487 =
                                 FStar_Syntax_Util.comp_to_comp_typ c21  in
-                              (uu____5509, uu____5510)  in
-                            (match uu____5504 with
+                              (uu____5486, uu____5487)  in
+                            (match uu____5481 with
                              | (ct11,ct21) ->
-                                 let uu____5517 =
-                                   let uu____5522 =
+                                 let uu____5494 =
+                                   let uu____5499 =
                                      FStar_TypeChecker_Env.is_layered_effect
                                        env m
                                       in
-                                   if uu____5522
+                                   if uu____5499
                                    then
                                      let bind_t =
-                                       let uu____5530 =
+                                       let uu____5507 =
                                          FStar_All.pipe_right m
                                            (FStar_TypeChecker_Env.get_effect_decl
                                               env)
                                           in
-                                       FStar_All.pipe_right uu____5530
+                                       FStar_All.pipe_right uu____5507
                                          FStar_Syntax_Util.get_bind_vc_combinator
                                         in
                                      mk_indexed_bind env m m m bind_t ct11 b
                                        ct21 flags r1
                                    else
-                                     (let uu____5533 =
+                                     (let uu____5510 =
                                         mk_wp_bind env m ct11 b ct21 flags r1
                                          in
-                                      (uu____5533,
+                                      (uu____5510,
                                         FStar_TypeChecker_Env.trivial_guard))
                                     in
-                                 (match uu____5517 with
+                                 (match uu____5494 with
                                   | (c,g_bind) ->
-                                      let uu____5540 =
+                                      let uu____5517 =
                                         FStar_TypeChecker_Env.conj_guard
                                           g_lift g_bind
                                          in
-                                      (c, uu____5540)))))
+                                      (c, uu____5517)))))
   
 let (bind_pure_wp_with :
   FStar_TypeChecker_Env.env ->
@@ -2021,20 +2004,20 @@ let (bind_pure_wp_with :
         fun flags  ->
           let r = FStar_TypeChecker_Env.get_range env  in
           let pure_c =
-            let uu____5576 =
-              let uu____5577 =
-                let uu____5588 =
+            let uu____5553 =
+              let uu____5554 =
+                let uu____5565 =
                   FStar_All.pipe_right wp1 FStar_Syntax_Syntax.as_arg  in
-                [uu____5588]  in
+                [uu____5565]  in
               {
                 FStar_Syntax_Syntax.comp_univs = [FStar_Syntax_Syntax.U_zero];
                 FStar_Syntax_Syntax.effect_name =
                   FStar_Parser_Const.effect_PURE_lid;
                 FStar_Syntax_Syntax.result_typ = FStar_Syntax_Syntax.t_unit;
-                FStar_Syntax_Syntax.effect_args = uu____5577;
+                FStar_Syntax_Syntax.effect_args = uu____5554;
                 FStar_Syntax_Syntax.flags = []
               }  in
-            FStar_Syntax_Syntax.mk_Comp uu____5576  in
+            FStar_Syntax_Syntax.mk_Comp uu____5553  in
           mk_bind env pure_c FStar_Pervasives_Native.None c flags r
   
 let (weaken_flags :
@@ -2042,21 +2025,21 @@ let (weaken_flags :
     FStar_Syntax_Syntax.cflag Prims.list)
   =
   fun flags  ->
-    let uu____5633 =
+    let uu____5610 =
       FStar_All.pipe_right flags
         (FStar_Util.for_some
-           (fun uu___1_5639  ->
-              match uu___1_5639 with
+           (fun uu___1_5616  ->
+              match uu___1_5616 with
               | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  -> true
-              | uu____5642 -> false))
+              | uu____5619 -> false))
        in
-    if uu____5633
+    if uu____5610
     then [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
     else
       FStar_All.pipe_right flags
         (FStar_List.collect
-           (fun uu___2_5654  ->
-              match uu___2_5654 with
+           (fun uu___2_5631  ->
+              match uu___2_5631 with
               | FStar_Syntax_Syntax.TOTAL  ->
                   [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
               | FStar_Syntax_Syntax.RETURN  ->
@@ -2073,30 +2056,30 @@ let (weaken_comp :
   fun env  ->
     fun c  ->
       fun formula  ->
-        let uu____5682 = FStar_Syntax_Util.is_ml_comp c  in
-        if uu____5682
+        let uu____5659 = FStar_Syntax_Util.is_ml_comp c  in
+        if uu____5659
         then (c, FStar_TypeChecker_Env.trivial_guard)
         else
           (let ct = FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
            let pure_assume_wp =
-             let uu____5693 =
+             let uu____5670 =
                FStar_Syntax_Syntax.lid_as_fv
                  FStar_Parser_Const.pure_assume_wp_lid
                  (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
                  FStar_Pervasives_Native.None
                 in
-             FStar_Syntax_Syntax.fv_to_tm uu____5693  in
+             FStar_Syntax_Syntax.fv_to_tm uu____5670  in
            let pure_assume_wp1 =
-             let uu____5698 = FStar_TypeChecker_Env.get_range env  in
-             let uu____5699 =
-               let uu____5704 =
-                 let uu____5705 =
-                   FStar_All.pipe_left FStar_Syntax_Syntax.as_arg formula  in
-                 [uu____5705]  in
-               FStar_Syntax_Syntax.mk_Tm_app pure_assume_wp uu____5704  in
-             uu____5699 FStar_Pervasives_Native.None uu____5698  in
-           let uu____5738 = weaken_flags ct.FStar_Syntax_Syntax.flags  in
-           bind_pure_wp_with env pure_assume_wp1 c uu____5738)
+             let uu____5673 =
+               let uu____5674 =
+                 FStar_All.pipe_left FStar_Syntax_Syntax.as_arg formula  in
+               [uu____5674]  in
+             let uu____5707 = FStar_TypeChecker_Env.get_range env  in
+             FStar_Syntax_Syntax.mk_Tm_app pure_assume_wp uu____5673
+               uu____5707
+              in
+           let uu____5708 = weaken_flags ct.FStar_Syntax_Syntax.flags  in
+           bind_pure_wp_with env pure_assume_wp1 c uu____5708)
   
 let (weaken_precondition :
   FStar_TypeChecker_Env.env ->
@@ -2107,30 +2090,30 @@ let (weaken_precondition :
   fun env  ->
     fun lc  ->
       fun f  ->
-        let weaken uu____5766 =
-          let uu____5767 = FStar_TypeChecker_Common.lcomp_comp lc  in
-          match uu____5767 with
+        let weaken uu____5736 =
+          let uu____5737 = FStar_TypeChecker_Common.lcomp_comp lc  in
+          match uu____5737 with
           | (c,g_c) ->
-              let uu____5778 =
+              let uu____5748 =
                 env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ())
                  in
-              if uu____5778
+              if uu____5748
               then (c, g_c)
               else
                 (match f with
                  | FStar_TypeChecker_Common.Trivial  -> (c, g_c)
                  | FStar_TypeChecker_Common.NonTrivial f1 ->
-                     let uu____5792 = weaken_comp env c f1  in
-                     (match uu____5792 with
+                     let uu____5762 = weaken_comp env c f1  in
+                     (match uu____5762 with
                       | (c1,g_w) ->
-                          let uu____5803 =
+                          let uu____5773 =
                             FStar_TypeChecker_Env.conj_guard g_c g_w  in
-                          (c1, uu____5803)))
+                          (c1, uu____5773)))
            in
-        let uu____5804 = weaken_flags lc.FStar_TypeChecker_Common.cflags  in
+        let uu____5774 = weaken_flags lc.FStar_TypeChecker_Common.cflags  in
         FStar_TypeChecker_Common.mk_lcomp
           lc.FStar_TypeChecker_Common.eff_name
-          lc.FStar_TypeChecker_Common.res_typ uu____5804 weaken
+          lc.FStar_TypeChecker_Common.res_typ uu____5774 weaken
   
 let (strengthen_comp :
   FStar_TypeChecker_Env.env ->
@@ -2150,25 +2133,23 @@ let (strengthen_comp :
             else
               (let r = FStar_TypeChecker_Env.get_range env  in
                let pure_assert_wp =
-                 let uu____5861 =
+                 let uu____5831 =
                    FStar_Syntax_Syntax.lid_as_fv
                      FStar_Parser_Const.pure_assert_wp_lid
                      (FStar_Syntax_Syntax.Delta_constant_at_level
                         Prims.int_one) FStar_Pervasives_Native.None
                     in
-                 FStar_Syntax_Syntax.fv_to_tm uu____5861  in
+                 FStar_Syntax_Syntax.fv_to_tm uu____5831  in
                let pure_assert_wp1 =
-                 let uu____5866 =
-                   let uu____5871 =
-                     let uu____5872 =
-                       let uu____5881 = label_opt env reason r f  in
-                       FStar_All.pipe_left FStar_Syntax_Syntax.as_arg
-                         uu____5881
-                        in
-                     [uu____5872]  in
-                   FStar_Syntax_Syntax.mk_Tm_app pure_assert_wp uu____5871
-                    in
-                 uu____5866 FStar_Pervasives_Native.None r  in
+                 let uu____5834 =
+                   let uu____5835 =
+                     let uu____5844 = label_opt env reason r f  in
+                     FStar_All.pipe_left FStar_Syntax_Syntax.as_arg
+                       uu____5844
+                      in
+                   [uu____5835]  in
+                 FStar_Syntax_Syntax.mk_Tm_app pure_assert_wp uu____5834 r
+                  in
                bind_pure_wp_with env pure_assert_wp1 c flags)
   
 let (strengthen_precondition :
@@ -2185,26 +2166,26 @@ let (strengthen_precondition :
       fun e_for_debugging_only  ->
         fun lc  ->
           fun g0  ->
-            let uu____5951 =
+            let uu____5914 =
               FStar_TypeChecker_Env.is_trivial_guard_formula g0  in
-            if uu____5951
+            if uu____5914
             then (lc, g0)
             else
               (let flags =
-                 let uu____5963 =
-                   let uu____5971 =
+                 let uu____5926 =
+                   let uu____5934 =
                      FStar_TypeChecker_Common.is_tot_or_gtot_lcomp lc  in
-                   if uu____5971
+                   if uu____5934
                    then (true, [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION])
                    else (false, [])  in
-                 match uu____5963 with
+                 match uu____5926 with
                  | (maybe_trivial_post,flags) ->
-                     let uu____6001 =
+                     let uu____5964 =
                        FStar_All.pipe_right
                          lc.FStar_TypeChecker_Common.cflags
                          (FStar_List.collect
-                            (fun uu___3_6009  ->
-                               match uu___3_6009 with
+                            (fun uu___3_5972  ->
+                               match uu___3_5972 with
                                | FStar_Syntax_Syntax.RETURN  ->
                                    [FStar_Syntax_Syntax.PARTIAL_RETURN]
                                | FStar_Syntax_Syntax.PARTIAL_RETURN  ->
@@ -2218,71 +2199,71 @@ let (strengthen_precondition :
                                    [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
                                | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  ->
                                    [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
-                               | uu____6012 -> []))
+                               | uu____5975 -> []))
                         in
-                     FStar_List.append flags uu____6001
+                     FStar_List.append flags uu____5964
                   in
-               let strengthen uu____6022 =
-                 let uu____6023 = FStar_TypeChecker_Common.lcomp_comp lc  in
-                 match uu____6023 with
+               let strengthen uu____5985 =
+                 let uu____5986 = FStar_TypeChecker_Common.lcomp_comp lc  in
+                 match uu____5986 with
                  | (c,g_c) ->
                      if env.FStar_TypeChecker_Env.lax
                      then (c, g_c)
                      else
                        (let g01 = FStar_TypeChecker_Rel.simplify_guard env g0
                            in
-                        let uu____6042 = FStar_TypeChecker_Env.guard_form g01
+                        let uu____6005 = FStar_TypeChecker_Env.guard_form g01
                            in
-                        match uu____6042 with
+                        match uu____6005 with
                         | FStar_TypeChecker_Common.Trivial  -> (c, g_c)
                         | FStar_TypeChecker_Common.NonTrivial f ->
-                            ((let uu____6049 =
+                            ((let uu____6012 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   FStar_Options.Extreme
                                  in
-                              if uu____6049
+                              if uu____6012
                               then
-                                let uu____6053 =
+                                let uu____6016 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env e_for_debugging_only
                                    in
-                                let uu____6055 =
+                                let uu____6018 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env f
                                    in
                                 FStar_Util.print2
                                   "-------------Strengthening pre-condition of term %s with guard %s\n"
-                                  uu____6053 uu____6055
+                                  uu____6016 uu____6018
                               else ());
-                             (let uu____6060 =
+                             (let uu____6023 =
                                 strengthen_comp env reason c f flags  in
-                              match uu____6060 with
+                              match uu____6023 with
                               | (c1,g_s) ->
-                                  let uu____6071 =
+                                  let uu____6034 =
                                     FStar_TypeChecker_Env.conj_guard g_c g_s
                                      in
-                                  (c1, uu____6071))))
+                                  (c1, uu____6034))))
                   in
-               let uu____6072 =
-                 let uu____6073 =
+               let uu____6035 =
+                 let uu____6036 =
                    FStar_TypeChecker_Env.norm_eff_name env
                      lc.FStar_TypeChecker_Common.eff_name
                     in
-                 FStar_TypeChecker_Common.mk_lcomp uu____6073
+                 FStar_TypeChecker_Common.mk_lcomp uu____6036
                    lc.FStar_TypeChecker_Common.res_typ flags strengthen
                   in
-               (uu____6072,
-                 (let uu___707_6075 = g0  in
+               (uu____6035,
+                 (let uu___707_6038 = g0  in
                   {
                     FStar_TypeChecker_Common.guard_f =
                       FStar_TypeChecker_Common.Trivial;
                     FStar_TypeChecker_Common.deferred =
-                      (uu___707_6075.FStar_TypeChecker_Common.deferred);
+                      (uu___707_6038.FStar_TypeChecker_Common.deferred);
                     FStar_TypeChecker_Common.univ_ineqs =
-                      (uu___707_6075.FStar_TypeChecker_Common.univ_ineqs);
+                      (uu___707_6038.FStar_TypeChecker_Common.univ_ineqs);
                     FStar_TypeChecker_Common.implicits =
-                      (uu___707_6075.FStar_TypeChecker_Common.implicits)
+                      (uu___707_6038.FStar_TypeChecker_Common.implicits)
                   })))
   
 let (lcomp_has_trivial_postcondition :
@@ -2290,11 +2271,11 @@ let (lcomp_has_trivial_postcondition :
   fun lc  ->
     (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp lc) ||
       (FStar_Util.for_some
-         (fun uu___4_6084  ->
-            match uu___4_6084 with
+         (fun uu___4_6047  ->
+            match uu___4_6047 with
             | FStar_Syntax_Syntax.SOMETRIVIAL  -> true
             | FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION  -> true
-            | uu____6088 -> false) lc.FStar_TypeChecker_Common.cflags)
+            | uu____6051 -> false) lc.FStar_TypeChecker_Common.cflags)
   
 let (maybe_add_with_type :
   FStar_TypeChecker_Env.env ->
@@ -2307,22 +2288,22 @@ let (maybe_add_with_type :
     fun uopt  ->
       fun lc  ->
         fun e  ->
-          let uu____6117 =
+          let uu____6080 =
             (FStar_TypeChecker_Common.is_lcomp_partial_return lc) ||
               env.FStar_TypeChecker_Env.lax
              in
-          if uu____6117
+          if uu____6080
           then e
           else
-            (let uu____6124 =
+            (let uu____6087 =
                (lcomp_has_trivial_postcondition lc) &&
-                 (let uu____6127 =
+                 (let uu____6090 =
                     FStar_TypeChecker_Env.try_lookup_lid env
                       FStar_Parser_Const.with_type_lid
                      in
-                  FStar_Option.isSome uu____6127)
+                  FStar_Option.isSome uu____6090)
                 in
-             if uu____6124
+             if uu____6087
              then
                let u =
                  match uopt with
@@ -2357,25 +2338,25 @@ let (maybe_capture_unit_refinement :
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.unit_lid
-                | uu____6197 -> false  in
+                | uu____6160 -> false  in
               if is_unit
               then
-                let uu____6204 =
-                  let uu____6206 =
-                    let uu____6207 =
+                let uu____6167 =
+                  let uu____6169 =
+                    let uu____6170 =
                       FStar_All.pipe_right c
                         FStar_Syntax_Util.comp_effect_name
                        in
-                    FStar_All.pipe_right uu____6207
+                    FStar_All.pipe_right uu____6170
                       (FStar_TypeChecker_Env.norm_eff_name env)
                      in
-                  FStar_All.pipe_right uu____6206
+                  FStar_All.pipe_right uu____6169
                     (FStar_TypeChecker_Env.is_layered_effect env)
                    in
-                (if uu____6204
+                (if uu____6167
                  then
-                   let uu____6216 = FStar_Syntax_Subst.open_term_bv b phi  in
-                   match uu____6216 with
+                   let uu____6179 = FStar_Syntax_Subst.open_term_bv b phi  in
+                   match uu____6179 with
                    | (b1,phi1) ->
                        let phi2 =
                          FStar_Syntax_Subst.subst
@@ -2384,10 +2365,10 @@ let (maybe_capture_unit_refinement :
                           in
                        weaken_comp env c phi2
                  else
-                   (let uu____6232 = close_wp_comp env [x] c  in
-                    (uu____6232, FStar_TypeChecker_Env.trivial_guard)))
+                   (let uu____6195 = close_wp_comp env [x] c  in
+                    (uu____6195, FStar_TypeChecker_Env.trivial_guard)))
               else (c, FStar_TypeChecker_Env.trivial_guard)
-          | uu____6235 -> (c, FStar_TypeChecker_Env.trivial_guard)
+          | uu____6198 -> (c, FStar_TypeChecker_Env.trivial_guard)
   
 let (bind :
   FStar_Range.range ->
@@ -2400,208 +2381,208 @@ let (bind :
     fun env  ->
       fun e1opt  ->
         fun lc1  ->
-          fun uu____6263  ->
-            match uu____6263 with
+          fun uu____6226  ->
+            match uu____6226 with
             | (b,lc2) ->
                 let debug f =
-                  let uu____6283 =
+                  let uu____6246 =
                     (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
                       ||
                       (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "bind"))
                      in
-                  if uu____6283 then f () else ()  in
+                  if uu____6246 then f () else ()  in
                 let lc11 =
                   FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc1  in
                 let lc21 =
                   FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env lc2  in
                 let joined_eff = join_lcomp env lc11 lc21  in
                 let bind_flags =
-                  let uu____6296 =
+                  let uu____6259 =
                     (should_not_inline_lc lc11) ||
                       (should_not_inline_lc lc21)
                      in
-                  if uu____6296
+                  if uu____6259
                   then [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
                   else
                     (let flags =
-                       let uu____6306 =
+                       let uu____6269 =
                          FStar_TypeChecker_Common.is_total_lcomp lc11  in
-                       if uu____6306
+                       if uu____6269
                        then
-                         let uu____6311 =
+                         let uu____6274 =
                            FStar_TypeChecker_Common.is_total_lcomp lc21  in
-                         (if uu____6311
+                         (if uu____6274
                           then [FStar_Syntax_Syntax.TOTAL]
                           else
-                            (let uu____6318 =
+                            (let uu____6281 =
                                FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  lc21
                                 in
-                             if uu____6318
+                             if uu____6281
                              then [FStar_Syntax_Syntax.SOMETRIVIAL]
                              else []))
                        else
-                         (let uu____6327 =
+                         (let uu____6290 =
                             (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                lc11)
                               &&
                               (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  lc21)
                              in
-                          if uu____6327
+                          if uu____6290
                           then [FStar_Syntax_Syntax.SOMETRIVIAL]
                           else [])
                         in
-                     let uu____6334 = lcomp_has_trivial_postcondition lc21
+                     let uu____6297 = lcomp_has_trivial_postcondition lc21
                         in
-                     if uu____6334
+                     if uu____6297
                      then FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION :: flags
                      else flags)
                    in
-                let bind_it uu____6350 =
-                  let uu____6351 =
+                let bind_it uu____6313 =
+                  let uu____6314 =
                     env.FStar_TypeChecker_Env.lax &&
                       (FStar_Options.ml_ish ())
                      in
-                  if uu____6351
+                  if uu____6314
                   then
                     let u_t =
                       env.FStar_TypeChecker_Env.universe_of env
                         lc21.FStar_TypeChecker_Common.res_typ
                        in
-                    let uu____6359 =
+                    let uu____6322 =
                       lax_mk_tot_or_comp_l joined_eff u_t
                         lc21.FStar_TypeChecker_Common.res_typ []
                        in
-                    (uu____6359, FStar_TypeChecker_Env.trivial_guard)
+                    (uu____6322, FStar_TypeChecker_Env.trivial_guard)
                   else
-                    (let uu____6362 =
+                    (let uu____6325 =
                        FStar_TypeChecker_Common.lcomp_comp lc11  in
-                     match uu____6362 with
+                     match uu____6325 with
                      | (c1,g_c1) ->
-                         let uu____6373 =
+                         let uu____6336 =
                            FStar_TypeChecker_Common.lcomp_comp lc21  in
-                         (match uu____6373 with
+                         (match uu____6336 with
                           | (c2,g_c2) ->
                               let trivial_guard =
-                                let uu____6385 =
+                                let uu____6348 =
                                   match b with
                                   | FStar_Pervasives_Native.Some x ->
                                       let b1 =
                                         FStar_Syntax_Syntax.mk_binder x  in
-                                      let uu____6388 =
+                                      let uu____6351 =
                                         FStar_Syntax_Syntax.is_null_binder b1
                                          in
-                                      if uu____6388
+                                      if uu____6351
                                       then g_c2
                                       else
                                         FStar_TypeChecker_Env.close_guard env
                                           [b1] g_c2
                                   | FStar_Pervasives_Native.None  -> g_c2  in
                                 FStar_TypeChecker_Env.conj_guard g_c1
-                                  uu____6385
+                                  uu____6348
                                  in
                               (debug
-                                 (fun uu____6414  ->
-                                    let uu____6415 =
+                                 (fun uu____6377  ->
+                                    let uu____6378 =
                                       FStar_Syntax_Print.comp_to_string c1
                                        in
-                                    let uu____6417 =
+                                    let uu____6380 =
                                       match b with
                                       | FStar_Pervasives_Native.None  ->
                                           "none"
                                       | FStar_Pervasives_Native.Some x ->
                                           FStar_Syntax_Print.bv_to_string x
                                        in
-                                    let uu____6422 =
+                                    let uu____6385 =
                                       FStar_Syntax_Print.comp_to_string c2
                                        in
                                     FStar_Util.print3
                                       "(1) bind: \n\tc1=%s\n\tx=%s\n\tc2=%s\n(1. end bind)\n"
-                                      uu____6415 uu____6417 uu____6422);
-                               (let aux uu____6440 =
-                                  let uu____6441 =
+                                      uu____6378 uu____6380 uu____6385);
+                               (let aux uu____6403 =
+                                  let uu____6404 =
                                     FStar_Syntax_Util.is_trivial_wp c1  in
-                                  if uu____6441
+                                  if uu____6404
                                   then
                                     match b with
                                     | FStar_Pervasives_Native.None  ->
                                         FStar_Util.Inl
                                           (c2, "trivial no binder")
-                                    | FStar_Pervasives_Native.Some uu____6472
+                                    | FStar_Pervasives_Native.Some uu____6435
                                         ->
-                                        let uu____6473 =
+                                        let uu____6436 =
                                           FStar_Syntax_Util.is_ml_comp c2  in
-                                        (if uu____6473
+                                        (if uu____6436
                                          then
                                            FStar_Util.Inl (c2, "trivial ml")
                                          else
                                            FStar_Util.Inr
                                              "c1 trivial; but c2 is not ML")
                                   else
-                                    (let uu____6505 =
+                                    (let uu____6468 =
                                        (FStar_Syntax_Util.is_ml_comp c1) &&
                                          (FStar_Syntax_Util.is_ml_comp c2)
                                         in
-                                     if uu____6505
+                                     if uu____6468
                                      then FStar_Util.Inl (c2, "both ml")
                                      else
                                        FStar_Util.Inr
                                          "c1 not trivial, and both are not ML")
                                    in
-                                let try_simplify uu____6552 =
-                                  let aux_with_trivial_guard uu____6582 =
-                                    let uu____6583 = aux ()  in
-                                    match uu____6583 with
+                                let try_simplify uu____6515 =
+                                  let aux_with_trivial_guard uu____6545 =
+                                    let uu____6546 = aux ()  in
+                                    match uu____6546 with
                                     | FStar_Util.Inl (c,reason) ->
                                         FStar_Util.Inl
                                           (c, trivial_guard, reason)
                                     | FStar_Util.Inr reason ->
                                         FStar_Util.Inr reason
                                      in
-                                  let uu____6641 =
-                                    let uu____6643 =
+                                  let uu____6604 =
+                                    let uu____6606 =
                                       FStar_TypeChecker_Env.try_lookup_effect_lid
                                         env
                                         FStar_Parser_Const.effect_GTot_lid
                                        in
-                                    FStar_Option.isNone uu____6643  in
-                                  if uu____6641
+                                    FStar_Option.isNone uu____6606  in
+                                  if uu____6604
                                   then
-                                    let uu____6659 =
+                                    let uu____6622 =
                                       (FStar_Syntax_Util.is_tot_or_gtot_comp
                                          c1)
                                         &&
                                         (FStar_Syntax_Util.is_tot_or_gtot_comp
                                            c2)
                                        in
-                                    (if uu____6659
+                                    (if uu____6622
                                      then
                                        FStar_Util.Inl
                                          (c2, trivial_guard,
                                            "Early in prims; we don't have bind yet")
                                      else
-                                       (let uu____6686 =
+                                       (let uu____6649 =
                                           FStar_TypeChecker_Env.get_range env
                                            in
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_NonTrivialPreConditionInPrims,
                                             "Non-trivial pre-conditions very early in prims, even before we have defined the PURE monad")
-                                          uu____6686))
+                                          uu____6649))
                                   else
-                                    (let uu____6703 =
+                                    (let uu____6666 =
                                        FStar_Syntax_Util.is_total_comp c1  in
-                                     if uu____6703
+                                     if uu____6666
                                      then
                                        let close_with_type_of_x x c =
                                          let x1 =
-                                           let uu___810_6734 = x  in
+                                           let uu___810_6697 = x  in
                                            {
                                              FStar_Syntax_Syntax.ppname =
-                                               (uu___810_6734.FStar_Syntax_Syntax.ppname);
+                                               (uu___810_6697.FStar_Syntax_Syntax.ppname);
                                              FStar_Syntax_Syntax.index =
-                                               (uu___810_6734.FStar_Syntax_Syntax.index);
+                                               (uu___810_6697.FStar_Syntax_Syntax.index);
                                              FStar_Syntax_Syntax.sort =
                                                (FStar_Syntax_Util.comp_result
                                                   c1)
@@ -2613,126 +2594,126 @@ let (bind :
                                        | (FStar_Pervasives_Native.Some
                                           e,FStar_Pervasives_Native.Some x)
                                            ->
-                                           let uu____6765 =
-                                             let uu____6770 =
+                                           let uu____6728 =
+                                             let uu____6733 =
                                                FStar_All.pipe_right c2
                                                  (FStar_Syntax_Subst.subst_comp
                                                     [FStar_Syntax_Syntax.NT
                                                        (x, e)])
                                                 in
-                                             FStar_All.pipe_right uu____6770
+                                             FStar_All.pipe_right uu____6733
                                                (close_with_type_of_x x)
                                               in
-                                           (match uu____6765 with
+                                           (match uu____6728 with
                                             | (c21,g_close) ->
-                                                let uu____6791 =
-                                                  let uu____6799 =
-                                                    let uu____6800 =
-                                                      let uu____6803 =
-                                                        let uu____6806 =
+                                                let uu____6754 =
+                                                  let uu____6762 =
+                                                    let uu____6763 =
+                                                      let uu____6766 =
+                                                        let uu____6769 =
                                                           FStar_TypeChecker_Env.map_guard
                                                             g_c2
                                                             (FStar_Syntax_Subst.subst
                                                                [FStar_Syntax_Syntax.NT
                                                                   (x, e)])
                                                            in
-                                                        [uu____6806; g_close]
+                                                        [uu____6769; g_close]
                                                          in
-                                                      g_c1 :: uu____6803  in
+                                                      g_c1 :: uu____6766  in
                                                     FStar_TypeChecker_Env.conj_guards
-                                                      uu____6800
+                                                      uu____6763
                                                      in
-                                                  (c21, uu____6799, "c1 Tot")
+                                                  (c21, uu____6762, "c1 Tot")
                                                    in
-                                                FStar_Util.Inl uu____6791)
-                                       | (uu____6819,FStar_Pervasives_Native.Some
+                                                FStar_Util.Inl uu____6754)
+                                       | (uu____6782,FStar_Pervasives_Native.Some
                                           x) ->
-                                           let uu____6831 =
+                                           let uu____6794 =
                                              FStar_All.pipe_right c2
                                                (close_with_type_of_x x)
                                               in
-                                           (match uu____6831 with
+                                           (match uu____6794 with
                                             | (c21,g_close) ->
-                                                let uu____6854 =
-                                                  let uu____6862 =
-                                                    let uu____6863 =
-                                                      let uu____6866 =
-                                                        let uu____6869 =
-                                                          let uu____6870 =
-                                                            let uu____6871 =
+                                                let uu____6817 =
+                                                  let uu____6825 =
+                                                    let uu____6826 =
+                                                      let uu____6829 =
+                                                        let uu____6832 =
+                                                          let uu____6833 =
+                                                            let uu____6834 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 x
                                                                in
-                                                            [uu____6871]  in
+                                                            [uu____6834]  in
                                                           FStar_TypeChecker_Env.close_guard
-                                                            env uu____6870
+                                                            env uu____6833
                                                             g_c2
                                                            in
-                                                        [uu____6869; g_close]
+                                                        [uu____6832; g_close]
                                                          in
-                                                      g_c1 :: uu____6866  in
+                                                      g_c1 :: uu____6829  in
                                                     FStar_TypeChecker_Env.conj_guards
-                                                      uu____6863
+                                                      uu____6826
                                                      in
-                                                  (c21, uu____6862,
+                                                  (c21, uu____6825,
                                                     "c1 Tot only close")
                                                    in
-                                                FStar_Util.Inl uu____6854)
-                                       | (uu____6900,uu____6901) ->
+                                                FStar_Util.Inl uu____6817)
+                                       | (uu____6863,uu____6864) ->
                                            aux_with_trivial_guard ()
                                      else
-                                       (let uu____6916 =
+                                       (let uu____6879 =
                                           (FStar_Syntax_Util.is_tot_or_gtot_comp
                                              c1)
                                             &&
                                             (FStar_Syntax_Util.is_tot_or_gtot_comp
                                                c2)
                                            in
-                                        if uu____6916
+                                        if uu____6879
                                         then
-                                          let uu____6931 =
-                                            let uu____6939 =
+                                          let uu____6894 =
+                                            let uu____6902 =
                                               FStar_Syntax_Syntax.mk_GTotal
                                                 (FStar_Syntax_Util.comp_result
                                                    c2)
                                                in
-                                            (uu____6939, trivial_guard,
+                                            (uu____6902, trivial_guard,
                                               "both GTot")
                                              in
-                                          FStar_Util.Inl uu____6931
+                                          FStar_Util.Inl uu____6894
                                         else aux_with_trivial_guard ()))
                                    in
-                                let uu____6952 = try_simplify ()  in
-                                match uu____6952 with
+                                let uu____6915 = try_simplify ()  in
+                                match uu____6915 with
                                 | FStar_Util.Inl (c,g,reason) ->
                                     (debug
-                                       (fun uu____6987  ->
-                                          let uu____6988 =
+                                       (fun uu____6950  ->
+                                          let uu____6951 =
                                             FStar_Syntax_Print.comp_to_string
                                               c
                                              in
                                           FStar_Util.print2
                                             "(2) bind: Simplified (because %s) to\n\t%s\n"
-                                            reason uu____6988);
+                                            reason uu____6951);
                                      (c, g))
                                 | FStar_Util.Inr reason ->
                                     (debug
-                                       (fun uu____7004  ->
+                                       (fun uu____6967  ->
                                           FStar_Util.print1
                                             "(2) bind: Not simplified because %s\n"
                                             reason);
                                      (let mk_bind1 c11 b1 c21 g =
-                                        let uu____7035 =
+                                        let uu____6998 =
                                           mk_bind env c11 b1 c21 bind_flags
                                             r1
                                            in
-                                        match uu____7035 with
+                                        match uu____6998 with
                                         | (c,g_bind) ->
-                                            let uu____7046 =
+                                            let uu____7009 =
                                               FStar_TypeChecker_Env.conj_guard
                                                 g g_bind
                                                in
-                                            (c, uu____7046)
+                                            (c, uu____7009)
                                          in
                                       let mk_seq c11 b1 c21 =
                                         let c12 =
@@ -2743,20 +2724,20 @@ let (bind :
                                           FStar_TypeChecker_Env.unfold_effect_abbrev
                                             env c21
                                            in
-                                        let uu____7073 =
+                                        let uu____7036 =
                                           FStar_TypeChecker_Env.join env
                                             c12.FStar_Syntax_Syntax.effect_name
                                             c22.FStar_Syntax_Syntax.effect_name
                                            in
-                                        match uu____7073 with
-                                        | (m,uu____7085,lift2) ->
-                                            let uu____7087 =
+                                        match uu____7036 with
+                                        | (m,uu____7048,lift2) ->
+                                            let uu____7050 =
                                               lift_comp env c22 lift2  in
-                                            (match uu____7087 with
+                                            (match uu____7050 with
                                              | (c23,g2) ->
-                                                 let uu____7098 =
+                                                 let uu____7061 =
                                                    destruct_wp_comp c12  in
-                                                 (match uu____7098 with
+                                                 (match uu____7061 with
                                                   | (u1,t1,wp1) ->
                                                       let md_pure_or_ghost =
                                                         FStar_TypeChecker_Env.get_effect_decl
@@ -2764,114 +2745,107 @@ let (bind :
                                                           c12.FStar_Syntax_Syntax.effect_name
                                                          in
                                                       let trivial =
-                                                        let uu____7114 =
+                                                        let uu____7077 =
                                                           FStar_All.pipe_right
                                                             md_pure_or_ghost
                                                             FStar_Syntax_Util.get_wp_trivial_combinator
                                                            in
                                                         FStar_All.pipe_right
-                                                          uu____7114
+                                                          uu____7077
                                                           FStar_Util.must
                                                          in
                                                       let vc1 =
-                                                        let uu____7124 =
-                                                          let uu____7129 =
-                                                            FStar_TypeChecker_Env.inst_effect_fun_with
-                                                              [u1] env
-                                                              md_pure_or_ghost
-                                                              trivial
-                                                             in
-                                                          let uu____7130 =
-                                                            let uu____7131 =
-                                                              FStar_Syntax_Syntax.as_arg
-                                                                t1
-                                                               in
-                                                            let uu____7140 =
-                                                              let uu____7151
-                                                                =
-                                                                FStar_Syntax_Syntax.as_arg
-                                                                  wp1
-                                                                 in
-                                                              [uu____7151]
-                                                               in
-                                                            uu____7131 ::
-                                                              uu____7140
-                                                             in
-                                                          FStar_Syntax_Syntax.mk_Tm_app
-                                                            uu____7129
-                                                            uu____7130
+                                                        let uu____7085 =
+                                                          FStar_TypeChecker_Env.inst_effect_fun_with
+                                                            [u1] env
+                                                            md_pure_or_ghost
+                                                            trivial
                                                            in
-                                                        uu____7124
-                                                          FStar_Pervasives_Native.None
-                                                          r1
+                                                        let uu____7086 =
+                                                          let uu____7087 =
+                                                            FStar_Syntax_Syntax.as_arg
+                                                              t1
+                                                             in
+                                                          let uu____7096 =
+                                                            let uu____7107 =
+                                                              FStar_Syntax_Syntax.as_arg
+                                                                wp1
+                                                               in
+                                                            [uu____7107]  in
+                                                          uu____7087 ::
+                                                            uu____7096
+                                                           in
+                                                        FStar_Syntax_Syntax.mk_Tm_app
+                                                          uu____7085
+                                                          uu____7086 r1
                                                          in
-                                                      let uu____7184 =
+                                                      let uu____7140 =
                                                         strengthen_comp env
                                                           FStar_Pervasives_Native.None
                                                           c23 vc1 bind_flags
                                                          in
-                                                      (match uu____7184 with
+                                                      (match uu____7140 with
                                                        | (c,g_s) ->
-                                                           let uu____7199 =
+                                                           let uu____7155 =
                                                              FStar_TypeChecker_Env.conj_guards
                                                                [g_c1;
                                                                g_c2;
                                                                g2;
                                                                g_s]
                                                               in
-                                                           (c, uu____7199))))
+                                                           (c, uu____7155))))
                                          in
-                                      let uu____7200 =
+                                      let uu____7156 =
                                         let t =
                                           FStar_Syntax_Util.comp_result c1
                                            in
                                         match comp_univ_opt c1 with
                                         | FStar_Pervasives_Native.None  ->
-                                            let uu____7216 =
+                                            let uu____7172 =
                                               env.FStar_TypeChecker_Env.universe_of
                                                 env t
                                                in
-                                            (uu____7216, t)
+                                            (uu____7172, t)
                                         | FStar_Pervasives_Native.Some u ->
                                             (u, t)
                                          in
-                                      match uu____7200 with
+                                      match uu____7156 with
                                       | (u_res_t1,res_t1) ->
-                                          let uu____7232 =
+                                          let uu____7188 =
                                             (FStar_Option.isSome b) &&
                                               (should_return env e1opt lc11)
                                              in
-                                          if uu____7232
+                                          if uu____7188
                                           then
                                             let e1 = FStar_Option.get e1opt
                                                in
                                             let x = FStar_Option.get b  in
-                                            let uu____7241 =
+                                            let uu____7197 =
                                               FStar_Syntax_Util.is_partial_return
                                                 c1
                                                in
-                                            (if uu____7241
+                                            (if uu____7197
                                              then
                                                (debug
-                                                  (fun uu____7255  ->
-                                                     let uu____7256 =
+                                                  (fun uu____7211  ->
+                                                     let uu____7212 =
                                                        FStar_TypeChecker_Normalize.term_to_string
                                                          env e1
                                                         in
-                                                     let uu____7258 =
+                                                     let uu____7214 =
                                                        FStar_Syntax_Print.bv_to_string
                                                          x
                                                         in
                                                      FStar_Util.print2
                                                        "(3) bind (case a): Substituting %s for %s"
-                                                       uu____7256 uu____7258);
+                                                       uu____7212 uu____7214);
                                                 (let c21 =
                                                    FStar_Syntax_Subst.subst_comp
                                                      [FStar_Syntax_Syntax.NT
                                                         (x, e1)] c2
                                                     in
                                                  let g =
-                                                   let uu____7265 =
+                                                   let uu____7221 =
                                                      FStar_TypeChecker_Env.map_guard
                                                        g_c2
                                                        (FStar_Syntax_Subst.subst
@@ -2879,51 +2853,51 @@ let (bind :
                                                              (x, e1)])
                                                       in
                                                    FStar_TypeChecker_Env.conj_guard
-                                                     g_c1 uu____7265
+                                                     g_c1 uu____7221
                                                     in
                                                  mk_bind1 c1 b c21 g))
                                              else
-                                               (let uu____7270 =
+                                               (let uu____7226 =
                                                   ((FStar_Options.vcgen_optimize_bind_as_seq
                                                       ())
                                                      &&
                                                      (lcomp_has_trivial_postcondition
                                                         lc11))
                                                     &&
-                                                    (let uu____7273 =
+                                                    (let uu____7229 =
                                                        FStar_TypeChecker_Env.try_lookup_lid
                                                          env
                                                          FStar_Parser_Const.with_type_lid
                                                         in
                                                      FStar_Option.isSome
-                                                       uu____7273)
+                                                       uu____7229)
                                                    in
-                                                if uu____7270
+                                                if uu____7226
                                                 then
                                                   let e1' =
-                                                    let uu____7298 =
+                                                    let uu____7254 =
                                                       FStar_Options.vcgen_decorate_with_type
                                                         ()
                                                        in
-                                                    if uu____7298
+                                                    if uu____7254
                                                     then
                                                       FStar_Syntax_Util.mk_with_type
                                                         u_res_t1 res_t1 e1
                                                     else e1  in
                                                   (debug
-                                                     (fun uu____7310  ->
-                                                        let uu____7311 =
+                                                     (fun uu____7266  ->
+                                                        let uu____7267 =
                                                           FStar_TypeChecker_Normalize.term_to_string
                                                             env e1'
                                                            in
-                                                        let uu____7313 =
+                                                        let uu____7269 =
                                                           FStar_Syntax_Print.bv_to_string
                                                             x
                                                            in
                                                         FStar_Util.print2
                                                           "(3) bind (case b): Substituting %s for %s"
-                                                          uu____7311
-                                                          uu____7313);
+                                                          uu____7267
+                                                          uu____7269);
                                                    (let c21 =
                                                       FStar_Syntax_Subst.subst_comp
                                                         [FStar_Syntax_Syntax.NT
@@ -2932,81 +2906,81 @@ let (bind :
                                                     mk_seq c1 b c21))
                                                 else
                                                   (debug
-                                                     (fun uu____7328  ->
-                                                        let uu____7329 =
+                                                     (fun uu____7284  ->
+                                                        let uu____7285 =
                                                           FStar_TypeChecker_Normalize.term_to_string
                                                             env e1
                                                            in
-                                                        let uu____7331 =
+                                                        let uu____7287 =
                                                           FStar_Syntax_Print.bv_to_string
                                                             x
                                                            in
                                                         FStar_Util.print2
                                                           "(3) bind (case c): Adding equality %s = %s"
-                                                          uu____7329
-                                                          uu____7331);
+                                                          uu____7285
+                                                          uu____7287);
                                                    (let c21 =
                                                       FStar_Syntax_Subst.subst_comp
                                                         [FStar_Syntax_Syntax.NT
                                                            (x, e1)] c2
                                                        in
                                                     let x_eq_e =
-                                                      let uu____7338 =
+                                                      let uu____7294 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           x
                                                          in
                                                       FStar_Syntax_Util.mk_eq2
                                                         u_res_t1 res_t1 e1
-                                                        uu____7338
+                                                        uu____7294
                                                        in
-                                                    let uu____7339 =
-                                                      let uu____7344 =
-                                                        let uu____7345 =
-                                                          let uu____7346 =
+                                                    let uu____7295 =
+                                                      let uu____7300 =
+                                                        let uu____7301 =
+                                                          let uu____7302 =
                                                             FStar_Syntax_Syntax.mk_binder
                                                               x
                                                              in
-                                                          [uu____7346]  in
+                                                          [uu____7302]  in
                                                         FStar_TypeChecker_Env.push_binders
-                                                          env uu____7345
+                                                          env uu____7301
                                                          in
-                                                      weaken_comp uu____7344
+                                                      weaken_comp uu____7300
                                                         c21 x_eq_e
                                                        in
-                                                    match uu____7339 with
+                                                    match uu____7295 with
                                                     | (c22,g_w) ->
                                                         let g =
-                                                          let uu____7372 =
-                                                            let uu____7373 =
-                                                              let uu____7374
+                                                          let uu____7328 =
+                                                            let uu____7329 =
+                                                              let uu____7330
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_binder
                                                                   x
                                                                  in
-                                                              [uu____7374]
+                                                              [uu____7330]
                                                                in
-                                                            let uu____7393 =
+                                                            let uu____7349 =
                                                               FStar_TypeChecker_Common.weaken_guard_formula
                                                                 g_c2 x_eq_e
                                                                in
                                                             FStar_TypeChecker_Env.close_guard
-                                                              env uu____7373
-                                                              uu____7393
+                                                              env uu____7329
+                                                              uu____7349
                                                              in
                                                           FStar_TypeChecker_Env.conj_guard
-                                                            g_c1 uu____7372
+                                                            g_c1 uu____7328
                                                            in
-                                                        let uu____7394 =
+                                                        let uu____7350 =
                                                           mk_bind1 c1 b c22 g
                                                            in
-                                                        (match uu____7394
+                                                        (match uu____7350
                                                          with
                                                          | (c,g_bind) ->
-                                                             let uu____7405 =
+                                                             let uu____7361 =
                                                                FStar_TypeChecker_Env.conj_guard
                                                                  g_w g_bind
                                                                 in
-                                                             (c, uu____7405))))))
+                                                             (c, uu____7361))))))
                                           else mk_bind1 c1 b c2 trivial_guard))))))
                    in
                 FStar_TypeChecker_Common.mk_lcomp joined_eff
@@ -3024,7 +2998,7 @@ let (weaken_guard :
          f1,FStar_TypeChecker_Common.NonTrivial f2) ->
           let g = FStar_Syntax_Util.mk_imp f1 f2  in
           FStar_TypeChecker_Common.NonTrivial g
-      | uu____7422 -> g2
+      | uu____7378 -> g2
   
 let (maybe_assume_result_eq_pure_term :
   FStar_TypeChecker_Env.env ->
@@ -3040,23 +3014,23 @@ let (maybe_assume_result_eq_pure_term :
                  FStar_Parser_Const.effect_GTot_lid))
              && (should_return env (FStar_Pervasives_Native.Some e) lc))
             &&
-            (let uu____7446 =
+            (let uu____7402 =
                FStar_TypeChecker_Common.is_lcomp_partial_return lc  in
-             Prims.op_Negation uu____7446)
+             Prims.op_Negation uu____7402)
            in
         let flags =
           if should_return1
           then
-            let uu____7454 = FStar_TypeChecker_Common.is_total_lcomp lc  in
-            (if uu____7454
+            let uu____7410 = FStar_TypeChecker_Common.is_total_lcomp lc  in
+            (if uu____7410
              then FStar_Syntax_Syntax.RETURN ::
                (lc.FStar_TypeChecker_Common.cflags)
              else FStar_Syntax_Syntax.PARTIAL_RETURN ::
                (lc.FStar_TypeChecker_Common.cflags))
           else lc.FStar_TypeChecker_Common.cflags  in
-        let refine uu____7472 =
-          let uu____7473 = FStar_TypeChecker_Common.lcomp_comp lc  in
-          match uu____7473 with
+        let refine uu____7428 =
+          let uu____7429 = FStar_TypeChecker_Common.lcomp_comp lc  in
+          match uu____7429 with
           | (c,g_c) ->
               let u_t =
                 match comp_univ_opt c with
@@ -3065,38 +3039,38 @@ let (maybe_assume_result_eq_pure_term :
                     env.FStar_TypeChecker_Env.universe_of env
                       (FStar_Syntax_Util.comp_result c)
                  in
-              let uu____7486 = FStar_Syntax_Util.is_tot_or_gtot_comp c  in
-              if uu____7486
+              let uu____7442 = FStar_Syntax_Util.is_tot_or_gtot_comp c  in
+              if uu____7442
               then
                 let retc =
                   return_value env (FStar_Pervasives_Native.Some u_t)
                     (FStar_Syntax_Util.comp_result c) e
                    in
-                let uu____7494 =
-                  let uu____7496 = FStar_Syntax_Util.is_pure_comp c  in
-                  Prims.op_Negation uu____7496  in
-                (if uu____7494
+                let uu____7450 =
+                  let uu____7452 = FStar_Syntax_Util.is_pure_comp c  in
+                  Prims.op_Negation uu____7452  in
+                (if uu____7450
                  then
                    let retc1 = FStar_Syntax_Util.comp_to_comp_typ retc  in
                    let retc2 =
-                     let uu___935_7505 = retc1  in
+                     let uu___935_7461 = retc1  in
                      {
                        FStar_Syntax_Syntax.comp_univs =
-                         (uu___935_7505.FStar_Syntax_Syntax.comp_univs);
+                         (uu___935_7461.FStar_Syntax_Syntax.comp_univs);
                        FStar_Syntax_Syntax.effect_name =
                          FStar_Parser_Const.effect_GHOST_lid;
                        FStar_Syntax_Syntax.result_typ =
-                         (uu___935_7505.FStar_Syntax_Syntax.result_typ);
+                         (uu___935_7461.FStar_Syntax_Syntax.result_typ);
                        FStar_Syntax_Syntax.effect_args =
-                         (uu___935_7505.FStar_Syntax_Syntax.effect_args);
+                         (uu___935_7461.FStar_Syntax_Syntax.effect_args);
                        FStar_Syntax_Syntax.flags = flags
                      }  in
-                   let uu____7506 = FStar_Syntax_Syntax.mk_Comp retc2  in
-                   (uu____7506, g_c)
+                   let uu____7462 = FStar_Syntax_Syntax.mk_Comp retc2  in
+                   (uu____7462, g_c)
                  else
-                   (let uu____7509 =
+                   (let uu____7465 =
                       FStar_Syntax_Util.comp_set_flags retc flags  in
-                    (uu____7509, g_c)))
+                    (uu____7465, g_c)))
               else
                 (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c
                     in
@@ -3109,38 +3083,38 @@ let (maybe_assume_result_eq_pure_term :
                     in
                  let xexp = FStar_Syntax_Syntax.bv_to_name x  in
                  let ret =
-                   let uu____7520 =
-                     let uu____7521 =
+                   let uu____7476 =
+                     let uu____7477 =
                        return_value env (FStar_Pervasives_Native.Some u_t) t
                          xexp
                         in
-                     FStar_Syntax_Util.comp_set_flags uu____7521
+                     FStar_Syntax_Util.comp_set_flags uu____7477
                        [FStar_Syntax_Syntax.PARTIAL_RETURN]
                       in
                    FStar_All.pipe_left FStar_TypeChecker_Common.lcomp_of_comp
-                     uu____7520
+                     uu____7476
                     in
                  let eq = FStar_Syntax_Util.mk_eq2 u_t t xexp e  in
                  let eq_ret =
                    weaken_precondition env ret
                      (FStar_TypeChecker_Common.NonTrivial eq)
                     in
-                 let uu____7524 =
-                   let uu____7529 =
-                     let uu____7530 =
+                 let uu____7480 =
+                   let uu____7485 =
+                     let uu____7486 =
                        FStar_TypeChecker_Common.lcomp_of_comp c2  in
                      bind e.FStar_Syntax_Syntax.pos env
-                       FStar_Pervasives_Native.None uu____7530
+                       FStar_Pervasives_Native.None uu____7486
                        ((FStar_Pervasives_Native.Some x), eq_ret)
                       in
-                   FStar_TypeChecker_Common.lcomp_comp uu____7529  in
-                 match uu____7524 with
+                   FStar_TypeChecker_Common.lcomp_comp uu____7485  in
+                 match uu____7480 with
                  | (bind_c,g_bind) ->
-                     let uu____7539 =
+                     let uu____7495 =
                        FStar_Syntax_Util.comp_set_flags bind_c flags  in
-                     let uu____7540 =
+                     let uu____7496 =
                        FStar_TypeChecker_Env.conj_guard g_c g_bind  in
-                     (uu____7539, uu____7540))
+                     (uu____7495, uu____7496))
            in
         if Prims.op_Negation should_return1
         then lc
@@ -3162,8 +3136,8 @@ let (maybe_return_e2_and_bind :
       fun e1opt  ->
         fun lc1  ->
           fun e2  ->
-            fun uu____7576  ->
-              match uu____7576 with
+            fun uu____7532  ->
+              match uu____7532 with
               | (x,lc2) ->
                   let lc21 =
                     let eff1 =
@@ -3174,13 +3148,13 @@ let (maybe_return_e2_and_bind :
                       FStar_TypeChecker_Env.norm_eff_name env
                         lc2.FStar_TypeChecker_Common.eff_name
                        in
-                    let uu____7588 =
-                      ((let uu____7592 = is_pure_or_ghost_effect env eff1  in
-                        Prims.op_Negation uu____7592) ||
+                    let uu____7544 =
+                      ((let uu____7548 = is_pure_or_ghost_effect env eff1  in
+                        Prims.op_Negation uu____7548) ||
                          (should_not_inline_lc lc1))
                         && (is_pure_or_ghost_effect env eff2)
                        in
-                    if uu____7588
+                    if uu____7544
                     then maybe_assume_result_eq_pure_term env e2 lc2
                     else lc2  in
                   bind r env e1opt lc1 (x, lc21)
@@ -3190,10 +3164,10 @@ let (fvar_const :
   =
   fun env  ->
     fun lid  ->
-      let uu____7610 =
-        let uu____7611 = FStar_TypeChecker_Env.get_range env  in
-        FStar_Ident.set_lid_range lid uu____7611  in
-      FStar_Syntax_Syntax.fvar uu____7610 FStar_Syntax_Syntax.delta_constant
+      let uu____7566 =
+        let uu____7567 = FStar_TypeChecker_Env.get_range env  in
+        FStar_Ident.set_lid_range lid uu____7567  in
+      FStar_Syntax_Syntax.fvar uu____7566 FStar_Syntax_Syntax.delta_constant
         FStar_Pervasives_Native.None
   
 let (mk_layered_conjunction :
@@ -3216,221 +3190,221 @@ let (mk_layered_conjunction :
             fun ct1  ->
               fun ct2  ->
                 fun r  ->
-                  let uu____7661 =
-                    let uu____7666 =
-                      let uu____7667 =
+                  let uu____7617 =
+                    let uu____7622 =
+                      let uu____7623 =
                         FStar_All.pipe_right ed
                           FStar_Syntax_Util.get_layered_if_then_else_combinator
                          in
-                      FStar_All.pipe_right uu____7667 FStar_Util.must  in
-                    FStar_TypeChecker_Env.inst_tscheme_with uu____7666 [u_a]
+                      FStar_All.pipe_right uu____7623 FStar_Util.must  in
+                    FStar_TypeChecker_Env.inst_tscheme_with uu____7622 [u_a]
                      in
-                  match uu____7661 with
-                  | (uu____7678,conjunction) ->
-                      let uu____7680 =
-                        let uu____7689 =
+                  match uu____7617 with
+                  | (uu____7634,conjunction) ->
+                      let uu____7636 =
+                        let uu____7645 =
                           FStar_List.map FStar_Pervasives_Native.fst
                             ct1.FStar_Syntax_Syntax.effect_args
                            in
-                        let uu____7704 =
+                        let uu____7660 =
                           FStar_List.map FStar_Pervasives_Native.fst
                             ct2.FStar_Syntax_Syntax.effect_args
                            in
-                        (uu____7689, uu____7704)  in
-                      (match uu____7680 with
+                        (uu____7645, uu____7660)  in
+                      (match uu____7636 with
                        | (is1,is2) ->
                            let conjunction_t_error s =
-                             let uu____7750 =
-                               let uu____7752 =
+                             let uu____7706 =
+                               let uu____7708 =
                                  FStar_Syntax_Print.term_to_string
                                    conjunction
                                   in
                                FStar_Util.format2
                                  "conjunction %s does not have proper shape (reason:%s)"
-                                 uu____7752 s
+                                 uu____7708 s
                                 in
                              (FStar_Errors.Fatal_UnexpectedEffect,
-                               uu____7750)
+                               uu____7706)
                               in
-                           let uu____7756 =
-                             let uu____7801 =
-                               let uu____7802 =
+                           let uu____7712 =
+                             let uu____7757 =
+                               let uu____7758 =
                                  FStar_Syntax_Subst.compress conjunction  in
-                               uu____7802.FStar_Syntax_Syntax.n  in
-                             match uu____7801 with
+                               uu____7758.FStar_Syntax_Syntax.n  in
+                             match uu____7757 with
                              | FStar_Syntax_Syntax.Tm_abs
-                                 (bs,body,uu____7851) when
+                                 (bs,body,uu____7807) when
                                  (FStar_List.length bs) >= (Prims.of_int (4))
                                  ->
-                                 let uu____7883 =
+                                 let uu____7839 =
                                    FStar_Syntax_Subst.open_term bs body  in
-                                 (match uu____7883 with
+                                 (match uu____7839 with
                                   | (a_b::bs1,body1) ->
-                                      let uu____7955 =
+                                      let uu____7911 =
                                         FStar_List.splitAt
                                           ((FStar_List.length bs1) -
                                              (Prims.of_int (3))) bs1
                                          in
-                                      (match uu____7955 with
+                                      (match uu____7911 with
                                        | (rest_bs,f_b::g_b::p_b::[]) ->
-                                           let uu____8103 =
+                                           let uu____8059 =
                                              FStar_All.pipe_right body1
                                                FStar_Syntax_Util.unascribe
                                               in
                                            (a_b, rest_bs, f_b, g_b, p_b,
-                                             uu____8103)))
-                             | uu____8136 ->
-                                 let uu____8137 =
+                                             uu____8059)))
+                             | uu____8092 ->
+                                 let uu____8093 =
                                    conjunction_t_error
                                      "Either not an abstraction or not enough binders"
                                     in
-                                 FStar_Errors.raise_error uu____8137 r
+                                 FStar_Errors.raise_error uu____8093 r
                               in
-                           (match uu____7756 with
+                           (match uu____7712 with
                             | (a_b,rest_bs,f_b,g_b,p_b,body) ->
-                                let uu____8262 =
-                                  let uu____8269 =
-                                    let uu____8270 =
-                                      let uu____8271 =
-                                        let uu____8278 =
+                                let uu____8218 =
+                                  let uu____8225 =
+                                    let uu____8226 =
+                                      let uu____8227 =
+                                        let uu____8234 =
                                           FStar_All.pipe_right a_b
                                             FStar_Pervasives_Native.fst
                                            in
-                                        (uu____8278, a)  in
-                                      FStar_Syntax_Syntax.NT uu____8271  in
-                                    [uu____8270]  in
+                                        (uu____8234, a)  in
+                                      FStar_Syntax_Syntax.NT uu____8227  in
+                                    [uu____8226]  in
                                   FStar_TypeChecker_Env.uvars_for_binders env
-                                    rest_bs uu____8269
+                                    rest_bs uu____8225
                                     (fun b  ->
-                                       let uu____8294 =
+                                       let uu____8250 =
                                          FStar_Syntax_Print.binder_to_string
                                            b
                                           in
-                                       let uu____8296 =
+                                       let uu____8252 =
                                          FStar_Ident.string_of_lid
                                            ed.FStar_Syntax_Syntax.mname
                                           in
-                                       let uu____8298 =
+                                       let uu____8254 =
                                          FStar_All.pipe_right r
                                            FStar_Range.string_of_range
                                           in
                                        FStar_Util.format3
                                          "implicit var for binder %s of %s:conjunction at %s"
-                                         uu____8294 uu____8296 uu____8298) r
+                                         uu____8250 uu____8252 uu____8254) r
                                    in
-                                (match uu____8262 with
+                                (match uu____8218 with
                                  | (rest_bs_uvars,g_uvars) ->
                                      let substs =
                                        FStar_List.map2
                                          (fun b  ->
                                             fun t  ->
-                                              let uu____8336 =
-                                                let uu____8343 =
+                                              let uu____8292 =
+                                                let uu____8299 =
                                                   FStar_All.pipe_right b
                                                     FStar_Pervasives_Native.fst
                                                    in
-                                                (uu____8343, t)  in
+                                                (uu____8299, t)  in
                                               FStar_Syntax_Syntax.NT
-                                                uu____8336) (a_b ::
+                                                uu____8292) (a_b ::
                                          (FStar_List.append rest_bs [p_b]))
                                          (a ::
                                          (FStar_List.append rest_bs_uvars [p]))
                                         in
                                      let f_guard =
                                        let f_sort_is =
-                                         let uu____8382 =
-                                           let uu____8383 =
-                                             let uu____8386 =
-                                               let uu____8387 =
+                                         let uu____8338 =
+                                           let uu____8339 =
+                                             let uu____8342 =
+                                               let uu____8343 =
                                                  FStar_All.pipe_right f_b
                                                    FStar_Pervasives_Native.fst
                                                   in
-                                               uu____8387.FStar_Syntax_Syntax.sort
+                                               uu____8343.FStar_Syntax_Syntax.sort
                                                 in
                                              FStar_Syntax_Subst.compress
-                                               uu____8386
+                                               uu____8342
                                               in
-                                           uu____8383.FStar_Syntax_Syntax.n
+                                           uu____8339.FStar_Syntax_Syntax.n
                                             in
-                                         match uu____8382 with
+                                         match uu____8338 with
                                          | FStar_Syntax_Syntax.Tm_app
-                                             (uu____8398,uu____8399::is) ->
-                                             let uu____8441 =
+                                             (uu____8354,uu____8355::is) ->
+                                             let uu____8397 =
                                                FStar_All.pipe_right is
                                                  (FStar_List.map
                                                     FStar_Pervasives_Native.fst)
                                                 in
-                                             FStar_All.pipe_right uu____8441
+                                             FStar_All.pipe_right uu____8397
                                                (FStar_List.map
                                                   (FStar_Syntax_Subst.subst
                                                      substs))
-                                         | uu____8474 ->
-                                             let uu____8475 =
+                                         | uu____8430 ->
+                                             let uu____8431 =
                                                conjunction_t_error
                                                  "f's type is not a repr type"
                                                 in
                                              FStar_Errors.raise_error
-                                               uu____8475 r
+                                               uu____8431 r
                                           in
                                        FStar_List.fold_left2
                                          (fun g  ->
                                             fun i1  ->
                                               fun f_i  ->
-                                                let uu____8491 =
+                                                let uu____8447 =
                                                   FStar_TypeChecker_Rel.teq
                                                     env i1 f_i
                                                    in
                                                 FStar_TypeChecker_Env.conj_guard
-                                                  g uu____8491)
+                                                  g uu____8447)
                                          FStar_TypeChecker_Env.trivial_guard
                                          is1 f_sort_is
                                         in
                                      let g_guard =
                                        let g_sort_is =
-                                         let uu____8496 =
-                                           let uu____8497 =
-                                             let uu____8500 =
-                                               let uu____8501 =
+                                         let uu____8452 =
+                                           let uu____8453 =
+                                             let uu____8456 =
+                                               let uu____8457 =
                                                  FStar_All.pipe_right g_b
                                                    FStar_Pervasives_Native.fst
                                                   in
-                                               uu____8501.FStar_Syntax_Syntax.sort
+                                               uu____8457.FStar_Syntax_Syntax.sort
                                                 in
                                              FStar_Syntax_Subst.compress
-                                               uu____8500
+                                               uu____8456
                                               in
-                                           uu____8497.FStar_Syntax_Syntax.n
+                                           uu____8453.FStar_Syntax_Syntax.n
                                             in
-                                         match uu____8496 with
+                                         match uu____8452 with
                                          | FStar_Syntax_Syntax.Tm_app
-                                             (uu____8512,uu____8513::is) ->
-                                             let uu____8555 =
+                                             (uu____8468,uu____8469::is) ->
+                                             let uu____8511 =
                                                FStar_All.pipe_right is
                                                  (FStar_List.map
                                                     FStar_Pervasives_Native.fst)
                                                 in
-                                             FStar_All.pipe_right uu____8555
+                                             FStar_All.pipe_right uu____8511
                                                (FStar_List.map
                                                   (FStar_Syntax_Subst.subst
                                                      substs))
-                                         | uu____8588 ->
-                                             let uu____8589 =
+                                         | uu____8544 ->
+                                             let uu____8545 =
                                                conjunction_t_error
                                                  "g's type is not a repr type"
                                                 in
                                              FStar_Errors.raise_error
-                                               uu____8589 r
+                                               uu____8545 r
                                           in
                                        FStar_List.fold_left2
                                          (fun g  ->
                                             fun i2  ->
                                               fun g_i  ->
-                                                let uu____8605 =
+                                                let uu____8561 =
                                                   FStar_TypeChecker_Rel.teq
                                                     env i2 g_i
                                                    in
                                                 FStar_TypeChecker_Env.conj_guard
-                                                  g uu____8605)
+                                                  g uu____8561)
                                          FStar_TypeChecker_Env.trivial_guard
                                          is2 g_sort_is
                                         in
@@ -3438,27 +3412,27 @@ let (mk_layered_conjunction :
                                        FStar_Syntax_Subst.subst substs body
                                         in
                                      let is =
-                                       let uu____8610 =
-                                         let uu____8611 =
+                                       let uu____8566 =
+                                         let uu____8567 =
                                            FStar_Syntax_Subst.compress body1
                                             in
-                                         uu____8611.FStar_Syntax_Syntax.n  in
-                                       match uu____8610 with
+                                         uu____8567.FStar_Syntax_Syntax.n  in
+                                       match uu____8566 with
                                        | FStar_Syntax_Syntax.Tm_app
-                                           (uu____8616,a1::args) ->
+                                           (uu____8572,a1::args) ->
                                            FStar_List.map
                                              FStar_Pervasives_Native.fst args
-                                       | uu____8671 ->
-                                           let uu____8672 =
+                                       | uu____8627 ->
+                                           let uu____8628 =
                                              conjunction_t_error
                                                "body is not a repr type"
                                               in
                                            FStar_Errors.raise_error
-                                             uu____8672 r
+                                             uu____8628 r
                                         in
-                                     let uu____8681 =
-                                       let uu____8682 =
-                                         let uu____8683 =
+                                     let uu____8637 =
+                                       let uu____8638 =
+                                         let uu____8639 =
                                            FStar_All.pipe_right is
                                              (FStar_List.map
                                                 FStar_Syntax_Syntax.as_arg)
@@ -3470,20 +3444,20 @@ let (mk_layered_conjunction :
                                              (ed.FStar_Syntax_Syntax.mname);
                                            FStar_Syntax_Syntax.result_typ = a;
                                            FStar_Syntax_Syntax.effect_args =
-                                             uu____8683;
+                                             uu____8639;
                                            FStar_Syntax_Syntax.flags = []
                                          }  in
-                                       FStar_Syntax_Syntax.mk_Comp uu____8682
+                                       FStar_Syntax_Syntax.mk_Comp uu____8638
                                         in
-                                     let uu____8706 =
-                                       let uu____8707 =
+                                     let uu____8662 =
+                                       let uu____8663 =
                                          FStar_TypeChecker_Env.conj_guard
                                            g_uvars f_guard
                                           in
                                        FStar_TypeChecker_Env.conj_guard
-                                         uu____8707 g_guard
+                                         uu____8663 g_guard
                                         in
-                                     (uu____8681, uu____8706))))
+                                     (uu____8637, uu____8662))))
   
 let (mk_non_layered_conjunction :
   FStar_TypeChecker_Env.env ->
@@ -3504,54 +3478,50 @@ let (mk_non_layered_conjunction :
           fun p  ->
             fun ct1  ->
               fun ct2  ->
-                fun uu____8752  ->
+                fun uu____8708  ->
                   let if_then_else =
-                    let uu____8758 =
+                    let uu____8714 =
                       FStar_All.pipe_right ed
                         FStar_Syntax_Util.get_wp_if_then_else_combinator
                        in
-                    FStar_All.pipe_right uu____8758 FStar_Util.must  in
-                  let uu____8765 = destruct_wp_comp ct1  in
-                  match uu____8765 with
-                  | (uu____8776,uu____8777,wp_t) ->
-                      let uu____8779 = destruct_wp_comp ct2  in
-                      (match uu____8779 with
-                       | (uu____8790,uu____8791,wp_e) ->
+                    FStar_All.pipe_right uu____8714 FStar_Util.must  in
+                  let uu____8721 = destruct_wp_comp ct1  in
+                  match uu____8721 with
+                  | (uu____8732,uu____8733,wp_t) ->
+                      let uu____8735 = destruct_wp_comp ct2  in
+                      (match uu____8735 with
+                       | (uu____8746,uu____8747,wp_e) ->
                            let wp =
-                             let uu____8796 =
+                             let uu____8750 =
+                               FStar_TypeChecker_Env.inst_effect_fun_with
+                                 [u_a] env ed if_then_else
+                                in
+                             let uu____8751 =
+                               let uu____8752 = FStar_Syntax_Syntax.as_arg a
+                                  in
+                               let uu____8761 =
+                                 let uu____8772 =
+                                   FStar_Syntax_Syntax.as_arg p  in
+                                 let uu____8781 =
+                                   let uu____8792 =
+                                     FStar_Syntax_Syntax.as_arg wp_t  in
+                                   let uu____8801 =
+                                     let uu____8812 =
+                                       FStar_Syntax_Syntax.as_arg wp_e  in
+                                     [uu____8812]  in
+                                   uu____8792 :: uu____8801  in
+                                 uu____8772 :: uu____8781  in
+                               uu____8752 :: uu____8761  in
+                             let uu____8861 =
                                FStar_Range.union_ranges
                                  wp_t.FStar_Syntax_Syntax.pos
                                  wp_e.FStar_Syntax_Syntax.pos
                                 in
-                             let uu____8797 =
-                               let uu____8802 =
-                                 FStar_TypeChecker_Env.inst_effect_fun_with
-                                   [u_a] env ed if_then_else
-                                  in
-                               let uu____8803 =
-                                 let uu____8804 =
-                                   FStar_Syntax_Syntax.as_arg a  in
-                                 let uu____8813 =
-                                   let uu____8824 =
-                                     FStar_Syntax_Syntax.as_arg p  in
-                                   let uu____8833 =
-                                     let uu____8844 =
-                                       FStar_Syntax_Syntax.as_arg wp_t  in
-                                     let uu____8853 =
-                                       let uu____8864 =
-                                         FStar_Syntax_Syntax.as_arg wp_e  in
-                                       [uu____8864]  in
-                                     uu____8844 :: uu____8853  in
-                                   uu____8824 :: uu____8833  in
-                                 uu____8804 :: uu____8813  in
-                               FStar_Syntax_Syntax.mk_Tm_app uu____8802
-                                 uu____8803
-                                in
-                             uu____8797 FStar_Pervasives_Native.None
-                               uu____8796
+                             FStar_Syntax_Syntax.mk_Tm_app uu____8750
+                               uu____8751 uu____8861
                               in
-                           let uu____8913 = mk_comp ed u_a a wp []  in
-                           (uu____8913, FStar_TypeChecker_Env.trivial_guard))
+                           let uu____8862 = mk_comp ed u_a a wp []  in
+                           (uu____8862, FStar_TypeChecker_Env.trivial_guard))
   
 let (bind_cases :
   FStar_TypeChecker_Env.env ->
@@ -3566,94 +3536,94 @@ let (bind_cases :
       fun lcases  ->
         fun scrutinee  ->
           let env =
-            let uu____8967 =
-              let uu____8968 =
+            let uu____8916 =
+              let uu____8917 =
                 FStar_All.pipe_right scrutinee FStar_Syntax_Syntax.mk_binder
                  in
-              [uu____8968]  in
-            FStar_TypeChecker_Env.push_binders env0 uu____8967  in
+              [uu____8917]  in
+            FStar_TypeChecker_Env.push_binders env0 uu____8916  in
           let eff =
             FStar_List.fold_left
               (fun eff  ->
-                 fun uu____9015  ->
-                   match uu____9015 with
-                   | (uu____9029,eff_label,uu____9031,uu____9032) ->
+                 fun uu____8964  ->
+                   match uu____8964 with
+                   | (uu____8978,eff_label,uu____8980,uu____8981) ->
                        join_effects env eff eff_label)
               FStar_Parser_Const.effect_PURE_lid lcases
              in
-          let uu____9045 =
-            let uu____9053 =
+          let uu____8994 =
+            let uu____9002 =
               FStar_All.pipe_right lcases
                 (FStar_Util.for_some
-                   (fun uu____9091  ->
-                      match uu____9091 with
-                      | (uu____9106,uu____9107,flags,uu____9109) ->
+                   (fun uu____9040  ->
+                      match uu____9040 with
+                      | (uu____9055,uu____9056,flags,uu____9058) ->
                           FStar_All.pipe_right flags
                             (FStar_Util.for_some
-                               (fun uu___5_9126  ->
-                                  match uu___5_9126 with
+                               (fun uu___5_9075  ->
+                                  match uu___5_9075 with
                                   | FStar_Syntax_Syntax.SHOULD_NOT_INLINE  ->
                                       true
-                                  | uu____9129 -> false))))
+                                  | uu____9078 -> false))))
                in
-            if uu____9053
+            if uu____9002
             then (true, [FStar_Syntax_Syntax.SHOULD_NOT_INLINE])
             else (false, [])  in
-          match uu____9045 with
+          match uu____8994 with
           | (should_not_inline_whole_match,bind_cases_flags) ->
-              let bind_cases uu____9166 =
+              let bind_cases uu____9115 =
                 let u_res_t = env.FStar_TypeChecker_Env.universe_of env res_t
                    in
-                let uu____9168 =
+                let uu____9117 =
                   env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ())
                    in
-                if uu____9168
+                if uu____9117
                 then
-                  let uu____9175 = lax_mk_tot_or_comp_l eff u_res_t res_t []
+                  let uu____9124 = lax_mk_tot_or_comp_l eff u_res_t res_t []
                      in
-                  (uu____9175, FStar_TypeChecker_Env.trivial_guard)
+                  (uu____9124, FStar_TypeChecker_Env.trivial_guard)
                 else
                   (let default_case =
                      let post_k =
-                       let uu____9182 =
-                         let uu____9191 =
+                       let uu____9131 =
+                         let uu____9140 =
                            FStar_Syntax_Syntax.null_binder res_t  in
-                         [uu____9191]  in
-                       let uu____9210 =
+                         [uu____9140]  in
+                       let uu____9159 =
                          FStar_Syntax_Syntax.mk_Total
                            FStar_Syntax_Util.ktype0
                           in
-                       FStar_Syntax_Util.arrow uu____9182 uu____9210  in
+                       FStar_Syntax_Util.arrow uu____9131 uu____9159  in
                      let kwp =
-                       let uu____9216 =
-                         let uu____9225 =
+                       let uu____9165 =
+                         let uu____9174 =
                            FStar_Syntax_Syntax.null_binder post_k  in
-                         [uu____9225]  in
-                       let uu____9244 =
+                         [uu____9174]  in
+                       let uu____9193 =
                          FStar_Syntax_Syntax.mk_Total
                            FStar_Syntax_Util.ktype0
                           in
-                       FStar_Syntax_Util.arrow uu____9216 uu____9244  in
+                       FStar_Syntax_Util.arrow uu____9165 uu____9193  in
                      let post =
                        FStar_Syntax_Syntax.new_bv
                          FStar_Pervasives_Native.None post_k
                         in
                      let wp =
-                       let uu____9251 =
-                         let uu____9252 = FStar_Syntax_Syntax.mk_binder post
+                       let uu____9200 =
+                         let uu____9201 = FStar_Syntax_Syntax.mk_binder post
                             in
-                         [uu____9252]  in
-                       let uu____9271 =
-                         let uu____9274 =
-                           let uu____9281 =
+                         [uu____9201]  in
+                       let uu____9220 =
+                         let uu____9223 =
+                           let uu____9230 =
                              FStar_TypeChecker_Env.get_range env  in
                            label FStar_TypeChecker_Err.exhaustiveness_check
-                             uu____9281
+                             uu____9230
                             in
-                         let uu____9282 =
+                         let uu____9231 =
                            fvar_const env FStar_Parser_Const.false_lid  in
-                         FStar_All.pipe_left uu____9274 uu____9282  in
-                       FStar_Syntax_Util.abs uu____9251 uu____9271
+                         FStar_All.pipe_left uu____9223 uu____9231  in
+                       FStar_Syntax_Util.abs uu____9200 uu____9220
                          (FStar_Pervasives_Native.Some
                             (FStar_Syntax_Util.mk_residual_comp
                                FStar_Parser_Const.effect_Tot_lid
@@ -3666,145 +3636,145 @@ let (bind_cases :
                         in
                      mk_comp md u_res_t res_t wp []  in
                    let maybe_return eff_label_then cthen =
-                     let uu____9306 =
+                     let uu____9255 =
                        should_not_inline_whole_match ||
-                         (let uu____9309 = is_pure_or_ghost_effect env eff
+                         (let uu____9258 = is_pure_or_ghost_effect env eff
                              in
-                          Prims.op_Negation uu____9309)
+                          Prims.op_Negation uu____9258)
                         in
-                     if uu____9306 then cthen true else cthen false  in
+                     if uu____9255 then cthen true else cthen false  in
                    let branch_conditions =
-                     let uu____9321 =
-                       let uu____9334 =
-                         let uu____9339 =
-                           let uu____9350 =
+                     let uu____9270 =
+                       let uu____9283 =
+                         let uu____9288 =
+                           let uu____9299 =
                              FStar_All.pipe_right lcases
                                (FStar_List.map
-                                  (fun uu____9394  ->
-                                     match uu____9394 with
-                                     | (g,uu____9409,uu____9410,uu____9411)
+                                  (fun uu____9343  ->
+                                     match uu____9343 with
+                                     | (g,uu____9358,uu____9359,uu____9360)
                                          -> g))
                               in
-                           FStar_All.pipe_right uu____9350
+                           FStar_All.pipe_right uu____9299
                              (FStar_List.fold_left
-                                (fun uu____9455  ->
+                                (fun uu____9404  ->
                                    fun g  ->
-                                     match uu____9455 with
+                                     match uu____9404 with
                                      | (conds,acc) ->
                                          let cond =
-                                           let uu____9496 =
+                                           let uu____9445 =
                                              FStar_Syntax_Util.mk_neg g  in
                                            FStar_Syntax_Util.mk_conj acc
-                                             uu____9496
+                                             uu____9445
                                             in
                                          ((FStar_List.append conds [cond]),
                                            cond))
                                 ([FStar_Syntax_Util.t_true],
                                   FStar_Syntax_Util.t_true))
                             in
-                         FStar_All.pipe_right uu____9339
+                         FStar_All.pipe_right uu____9288
                            FStar_Pervasives_Native.fst
                           in
-                       FStar_All.pipe_right uu____9334
+                       FStar_All.pipe_right uu____9283
                          (FStar_List.splitAt (FStar_List.length lcases))
                         in
-                     FStar_All.pipe_right uu____9321
+                     FStar_All.pipe_right uu____9270
                        FStar_Pervasives_Native.fst
                       in
-                   let uu____9597 =
+                   let uu____9546 =
                      FStar_List.fold_right2
-                       (fun uu____9660  ->
+                       (fun uu____9609  ->
                           fun bcond  ->
-                            fun uu____9662  ->
-                              match (uu____9660, uu____9662) with
-                              | ((g,eff_label,uu____9722,cthen),(uu____9724,celse,g_comp))
+                            fun uu____9611  ->
+                              match (uu____9609, uu____9611) with
+                              | ((g,eff_label,uu____9671,cthen),(uu____9673,celse,g_comp))
                                   ->
-                                  let uu____9771 =
-                                    let uu____9776 =
+                                  let uu____9720 =
+                                    let uu____9725 =
                                       maybe_return eff_label cthen  in
                                     FStar_TypeChecker_Common.lcomp_comp
-                                      uu____9776
+                                      uu____9725
                                      in
-                                  (match uu____9771 with
+                                  (match uu____9720 with
                                    | (cthen1,gthen) ->
                                        let gthen1 =
-                                         let uu____9788 =
+                                         let uu____9737 =
                                            FStar_Syntax_Util.mk_conj bcond g
                                             in
                                          FStar_TypeChecker_Common.weaken_guard_formula
-                                           gthen uu____9788
+                                           gthen uu____9737
                                           in
-                                       let uu____9789 =
-                                         let uu____9800 =
+                                       let uu____9738 =
+                                         let uu____9749 =
                                            lift_comps_sep_guards env cthen1
                                              celse
                                              FStar_Pervasives_Native.None
                                              false
                                             in
-                                         match uu____9800 with
+                                         match uu____9749 with
                                          | (m,cthen2,celse1,g_lift_then,g_lift_else)
                                              ->
                                              let md =
                                                FStar_TypeChecker_Env.get_effect_decl
                                                  env m
                                                 in
-                                             let uu____9828 =
+                                             let uu____9777 =
                                                FStar_All.pipe_right cthen2
                                                  FStar_Syntax_Util.comp_to_comp_typ
                                                 in
-                                             let uu____9829 =
+                                             let uu____9778 =
                                                FStar_All.pipe_right celse1
                                                  FStar_Syntax_Util.comp_to_comp_typ
                                                 in
-                                             (md, uu____9828, uu____9829,
+                                             (md, uu____9777, uu____9778,
                                                g_lift_then, g_lift_else)
                                           in
-                                       (match uu____9789 with
+                                       (match uu____9738 with
                                         | (md,ct_then,ct_else,g_lift_then,g_lift_else)
                                             ->
                                             let fn =
-                                              let uu____9880 =
+                                              let uu____9829 =
                                                 FStar_All.pipe_right md
                                                   FStar_Syntax_Util.is_layered
                                                  in
-                                              if uu____9880
+                                              if uu____9829
                                               then mk_layered_conjunction
                                               else mk_non_layered_conjunction
                                                in
                                             let g_lift_then1 =
-                                              let uu____9915 =
+                                              let uu____9864 =
                                                 FStar_Syntax_Util.mk_conj
                                                   bcond g
                                                  in
                                               FStar_TypeChecker_Common.weaken_guard_formula
-                                                g_lift_then uu____9915
+                                                g_lift_then uu____9864
                                                in
                                             let g_lift_else1 =
-                                              let uu____9917 =
-                                                let uu____9918 =
+                                              let uu____9866 =
+                                                let uu____9867 =
                                                   FStar_Syntax_Util.mk_neg g
                                                    in
                                                 FStar_Syntax_Util.mk_conj
-                                                  bcond uu____9918
+                                                  bcond uu____9867
                                                  in
                                               FStar_TypeChecker_Common.weaken_guard_formula
-                                                g_lift_else uu____9917
+                                                g_lift_else uu____9866
                                                in
                                             let g_lift =
                                               FStar_TypeChecker_Env.conj_guard
                                                 g_lift_then1 g_lift_else1
                                                in
-                                            let uu____9922 =
-                                              let uu____9927 =
+                                            let uu____9871 =
+                                              let uu____9876 =
                                                 FStar_TypeChecker_Env.get_range
                                                   env
                                                  in
                                               fn env md u_res_t res_t g
-                                                ct_then ct_else uu____9927
+                                                ct_then ct_else uu____9876
                                                in
-                                            (match uu____9922 with
+                                            (match uu____9871 with
                                              | (c,g_conjunction) ->
-                                                 let uu____9938 =
+                                                 let uu____9887 =
                                                    FStar_TypeChecker_Env.conj_guards
                                                      [g_comp;
                                                      gthen1;
@@ -3812,34 +3782,34 @@ let (bind_cases :
                                                      g_conjunction]
                                                     in
                                                  ((FStar_Pervasives_Native.Some
-                                                     md), c, uu____9938)))))
+                                                     md), c, uu____9887)))))
                        lcases branch_conditions
                        (FStar_Pervasives_Native.None, default_case,
                          FStar_TypeChecker_Env.trivial_guard)
                       in
-                   match uu____9597 with
+                   match uu____9546 with
                    | (md,comp,g_comp) ->
                        let g_comp1 =
-                         let uu____9955 =
-                           let uu____9956 =
+                         let uu____9904 =
+                           let uu____9905 =
                              FStar_All.pipe_right scrutinee
                                FStar_Syntax_Syntax.mk_binder
                               in
-                           [uu____9956]  in
-                         FStar_TypeChecker_Env.close_guard env0 uu____9955
+                           [uu____9905]  in
+                         FStar_TypeChecker_Env.close_guard env0 uu____9904
                            g_comp
                           in
                        (match lcases with
                         | [] -> (comp, g_comp1)
-                        | uu____9999::[] -> (comp, g_comp1)
-                        | uu____10042 ->
-                            let uu____10059 =
-                              let uu____10061 =
+                        | uu____9948::[] -> (comp, g_comp1)
+                        | uu____9991 ->
+                            let uu____10008 =
+                              let uu____10010 =
                                 FStar_All.pipe_right md FStar_Util.must  in
-                              FStar_All.pipe_right uu____10061
+                              FStar_All.pipe_right uu____10010
                                 FStar_Syntax_Util.is_layered
                                in
-                            if uu____10059
+                            if uu____10008
                             then (comp, g_comp1)
                             else
                               (let comp1 =
@@ -3850,44 +3820,39 @@ let (bind_cases :
                                  FStar_TypeChecker_Env.get_effect_decl env
                                    comp1.FStar_Syntax_Syntax.effect_name
                                   in
-                               let uu____10074 = destruct_wp_comp comp1  in
-                               match uu____10074 with
-                               | (uu____10085,uu____10086,wp) ->
+                               let uu____10023 = destruct_wp_comp comp1  in
+                               match uu____10023 with
+                               | (uu____10034,uu____10035,wp) ->
                                    let ite_wp =
-                                     let uu____10089 =
+                                     let uu____10038 =
                                        FStar_All.pipe_right md1
                                          FStar_Syntax_Util.get_wp_ite_combinator
                                         in
-                                     FStar_All.pipe_right uu____10089
+                                     FStar_All.pipe_right uu____10038
                                        FStar_Util.must
                                       in
                                    let wp1 =
-                                     let uu____10099 =
-                                       let uu____10104 =
-                                         FStar_TypeChecker_Env.inst_effect_fun_with
-                                           [u_res_t] env md1 ite_wp
-                                          in
-                                       let uu____10105 =
-                                         let uu____10106 =
-                                           FStar_Syntax_Syntax.as_arg res_t
-                                            in
-                                         let uu____10115 =
-                                           let uu____10126 =
-                                             FStar_Syntax_Syntax.as_arg wp
-                                              in
-                                           [uu____10126]  in
-                                         uu____10106 :: uu____10115  in
-                                       FStar_Syntax_Syntax.mk_Tm_app
-                                         uu____10104 uu____10105
+                                     let uu____10046 =
+                                       FStar_TypeChecker_Env.inst_effect_fun_with
+                                         [u_res_t] env md1 ite_wp
                                         in
-                                     uu____10099 FStar_Pervasives_Native.None
+                                     let uu____10047 =
+                                       let uu____10048 =
+                                         FStar_Syntax_Syntax.as_arg res_t  in
+                                       let uu____10057 =
+                                         let uu____10068 =
+                                           FStar_Syntax_Syntax.as_arg wp  in
+                                         [uu____10068]  in
+                                       uu____10048 :: uu____10057  in
+                                     FStar_Syntax_Syntax.mk_Tm_app
+                                       uu____10046 uu____10047
                                        wp.FStar_Syntax_Syntax.pos
                                       in
-                                   let uu____10159 =
+                                   let uu____10101 =
                                      mk_comp md1 u_res_t res_t wp1
                                        bind_cases_flags
                                       in
-                                   (uu____10159, g_comp1))))
+                                   (uu____10101, g_comp1))))
                  in
               FStar_TypeChecker_Common.mk_lcomp eff res_t bind_cases_flags
                 bind_cases
@@ -3904,24 +3869,24 @@ let (check_comp :
     fun e  ->
       fun c  ->
         fun c'  ->
-          let uu____10194 = FStar_TypeChecker_Rel.sub_comp env c c'  in
-          match uu____10194 with
+          let uu____10136 = FStar_TypeChecker_Rel.sub_comp env c c'  in
+          match uu____10136 with
           | FStar_Pervasives_Native.None  ->
               if env.FStar_TypeChecker_Env.use_eq
               then
-                let uu____10210 =
+                let uu____10152 =
                   FStar_TypeChecker_Err.computed_computation_type_does_not_match_annotation_eq
                     env e c c'
                    in
-                let uu____10216 = FStar_TypeChecker_Env.get_range env  in
-                FStar_Errors.raise_error uu____10210 uu____10216
+                let uu____10158 = FStar_TypeChecker_Env.get_range env  in
+                FStar_Errors.raise_error uu____10152 uu____10158
               else
-                (let uu____10225 =
+                (let uu____10167 =
                    FStar_TypeChecker_Err.computed_computation_type_does_not_match_annotation
                      env e c c'
                     in
-                 let uu____10231 = FStar_TypeChecker_Env.get_range env  in
-                 FStar_Errors.raise_error uu____10225 uu____10231)
+                 let uu____10173 = FStar_TypeChecker_Env.get_range env  in
+                 FStar_Errors.raise_error uu____10167 uu____10173)
           | FStar_Pervasives_Native.Some g -> (e, c', g)
   
 let (universe_of_comp :
@@ -3933,40 +3898,40 @@ let (universe_of_comp :
     fun u_res  ->
       fun c  ->
         let c_lid =
-          let uu____10256 =
+          let uu____10198 =
             FStar_All.pipe_right c FStar_Syntax_Util.comp_effect_name  in
-          FStar_All.pipe_right uu____10256
+          FStar_All.pipe_right uu____10198
             (FStar_TypeChecker_Env.norm_eff_name env)
            in
-        let uu____10259 = FStar_Syntax_Util.is_pure_or_ghost_effect c_lid  in
-        if uu____10259
+        let uu____10201 = FStar_Syntax_Util.is_pure_or_ghost_effect c_lid  in
+        if uu____10201
         then u_res
         else
           (let is_total =
-             let uu____10266 =
+             let uu____10208 =
                FStar_TypeChecker_Env.lookup_effect_quals env c_lid  in
-             FStar_All.pipe_right uu____10266
+             FStar_All.pipe_right uu____10208
                (FStar_List.existsb
                   (fun q  -> q = FStar_Syntax_Syntax.TotalEffect))
               in
            if Prims.op_Negation is_total
            then FStar_Syntax_Syntax.U_zero
            else
-             (let uu____10277 = FStar_TypeChecker_Env.effect_repr env c u_res
+             (let uu____10219 = FStar_TypeChecker_Env.effect_repr env c u_res
                  in
-              match uu____10277 with
+              match uu____10219 with
               | FStar_Pervasives_Native.None  ->
-                  let uu____10280 =
-                    let uu____10286 =
-                      let uu____10288 =
+                  let uu____10222 =
+                    let uu____10228 =
+                      let uu____10230 =
                         FStar_Syntax_Print.lid_to_string c_lid  in
                       FStar_Util.format1
                         "Effect %s is marked total but does not have a repr"
-                        uu____10288
+                        uu____10230
                        in
-                    (FStar_Errors.Fatal_EffectCannotBeReified, uu____10286)
+                    (FStar_Errors.Fatal_EffectCannotBeReified, uu____10228)
                      in
-                  FStar_Errors.raise_error uu____10280
+                  FStar_Errors.raise_error uu____10222
                     c.FStar_Syntax_Syntax.pos
               | FStar_Pervasives_Native.Some tm ->
                   env.FStar_TypeChecker_Env.universe_of env tm))
@@ -3987,35 +3952,34 @@ let (check_trivial_precondition :
         FStar_TypeChecker_Env.get_effect_decl env
           ct.FStar_Syntax_Syntax.effect_name
          in
-      let uu____10312 = destruct_wp_comp ct  in
-      match uu____10312 with
+      let uu____10254 = destruct_wp_comp ct  in
+      match uu____10254 with
       | (u_t,t,wp) ->
           let vc =
-            let uu____10331 = FStar_TypeChecker_Env.get_range env  in
-            let uu____10332 =
-              let uu____10337 =
-                let uu____10338 =
-                  let uu____10339 =
-                    FStar_All.pipe_right md
-                      FStar_Syntax_Util.get_wp_trivial_combinator
-                     in
-                  FStar_All.pipe_right uu____10339 FStar_Util.must  in
-                FStar_TypeChecker_Env.inst_effect_fun_with [u_t] env md
-                  uu____10338
-                 in
-              let uu____10346 =
-                let uu____10347 = FStar_Syntax_Syntax.as_arg t  in
-                let uu____10356 =
-                  let uu____10367 = FStar_Syntax_Syntax.as_arg wp  in
-                  [uu____10367]  in
-                uu____10347 :: uu____10356  in
-              FStar_Syntax_Syntax.mk_Tm_app uu____10337 uu____10346  in
-            uu____10332 FStar_Pervasives_Native.None uu____10331  in
-          let uu____10400 =
+            let uu____10271 =
+              let uu____10272 =
+                let uu____10273 =
+                  FStar_All.pipe_right md
+                    FStar_Syntax_Util.get_wp_trivial_combinator
+                   in
+                FStar_All.pipe_right uu____10273 FStar_Util.must  in
+              FStar_TypeChecker_Env.inst_effect_fun_with [u_t] env md
+                uu____10272
+               in
+            let uu____10280 =
+              let uu____10281 = FStar_Syntax_Syntax.as_arg t  in
+              let uu____10290 =
+                let uu____10301 = FStar_Syntax_Syntax.as_arg wp  in
+                [uu____10301]  in
+              uu____10281 :: uu____10290  in
+            let uu____10334 = FStar_TypeChecker_Env.get_range env  in
+            FStar_Syntax_Syntax.mk_Tm_app uu____10271 uu____10280 uu____10334
+             in
+          let uu____10335 =
             FStar_All.pipe_left FStar_TypeChecker_Env.guard_of_guard_formula
               (FStar_TypeChecker_Common.NonTrivial vc)
              in
-          (ct, vc, uu____10400)
+          (ct, vc, uu____10335)
   
 let (coerce_with :
   FStar_TypeChecker_Env.env ->
@@ -4036,25 +4000,25 @@ let (coerce_with :
             fun us  ->
               fun eargs  ->
                 fun mkcomp  ->
-                  let uu____10455 =
+                  let uu____10390 =
                     FStar_TypeChecker_Env.try_lookup_lid env f  in
-                  match uu____10455 with
-                  | FStar_Pervasives_Native.Some uu____10470 ->
-                      ((let uu____10488 =
+                  match uu____10390 with
+                  | FStar_Pervasives_Native.Some uu____10405 ->
+                      ((let uu____10423 =
                           FStar_TypeChecker_Env.debug env
                             (FStar_Options.Other "Coercions")
                            in
-                        if uu____10488
+                        if uu____10423
                         then
-                          let uu____10492 = FStar_Ident.string_of_lid f  in
-                          FStar_Util.print1 "Coercing with %s!\n" uu____10492
+                          let uu____10427 = FStar_Ident.string_of_lid f  in
+                          FStar_Util.print1 "Coercing with %s!\n" uu____10427
                         else ());
                        (let coercion =
-                          let uu____10498 =
+                          let uu____10433 =
                             FStar_Ident.set_lid_range f
                               e.FStar_Syntax_Syntax.pos
                              in
-                          FStar_Syntax_Syntax.fvar uu____10498
+                          FStar_Syntax_Syntax.fvar uu____10433
                             (FStar_Syntax_Syntax.Delta_constant_at_level
                                Prims.int_one) FStar_Pervasives_Native.None
                            in
@@ -4063,43 +4027,39 @@ let (coerce_with :
                         let coercion2 =
                           FStar_Syntax_Util.mk_app coercion1 eargs  in
                         let lc1 =
-                          let uu____10505 =
-                            let uu____10506 =
-                              let uu____10507 = mkcomp ty  in
+                          let uu____10440 =
+                            let uu____10441 =
+                              let uu____10442 = mkcomp ty  in
                               FStar_All.pipe_left
                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                uu____10507
+                                uu____10442
                                in
-                            (FStar_Pervasives_Native.None, uu____10506)  in
+                            (FStar_Pervasives_Native.None, uu____10441)  in
                           bind e.FStar_Syntax_Syntax.pos env
-                            (FStar_Pervasives_Native.Some e) lc uu____10505
+                            (FStar_Pervasives_Native.Some e) lc uu____10440
                            in
                         let e1 =
-                          let uu____10513 =
-                            let uu____10518 =
-                              let uu____10519 = FStar_Syntax_Syntax.as_arg e
-                                 in
-                              [uu____10519]  in
-                            FStar_Syntax_Syntax.mk_Tm_app coercion2
-                              uu____10518
-                             in
-                          uu____10513 FStar_Pervasives_Native.None
+                          let uu____10446 =
+                            let uu____10447 = FStar_Syntax_Syntax.as_arg e
+                               in
+                            [uu____10447]  in
+                          FStar_Syntax_Syntax.mk_Tm_app coercion2 uu____10446
                             e.FStar_Syntax_Syntax.pos
                            in
                         (e1, lc1)))
                   | FStar_Pervasives_Native.None  ->
-                      ((let uu____10553 =
-                          let uu____10559 =
-                            let uu____10561 = FStar_Ident.string_of_lid f  in
+                      ((let uu____10481 =
+                          let uu____10487 =
+                            let uu____10489 = FStar_Ident.string_of_lid f  in
                             FStar_Util.format1
                               "Coercion %s was not found in the environment, not coercing."
-                              uu____10561
+                              uu____10489
                              in
                           (FStar_Errors.Warning_CoercionNotFound,
-                            uu____10559)
+                            uu____10487)
                            in
                         FStar_Errors.log_issue e.FStar_Syntax_Syntax.pos
-                          uu____10553);
+                          uu____10481);
                        (e, lc))
   
 type isErased =
@@ -4108,16 +4068,16 @@ type isErased =
   | No 
 let (uu___is_Yes : isErased -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Yes _0 -> true | uu____10580 -> false
+    match projectee with | Yes _0 -> true | uu____10508 -> false
   
 let (__proj__Yes__item___0 : isErased -> FStar_Syntax_Syntax.term) =
   fun projectee  -> match projectee with | Yes _0 -> _0 
 let (uu___is_Maybe : isErased -> Prims.bool) =
   fun projectee  ->
-    match projectee with | Maybe  -> true | uu____10598 -> false
+    match projectee with | Maybe  -> true | uu____10526 -> false
   
 let (uu___is_No : isErased -> Prims.bool) =
-  fun projectee  -> match projectee with | No  -> true | uu____10609 -> false 
+  fun projectee  -> match projectee with | No  -> true | uu____10537 -> false 
 let rec (check_erased :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> isErased) =
   fun env  ->
@@ -4136,60 +4096,60 @@ let rec (check_erased :
          in
       let t1 = norm' env t  in
       let t2 = FStar_Syntax_Util.unrefine t1  in
-      let uu____10633 = FStar_Syntax_Util.head_and_args t2  in
-      match uu____10633 with
+      let uu____10561 = FStar_Syntax_Util.head_and_args t2  in
+      match uu____10561 with
       | (h,args) ->
           let h1 = FStar_Syntax_Util.un_uinst h  in
           let r =
-            let uu____10678 =
-              let uu____10693 =
-                let uu____10694 = FStar_Syntax_Subst.compress h1  in
-                uu____10694.FStar_Syntax_Syntax.n  in
-              (uu____10693, args)  in
-            match uu____10678 with
+            let uu____10606 =
+              let uu____10621 =
+                let uu____10622 = FStar_Syntax_Subst.compress h1  in
+                uu____10622.FStar_Syntax_Syntax.n  in
+              (uu____10621, args)  in
+            match uu____10606 with
             | (FStar_Syntax_Syntax.Tm_fvar
                fv,(a,FStar_Pervasives_Native.None )::[]) when
                 FStar_Syntax_Syntax.fv_eq_lid fv
                   FStar_Parser_Const.erased_lid
                 -> Yes a
-            | (FStar_Syntax_Syntax.Tm_uvar uu____10741,uu____10742) -> Maybe
-            | (FStar_Syntax_Syntax.Tm_unknown ,uu____10775) -> Maybe
+            | (FStar_Syntax_Syntax.Tm_uvar uu____10669,uu____10670) -> Maybe
+            | (FStar_Syntax_Syntax.Tm_unknown ,uu____10703) -> Maybe
             | (FStar_Syntax_Syntax.Tm_match
-               (uu____10796,branches),uu____10798) ->
+               (uu____10724,branches),uu____10726) ->
                 FStar_All.pipe_right branches
                   (FStar_List.fold_left
                      (fun acc  ->
                         fun br  ->
                           match acc with
-                          | Yes uu____10862 -> Maybe
+                          | Yes uu____10790 -> Maybe
                           | Maybe  -> Maybe
                           | No  ->
-                              let uu____10863 =
+                              let uu____10791 =
                                 FStar_Syntax_Subst.open_branch br  in
-                              (match uu____10863 with
-                               | (uu____10864,uu____10865,br_body) ->
-                                   let uu____10883 =
-                                     let uu____10884 =
-                                       let uu____10889 =
-                                         let uu____10890 =
-                                           let uu____10893 =
+                              (match uu____10791 with
+                               | (uu____10792,uu____10793,br_body) ->
+                                   let uu____10811 =
+                                     let uu____10812 =
+                                       let uu____10817 =
+                                         let uu____10818 =
+                                           let uu____10821 =
                                              FStar_All.pipe_right br_body
                                                FStar_Syntax_Free.names
                                               in
-                                           FStar_All.pipe_right uu____10893
+                                           FStar_All.pipe_right uu____10821
                                              FStar_Util.set_elements
                                             in
-                                         FStar_All.pipe_right uu____10890
+                                         FStar_All.pipe_right uu____10818
                                            (FStar_TypeChecker_Env.push_bvs
                                               env)
                                           in
-                                       check_erased uu____10889  in
-                                     FStar_All.pipe_right br_body uu____10884
+                                       check_erased uu____10817  in
+                                     FStar_All.pipe_right br_body uu____10812
                                       in
-                                   (match uu____10883 with
+                                   (match uu____10811 with
                                     | No  -> No
-                                    | uu____10904 -> Maybe))) No)
-            | uu____10905 -> No  in
+                                    | uu____10832 -> Maybe))) No)
+            | uu____10833 -> No  in
           r
   
 let (maybe_coerce_lc :
@@ -4205,8 +4165,8 @@ let (maybe_coerce_lc :
       fun lc  ->
         fun exp_t  ->
           let should_coerce =
-            (((let uu____10957 = FStar_Options.use_two_phase_tc ()  in
-               Prims.op_Negation uu____10957) ||
+            (((let uu____10885 = FStar_Options.use_two_phase_tc ()  in
+               Prims.op_Negation uu____10885) ||
                 env.FStar_TypeChecker_Env.phase1)
                || env.FStar_TypeChecker_Env.lax)
               || (FStar_Options.lax ())
@@ -4216,84 +4176,84 @@ let (maybe_coerce_lc :
           else
             (let is_t_term t =
                let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t  in
-               let uu____10976 =
-                 let uu____10977 = FStar_Syntax_Subst.compress t1  in
-                 uu____10977.FStar_Syntax_Syntax.n  in
-               match uu____10976 with
+               let uu____10904 =
+                 let uu____10905 = FStar_Syntax_Subst.compress t1  in
+                 uu____10905.FStar_Syntax_Syntax.n  in
+               match uu____10904 with
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.term_lid
-               | uu____10982 -> false  in
+               | uu____10910 -> false  in
              let is_t_term_view t =
                let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t  in
-               let uu____10992 =
-                 let uu____10993 = FStar_Syntax_Subst.compress t1  in
-                 uu____10993.FStar_Syntax_Syntax.n  in
-               match uu____10992 with
+               let uu____10920 =
+                 let uu____10921 = FStar_Syntax_Subst.compress t1  in
+                 uu____10921.FStar_Syntax_Syntax.n  in
+               match uu____10920 with
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.term_view_lid
-               | uu____10998 -> false  in
+               | uu____10926 -> false  in
              let is_type t =
                let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t  in
                let t2 = FStar_Syntax_Util.unrefine t1  in
-               let uu____11009 =
-                 let uu____11010 = FStar_Syntax_Subst.compress t2  in
-                 uu____11010.FStar_Syntax_Syntax.n  in
-               match uu____11009 with
-               | FStar_Syntax_Syntax.Tm_type uu____11014 -> true
-               | uu____11016 -> false  in
+               let uu____10937 =
+                 let uu____10938 = FStar_Syntax_Subst.compress t2  in
+                 uu____10938.FStar_Syntax_Syntax.n  in
+               match uu____10937 with
+               | FStar_Syntax_Syntax.Tm_type uu____10942 -> true
+               | uu____10944 -> false  in
              let res_typ =
                FStar_Syntax_Util.unrefine lc.FStar_TypeChecker_Common.res_typ
                 in
-             let uu____11019 = FStar_Syntax_Util.head_and_args res_typ  in
-             match uu____11019 with
+             let uu____10947 = FStar_Syntax_Util.head_and_args res_typ  in
+             match uu____10947 with
              | (head,args) ->
-                 ((let uu____11069 =
+                 ((let uu____10997 =
                      FStar_TypeChecker_Env.debug env
                        (FStar_Options.Other "Coercions")
                       in
-                   if uu____11069
+                   if uu____10997
                    then
-                     let uu____11073 =
+                     let uu____11001 =
                        FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos
                         in
-                     let uu____11075 = FStar_Syntax_Print.term_to_string e
+                     let uu____11003 = FStar_Syntax_Print.term_to_string e
                         in
-                     let uu____11077 =
+                     let uu____11005 =
                        FStar_Syntax_Print.term_to_string res_typ  in
-                     let uu____11079 =
+                     let uu____11007 =
                        FStar_Syntax_Print.term_to_string exp_t  in
                      FStar_Util.print4
                        "(%s) Trying to coerce %s from type (%s) to type (%s)\n"
-                       uu____11073 uu____11075 uu____11077 uu____11079
+                       uu____11001 uu____11003 uu____11005 uu____11007
                    else ());
                   (let mk_erased u t =
-                     let uu____11097 =
-                       let uu____11100 =
+                     let uu____11025 =
+                       let uu____11028 =
                          fvar_const env FStar_Parser_Const.erased_lid  in
-                       FStar_Syntax_Syntax.mk_Tm_uinst uu____11100 [u]  in
-                     let uu____11101 =
-                       let uu____11112 = FStar_Syntax_Syntax.as_arg t  in
-                       [uu____11112]  in
-                     FStar_Syntax_Util.mk_app uu____11097 uu____11101  in
-                   let uu____11137 =
-                     let uu____11152 =
-                       let uu____11153 = FStar_Syntax_Util.un_uinst head  in
-                       uu____11153.FStar_Syntax_Syntax.n  in
-                     (uu____11152, args)  in
-                   match uu____11137 with
+                       FStar_Syntax_Syntax.mk_Tm_uinst uu____11028 [u]  in
+                     let uu____11029 =
+                       let uu____11040 = FStar_Syntax_Syntax.as_arg t  in
+                       [uu____11040]  in
+                     FStar_Syntax_Util.mk_app uu____11025 uu____11029  in
+                   let uu____11065 =
+                     let uu____11080 =
+                       let uu____11081 = FStar_Syntax_Util.un_uinst head  in
+                       uu____11081.FStar_Syntax_Syntax.n  in
+                     (uu____11080, args)  in
+                   match uu____11065 with
                    | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
                        (FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.bool_lid)
                          && (is_type exp_t)
                        ->
-                       let uu____11191 =
+                       let uu____11119 =
                          coerce_with env e lc FStar_Syntax_Util.ktype0
                            FStar_Parser_Const.b2t_lid [] []
                            FStar_Syntax_Syntax.mk_Total
                           in
-                       (match uu____11191 with
+                       (match uu____11119 with
                         | (e1,lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
                    | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
@@ -4301,12 +4261,12 @@ let (maybe_coerce_lc :
                           FStar_Parser_Const.term_lid)
                          && (is_t_term_view exp_t)
                        ->
-                       let uu____11231 =
+                       let uu____11159 =
                          coerce_with env e lc FStar_Syntax_Syntax.t_term_view
                            FStar_Parser_Const.inspect [] []
                            FStar_Syntax_Syntax.mk_Tac
                           in
-                       (match uu____11231 with
+                       (match uu____11159 with
                         | (e1,lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
                    | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
@@ -4314,12 +4274,12 @@ let (maybe_coerce_lc :
                           FStar_Parser_Const.term_view_lid)
                          && (is_t_term exp_t)
                        ->
-                       let uu____11271 =
+                       let uu____11199 =
                          coerce_with env e lc FStar_Syntax_Syntax.t_term
                            FStar_Parser_Const.pack [] []
                            FStar_Syntax_Syntax.mk_Tac
                           in
-                       (match uu____11271 with
+                       (match uu____11199 with
                         | (e1,lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
                    | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
@@ -4327,63 +4287,63 @@ let (maybe_coerce_lc :
                           FStar_Parser_Const.binder_lid)
                          && (is_t_term exp_t)
                        ->
-                       let uu____11311 =
+                       let uu____11239 =
                          coerce_with env e lc FStar_Syntax_Syntax.t_term
                            FStar_Parser_Const.binder_to_term [] []
                            FStar_Syntax_Syntax.mk_Tac
                           in
-                       (match uu____11311 with
+                       (match uu____11239 with
                         | (e1,lc1) ->
                             (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
-                   | uu____11332 ->
-                       let uu____11347 =
-                         let uu____11352 = check_erased env res_typ  in
-                         let uu____11353 = check_erased env exp_t  in
-                         (uu____11352, uu____11353)  in
-                       (match uu____11347 with
+                   | uu____11260 ->
+                       let uu____11275 =
+                         let uu____11280 = check_erased env res_typ  in
+                         let uu____11281 = check_erased env exp_t  in
+                         (uu____11280, uu____11281)  in
+                       (match uu____11275 with
                         | (No ,Yes ty) ->
                             let u =
                               env.FStar_TypeChecker_Env.universe_of env ty
                                in
-                            let uu____11362 =
+                            let uu____11290 =
                               FStar_TypeChecker_Rel.get_subtyping_predicate
                                 env res_typ ty
                                in
-                            (match uu____11362 with
+                            (match uu____11290 with
                              | FStar_Pervasives_Native.None  ->
                                  (e, lc, FStar_TypeChecker_Env.trivial_guard)
                              | FStar_Pervasives_Native.Some g ->
                                  let g1 =
                                    FStar_TypeChecker_Env.apply_guard g e  in
-                                 let uu____11373 =
-                                   let uu____11378 =
-                                     let uu____11379 =
+                                 let uu____11301 =
+                                   let uu____11306 =
+                                     let uu____11307 =
                                        FStar_Syntax_Syntax.iarg ty  in
-                                     [uu____11379]  in
+                                     [uu____11307]  in
                                    coerce_with env e lc exp_t
-                                     FStar_Parser_Const.hide [u] uu____11378
+                                     FStar_Parser_Const.hide [u] uu____11306
                                      FStar_Syntax_Syntax.mk_Total
                                     in
-                                 (match uu____11373 with
+                                 (match uu____11301 with
                                   | (e1,lc1) -> (e1, lc1, g1)))
                         | (Yes ty,No ) ->
                             let u =
                               env.FStar_TypeChecker_Env.universe_of env ty
                                in
-                            let uu____11414 =
-                              let uu____11419 =
-                                let uu____11420 = FStar_Syntax_Syntax.iarg ty
+                            let uu____11342 =
+                              let uu____11347 =
+                                let uu____11348 = FStar_Syntax_Syntax.iarg ty
                                    in
-                                [uu____11420]  in
+                                [uu____11348]  in
                               coerce_with env e lc ty
-                                FStar_Parser_Const.reveal [u] uu____11419
+                                FStar_Parser_Const.reveal [u] uu____11347
                                 FStar_Syntax_Syntax.mk_GTotal
                                in
-                            (match uu____11414 with
+                            (match uu____11342 with
                              | (e1,lc1) ->
                                  (e1, lc1,
                                    FStar_TypeChecker_Env.trivial_guard))
-                        | uu____11453 ->
+                        | uu____11381 ->
                             (e, lc, FStar_TypeChecker_Env.trivial_guard)))))
   
 let (coerce_views :
@@ -4398,27 +4358,27 @@ let (coerce_views :
       fun lc  ->
         let rt = lc.FStar_TypeChecker_Common.res_typ  in
         let rt1 = FStar_Syntax_Util.unrefine rt  in
-        let uu____11488 = FStar_Syntax_Util.head_and_args rt1  in
-        match uu____11488 with
+        let uu____11416 = FStar_Syntax_Util.head_and_args rt1  in
+        match uu____11416 with
         | (hd,args) ->
-            let uu____11537 =
-              let uu____11552 =
-                let uu____11553 = FStar_Syntax_Subst.compress hd  in
-                uu____11553.FStar_Syntax_Syntax.n  in
-              (uu____11552, args)  in
-            (match uu____11537 with
+            let uu____11465 =
+              let uu____11480 =
+                let uu____11481 = FStar_Syntax_Subst.compress hd  in
+                uu____11481.FStar_Syntax_Syntax.n  in
+              (uu____11480, args)  in
+            (match uu____11465 with
              | (FStar_Syntax_Syntax.Tm_fvar fv,[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.term_lid
                  ->
-                 let uu____11591 =
+                 let uu____11519 =
                    coerce_with env e lc FStar_Syntax_Syntax.t_term_view
                      FStar_Parser_Const.inspect [] []
                      FStar_Syntax_Syntax.mk_Tac
                     in
                  FStar_All.pipe_left
-                   (fun uu____11618  ->
-                      FStar_Pervasives_Native.Some uu____11618) uu____11591
-             | uu____11619 -> FStar_Pervasives_Native.None)
+                   (fun uu____11546  ->
+                      FStar_Pervasives_Native.Some uu____11546) uu____11519
+             | uu____11547 -> FStar_Pervasives_Native.None)
   
 let (weaken_result_typ :
   FStar_TypeChecker_Env.env ->
@@ -4432,106 +4392,106 @@ let (weaken_result_typ :
     fun e  ->
       fun lc  ->
         fun t  ->
-          (let uu____11672 =
+          (let uu____11600 =
              FStar_TypeChecker_Env.debug env FStar_Options.High  in
-           if uu____11672
+           if uu____11600
            then
-             let uu____11675 = FStar_Syntax_Print.term_to_string e  in
-             let uu____11677 = FStar_TypeChecker_Common.lcomp_to_string lc
+             let uu____11603 = FStar_Syntax_Print.term_to_string e  in
+             let uu____11605 = FStar_TypeChecker_Common.lcomp_to_string lc
                 in
-             let uu____11679 = FStar_Syntax_Print.term_to_string t  in
+             let uu____11607 = FStar_Syntax_Print.term_to_string t  in
              FStar_Util.print3 "weaken_result_typ e=(%s) lc=(%s) t=(%s)\n"
-               uu____11675 uu____11677 uu____11679
+               uu____11603 uu____11605 uu____11607
            else ());
           (let use_eq =
              (env.FStar_TypeChecker_Env.use_eq_strict ||
                 env.FStar_TypeChecker_Env.use_eq)
                ||
-               (let uu____11689 =
+               (let uu____11617 =
                   FStar_TypeChecker_Env.effect_decl_opt env
                     lc.FStar_TypeChecker_Common.eff_name
                    in
-                match uu____11689 with
+                match uu____11617 with
                 | FStar_Pervasives_Native.Some (ed,qualifiers) ->
                     FStar_All.pipe_right qualifiers
                       (FStar_List.contains FStar_Syntax_Syntax.Reifiable)
-                | uu____11714 -> false)
+                | uu____11642 -> false)
               in
            let gopt =
              if use_eq
              then
-               let uu____11740 =
+               let uu____11668 =
                  FStar_TypeChecker_Rel.try_teq true env
                    lc.FStar_TypeChecker_Common.res_typ t
                   in
-               (uu____11740, false)
+               (uu____11668, false)
              else
-               (let uu____11750 =
+               (let uu____11678 =
                   FStar_TypeChecker_Rel.get_subtyping_predicate env
                     lc.FStar_TypeChecker_Common.res_typ t
                    in
-                (uu____11750, true))
+                (uu____11678, true))
               in
            match gopt with
-           | (FStar_Pervasives_Native.None ,uu____11763) ->
+           | (FStar_Pervasives_Native.None ,uu____11691) ->
                if env.FStar_TypeChecker_Env.failhard
                then
-                 let uu____11775 =
+                 let uu____11703 =
                    FStar_TypeChecker_Err.basic_type_error env
                      (FStar_Pervasives_Native.Some e) t
                      lc.FStar_TypeChecker_Common.res_typ
                     in
-                 FStar_Errors.raise_error uu____11775
+                 FStar_Errors.raise_error uu____11703
                    e.FStar_Syntax_Syntax.pos
                else
                  (FStar_TypeChecker_Rel.subtype_fail env e
                     lc.FStar_TypeChecker_Common.res_typ t;
                   (e,
-                    ((let uu___1377_11791 = lc  in
+                    ((let uu___1377_11719 = lc  in
                       {
                         FStar_TypeChecker_Common.eff_name =
-                          (uu___1377_11791.FStar_TypeChecker_Common.eff_name);
+                          (uu___1377_11719.FStar_TypeChecker_Common.eff_name);
                         FStar_TypeChecker_Common.res_typ = t;
                         FStar_TypeChecker_Common.cflags =
-                          (uu___1377_11791.FStar_TypeChecker_Common.cflags);
+                          (uu___1377_11719.FStar_TypeChecker_Common.cflags);
                         FStar_TypeChecker_Common.comp_thunk =
-                          (uu___1377_11791.FStar_TypeChecker_Common.comp_thunk)
+                          (uu___1377_11719.FStar_TypeChecker_Common.comp_thunk)
                       })), FStar_TypeChecker_Env.trivial_guard))
            | (FStar_Pervasives_Native.Some g,apply_guard) ->
-               let uu____11798 = FStar_TypeChecker_Env.guard_form g  in
-               (match uu____11798 with
+               let uu____11726 = FStar_TypeChecker_Env.guard_form g  in
+               (match uu____11726 with
                 | FStar_TypeChecker_Common.Trivial  ->
-                    let strengthen_trivial uu____11814 =
-                      let uu____11815 =
+                    let strengthen_trivial uu____11742 =
+                      let uu____11743 =
                         FStar_TypeChecker_Common.lcomp_comp lc  in
-                      match uu____11815 with
+                      match uu____11743 with
                       | (c,g_c) ->
                           let res_t = FStar_Syntax_Util.comp_result c  in
                           let set_result_typ c1 =
                             FStar_Syntax_Util.set_result_typ c1 t  in
-                          let uu____11835 =
-                            let uu____11837 = FStar_Syntax_Util.eq_tm t res_t
+                          let uu____11763 =
+                            let uu____11765 = FStar_Syntax_Util.eq_tm t res_t
                                in
-                            uu____11837 = FStar_Syntax_Util.Equal  in
-                          if uu____11835
+                            uu____11765 = FStar_Syntax_Util.Equal  in
+                          if uu____11763
                           then
-                            ((let uu____11844 =
+                            ((let uu____11772 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   FStar_Options.Extreme
                                  in
-                              if uu____11844
+                              if uu____11772
                               then
-                                let uu____11848 =
+                                let uu____11776 =
                                   FStar_Syntax_Print.term_to_string res_t  in
-                                let uu____11850 =
+                                let uu____11778 =
                                   FStar_Syntax_Print.term_to_string t  in
                                 FStar_Util.print2
                                   "weaken_result_type::strengthen_trivial: res_t:%s is same as t:%s\n"
-                                  uu____11848 uu____11850
+                                  uu____11776 uu____11778
                               else ());
-                             (let uu____11855 = set_result_typ c  in
-                              (uu____11855, g_c)))
+                             (let uu____11783 = set_result_typ c  in
+                              (uu____11783, g_c)))
                           else
                             (let is_res_t_refinement =
                                let res_t1 =
@@ -4540,9 +4500,9 @@ let (weaken_result_typ :
                                    res_t
                                   in
                                match res_t1.FStar_Syntax_Syntax.n with
-                               | FStar_Syntax_Syntax.Tm_refine uu____11862 ->
+                               | FStar_Syntax_Syntax.Tm_refine uu____11790 ->
                                    true
-                               | uu____11870 -> false  in
+                               | uu____11798 -> false  in
                              if is_res_t_refinement
                              then
                                let x =
@@ -4551,79 +4511,79 @@ let (weaken_result_typ :
                                       (res_t.FStar_Syntax_Syntax.pos)) res_t
                                   in
                                let cret =
-                                 let uu____11879 =
+                                 let uu____11807 =
                                    FStar_Syntax_Syntax.bv_to_name x  in
                                  return_value env (comp_univ_opt c) res_t
-                                   uu____11879
+                                   uu____11807
                                   in
                                let lc1 =
-                                 let uu____11881 =
+                                 let uu____11809 =
                                    FStar_TypeChecker_Common.lcomp_of_comp c
                                     in
-                                 let uu____11882 =
-                                   let uu____11883 =
+                                 let uu____11810 =
+                                   let uu____11811 =
                                      FStar_TypeChecker_Common.lcomp_of_comp
                                        cret
                                       in
                                    ((FStar_Pervasives_Native.Some x),
-                                     uu____11883)
+                                     uu____11811)
                                     in
                                  bind e.FStar_Syntax_Syntax.pos env
                                    (FStar_Pervasives_Native.Some e)
-                                   uu____11881 uu____11882
+                                   uu____11809 uu____11810
                                   in
-                               ((let uu____11887 =
+                               ((let uu____11815 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____11887
+                                 if uu____11815
                                  then
-                                   let uu____11891 =
+                                   let uu____11819 =
                                      FStar_Syntax_Print.term_to_string e  in
-                                   let uu____11893 =
+                                   let uu____11821 =
                                      FStar_Syntax_Print.comp_to_string c  in
-                                   let uu____11895 =
+                                   let uu____11823 =
                                      FStar_Syntax_Print.term_to_string t  in
-                                   let uu____11897 =
+                                   let uu____11825 =
                                      FStar_TypeChecker_Common.lcomp_to_string
                                        lc1
                                       in
                                    FStar_Util.print4
                                      "weaken_result_type::strengthen_trivial: inserting a return for e: %s, c: %s, t: %s, and then post return lc: %s\n"
-                                     uu____11891 uu____11893 uu____11895
-                                     uu____11897
+                                     uu____11819 uu____11821 uu____11823
+                                     uu____11825
                                  else ());
-                                (let uu____11902 =
+                                (let uu____11830 =
                                    FStar_TypeChecker_Common.lcomp_comp lc1
                                     in
-                                 match uu____11902 with
+                                 match uu____11830 with
                                  | (c1,g_lc) ->
-                                     let uu____11913 = set_result_typ c1  in
-                                     let uu____11914 =
+                                     let uu____11841 = set_result_typ c1  in
+                                     let uu____11842 =
                                        FStar_TypeChecker_Env.conj_guard g_c
                                          g_lc
                                         in
-                                     (uu____11913, uu____11914)))
+                                     (uu____11841, uu____11842)))
                              else
-                               ((let uu____11918 =
+                               ((let uu____11846 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme
                                     in
-                                 if uu____11918
+                                 if uu____11846
                                  then
-                                   let uu____11922 =
+                                   let uu____11850 =
                                      FStar_Syntax_Print.term_to_string res_t
                                       in
-                                   let uu____11924 =
+                                   let uu____11852 =
                                      FStar_Syntax_Print.comp_to_string c  in
                                    FStar_Util.print2
                                      "weaken_result_type::strengthen_trivial: res_t:%s is not a refinement, leaving c:%s as is\n"
-                                     uu____11922 uu____11924
+                                     uu____11850 uu____11852
                                  else ());
-                                (let uu____11929 = set_result_typ c  in
-                                 (uu____11929, g_c))))
+                                (let uu____11857 = set_result_typ c  in
+                                 (uu____11857, g_c))))
                        in
                     let lc1 =
                       FStar_TypeChecker_Common.mk_lcomp
@@ -4633,23 +4593,23 @@ let (weaken_result_typ :
                     (e, lc1, g)
                 | FStar_TypeChecker_Common.NonTrivial f ->
                     let g1 =
-                      let uu___1414_11933 = g  in
+                      let uu___1414_11861 = g  in
                       {
                         FStar_TypeChecker_Common.guard_f =
                           FStar_TypeChecker_Common.Trivial;
                         FStar_TypeChecker_Common.deferred =
-                          (uu___1414_11933.FStar_TypeChecker_Common.deferred);
+                          (uu___1414_11861.FStar_TypeChecker_Common.deferred);
                         FStar_TypeChecker_Common.univ_ineqs =
-                          (uu___1414_11933.FStar_TypeChecker_Common.univ_ineqs);
+                          (uu___1414_11861.FStar_TypeChecker_Common.univ_ineqs);
                         FStar_TypeChecker_Common.implicits =
-                          (uu___1414_11933.FStar_TypeChecker_Common.implicits)
+                          (uu___1414_11861.FStar_TypeChecker_Common.implicits)
                       }  in
-                    let strengthen uu____11943 =
-                      let uu____11944 =
+                    let strengthen uu____11871 =
+                      let uu____11872 =
                         env.FStar_TypeChecker_Env.lax &&
                           (FStar_Options.ml_ish ())
                          in
-                      if uu____11944
+                      if uu____11872
                       then FStar_TypeChecker_Common.lcomp_comp lc
                       else
                         (let f1 =
@@ -4659,68 +4619,68 @@ let (weaken_result_typ :
                              FStar_TypeChecker_Env.Simplify;
                              FStar_TypeChecker_Env.Primops] env f
                             in
-                         let uu____11954 =
-                           let uu____11955 = FStar_Syntax_Subst.compress f1
+                         let uu____11882 =
+                           let uu____11883 = FStar_Syntax_Subst.compress f1
                               in
-                           uu____11955.FStar_Syntax_Syntax.n  in
-                         match uu____11954 with
+                           uu____11883.FStar_Syntax_Syntax.n  in
+                         match uu____11882 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (uu____11962,{
+                             (uu____11890,{
                                             FStar_Syntax_Syntax.n =
                                               FStar_Syntax_Syntax.Tm_fvar fv;
                                             FStar_Syntax_Syntax.pos =
-                                              uu____11964;
+                                              uu____11892;
                                             FStar_Syntax_Syntax.vars =
-                                              uu____11965;_},uu____11966)
+                                              uu____11893;_},uu____11894)
                              when
                              FStar_Syntax_Syntax.fv_eq_lid fv
                                FStar_Parser_Const.true_lid
                              ->
                              let lc1 =
-                               let uu___1430_11992 = lc  in
+                               let uu___1430_11920 = lc  in
                                {
                                  FStar_TypeChecker_Common.eff_name =
-                                   (uu___1430_11992.FStar_TypeChecker_Common.eff_name);
+                                   (uu___1430_11920.FStar_TypeChecker_Common.eff_name);
                                  FStar_TypeChecker_Common.res_typ = t;
                                  FStar_TypeChecker_Common.cflags =
-                                   (uu___1430_11992.FStar_TypeChecker_Common.cflags);
+                                   (uu___1430_11920.FStar_TypeChecker_Common.cflags);
                                  FStar_TypeChecker_Common.comp_thunk =
-                                   (uu___1430_11992.FStar_TypeChecker_Common.comp_thunk)
+                                   (uu___1430_11920.FStar_TypeChecker_Common.comp_thunk)
                                }  in
                              FStar_TypeChecker_Common.lcomp_comp lc1
-                         | uu____11993 ->
-                             let uu____11994 =
+                         | uu____11921 ->
+                             let uu____11922 =
                                FStar_TypeChecker_Common.lcomp_comp lc  in
-                             (match uu____11994 with
+                             (match uu____11922 with
                               | (c,g_c) ->
-                                  ((let uu____12006 =
+                                  ((let uu____11934 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env)
                                         FStar_Options.Extreme
                                        in
-                                    if uu____12006
+                                    if uu____11934
                                     then
-                                      let uu____12010 =
+                                      let uu____11938 =
                                         FStar_TypeChecker_Normalize.term_to_string
                                           env
                                           lc.FStar_TypeChecker_Common.res_typ
                                          in
-                                      let uu____12012 =
+                                      let uu____11940 =
                                         FStar_TypeChecker_Normalize.term_to_string
                                           env t
                                          in
-                                      let uu____12014 =
+                                      let uu____11942 =
                                         FStar_TypeChecker_Normalize.comp_to_string
                                           env c
                                          in
-                                      let uu____12016 =
+                                      let uu____11944 =
                                         FStar_TypeChecker_Normalize.term_to_string
                                           env f1
                                          in
                                       FStar_Util.print4
                                         "Weakened from %s to %s\nStrengthening %s with guard %s\n"
-                                        uu____12010 uu____12012 uu____12014
-                                        uu____12016
+                                        uu____11938 uu____11940 uu____11942
+                                        uu____11944
                                     else ());
                                    (let u_t_opt = comp_univ_opt c  in
                                     let x =
@@ -4735,130 +4695,126 @@ let (weaken_result_typ :
                                     let guard =
                                       if apply_guard
                                       then
-                                        let uu____12029 =
-                                          let uu____12034 =
-                                            let uu____12035 =
-                                              FStar_Syntax_Syntax.as_arg xexp
-                                               in
-                                            [uu____12035]  in
-                                          FStar_Syntax_Syntax.mk_Tm_app f1
-                                            uu____12034
-                                           in
-                                        uu____12029
-                                          FStar_Pervasives_Native.None
+                                        let uu____11957 =
+                                          let uu____11958 =
+                                            FStar_Syntax_Syntax.as_arg xexp
+                                             in
+                                          [uu____11958]  in
+                                        FStar_Syntax_Syntax.mk_Tm_app f1
+                                          uu____11957
                                           f1.FStar_Syntax_Syntax.pos
                                       else f1  in
-                                    let uu____12062 =
-                                      let uu____12067 =
+                                    let uu____11985 =
+                                      let uu____11990 =
                                         FStar_All.pipe_left
-                                          (fun uu____12088  ->
+                                          (fun uu____12011  ->
                                              FStar_Pervasives_Native.Some
-                                               uu____12088)
+                                               uu____12011)
                                           (FStar_TypeChecker_Err.subtyping_failed
                                              env
                                              lc.FStar_TypeChecker_Common.res_typ
                                              t)
                                          in
-                                      let uu____12089 =
+                                      let uu____12012 =
                                         FStar_TypeChecker_Env.set_range env
                                           e.FStar_Syntax_Syntax.pos
                                          in
-                                      let uu____12090 =
+                                      let uu____12013 =
                                         FStar_TypeChecker_Common.lcomp_of_comp
                                           cret
                                          in
-                                      let uu____12091 =
+                                      let uu____12014 =
                                         FStar_All.pipe_left
                                           FStar_TypeChecker_Env.guard_of_guard_formula
                                           (FStar_TypeChecker_Common.NonTrivial
                                              guard)
                                          in
-                                      strengthen_precondition uu____12067
-                                        uu____12089 e uu____12090 uu____12091
+                                      strengthen_precondition uu____11990
+                                        uu____12012 e uu____12013 uu____12014
                                        in
-                                    match uu____12062 with
+                                    match uu____11985 with
                                     | (eq_ret,_trivial_so_ok_to_discard) ->
                                         let x1 =
-                                          let uu___1448_12099 = x  in
+                                          let uu___1448_12022 = x  in
                                           {
                                             FStar_Syntax_Syntax.ppname =
-                                              (uu___1448_12099.FStar_Syntax_Syntax.ppname);
+                                              (uu___1448_12022.FStar_Syntax_Syntax.ppname);
                                             FStar_Syntax_Syntax.index =
-                                              (uu___1448_12099.FStar_Syntax_Syntax.index);
+                                              (uu___1448_12022.FStar_Syntax_Syntax.index);
                                             FStar_Syntax_Syntax.sort =
                                               (lc.FStar_TypeChecker_Common.res_typ)
                                           }  in
                                         let c1 =
-                                          let uu____12101 =
+                                          let uu____12024 =
                                             FStar_TypeChecker_Common.lcomp_of_comp
                                               c
                                              in
                                           bind e.FStar_Syntax_Syntax.pos env
                                             (FStar_Pervasives_Native.Some e)
-                                            uu____12101
+                                            uu____12024
                                             ((FStar_Pervasives_Native.Some x1),
                                               eq_ret)
                                            in
-                                        let uu____12104 =
+                                        let uu____12027 =
                                           FStar_TypeChecker_Common.lcomp_comp
                                             c1
                                            in
-                                        (match uu____12104 with
+                                        (match uu____12027 with
                                          | (c2,g_lc) ->
-                                             ((let uu____12116 =
+                                             ((let uu____12039 =
                                                  FStar_All.pipe_left
                                                    (FStar_TypeChecker_Env.debug
                                                       env)
                                                    FStar_Options.Extreme
                                                   in
-                                               if uu____12116
+                                               if uu____12039
                                                then
-                                                 let uu____12120 =
+                                                 let uu____12043 =
                                                    FStar_TypeChecker_Normalize.comp_to_string
                                                      env c2
                                                     in
                                                  FStar_Util.print1
                                                    "Strengthened to %s\n"
-                                                   uu____12120
+                                                   uu____12043
                                                else ());
-                                              (let uu____12125 =
+                                              (let uu____12048 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g_c g_lc
                                                   in
-                                               (c2, uu____12125))))))))
+                                               (c2, uu____12048))))))))
                        in
                     let flags =
                       FStar_All.pipe_right lc.FStar_TypeChecker_Common.cflags
                         (FStar_List.collect
-                           (fun uu___6_12134  ->
-                              match uu___6_12134 with
+                           (fun uu___6_12057  ->
+                              match uu___6_12057 with
                               | FStar_Syntax_Syntax.RETURN  ->
                                   [FStar_Syntax_Syntax.PARTIAL_RETURN]
                               | FStar_Syntax_Syntax.PARTIAL_RETURN  ->
                                   [FStar_Syntax_Syntax.PARTIAL_RETURN]
                               | FStar_Syntax_Syntax.CPS  ->
                                   [FStar_Syntax_Syntax.CPS]
-                              | uu____12137 -> []))
+                              | uu____12060 -> []))
                        in
                     let lc1 =
-                      let uu____12139 =
+                      let uu____12062 =
                         FStar_TypeChecker_Env.norm_eff_name env
                           lc.FStar_TypeChecker_Common.eff_name
                          in
-                      FStar_TypeChecker_Common.mk_lcomp uu____12139 t flags
+                      FStar_TypeChecker_Common.mk_lcomp uu____12062 t flags
                         strengthen
                        in
                     let g2 =
-                      let uu___1464_12141 = g1  in
+                      let uu___1464_12064 = g1  in
                       {
                         FStar_TypeChecker_Common.guard_f =
                           FStar_TypeChecker_Common.Trivial;
                         FStar_TypeChecker_Common.deferred =
-                          (uu___1464_12141.FStar_TypeChecker_Common.deferred);
+                          (uu___1464_12064.FStar_TypeChecker_Common.deferred);
                         FStar_TypeChecker_Common.univ_ineqs =
-                          (uu___1464_12141.FStar_TypeChecker_Common.univ_ineqs);
+                          (uu___1464_12064.FStar_TypeChecker_Common.univ_ineqs);
                         FStar_TypeChecker_Common.implicits =
-                          (uu___1464_12141.FStar_TypeChecker_Common.implicits)
+                          (uu___1464_12064.FStar_TypeChecker_Common.implicits)
                       }  in
                     (e, lc1, g2)))
   
@@ -4873,168 +4829,160 @@ let (pure_or_ghost_pre_and_post :
       let mk_post_type res_t ens =
         let x = FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None res_t
            in
-        let uu____12177 =
-          let uu____12180 =
-            let uu____12185 =
-              let uu____12186 =
-                let uu____12195 = FStar_Syntax_Syntax.bv_to_name x  in
-                FStar_Syntax_Syntax.as_arg uu____12195  in
-              [uu____12186]  in
-            FStar_Syntax_Syntax.mk_Tm_app ens uu____12185  in
-          uu____12180 FStar_Pervasives_Native.None
+        let uu____12100 =
+          let uu____12103 =
+            let uu____12104 =
+              let uu____12113 = FStar_Syntax_Syntax.bv_to_name x  in
+              FStar_Syntax_Syntax.as_arg uu____12113  in
+            [uu____12104]  in
+          FStar_Syntax_Syntax.mk_Tm_app ens uu____12103
             res_t.FStar_Syntax_Syntax.pos
            in
-        FStar_Syntax_Util.refine x uu____12177  in
+        FStar_Syntax_Util.refine x uu____12100  in
       let norm t =
         FStar_TypeChecker_Normalize.normalize
           [FStar_TypeChecker_Env.Beta;
           FStar_TypeChecker_Env.Eager_unfolding;
           FStar_TypeChecker_Env.EraseUniverses] env t
          in
-      let uu____12218 = FStar_Syntax_Util.is_tot_or_gtot_comp comp  in
-      if uu____12218
+      let uu____12136 = FStar_Syntax_Util.is_tot_or_gtot_comp comp  in
+      if uu____12136
       then
         (FStar_Pervasives_Native.None, (FStar_Syntax_Util.comp_result comp))
       else
         (match comp.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.GTotal uu____12237 -> failwith "Impossible"
-         | FStar_Syntax_Syntax.Total uu____12253 -> failwith "Impossible"
+         | FStar_Syntax_Syntax.GTotal uu____12155 -> failwith "Impossible"
+         | FStar_Syntax_Syntax.Total uu____12171 -> failwith "Impossible"
          | FStar_Syntax_Syntax.Comp ct ->
-             let uu____12270 =
+             let uu____12188 =
                (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                   FStar_Parser_Const.effect_Pure_lid)
                  ||
                  (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
                     FStar_Parser_Const.effect_Ghost_lid)
                 in
-             if uu____12270
+             if uu____12188
              then
                (match ct.FStar_Syntax_Syntax.effect_args with
-                | (req,uu____12286)::(ens,uu____12288)::uu____12289 ->
-                    let uu____12332 =
-                      let uu____12335 = norm req  in
-                      FStar_Pervasives_Native.Some uu____12335  in
-                    let uu____12336 =
-                      let uu____12337 =
+                | (req,uu____12204)::(ens,uu____12206)::uu____12207 ->
+                    let uu____12250 =
+                      let uu____12253 = norm req  in
+                      FStar_Pervasives_Native.Some uu____12253  in
+                    let uu____12254 =
+                      let uu____12255 =
                         mk_post_type ct.FStar_Syntax_Syntax.result_typ ens
                          in
-                      FStar_All.pipe_left norm uu____12337  in
-                    (uu____12332, uu____12336)
-                | uu____12340 ->
-                    let uu____12351 =
-                      let uu____12357 =
-                        let uu____12359 =
+                      FStar_All.pipe_left norm uu____12255  in
+                    (uu____12250, uu____12254)
+                | uu____12258 ->
+                    let uu____12269 =
+                      let uu____12275 =
+                        let uu____12277 =
                           FStar_Syntax_Print.comp_to_string comp  in
                         FStar_Util.format1
                           "Effect constructor is not fully applied; got %s"
-                          uu____12359
+                          uu____12277
                          in
                       (FStar_Errors.Fatal_EffectConstructorNotFullyApplied,
-                        uu____12357)
+                        uu____12275)
                        in
-                    FStar_Errors.raise_error uu____12351
+                    FStar_Errors.raise_error uu____12269
                       comp.FStar_Syntax_Syntax.pos)
              else
                (let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env comp
                    in
                 match ct1.FStar_Syntax_Syntax.effect_args with
-                | (wp,uu____12379)::uu____12380 ->
-                    let uu____12407 =
-                      let uu____12412 =
+                | (wp,uu____12297)::uu____12298 ->
+                    let uu____12325 =
+                      let uu____12330 =
                         FStar_TypeChecker_Env.lookup_lid env
                           FStar_Parser_Const.as_requires
                          in
                       FStar_All.pipe_left FStar_Pervasives_Native.fst
-                        uu____12412
+                        uu____12330
                        in
-                    (match uu____12407 with
-                     | (us_r,uu____12444) ->
-                         let uu____12445 =
-                           let uu____12450 =
+                    (match uu____12325 with
+                     | (us_r,uu____12362) ->
+                         let uu____12363 =
+                           let uu____12368 =
                              FStar_TypeChecker_Env.lookup_lid env
                                FStar_Parser_Const.as_ensures
                               in
                            FStar_All.pipe_left FStar_Pervasives_Native.fst
-                             uu____12450
+                             uu____12368
                             in
-                         (match uu____12445 with
-                          | (us_e,uu____12482) ->
+                         (match uu____12363 with
+                          | (us_e,uu____12400) ->
                               let r =
                                 (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
                                  in
                               let as_req =
-                                let uu____12485 =
-                                  let uu____12486 =
+                                let uu____12403 =
+                                  let uu____12404 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_requires r
                                      in
-                                  FStar_Syntax_Syntax.fvar uu____12486
+                                  FStar_Syntax_Syntax.fvar uu____12404
                                     FStar_Syntax_Syntax.delta_equational
                                     FStar_Pervasives_Native.None
                                    in
-                                FStar_Syntax_Syntax.mk_Tm_uinst uu____12485
+                                FStar_Syntax_Syntax.mk_Tm_uinst uu____12403
                                   us_r
                                  in
                               let as_ens =
-                                let uu____12488 =
-                                  let uu____12489 =
+                                let uu____12406 =
+                                  let uu____12407 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_ensures r
                                      in
-                                  FStar_Syntax_Syntax.fvar uu____12489
+                                  FStar_Syntax_Syntax.fvar uu____12407
                                     FStar_Syntax_Syntax.delta_equational
                                     FStar_Pervasives_Native.None
                                    in
-                                FStar_Syntax_Syntax.mk_Tm_uinst uu____12488
+                                FStar_Syntax_Syntax.mk_Tm_uinst uu____12406
                                   us_e
                                  in
                               let req =
-                                let uu____12493 =
-                                  let uu____12498 =
-                                    let uu____12499 =
-                                      let uu____12510 =
-                                        FStar_Syntax_Syntax.as_arg wp  in
-                                      [uu____12510]  in
-                                    ((ct1.FStar_Syntax_Syntax.result_typ),
-                                      (FStar_Pervasives_Native.Some
-                                         FStar_Syntax_Syntax.imp_tag))
-                                      :: uu____12499
-                                     in
-                                  FStar_Syntax_Syntax.mk_Tm_app as_req
-                                    uu____12498
+                                let uu____12409 =
+                                  let uu____12410 =
+                                    let uu____12421 =
+                                      FStar_Syntax_Syntax.as_arg wp  in
+                                    [uu____12421]  in
+                                  ((ct1.FStar_Syntax_Syntax.result_typ),
+                                    (FStar_Pervasives_Native.Some
+                                       FStar_Syntax_Syntax.imp_tag))
+                                    :: uu____12410
                                    in
-                                uu____12493 FStar_Pervasives_Native.None
+                                FStar_Syntax_Syntax.mk_Tm_app as_req
+                                  uu____12409
                                   (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
                                  in
                               let ens =
-                                let uu____12550 =
-                                  let uu____12555 =
-                                    let uu____12556 =
-                                      let uu____12567 =
-                                        FStar_Syntax_Syntax.as_arg wp  in
-                                      [uu____12567]  in
-                                    ((ct1.FStar_Syntax_Syntax.result_typ),
-                                      (FStar_Pervasives_Native.Some
-                                         FStar_Syntax_Syntax.imp_tag))
-                                      :: uu____12556
-                                     in
-                                  FStar_Syntax_Syntax.mk_Tm_app as_ens
-                                    uu____12555
+                                let uu____12459 =
+                                  let uu____12460 =
+                                    let uu____12471 =
+                                      FStar_Syntax_Syntax.as_arg wp  in
+                                    [uu____12471]  in
+                                  ((ct1.FStar_Syntax_Syntax.result_typ),
+                                    (FStar_Pervasives_Native.Some
+                                       FStar_Syntax_Syntax.imp_tag))
+                                    :: uu____12460
                                    in
-                                uu____12550 FStar_Pervasives_Native.None
+                                FStar_Syntax_Syntax.mk_Tm_app as_ens
+                                  uu____12459
                                   (ct1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos
                                  in
-                              let uu____12604 =
-                                let uu____12607 = norm req  in
-                                FStar_Pervasives_Native.Some uu____12607  in
-                              let uu____12608 =
-                                let uu____12609 =
+                              let uu____12508 =
+                                let uu____12511 = norm req  in
+                                FStar_Pervasives_Native.Some uu____12511  in
+                              let uu____12512 =
+                                let uu____12513 =
                                   mk_post_type
                                     ct1.FStar_Syntax_Syntax.result_typ ens
                                    in
-                                norm uu____12609  in
-                              (uu____12604, uu____12608)))
-                | uu____12612 -> failwith "Impossible"))
+                                norm uu____12513  in
+                              (uu____12508, uu____12512)))
+                | uu____12516 -> failwith "Impossible"))
   
 let (reify_body :
   FStar_TypeChecker_Env.env ->
@@ -5056,16 +5004,16 @@ let (reify_body :
                FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta]
                steps) env tm
            in
-        (let uu____12651 =
+        (let uu____12555 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "SMTEncodingReify")
             in
-         if uu____12651
+         if uu____12555
          then
-           let uu____12656 = FStar_Syntax_Print.term_to_string tm  in
-           let uu____12658 = FStar_Syntax_Print.term_to_string tm'  in
-           FStar_Util.print2 "Reified body %s \nto %s\n" uu____12656
-             uu____12658
+           let uu____12560 = FStar_Syntax_Print.term_to_string tm  in
+           let uu____12562 = FStar_Syntax_Print.term_to_string tm'  in
+           FStar_Util.print2 "Reified body %s \nto %s\n" uu____12560
+             uu____12562
          else ());
         tm'
   
@@ -5081,7 +5029,7 @@ let (reify_body_with_arg :
         fun arg  ->
           let tm =
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (head, [arg]))
-              FStar_Pervasives_Native.None head.FStar_Syntax_Syntax.pos
+              head.FStar_Syntax_Syntax.pos
              in
           let tm' =
             FStar_TypeChecker_Normalize.normalize
@@ -5094,47 +5042,47 @@ let (reify_body_with_arg :
                  FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta]
                  steps) env tm
              in
-          (let uu____12717 =
+          (let uu____12621 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "SMTEncodingReify")
               in
-           if uu____12717
+           if uu____12621
            then
-             let uu____12722 = FStar_Syntax_Print.term_to_string tm  in
-             let uu____12724 = FStar_Syntax_Print.term_to_string tm'  in
-             FStar_Util.print2 "Reified body %s \nto %s\n" uu____12722
-               uu____12724
+             let uu____12626 = FStar_Syntax_Print.term_to_string tm  in
+             let uu____12628 = FStar_Syntax_Print.term_to_string tm'  in
+             FStar_Util.print2 "Reified body %s \nto %s\n" uu____12626
+               uu____12628
            else ());
           tm'
   
 let (remove_reify : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t  ->
-    let uu____12735 =
-      let uu____12737 =
-        let uu____12738 = FStar_Syntax_Subst.compress t  in
-        uu____12738.FStar_Syntax_Syntax.n  in
-      match uu____12737 with
-      | FStar_Syntax_Syntax.Tm_app uu____12742 -> false
-      | uu____12760 -> true  in
-    if uu____12735
+    let uu____12639 =
+      let uu____12641 =
+        let uu____12642 = FStar_Syntax_Subst.compress t  in
+        uu____12642.FStar_Syntax_Syntax.n  in
+      match uu____12641 with
+      | FStar_Syntax_Syntax.Tm_app uu____12646 -> false
+      | uu____12664 -> true  in
+    if uu____12639
     then t
     else
-      (let uu____12765 = FStar_Syntax_Util.head_and_args t  in
-       match uu____12765 with
+      (let uu____12669 = FStar_Syntax_Util.head_and_args t  in
+       match uu____12669 with
        | (head,args) ->
-           let uu____12808 =
-             let uu____12810 =
-               let uu____12811 = FStar_Syntax_Subst.compress head  in
-               uu____12811.FStar_Syntax_Syntax.n  in
-             match uu____12810 with
+           let uu____12712 =
+             let uu____12714 =
+               let uu____12715 = FStar_Syntax_Subst.compress head  in
+               uu____12715.FStar_Syntax_Syntax.n  in
+             match uu____12714 with
              | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify ) ->
                  true
-             | uu____12816 -> false  in
-           if uu____12808
+             | uu____12720 -> false  in
+           if uu____12712
            then
              (match args with
               | x::[] -> FStar_Pervasives_Native.fst x
-              | uu____12848 ->
+              | uu____12752 ->
                   failwith
                     "Impossible : Reify applied to multiple arguments after normalization.")
            else t)
@@ -5153,26 +5101,26 @@ let (maybe_instantiate :
         if Prims.op_Negation env.FStar_TypeChecker_Env.instantiate_imp
         then (e, torig, FStar_TypeChecker_Env.trivial_guard)
         else
-          ((let uu____12895 =
+          ((let uu____12799 =
               FStar_TypeChecker_Env.debug env FStar_Options.High  in
-            if uu____12895
+            if uu____12799
             then
-              let uu____12898 = FStar_Syntax_Print.term_to_string e  in
-              let uu____12900 = FStar_Syntax_Print.term_to_string t  in
-              let uu____12902 =
-                let uu____12904 = FStar_TypeChecker_Env.expected_typ env  in
+              let uu____12802 = FStar_Syntax_Print.term_to_string e  in
+              let uu____12804 = FStar_Syntax_Print.term_to_string t  in
+              let uu____12806 =
+                let uu____12808 = FStar_TypeChecker_Env.expected_typ env  in
                 FStar_Common.string_of_option
-                  FStar_Syntax_Print.term_to_string uu____12904
+                  FStar_Syntax_Print.term_to_string uu____12808
                  in
               FStar_Util.print3
                 "maybe_instantiate: starting check for (%s) of type (%s), expected type is %s\n"
-                uu____12898 uu____12900 uu____12902
+                uu____12802 uu____12804 uu____12806
             else ());
            (let unfolded_arrow_formals t1 =
               let rec aux bs t2 =
                 let t3 = FStar_TypeChecker_Normalize.unfold_whnf env t2  in
-                let uu____12940 = FStar_Syntax_Util.arrow_formals t3  in
-                match uu____12940 with
+                let uu____12844 = FStar_Syntax_Util.arrow_formals t3  in
+                match uu____12844 with
                 | (bs',t4) ->
                     (match bs' with
                      | [] -> bs
@@ -5182,21 +5130,21 @@ let (maybe_instantiate :
             let number_of_implicits t1 =
               let formals = unfolded_arrow_formals t1  in
               let n_implicits =
-                let uu____12974 =
+                let uu____12878 =
                   FStar_All.pipe_right formals
                     (FStar_Util.prefix_until
-                       (fun uu____13052  ->
-                          match uu____13052 with
-                          | (uu____13060,imp) ->
+                       (fun uu____12956  ->
+                          match uu____12956 with
+                          | (uu____12964,imp) ->
                               (FStar_Option.isNone imp) ||
-                                (let uu____13067 =
+                                (let uu____12971 =
                                    FStar_Syntax_Util.eq_aqual imp
                                      (FStar_Pervasives_Native.Some
                                         FStar_Syntax_Syntax.Equality)
                                     in
-                                 uu____13067 = FStar_Syntax_Util.Equal)))
+                                 uu____12971 = FStar_Syntax_Util.Equal)))
                    in
-                match uu____12974 with
+                match uu____12878 with
                 | FStar_Pervasives_Native.None  -> FStar_List.length formals
                 | FStar_Pervasives_Native.Some
                     (implicits,_first_explicit,_rest) ->
@@ -5204,36 +5152,36 @@ let (maybe_instantiate :
                  in
               n_implicits  in
             let inst_n_binders t1 =
-              let uu____13186 = FStar_TypeChecker_Env.expected_typ env  in
-              match uu____13186 with
+              let uu____13090 = FStar_TypeChecker_Env.expected_typ env  in
+              match uu____13090 with
               | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some expected_t ->
                   let n_expected = number_of_implicits expected_t  in
                   let n_available = number_of_implicits t1  in
                   if n_available < n_expected
                   then
-                    let uu____13200 =
-                      let uu____13206 =
-                        let uu____13208 = FStar_Util.string_of_int n_expected
+                    let uu____13104 =
+                      let uu____13110 =
+                        let uu____13112 = FStar_Util.string_of_int n_expected
                            in
-                        let uu____13210 = FStar_Syntax_Print.term_to_string e
+                        let uu____13114 = FStar_Syntax_Print.term_to_string e
                            in
-                        let uu____13212 =
+                        let uu____13116 =
                           FStar_Util.string_of_int n_available  in
                         FStar_Util.format3
                           "Expected a term with %s implicit arguments, but %s has only %s"
-                          uu____13208 uu____13210 uu____13212
+                          uu____13112 uu____13114 uu____13116
                          in
                       (FStar_Errors.Fatal_MissingImplicitArguments,
-                        uu____13206)
+                        uu____13110)
                        in
-                    let uu____13216 = FStar_TypeChecker_Env.get_range env  in
-                    FStar_Errors.raise_error uu____13200 uu____13216
+                    let uu____13120 = FStar_TypeChecker_Env.get_range env  in
+                    FStar_Errors.raise_error uu____13104 uu____13120
                   else
                     FStar_Pervasives_Native.Some (n_available - n_expected)
                in
-            let decr_inst uu___7_13234 =
-              match uu___7_13234 with
+            let decr_inst uu___7_13138 =
+              match uu___7_13138 with
               | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some i ->
                   FStar_Pervasives_Native.Some (i - Prims.int_one)
@@ -5241,148 +5189,147 @@ let (maybe_instantiate :
             let t1 = FStar_TypeChecker_Normalize.unfold_whnf env t  in
             match t1.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_arrow (bs,c) ->
-                let uu____13277 = FStar_Syntax_Subst.open_comp bs c  in
-                (match uu____13277 with
+                let uu____13181 = FStar_Syntax_Subst.open_comp bs c  in
+                (match uu____13181 with
                  | (bs1,c1) ->
                      let rec aux subst inst_n bs2 =
                        match (inst_n, bs2) with
                        | (FStar_Pervasives_Native.Some
-                          uu____13408,uu____13395) when
-                           uu____13408 = Prims.int_zero ->
+                          uu____13312,uu____13299) when
+                           uu____13312 = Prims.int_zero ->
                            ([], bs2, subst,
                              FStar_TypeChecker_Env.trivial_guard)
-                       | (uu____13441,(x,FStar_Pervasives_Native.Some
+                       | (uu____13345,(x,FStar_Pervasives_Native.Some
                                        (FStar_Syntax_Syntax.Implicit
-                                       uu____13443))::rest)
+                                       uu____13347))::rest)
                            ->
                            let t2 =
                              FStar_Syntax_Subst.subst subst
                                x.FStar_Syntax_Syntax.sort
                               in
-                           let uu____13477 =
+                           let uu____13381 =
                              new_implicit_var
                                "Instantiation of implicit argument"
                                e.FStar_Syntax_Syntax.pos env t2
                               in
-                           (match uu____13477 with
-                            | (v,uu____13518,g) ->
-                                ((let uu____13533 =
+                           (match uu____13381 with
+                            | (v,uu____13422,g) ->
+                                ((let uu____13437 =
                                     FStar_TypeChecker_Env.debug env
                                       FStar_Options.High
                                      in
-                                  if uu____13533
+                                  if uu____13437
                                   then
-                                    let uu____13536 =
+                                    let uu____13440 =
                                       FStar_Syntax_Print.term_to_string v  in
                                     FStar_Util.print1
                                       "maybe_instantiate: Instantiating implicit with %s\n"
-                                      uu____13536
+                                      uu____13440
                                   else ());
                                  (let subst1 =
                                     (FStar_Syntax_Syntax.NT (x, v)) :: subst
                                      in
-                                  let uu____13546 =
+                                  let uu____13450 =
                                     aux subst1 (decr_inst inst_n) rest  in
-                                  match uu____13546 with
+                                  match uu____13450 with
                                   | (args,bs3,subst2,g') ->
-                                      let uu____13639 =
+                                      let uu____13543 =
                                         FStar_TypeChecker_Env.conj_guard g g'
                                          in
                                       (((v,
                                           (FStar_Pervasives_Native.Some
                                              FStar_Syntax_Syntax.imp_tag)) ::
-                                        args), bs3, subst2, uu____13639))))
-                       | (uu____13666,(x,FStar_Pervasives_Native.Some
+                                        args), bs3, subst2, uu____13543))))
+                       | (uu____13570,(x,FStar_Pervasives_Native.Some
                                        (FStar_Syntax_Syntax.Meta tau))::rest)
                            ->
                            let t2 =
                              FStar_Syntax_Subst.subst subst
                                x.FStar_Syntax_Syntax.sort
                               in
-                           let uu____13703 =
-                             let uu____13716 =
-                               let uu____13723 =
-                                 let uu____13728 = FStar_Dyn.mkdyn env  in
-                                 (uu____13728, tau)  in
-                               FStar_Pervasives_Native.Some uu____13723  in
+                           let uu____13607 =
+                             let uu____13620 =
+                               let uu____13627 =
+                                 let uu____13632 = FStar_Dyn.mkdyn env  in
+                                 (uu____13632, tau)  in
+                               FStar_Pervasives_Native.Some uu____13627  in
                              FStar_TypeChecker_Env.new_implicit_var_aux
                                "Instantiation of meta argument"
                                e.FStar_Syntax_Syntax.pos env t2
-                               FStar_Syntax_Syntax.Strict uu____13716
+                               FStar_Syntax_Syntax.Strict uu____13620
                               in
-                           (match uu____13703 with
-                            | (v,uu____13761,g) ->
-                                ((let uu____13776 =
+                           (match uu____13607 with
+                            | (v,uu____13665,g) ->
+                                ((let uu____13680 =
                                     FStar_TypeChecker_Env.debug env
                                       FStar_Options.High
                                      in
-                                  if uu____13776
+                                  if uu____13680
                                   then
-                                    let uu____13779 =
+                                    let uu____13683 =
                                       FStar_Syntax_Print.term_to_string v  in
                                     FStar_Util.print1
                                       "maybe_instantiate: Instantiating meta argument with %s\n"
-                                      uu____13779
+                                      uu____13683
                                   else ());
                                  (let subst1 =
                                     (FStar_Syntax_Syntax.NT (x, v)) :: subst
                                      in
-                                  let uu____13789 =
+                                  let uu____13693 =
                                     aux subst1 (decr_inst inst_n) rest  in
-                                  match uu____13789 with
+                                  match uu____13693 with
                                   | (args,bs3,subst2,g') ->
-                                      let uu____13882 =
+                                      let uu____13786 =
                                         FStar_TypeChecker_Env.conj_guard g g'
                                          in
                                       (((v,
                                           (FStar_Pervasives_Native.Some
                                              FStar_Syntax_Syntax.imp_tag)) ::
-                                        args), bs3, subst2, uu____13882))))
-                       | (uu____13909,bs3) ->
+                                        args), bs3, subst2, uu____13786))))
+                       | (uu____13813,bs3) ->
                            ([], bs3, subst,
                              FStar_TypeChecker_Env.trivial_guard)
                         in
-                     let uu____13957 =
-                       let uu____13984 = inst_n_binders t1  in
-                       aux [] uu____13984 bs1  in
-                     (match uu____13957 with
+                     let uu____13861 =
+                       let uu____13888 = inst_n_binders t1  in
+                       aux [] uu____13888 bs1  in
+                     (match uu____13861 with
                       | (args,bs2,subst,guard) ->
                           (match (args, bs2) with
-                           | ([],uu____14056) -> (e, torig, guard)
-                           | (uu____14087,[]) when
-                               let uu____14118 =
+                           | ([],uu____13960) -> (e, torig, guard)
+                           | (uu____13991,[]) when
+                               let uu____14022 =
                                  FStar_Syntax_Util.is_total_comp c1  in
-                               Prims.op_Negation uu____14118 ->
+                               Prims.op_Negation uu____14022 ->
                                (e, torig,
                                  FStar_TypeChecker_Env.trivial_guard)
-                           | uu____14120 ->
+                           | uu____14024 ->
                                let t2 =
                                  match bs2 with
                                  | [] -> FStar_Syntax_Util.comp_result c1
-                                 | uu____14148 ->
+                                 | uu____14052 ->
                                      FStar_Syntax_Util.arrow bs2 c1
                                   in
                                let t3 = FStar_Syntax_Subst.subst subst t2  in
                                let e1 =
                                  FStar_Syntax_Syntax.mk_Tm_app e args
-                                   FStar_Pervasives_Native.None
                                    e.FStar_Syntax_Syntax.pos
                                   in
                                (e1, t3, guard))))
-            | uu____14161 -> (e, torig, FStar_TypeChecker_Env.trivial_guard)))
+            | uu____14063 -> (e, torig, FStar_TypeChecker_Env.trivial_guard)))
   
 let (string_of_univs :
   FStar_Syntax_Syntax.universe_uvar FStar_Util.set -> Prims.string) =
   fun univs  ->
-    let uu____14173 =
-      let uu____14177 = FStar_Util.set_elements univs  in
-      FStar_All.pipe_right uu____14177
+    let uu____14075 =
+      let uu____14079 = FStar_Util.set_elements univs  in
+      FStar_All.pipe_right uu____14079
         (FStar_List.map
            (fun u  ->
-              let uu____14189 = FStar_Syntax_Unionfind.univ_uvar_id u  in
-              FStar_All.pipe_right uu____14189 FStar_Util.string_of_int))
+              let uu____14091 = FStar_Syntax_Unionfind.univ_uvar_id u  in
+              FStar_All.pipe_right uu____14091 FStar_Util.string_of_int))
        in
-    FStar_All.pipe_right uu____14173 (FStar_String.concat ", ")
+    FStar_All.pipe_right uu____14075 (FStar_String.concat ", ")
   
 let (gen_univs :
   FStar_TypeChecker_Env.env ->
@@ -5391,56 +5338,56 @@ let (gen_univs :
   =
   fun env  ->
     fun x  ->
-      let uu____14217 = FStar_Util.set_is_empty x  in
-      if uu____14217
+      let uu____14119 = FStar_Util.set_is_empty x  in
+      if uu____14119
       then []
       else
         (let s =
-           let uu____14237 =
-             let uu____14240 = FStar_TypeChecker_Env.univ_vars env  in
-             FStar_Util.set_difference x uu____14240  in
-           FStar_All.pipe_right uu____14237 FStar_Util.set_elements  in
-         (let uu____14258 =
+           let uu____14139 =
+             let uu____14142 = FStar_TypeChecker_Env.univ_vars env  in
+             FStar_Util.set_difference x uu____14142  in
+           FStar_All.pipe_right uu____14139 FStar_Util.set_elements  in
+         (let uu____14160 =
             FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
               (FStar_Options.Other "Gen")
              in
-          if uu____14258
+          if uu____14160
           then
-            let uu____14263 =
-              let uu____14265 = FStar_TypeChecker_Env.univ_vars env  in
-              string_of_univs uu____14265  in
-            FStar_Util.print1 "univ_vars in env: %s\n" uu____14263
+            let uu____14165 =
+              let uu____14167 = FStar_TypeChecker_Env.univ_vars env  in
+              string_of_univs uu____14167  in
+            FStar_Util.print1 "univ_vars in env: %s\n" uu____14165
           else ());
          (let r =
-            let uu____14274 = FStar_TypeChecker_Env.get_range env  in
-            FStar_Pervasives_Native.Some uu____14274  in
+            let uu____14176 = FStar_TypeChecker_Env.get_range env  in
+            FStar_Pervasives_Native.Some uu____14176  in
           let u_names =
             FStar_All.pipe_right s
               (FStar_List.map
                  (fun u  ->
                     let u_name = FStar_Syntax_Syntax.new_univ_name r  in
-                    (let uu____14319 =
+                    (let uu____14221 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "Gen")
                         in
-                     if uu____14319
+                     if uu____14221
                      then
-                       let uu____14324 =
-                         let uu____14326 =
+                       let uu____14226 =
+                         let uu____14228 =
                            FStar_Syntax_Unionfind.univ_uvar_id u  in
                          FStar_All.pipe_left FStar_Util.string_of_int
-                           uu____14326
+                           uu____14228
                           in
-                       let uu____14330 =
+                       let uu____14232 =
                          FStar_Syntax_Print.univ_to_string
                            (FStar_Syntax_Syntax.U_unif u)
                           in
-                       let uu____14332 =
+                       let uu____14234 =
                          FStar_Syntax_Print.univ_to_string
                            (FStar_Syntax_Syntax.U_name u_name)
                           in
                        FStar_Util.print3 "Setting ?%s (%s) to %s\n"
-                         uu____14324 uu____14330 uu____14332
+                         uu____14226 uu____14232 uu____14234
                      else ());
                     FStar_Syntax_Unionfind.univ_change u
                       (FStar_Syntax_Syntax.U_name u_name);
@@ -5457,9 +5404,9 @@ let (gather_free_univnames :
       let ctx_univnames = FStar_TypeChecker_Env.univnames env  in
       let tm_univnames = FStar_Syntax_Free.univnames t  in
       let univnames =
-        let uu____14362 =
+        let uu____14264 =
           FStar_Util.set_difference tm_univnames ctx_univnames  in
-        FStar_All.pipe_right uu____14362 FStar_Util.set_elements  in
+        FStar_All.pipe_right uu____14264 FStar_Util.set_elements  in
       univnames
   
 let (check_universe_generalization :
@@ -5471,19 +5418,19 @@ let (check_universe_generalization :
     fun generalized_univ_names  ->
       fun t  ->
         match (explicit_univ_names, generalized_univ_names) with
-        | ([],uu____14401) -> generalized_univ_names
-        | (uu____14408,[]) -> explicit_univ_names
-        | uu____14415 ->
-            let uu____14424 =
-              let uu____14430 =
-                let uu____14432 = FStar_Syntax_Print.term_to_string t  in
+        | ([],uu____14303) -> generalized_univ_names
+        | (uu____14310,[]) -> explicit_univ_names
+        | uu____14317 ->
+            let uu____14326 =
+              let uu____14332 =
+                let uu____14334 = FStar_Syntax_Print.term_to_string t  in
                 Prims.op_Hat
                   "Generalized universe in a term containing explicit universe annotation : "
-                  uu____14432
+                  uu____14334
                  in
-              (FStar_Errors.Fatal_UnexpectedGeneralizedUniverse, uu____14430)
+              (FStar_Errors.Fatal_UnexpectedGeneralizedUniverse, uu____14332)
                in
-            FStar_Errors.raise_error uu____14424 t.FStar_Syntax_Syntax.pos
+            FStar_Errors.raise_error uu____14326 t.FStar_Syntax_Syntax.pos
   
 let (generalize_universes :
   FStar_TypeChecker_Env.env ->
@@ -5498,40 +5445,40 @@ let (generalize_universes :
           FStar_TypeChecker_Env.DoNotUnfoldPureLets] env t0
          in
       let univnames = gather_free_univnames env t  in
-      (let uu____14454 =
+      (let uu____14356 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "Gen")
           in
-       if uu____14454
+       if uu____14356
        then
-         let uu____14459 = FStar_Syntax_Print.term_to_string t  in
-         let uu____14461 = FStar_Syntax_Print.univ_names_to_string univnames
+         let uu____14361 = FStar_Syntax_Print.term_to_string t  in
+         let uu____14363 = FStar_Syntax_Print.univ_names_to_string univnames
             in
          FStar_Util.print2
            "generalizing universes in the term (post norm): %s with univnames: %s\n"
-           uu____14459 uu____14461
+           uu____14361 uu____14363
        else ());
       (let univs = FStar_Syntax_Free.univs t  in
-       (let uu____14470 =
+       (let uu____14372 =
           FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
             (FStar_Options.Other "Gen")
            in
-        if uu____14470
+        if uu____14372
         then
-          let uu____14475 = string_of_univs univs  in
-          FStar_Util.print1 "univs to gen : %s\n" uu____14475
+          let uu____14377 = string_of_univs univs  in
+          FStar_Util.print1 "univs to gen : %s\n" uu____14377
         else ());
        (let gen = gen_univs env univs  in
-        (let uu____14484 =
+        (let uu____14386 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Gen")
             in
-         if uu____14484
+         if uu____14386
          then
-           let uu____14489 = FStar_Syntax_Print.term_to_string t  in
-           let uu____14491 = FStar_Syntax_Print.univ_names_to_string gen  in
+           let uu____14391 = FStar_Syntax_Print.term_to_string t  in
+           let uu____14393 = FStar_Syntax_Print.univ_names_to_string gen  in
            FStar_Util.print2 "After generalization, t: %s and univs: %s\n"
-             uu____14489 uu____14491
+             uu____14391 uu____14393
          else ());
         (let univs1 = check_universe_generalization univnames gen t0  in
          let t1 = FStar_TypeChecker_Normalize.reduce_uvar_solutions env t  in
@@ -5551,26 +5498,26 @@ let (gen :
   fun env  ->
     fun is_rec  ->
       fun lecs  ->
-        let uu____14575 =
-          let uu____14577 =
+        let uu____14477 =
+          let uu____14479 =
             FStar_Util.for_all
-              (fun uu____14591  ->
-                 match uu____14591 with
-                 | (uu____14601,uu____14602,c) ->
+              (fun uu____14493  ->
+                 match uu____14493 with
+                 | (uu____14503,uu____14504,c) ->
                      FStar_Syntax_Util.is_pure_or_ghost_comp c) lecs
              in
-          FStar_All.pipe_left Prims.op_Negation uu____14577  in
-        if uu____14575
+          FStar_All.pipe_left Prims.op_Negation uu____14479  in
+        if uu____14477
         then FStar_Pervasives_Native.None
         else
           (let norm c =
-             (let uu____14654 =
+             (let uu____14556 =
                 FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
-              if uu____14654
+              if uu____14556
               then
-                let uu____14657 = FStar_Syntax_Print.comp_to_string c  in
+                let uu____14559 = FStar_Syntax_Print.comp_to_string c  in
                 FStar_Util.print1 "Normalizing before generalizing:\n\t %s\n"
-                  uu____14657
+                  uu____14559
               else ());
              (let c1 =
                 FStar_TypeChecker_Normalize.normalize_comp
@@ -5579,158 +5526,158 @@ let (gen :
                   FStar_TypeChecker_Env.NoFullNorm;
                   FStar_TypeChecker_Env.DoNotUnfoldPureLets] env c
                  in
-              (let uu____14664 =
+              (let uu____14566 =
                  FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
-               if uu____14664
+               if uu____14566
                then
-                 let uu____14667 = FStar_Syntax_Print.comp_to_string c1  in
-                 FStar_Util.print1 "Normalized to:\n\t %s\n" uu____14667
+                 let uu____14569 = FStar_Syntax_Print.comp_to_string c1  in
+                 FStar_Util.print1 "Normalized to:\n\t %s\n" uu____14569
                else ());
               c1)
               in
            let env_uvars = FStar_TypeChecker_Env.uvars_in_env env  in
            let gen_uvars uvs =
-             let uu____14685 = FStar_Util.set_difference uvs env_uvars  in
-             FStar_All.pipe_right uu____14685 FStar_Util.set_elements  in
-           let univs_and_uvars_of_lec uu____14719 =
-             match uu____14719 with
+             let uu____14587 = FStar_Util.set_difference uvs env_uvars  in
+             FStar_All.pipe_right uu____14587 FStar_Util.set_elements  in
+           let univs_and_uvars_of_lec uu____14621 =
+             match uu____14621 with
              | (lbname,e,c) ->
                  let c1 = norm c  in
                  let t = FStar_Syntax_Util.comp_result c1  in
                  let univs = FStar_Syntax_Free.univs t  in
                  let uvt = FStar_Syntax_Free.uvars t  in
-                 ((let uu____14756 =
+                 ((let uu____14658 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                        (FStar_Options.Other "Gen")
                       in
-                   if uu____14756
+                   if uu____14658
                    then
-                     let uu____14761 =
-                       let uu____14763 =
-                         let uu____14767 = FStar_Util.set_elements univs  in
-                         FStar_All.pipe_right uu____14767
+                     let uu____14663 =
+                       let uu____14665 =
+                         let uu____14669 = FStar_Util.set_elements univs  in
+                         FStar_All.pipe_right uu____14669
                            (FStar_List.map
                               (fun u  ->
                                  FStar_Syntax_Print.univ_to_string
                                    (FStar_Syntax_Syntax.U_unif u)))
                           in
-                       FStar_All.pipe_right uu____14763
+                       FStar_All.pipe_right uu____14665
                          (FStar_String.concat ", ")
                         in
-                     let uu____14823 =
-                       let uu____14825 =
-                         let uu____14829 = FStar_Util.set_elements uvt  in
-                         FStar_All.pipe_right uu____14829
+                     let uu____14725 =
+                       let uu____14727 =
+                         let uu____14731 = FStar_Util.set_elements uvt  in
+                         FStar_All.pipe_right uu____14731
                            (FStar_List.map
                               (fun u  ->
-                                 let uu____14842 =
+                                 let uu____14744 =
                                    FStar_Syntax_Print.uvar_to_string
                                      u.FStar_Syntax_Syntax.ctx_uvar_head
                                     in
-                                 let uu____14844 =
+                                 let uu____14746 =
                                    FStar_Syntax_Print.term_to_string
                                      u.FStar_Syntax_Syntax.ctx_uvar_typ
                                     in
-                                 FStar_Util.format2 "(%s : %s)" uu____14842
-                                   uu____14844))
+                                 FStar_Util.format2 "(%s : %s)" uu____14744
+                                   uu____14746))
                           in
-                       FStar_All.pipe_right uu____14825
+                       FStar_All.pipe_right uu____14727
                          (FStar_String.concat ", ")
                         in
                      FStar_Util.print2
-                       "^^^^\n\tFree univs = %s\n\tFree uvt=%s\n" uu____14761
-                       uu____14823
+                       "^^^^\n\tFree univs = %s\n\tFree uvt=%s\n" uu____14663
+                       uu____14725
                    else ());
                   (let univs1 =
-                     let uu____14858 = FStar_Util.set_elements uvt  in
+                     let uu____14760 = FStar_Util.set_elements uvt  in
                      FStar_List.fold_left
                        (fun univs1  ->
                           fun uv  ->
-                            let uu____14870 =
+                            let uu____14772 =
                               FStar_Syntax_Free.univs
                                 uv.FStar_Syntax_Syntax.ctx_uvar_typ
                                in
-                            FStar_Util.set_union univs1 uu____14870) univs
-                       uu____14858
+                            FStar_Util.set_union univs1 uu____14772) univs
+                       uu____14760
                       in
                    let uvs = gen_uvars uvt  in
-                   (let uu____14877 =
+                   (let uu____14779 =
                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                         (FStar_Options.Other "Gen")
                        in
-                    if uu____14877
+                    if uu____14779
                     then
-                      let uu____14882 =
-                        let uu____14884 =
-                          let uu____14888 = FStar_Util.set_elements univs1
+                      let uu____14784 =
+                        let uu____14786 =
+                          let uu____14790 = FStar_Util.set_elements univs1
                              in
-                          FStar_All.pipe_right uu____14888
+                          FStar_All.pipe_right uu____14790
                             (FStar_List.map
                                (fun u  ->
                                   FStar_Syntax_Print.univ_to_string
                                     (FStar_Syntax_Syntax.U_unif u)))
                            in
-                        FStar_All.pipe_right uu____14884
+                        FStar_All.pipe_right uu____14786
                           (FStar_String.concat ", ")
                          in
-                      let uu____14944 =
-                        let uu____14946 =
+                      let uu____14846 =
+                        let uu____14848 =
                           FStar_All.pipe_right uvs
                             (FStar_List.map
                                (fun u  ->
-                                  let uu____14960 =
+                                  let uu____14862 =
                                     FStar_Syntax_Print.uvar_to_string
                                       u.FStar_Syntax_Syntax.ctx_uvar_head
                                      in
-                                  let uu____14962 =
+                                  let uu____14864 =
                                     FStar_TypeChecker_Normalize.term_to_string
                                       env u.FStar_Syntax_Syntax.ctx_uvar_typ
                                      in
-                                  FStar_Util.format2 "(%s : %s)" uu____14960
-                                    uu____14962))
+                                  FStar_Util.format2 "(%s : %s)" uu____14862
+                                    uu____14864))
                            in
-                        FStar_All.pipe_right uu____14946
+                        FStar_All.pipe_right uu____14848
                           (FStar_String.concat ", ")
                          in
                       FStar_Util.print2
                         "^^^^\n\tFree univs = %s\n\tgen_uvars =%s"
-                        uu____14882 uu____14944
+                        uu____14784 uu____14846
                     else ());
                    (univs1, uvs, (lbname, e, c1))))
               in
-           let uu____14983 =
-             let uu____15000 = FStar_List.hd lecs  in
-             univs_and_uvars_of_lec uu____15000  in
-           match uu____14983 with
+           let uu____14885 =
+             let uu____14902 = FStar_List.hd lecs  in
+             univs_and_uvars_of_lec uu____14902  in
+           match uu____14885 with
            | (univs,uvs,lec_hd) ->
                let force_univs_eq lec2 u1 u2 =
-                 let uu____15090 =
+                 let uu____14992 =
                    (FStar_Util.set_is_subset_of u1 u2) &&
                      (FStar_Util.set_is_subset_of u2 u1)
                     in
-                 if uu____15090
+                 if uu____14992
                  then ()
                  else
-                   (let uu____15095 = lec_hd  in
-                    match uu____15095 with
-                    | (lb1,uu____15103,uu____15104) ->
-                        let uu____15105 = lec2  in
-                        (match uu____15105 with
-                         | (lb2,uu____15113,uu____15114) ->
+                   (let uu____14997 = lec_hd  in
+                    match uu____14997 with
+                    | (lb1,uu____15005,uu____15006) ->
+                        let uu____15007 = lec2  in
+                        (match uu____15007 with
+                         | (lb2,uu____15015,uu____15016) ->
                              let msg =
-                               let uu____15117 =
+                               let uu____15019 =
                                  FStar_Syntax_Print.lbname_to_string lb1  in
-                               let uu____15119 =
+                               let uu____15021 =
                                  FStar_Syntax_Print.lbname_to_string lb2  in
                                FStar_Util.format2
                                  "Generalizing the types of these mutually recursive definitions requires an incompatible set of universes for %s and %s"
-                                 uu____15117 uu____15119
+                                 uu____15019 uu____15021
                                 in
-                             let uu____15122 =
+                             let uu____15024 =
                                FStar_TypeChecker_Env.get_range env  in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_IncompatibleSetOfUniverse,
-                                 msg) uu____15122))
+                                 msg) uu____15024))
                   in
                let force_uvars_eq lec2 u1 u2 =
                  let uvars_subseteq u11 u21 =
@@ -5744,83 +5691,83 @@ let (gen :
                                      u.FStar_Syntax_Syntax.ctx_uvar_head
                                      u'.FStar_Syntax_Syntax.ctx_uvar_head))))
                     in
-                 let uu____15190 =
+                 let uu____15092 =
                    (uvars_subseteq u1 u2) && (uvars_subseteq u2 u1)  in
-                 if uu____15190
+                 if uu____15092
                  then ()
                  else
-                   (let uu____15195 = lec_hd  in
-                    match uu____15195 with
-                    | (lb1,uu____15203,uu____15204) ->
-                        let uu____15205 = lec2  in
-                        (match uu____15205 with
-                         | (lb2,uu____15213,uu____15214) ->
+                   (let uu____15097 = lec_hd  in
+                    match uu____15097 with
+                    | (lb1,uu____15105,uu____15106) ->
+                        let uu____15107 = lec2  in
+                        (match uu____15107 with
+                         | (lb2,uu____15115,uu____15116) ->
                              let msg =
-                               let uu____15217 =
+                               let uu____15119 =
                                  FStar_Syntax_Print.lbname_to_string lb1  in
-                               let uu____15219 =
+                               let uu____15121 =
                                  FStar_Syntax_Print.lbname_to_string lb2  in
                                FStar_Util.format2
                                  "Generalizing the types of these mutually recursive definitions requires an incompatible number of types for %s and %s"
-                                 uu____15217 uu____15219
+                                 uu____15119 uu____15121
                                 in
-                             let uu____15222 =
+                             let uu____15124 =
                                FStar_TypeChecker_Env.get_range env  in
                              FStar_Errors.raise_error
                                (FStar_Errors.Fatal_IncompatibleNumberOfTypes,
-                                 msg) uu____15222))
+                                 msg) uu____15124))
                   in
                let lecs1 =
-                 let uu____15233 = FStar_List.tl lecs  in
+                 let uu____15135 = FStar_List.tl lecs  in
                  FStar_List.fold_right
                    (fun this_lec  ->
                       fun lecs1  ->
-                        let uu____15286 = univs_and_uvars_of_lec this_lec  in
-                        match uu____15286 with
+                        let uu____15188 = univs_and_uvars_of_lec this_lec  in
+                        match uu____15188 with
                         | (this_univs,this_uvs,this_lec1) ->
                             (force_univs_eq this_lec1 univs this_univs;
                              force_uvars_eq this_lec1 uvs this_uvs;
                              this_lec1
                              ::
-                             lecs1)) uu____15233 []
+                             lecs1)) uu____15135 []
                   in
                let lecs2 = lec_hd :: lecs1  in
                let gen_types uvs1 =
                  let fail rng k =
-                   let uu____15396 = lec_hd  in
-                   match uu____15396 with
+                   let uu____15298 = lec_hd  in
+                   match uu____15298 with
                    | (lbname,e,c) ->
-                       let uu____15406 =
-                         let uu____15412 =
-                           let uu____15414 =
+                       let uu____15308 =
+                         let uu____15314 =
+                           let uu____15316 =
                              FStar_Syntax_Print.term_to_string k  in
-                           let uu____15416 =
+                           let uu____15318 =
                              FStar_Syntax_Print.lbname_to_string lbname  in
-                           let uu____15418 =
+                           let uu____15320 =
                              FStar_Syntax_Print.term_to_string
                                (FStar_Syntax_Util.comp_result c)
                               in
                            FStar_Util.format3
                              "Failed to resolve implicit argument of type '%s' in the type of %s (%s)"
-                             uu____15414 uu____15416 uu____15418
+                             uu____15316 uu____15318 uu____15320
                             in
                          (FStar_Errors.Fatal_FailToResolveImplicitArgument,
-                           uu____15412)
+                           uu____15314)
                           in
-                       FStar_Errors.raise_error uu____15406 rng
+                       FStar_Errors.raise_error uu____15308 rng
                     in
                  FStar_All.pipe_right uvs1
                    (FStar_List.map
                       (fun u  ->
-                         let uu____15440 =
+                         let uu____15342 =
                            FStar_Syntax_Unionfind.find
                              u.FStar_Syntax_Syntax.ctx_uvar_head
                             in
-                         match uu____15440 with
-                         | FStar_Pervasives_Native.Some uu____15449 ->
+                         match uu____15342 with
+                         | FStar_Pervasives_Native.Some uu____15351 ->
                              failwith
                                "Unexpected instantiation of mutually recursive uvar"
-                         | uu____15457 ->
+                         | uu____15359 ->
                              let k =
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.Beta;
@@ -5828,62 +5775,62 @@ let (gen :
                                    FStar_TypeChecker_Env.Zeta] env
                                  u.FStar_Syntax_Syntax.ctx_uvar_typ
                                 in
-                             let uu____15461 =
+                             let uu____15363 =
                                FStar_Syntax_Util.arrow_formals k  in
-                             (match uu____15461 with
+                             (match uu____15363 with
                               | (bs,kres) ->
-                                  ((let uu____15481 =
-                                      let uu____15482 =
-                                        let uu____15485 =
+                                  ((let uu____15383 =
+                                      let uu____15384 =
+                                        let uu____15387 =
                                           FStar_TypeChecker_Normalize.unfold_whnf
                                             env kres
                                            in
                                         FStar_Syntax_Util.unrefine
-                                          uu____15485
+                                          uu____15387
                                          in
-                                      uu____15482.FStar_Syntax_Syntax.n  in
-                                    match uu____15481 with
-                                    | FStar_Syntax_Syntax.Tm_type uu____15486
+                                      uu____15384.FStar_Syntax_Syntax.n  in
+                                    match uu____15383 with
+                                    | FStar_Syntax_Syntax.Tm_type uu____15388
                                         ->
                                         let free =
                                           FStar_Syntax_Free.names kres  in
-                                        let uu____15490 =
-                                          let uu____15492 =
+                                        let uu____15392 =
+                                          let uu____15394 =
                                             FStar_Util.set_is_empty free  in
-                                          Prims.op_Negation uu____15492  in
-                                        if uu____15490
+                                          Prims.op_Negation uu____15394  in
+                                        if uu____15392
                                         then
                                           fail
                                             u.FStar_Syntax_Syntax.ctx_uvar_range
                                             kres
                                         else ()
-                                    | uu____15497 ->
+                                    | uu____15399 ->
                                         fail
                                           u.FStar_Syntax_Syntax.ctx_uvar_range
                                           kres);
                                    (let a =
-                                      let uu____15499 =
-                                        let uu____15502 =
+                                      let uu____15401 =
+                                        let uu____15404 =
                                           FStar_TypeChecker_Env.get_range env
                                            in
                                         FStar_All.pipe_left
-                                          (fun uu____15505  ->
+                                          (fun uu____15407  ->
                                              FStar_Pervasives_Native.Some
-                                               uu____15505) uu____15502
+                                               uu____15407) uu____15404
                                          in
-                                      FStar_Syntax_Syntax.new_bv uu____15499
+                                      FStar_Syntax_Syntax.new_bv uu____15401
                                         kres
                                        in
                                     let t =
                                       match bs with
                                       | [] ->
                                           FStar_Syntax_Syntax.bv_to_name a
-                                      | uu____15513 ->
-                                          let uu____15514 =
+                                      | uu____15415 ->
+                                          let uu____15416 =
                                             FStar_Syntax_Syntax.bv_to_name a
                                              in
                                           FStar_Syntax_Util.abs bs
-                                            uu____15514
+                                            uu____15416
                                             (FStar_Pervasives_Native.Some
                                                (FStar_Syntax_Util.residual_tot
                                                   kres))
@@ -5899,15 +5846,15 @@ let (gen :
                let ecs =
                  FStar_All.pipe_right lecs2
                    (FStar_List.map
-                      (fun uu____15617  ->
-                         match uu____15617 with
+                      (fun uu____15519  ->
+                         match uu____15519 with
                          | (lbname,e,c) ->
-                             let uu____15663 =
+                             let uu____15565 =
                                match (gen_tvars, gen_univs1) with
                                | ([],[]) -> (e, c, [])
-                               | uu____15724 ->
-                                   let uu____15737 = (e, c)  in
-                                   (match uu____15737 with
+                               | uu____15626 ->
+                                   let uu____15639 = (e, c)  in
+                                   (match uu____15639 with
                                     | (e0,c0) ->
                                         let c1 =
                                           FStar_TypeChecker_Normalize.normalize_comp
@@ -5928,57 +5875,56 @@ let (gen :
                                           then
                                             let tvar_args =
                                               FStar_List.map
-                                                (fun uu____15777  ->
-                                                   match uu____15777 with
-                                                   | (x,uu____15783) ->
-                                                       let uu____15784 =
+                                                (fun uu____15679  ->
+                                                   match uu____15679 with
+                                                   | (x,uu____15685) ->
+                                                       let uu____15686 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            x
                                                           in
                                                        FStar_Syntax_Syntax.iarg
-                                                         uu____15784)
+                                                         uu____15686)
                                                 gen_tvars
                                                in
                                             let instantiate_lbname_with_app
                                               tm fv =
-                                              let uu____15802 =
-                                                let uu____15804 =
+                                              let uu____15704 =
+                                                let uu____15706 =
                                                   FStar_Util.right lbname  in
                                                 FStar_Syntax_Syntax.fv_eq fv
-                                                  uu____15804
+                                                  uu____15706
                                                  in
-                                              if uu____15802
+                                              if uu____15704
                                               then
                                                 FStar_Syntax_Syntax.mk_Tm_app
                                                   tm tvar_args
-                                                  FStar_Pervasives_Native.None
                                                   tm.FStar_Syntax_Syntax.pos
                                               else tm  in
                                             FStar_Syntax_InstFV.inst
                                               instantiate_lbname_with_app e1
                                           else e1  in
                                         let t =
-                                          let uu____15813 =
-                                            let uu____15814 =
+                                          let uu____15715 =
+                                            let uu____15716 =
                                               FStar_Syntax_Subst.compress
                                                 (FStar_Syntax_Util.comp_result
                                                    c1)
                                                in
-                                            uu____15814.FStar_Syntax_Syntax.n
+                                            uu____15716.FStar_Syntax_Syntax.n
                                              in
-                                          match uu____15813 with
+                                          match uu____15715 with
                                           | FStar_Syntax_Syntax.Tm_arrow
                                               (bs,cod) ->
-                                              let uu____15839 =
+                                              let uu____15741 =
                                                 FStar_Syntax_Subst.open_comp
                                                   bs cod
                                                  in
-                                              (match uu____15839 with
+                                              (match uu____15741 with
                                                | (bs1,cod1) ->
                                                    FStar_Syntax_Util.arrow
                                                      (FStar_List.append
                                                         gen_tvars bs1) cod1)
-                                          | uu____15850 ->
+                                          | uu____15752 ->
                                               FStar_Syntax_Util.arrow
                                                 gen_tvars c1
                                            in
@@ -5988,11 +5934,11 @@ let (gen :
                                                (FStar_Syntax_Util.residual_comp_of_comp
                                                   c1))
                                            in
-                                        let uu____15854 =
+                                        let uu____15756 =
                                           FStar_Syntax_Syntax.mk_Total t  in
-                                        (e', uu____15854, gen_tvars))
+                                        (e', uu____15756, gen_tvars))
                                 in
-                             (match uu____15663 with
+                             (match uu____15565 with
                               | (e1,c1,gvs) ->
                                   (lbname, gen_univs1, e1, c1, gvs))))
                   in
@@ -6010,78 +5956,78 @@ let (generalize' :
   fun env  ->
     fun is_rec  ->
       fun lecs  ->
-        (let uu____16001 = FStar_TypeChecker_Env.debug env FStar_Options.Low
+        (let uu____15903 = FStar_TypeChecker_Env.debug env FStar_Options.Low
             in
-         if uu____16001
+         if uu____15903
          then
-           let uu____16004 =
-             let uu____16006 =
+           let uu____15906 =
+             let uu____15908 =
                FStar_List.map
-                 (fun uu____16021  ->
-                    match uu____16021 with
-                    | (lb,uu____16030,uu____16031) ->
+                 (fun uu____15923  ->
+                    match uu____15923 with
+                    | (lb,uu____15932,uu____15933) ->
                         FStar_Syntax_Print.lbname_to_string lb) lecs
                 in
-             FStar_All.pipe_right uu____16006 (FStar_String.concat ", ")  in
-           FStar_Util.print1 "Generalizing: %s\n" uu____16004
+             FStar_All.pipe_right uu____15908 (FStar_String.concat ", ")  in
+           FStar_Util.print1 "Generalizing: %s\n" uu____15906
          else ());
         (let univnames_lecs =
            FStar_List.map
-             (fun uu____16057  ->
-                match uu____16057 with
+             (fun uu____15959  ->
+                match uu____15959 with
                 | (l,t,c) -> gather_free_univnames env t) lecs
             in
          let generalized_lecs =
-           let uu____16086 = gen env is_rec lecs  in
-           match uu____16086 with
+           let uu____15988 = gen env is_rec lecs  in
+           match uu____15988 with
            | FStar_Pervasives_Native.None  ->
                FStar_All.pipe_right lecs
                  (FStar_List.map
-                    (fun uu____16185  ->
-                       match uu____16185 with | (l,t,c) -> (l, [], t, c, [])))
+                    (fun uu____16087  ->
+                       match uu____16087 with | (l,t,c) -> (l, [], t, c, [])))
            | FStar_Pervasives_Native.Some luecs ->
-               ((let uu____16247 =
+               ((let uu____16149 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
-                 if uu____16247
+                 if uu____16149
                  then
                    FStar_All.pipe_right luecs
                      (FStar_List.iter
-                        (fun uu____16295  ->
-                           match uu____16295 with
+                        (fun uu____16197  ->
+                           match uu____16197 with
                            | (l,us,e,c,gvs) ->
-                               let uu____16329 =
+                               let uu____16231 =
                                  FStar_Range.string_of_range
                                    e.FStar_Syntax_Syntax.pos
                                   in
-                               let uu____16331 =
+                               let uu____16233 =
                                  FStar_Syntax_Print.lbname_to_string l  in
-                               let uu____16333 =
+                               let uu____16235 =
                                  FStar_Syntax_Print.term_to_string
                                    (FStar_Syntax_Util.comp_result c)
                                   in
-                               let uu____16335 =
+                               let uu____16237 =
                                  FStar_Syntax_Print.term_to_string e  in
-                               let uu____16337 =
+                               let uu____16239 =
                                  FStar_Syntax_Print.binders_to_string ", "
                                    gvs
                                   in
                                FStar_Util.print5
                                  "(%s) Generalized %s at type %s\n%s\nVars = (%s)\n"
-                                 uu____16329 uu____16331 uu____16333
-                                 uu____16335 uu____16337))
+                                 uu____16231 uu____16233 uu____16235
+                                 uu____16237 uu____16239))
                  else ());
                 luecs)
             in
          FStar_List.map2
            (fun univnames  ->
-              fun uu____16382  ->
-                match uu____16382 with
+              fun uu____16284  ->
+                match uu____16284 with
                 | (l,generalized_univs,t,c,gvs) ->
-                    let uu____16426 =
+                    let uu____16328 =
                       check_universe_generalization univnames
                         generalized_univs t
                        in
-                    (l, uu____16426, t, c, gvs)) univnames_lecs
+                    (l, uu____16328, t, c, gvs)) univnames_lecs
            generalized_lecs)
   
 let (generalize :
@@ -6096,13 +6042,13 @@ let (generalize :
   fun env  ->
     fun is_rec  ->
       fun lecs  ->
-        let uu____16481 =
-          let uu____16485 =
-            let uu____16487 = FStar_TypeChecker_Env.current_module env  in
-            FStar_Ident.string_of_lid uu____16487  in
-          FStar_Pervasives_Native.Some uu____16485  in
+        let uu____16383 =
+          let uu____16387 =
+            let uu____16389 = FStar_TypeChecker_Env.current_module env  in
+            FStar_Ident.string_of_lid uu____16389  in
+          FStar_Pervasives_Native.Some uu____16387  in
         FStar_Profiling.profile
-          (fun uu____16504  -> generalize' env is_rec lecs) uu____16481
+          (fun uu____16406  -> generalize' env is_rec lecs) uu____16383
           "FStar.TypeChecker.Util.generalize"
   
 let (check_has_type :
@@ -6122,62 +6068,62 @@ let (check_has_type :
           let check env2 t1 t21 =
             if env2.FStar_TypeChecker_Env.use_eq_strict
             then
-              let uu____16561 =
+              let uu____16463 =
                 FStar_TypeChecker_Rel.get_teq_predicate env2 t1 t21  in
-              match uu____16561 with
+              match uu____16463 with
               | FStar_Pervasives_Native.None  -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some f ->
-                  let uu____16567 = FStar_TypeChecker_Env.apply_guard f e  in
-                  FStar_All.pipe_right uu____16567
-                    (fun uu____16570  ->
-                       FStar_Pervasives_Native.Some uu____16570)
+                  let uu____16469 = FStar_TypeChecker_Env.apply_guard f e  in
+                  FStar_All.pipe_right uu____16469
+                    (fun uu____16472  ->
+                       FStar_Pervasives_Native.Some uu____16472)
             else
               if env2.FStar_TypeChecker_Env.use_eq
               then FStar_TypeChecker_Rel.try_teq true env2 t1 t21
               else
-                (let uu____16579 =
+                (let uu____16481 =
                    FStar_TypeChecker_Rel.get_subtyping_predicate env2 t1 t21
                     in
-                 match uu____16579 with
+                 match uu____16481 with
                  | FStar_Pervasives_Native.None  ->
                      FStar_Pervasives_Native.None
                  | FStar_Pervasives_Native.Some f ->
-                     let uu____16585 = FStar_TypeChecker_Env.apply_guard f e
+                     let uu____16487 = FStar_TypeChecker_Env.apply_guard f e
                         in
                      FStar_All.pipe_left
-                       (fun uu____16588  ->
-                          FStar_Pervasives_Native.Some uu____16588)
-                       uu____16585)
+                       (fun uu____16490  ->
+                          FStar_Pervasives_Native.Some uu____16490)
+                       uu____16487)
              in
-          let uu____16589 = maybe_coerce_lc env1 e lc t2  in
-          match uu____16589 with
+          let uu____16491 = maybe_coerce_lc env1 e lc t2  in
+          match uu____16491 with
           | (e1,lc1,g_c) ->
-              let uu____16605 =
+              let uu____16507 =
                 check env1 lc1.FStar_TypeChecker_Common.res_typ t2  in
-              (match uu____16605 with
+              (match uu____16507 with
                | FStar_Pervasives_Native.None  ->
-                   let uu____16614 =
+                   let uu____16516 =
                      FStar_TypeChecker_Err.expected_expression_of_type env1
                        t2 e1 lc1.FStar_TypeChecker_Common.res_typ
                       in
-                   let uu____16620 = FStar_TypeChecker_Env.get_range env1  in
-                   FStar_Errors.raise_error uu____16614 uu____16620
+                   let uu____16522 = FStar_TypeChecker_Env.get_range env1  in
+                   FStar_Errors.raise_error uu____16516 uu____16522
                | FStar_Pervasives_Native.Some g ->
-                   ((let uu____16629 =
+                   ((let uu____16531 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                          (FStar_Options.Other "Rel")
                         in
-                     if uu____16629
+                     if uu____16531
                      then
-                       let uu____16634 =
+                       let uu____16536 =
                          FStar_TypeChecker_Rel.guard_to_string env1 g  in
                        FStar_All.pipe_left
                          (FStar_Util.print1 "Applied guard is %s\n")
-                         uu____16634
+                         uu____16536
                      else ());
-                    (let uu____16640 = FStar_TypeChecker_Env.conj_guard g g_c
+                    (let uu____16542 = FStar_TypeChecker_Env.conj_guard g g_c
                         in
-                     (e1, lc1, uu____16640))))
+                     (e1, lc1, uu____16542))))
   
 let (check_top_level :
   FStar_TypeChecker_Env.env ->
@@ -6188,66 +6134,66 @@ let (check_top_level :
   fun env  ->
     fun g  ->
       fun lc  ->
-        (let uu____16668 =
+        (let uu____16570 =
            FStar_TypeChecker_Env.debug env FStar_Options.Medium  in
-         if uu____16668
+         if uu____16570
          then
-           let uu____16671 = FStar_TypeChecker_Common.lcomp_to_string lc  in
-           FStar_Util.print1 "check_top_level, lc = %s\n" uu____16671
+           let uu____16573 = FStar_TypeChecker_Common.lcomp_to_string lc  in
+           FStar_Util.print1 "check_top_level, lc = %s\n" uu____16573
          else ());
         (let discharge g1 =
            FStar_TypeChecker_Rel.force_trivial_guard env g1;
            FStar_TypeChecker_Common.is_pure_lcomp lc  in
          let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g  in
-         let uu____16685 = FStar_TypeChecker_Common.lcomp_comp lc  in
-         match uu____16685 with
+         let uu____16587 = FStar_TypeChecker_Common.lcomp_comp lc  in
+         match uu____16587 with
          | (c,g_c) ->
-             let uu____16697 = FStar_TypeChecker_Common.is_total_lcomp lc  in
-             if uu____16697
+             let uu____16599 = FStar_TypeChecker_Common.is_total_lcomp lc  in
+             if uu____16599
              then
-               let uu____16705 =
-                 let uu____16707 = FStar_TypeChecker_Env.conj_guard g1 g_c
+               let uu____16607 =
+                 let uu____16609 = FStar_TypeChecker_Env.conj_guard g1 g_c
                     in
-                 discharge uu____16707  in
-               (uu____16705, c)
+                 discharge uu____16609  in
+               (uu____16607, c)
              else
                (let steps =
                   [FStar_TypeChecker_Env.Beta;
                   FStar_TypeChecker_Env.NoFullNorm;
                   FStar_TypeChecker_Env.DoNotUnfoldPureLets]  in
                 let c1 =
-                  let uu____16715 =
-                    let uu____16716 =
+                  let uu____16617 =
+                    let uu____16618 =
                       FStar_TypeChecker_Env.unfold_effect_abbrev env c  in
-                    FStar_All.pipe_right uu____16716
+                    FStar_All.pipe_right uu____16618
                       FStar_Syntax_Syntax.mk_Comp
                      in
-                  FStar_All.pipe_right uu____16715
+                  FStar_All.pipe_right uu____16617
                     (FStar_TypeChecker_Normalize.normalize_comp steps env)
                    in
-                let uu____16717 = check_trivial_precondition env c1  in
-                match uu____16717 with
+                let uu____16619 = check_trivial_precondition env c1  in
+                match uu____16619 with
                 | (ct,vc,g_pre) ->
-                    ((let uu____16733 =
+                    ((let uu____16635 =
                         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "Simplification")
                          in
-                      if uu____16733
+                      if uu____16635
                       then
-                        let uu____16738 =
+                        let uu____16640 =
                           FStar_Syntax_Print.term_to_string vc  in
-                        FStar_Util.print1 "top-level VC: %s\n" uu____16738
+                        FStar_Util.print1 "top-level VC: %s\n" uu____16640
                       else ());
-                     (let uu____16743 =
-                        let uu____16745 =
-                          let uu____16746 =
+                     (let uu____16645 =
+                        let uu____16647 =
+                          let uu____16648 =
                             FStar_TypeChecker_Env.conj_guard g_c g_pre  in
-                          FStar_TypeChecker_Env.conj_guard g1 uu____16746  in
-                        discharge uu____16745  in
-                      let uu____16747 =
+                          FStar_TypeChecker_Env.conj_guard g1 uu____16648  in
+                        discharge uu____16647  in
+                      let uu____16649 =
                         FStar_All.pipe_right ct FStar_Syntax_Syntax.mk_Comp
                          in
-                      (uu____16743, uu____16747)))))
+                      (uu____16645, uu____16649)))))
   
 let (short_circuit :
   FStar_Syntax_Syntax.term ->
@@ -6255,105 +6201,105 @@ let (short_circuit :
   =
   fun head  ->
     fun seen_args  ->
-      let short_bin_op f uu___8_16781 =
-        match uu___8_16781 with
+      let short_bin_op f uu___8_16683 =
+        match uu___8_16683 with
         | [] -> FStar_TypeChecker_Common.Trivial
-        | (fst,uu____16791)::[] -> f fst
-        | uu____16816 -> failwith "Unexpexted args to binary operator"  in
+        | (fst,uu____16693)::[] -> f fst
+        | uu____16718 -> failwith "Unexpexted args to binary operator"  in
       let op_and_e e =
-        let uu____16828 = FStar_Syntax_Util.b2t e  in
-        FStar_All.pipe_right uu____16828
-          (fun uu____16829  ->
-             FStar_TypeChecker_Common.NonTrivial uu____16829)
+        let uu____16730 = FStar_Syntax_Util.b2t e  in
+        FStar_All.pipe_right uu____16730
+          (fun uu____16731  ->
+             FStar_TypeChecker_Common.NonTrivial uu____16731)
          in
       let op_or_e e =
-        let uu____16840 =
-          let uu____16841 = FStar_Syntax_Util.b2t e  in
-          FStar_Syntax_Util.mk_neg uu____16841  in
-        FStar_All.pipe_right uu____16840
-          (fun uu____16844  ->
-             FStar_TypeChecker_Common.NonTrivial uu____16844)
+        let uu____16742 =
+          let uu____16743 = FStar_Syntax_Util.b2t e  in
+          FStar_Syntax_Util.mk_neg uu____16743  in
+        FStar_All.pipe_right uu____16742
+          (fun uu____16746  ->
+             FStar_TypeChecker_Common.NonTrivial uu____16746)
          in
       let op_and_t t =
         FStar_All.pipe_right t
-          (fun uu____16851  ->
-             FStar_TypeChecker_Common.NonTrivial uu____16851)
+          (fun uu____16753  ->
+             FStar_TypeChecker_Common.NonTrivial uu____16753)
          in
       let op_or_t t =
-        let uu____16862 = FStar_All.pipe_right t FStar_Syntax_Util.mk_neg  in
-        FStar_All.pipe_right uu____16862
-          (fun uu____16865  ->
-             FStar_TypeChecker_Common.NonTrivial uu____16865)
+        let uu____16764 = FStar_All.pipe_right t FStar_Syntax_Util.mk_neg  in
+        FStar_All.pipe_right uu____16764
+          (fun uu____16767  ->
+             FStar_TypeChecker_Common.NonTrivial uu____16767)
          in
       let op_imp_t t =
         FStar_All.pipe_right t
-          (fun uu____16872  ->
-             FStar_TypeChecker_Common.NonTrivial uu____16872)
+          (fun uu____16774  ->
+             FStar_TypeChecker_Common.NonTrivial uu____16774)
          in
-      let short_op_ite uu___9_16878 =
-        match uu___9_16878 with
+      let short_op_ite uu___9_16780 =
+        match uu___9_16780 with
         | [] -> FStar_TypeChecker_Common.Trivial
-        | (guard,uu____16888)::[] ->
+        | (guard,uu____16790)::[] ->
             FStar_TypeChecker_Common.NonTrivial guard
-        | _then::(guard,uu____16915)::[] ->
-            let uu____16956 = FStar_Syntax_Util.mk_neg guard  in
-            FStar_All.pipe_right uu____16956
-              (fun uu____16957  ->
-                 FStar_TypeChecker_Common.NonTrivial uu____16957)
-        | uu____16958 -> failwith "Unexpected args to ITE"  in
+        | _then::(guard,uu____16817)::[] ->
+            let uu____16858 = FStar_Syntax_Util.mk_neg guard  in
+            FStar_All.pipe_right uu____16858
+              (fun uu____16859  ->
+                 FStar_TypeChecker_Common.NonTrivial uu____16859)
+        | uu____16860 -> failwith "Unexpected args to ITE"  in
       let table =
-        let uu____16970 =
-          let uu____16978 = short_bin_op op_and_e  in
-          (FStar_Parser_Const.op_And, uu____16978)  in
-        let uu____16986 =
-          let uu____16996 =
-            let uu____17004 = short_bin_op op_or_e  in
-            (FStar_Parser_Const.op_Or, uu____17004)  in
-          let uu____17012 =
-            let uu____17022 =
-              let uu____17030 = short_bin_op op_and_t  in
-              (FStar_Parser_Const.and_lid, uu____17030)  in
-            let uu____17038 =
-              let uu____17048 =
-                let uu____17056 = short_bin_op op_or_t  in
-                (FStar_Parser_Const.or_lid, uu____17056)  in
-              let uu____17064 =
-                let uu____17074 =
-                  let uu____17082 = short_bin_op op_imp_t  in
-                  (FStar_Parser_Const.imp_lid, uu____17082)  in
-                [uu____17074; (FStar_Parser_Const.ite_lid, short_op_ite)]  in
-              uu____17048 :: uu____17064  in
-            uu____17022 :: uu____17038  in
-          uu____16996 :: uu____17012  in
-        uu____16970 :: uu____16986  in
+        let uu____16872 =
+          let uu____16880 = short_bin_op op_and_e  in
+          (FStar_Parser_Const.op_And, uu____16880)  in
+        let uu____16888 =
+          let uu____16898 =
+            let uu____16906 = short_bin_op op_or_e  in
+            (FStar_Parser_Const.op_Or, uu____16906)  in
+          let uu____16914 =
+            let uu____16924 =
+              let uu____16932 = short_bin_op op_and_t  in
+              (FStar_Parser_Const.and_lid, uu____16932)  in
+            let uu____16940 =
+              let uu____16950 =
+                let uu____16958 = short_bin_op op_or_t  in
+                (FStar_Parser_Const.or_lid, uu____16958)  in
+              let uu____16966 =
+                let uu____16976 =
+                  let uu____16984 = short_bin_op op_imp_t  in
+                  (FStar_Parser_Const.imp_lid, uu____16984)  in
+                [uu____16976; (FStar_Parser_Const.ite_lid, short_op_ite)]  in
+              uu____16950 :: uu____16966  in
+            uu____16924 :: uu____16940  in
+          uu____16898 :: uu____16914  in
+        uu____16872 :: uu____16888  in
       match head.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
              in
-          let uu____17144 =
+          let uu____17046 =
             FStar_Util.find_map table
-              (fun uu____17159  ->
-                 match uu____17159 with
+              (fun uu____17061  ->
+                 match uu____17061 with
                  | (x,mk) ->
-                     let uu____17176 = FStar_Ident.lid_equals x lid  in
-                     if uu____17176
+                     let uu____17078 = FStar_Ident.lid_equals x lid  in
+                     if uu____17078
                      then
-                       let uu____17181 = mk seen_args  in
-                       FStar_Pervasives_Native.Some uu____17181
+                       let uu____17083 = mk seen_args  in
+                       FStar_Pervasives_Native.Some uu____17083
                      else FStar_Pervasives_Native.None)
              in
-          (match uu____17144 with
+          (match uu____17046 with
            | FStar_Pervasives_Native.None  ->
                FStar_TypeChecker_Common.Trivial
            | FStar_Pervasives_Native.Some g -> g)
-      | uu____17185 -> FStar_TypeChecker_Common.Trivial
+      | uu____17087 -> FStar_TypeChecker_Common.Trivial
   
 let (short_circuit_head : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun l  ->
-    let uu____17193 =
-      let uu____17194 = FStar_Syntax_Util.un_uinst l  in
-      uu____17194.FStar_Syntax_Syntax.n  in
-    match uu____17193 with
+    let uu____17095 =
+      let uu____17096 = FStar_Syntax_Util.un_uinst l  in
+      uu____17096.FStar_Syntax_Syntax.n  in
+    match uu____17095 with
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Util.for_some (FStar_Syntax_Syntax.fv_eq_lid fv)
           [FStar_Parser_Const.op_And;
@@ -6362,7 +6308,7 @@ let (short_circuit_head : FStar_Syntax_Syntax.term -> Prims.bool) =
           FStar_Parser_Const.or_lid;
           FStar_Parser_Const.imp_lid;
           FStar_Parser_Const.ite_lid]
-    | uu____17199 -> false
+    | uu____17101 -> false
   
 let (maybe_add_implicit_binders :
   FStar_TypeChecker_Env.env ->
@@ -6372,66 +6318,66 @@ let (maybe_add_implicit_binders :
     fun bs  ->
       let pos bs1 =
         match bs1 with
-        | (hd,uu____17235)::uu____17236 -> FStar_Syntax_Syntax.range_of_bv hd
-        | uu____17255 -> FStar_TypeChecker_Env.get_range env  in
+        | (hd,uu____17137)::uu____17138 -> FStar_Syntax_Syntax.range_of_bv hd
+        | uu____17157 -> FStar_TypeChecker_Env.get_range env  in
       match bs with
-      | (uu____17264,FStar_Pervasives_Native.Some
-         (FStar_Syntax_Syntax.Implicit uu____17265))::uu____17266 -> bs
-      | uu____17284 ->
-          let uu____17285 = FStar_TypeChecker_Env.expected_typ env  in
-          (match uu____17285 with
+      | (uu____17166,FStar_Pervasives_Native.Some
+         (FStar_Syntax_Syntax.Implicit uu____17167))::uu____17168 -> bs
+      | uu____17186 ->
+          let uu____17187 = FStar_TypeChecker_Env.expected_typ env  in
+          (match uu____17187 with
            | FStar_Pervasives_Native.None  -> bs
            | FStar_Pervasives_Native.Some t ->
-               let uu____17289 =
-                 let uu____17290 = FStar_Syntax_Subst.compress t  in
-                 uu____17290.FStar_Syntax_Syntax.n  in
-               (match uu____17289 with
-                | FStar_Syntax_Syntax.Tm_arrow (bs',uu____17294) ->
-                    let uu____17315 =
+               let uu____17191 =
+                 let uu____17192 = FStar_Syntax_Subst.compress t  in
+                 uu____17192.FStar_Syntax_Syntax.n  in
+               (match uu____17191 with
+                | FStar_Syntax_Syntax.Tm_arrow (bs',uu____17196) ->
+                    let uu____17217 =
                       FStar_Util.prefix_until
-                        (fun uu___10_17355  ->
-                           match uu___10_17355 with
-                           | (uu____17363,FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Implicit uu____17364)) ->
+                        (fun uu___10_17257  ->
+                           match uu___10_17257 with
+                           | (uu____17265,FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Implicit uu____17266)) ->
                                false
-                           | uu____17369 -> true) bs'
+                           | uu____17271 -> true) bs'
                        in
-                    (match uu____17315 with
+                    (match uu____17217 with
                      | FStar_Pervasives_Native.None  -> bs
                      | FStar_Pervasives_Native.Some
-                         ([],uu____17405,uu____17406) -> bs
+                         ([],uu____17307,uu____17308) -> bs
                      | FStar_Pervasives_Native.Some
-                         (imps,uu____17478,uu____17479) ->
-                         let uu____17552 =
+                         (imps,uu____17380,uu____17381) ->
+                         let uu____17454 =
                            FStar_All.pipe_right imps
                              (FStar_Util.for_all
-                                (fun uu____17573  ->
-                                   match uu____17573 with
-                                   | (x,uu____17582) ->
-                                       let uu____17587 =
+                                (fun uu____17475  ->
+                                   match uu____17475 with
+                                   | (x,uu____17484) ->
+                                       let uu____17489 =
                                          FStar_Ident.text_of_id
                                            x.FStar_Syntax_Syntax.ppname
                                           in
-                                       FStar_Util.starts_with uu____17587 "'"))
+                                       FStar_Util.starts_with uu____17489 "'"))
                             in
-                         if uu____17552
+                         if uu____17454
                          then
                            let r = pos bs  in
                            let imps1 =
                              FStar_All.pipe_right imps
                                (FStar_List.map
-                                  (fun uu____17633  ->
-                                     match uu____17633 with
+                                  (fun uu____17535  ->
+                                     match uu____17535 with
                                      | (x,i) ->
-                                         let uu____17652 =
+                                         let uu____17554 =
                                            FStar_Syntax_Syntax.set_range_of_bv
                                              x r
                                             in
-                                         (uu____17652, i)))
+                                         (uu____17554, i)))
                               in
                            FStar_List.append imps1 bs
                          else bs)
-                | uu____17663 -> bs))
+                | uu____17565 -> bs))
   
 let (maybe_lift :
   FStar_TypeChecker_Env.env ->
@@ -6447,7 +6393,7 @@ let (maybe_lift :
           fun t  ->
             let m1 = FStar_TypeChecker_Env.norm_eff_name env c1  in
             let m2 = FStar_TypeChecker_Env.norm_eff_name env c2  in
-            let uu____17692 =
+            let uu____17594 =
               ((FStar_Ident.lid_equals m1 m2) ||
                  ((FStar_Syntax_Util.is_pure_effect c1) &&
                     (FStar_Syntax_Util.is_ghost_effect c2)))
@@ -6455,13 +6401,13 @@ let (maybe_lift :
                 ((FStar_Syntax_Util.is_pure_effect c2) &&
                    (FStar_Syntax_Util.is_ghost_effect c1))
                in
-            if uu____17692
+            if uu____17594
             then e
             else
               FStar_Syntax_Syntax.mk
                 (FStar_Syntax_Syntax.Tm_meta
                    (e, (FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, t))))
-                FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+                e.FStar_Syntax_Syntax.pos
   
 let (maybe_monadic :
   FStar_TypeChecker_Env.env ->
@@ -6474,19 +6420,19 @@ let (maybe_monadic :
       fun c  ->
         fun t  ->
           let m = FStar_TypeChecker_Env.norm_eff_name env c  in
-          let uu____17723 =
+          let uu____17625 =
             ((is_pure_or_ghost_effect env m) ||
                (FStar_Ident.lid_equals m FStar_Parser_Const.effect_Tot_lid))
               ||
               (FStar_Ident.lid_equals m FStar_Parser_Const.effect_GTot_lid)
              in
-          if uu____17723
+          if uu____17625
           then e
           else
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_meta
                  (e, (FStar_Syntax_Syntax.Meta_monadic (m, t))))
-              FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+              e.FStar_Syntax_Syntax.pos
   
 let (d : Prims.string -> unit) =
   fun s  -> FStar_Util.print1 "\027[01;36m%s\027[00m\n" s 
@@ -6499,20 +6445,20 @@ let (mk_toplevel_definition :
   fun env  ->
     fun lident  ->
       fun def  ->
-        (let uu____17766 =
+        (let uu____17668 =
            FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED")  in
-         if uu____17766
+         if uu____17668
          then
-           ((let uu____17771 = FStar_Ident.string_of_lid lident  in
-             d uu____17771);
-            (let uu____17773 = FStar_Ident.string_of_lid lident  in
-             let uu____17775 = FStar_Syntax_Print.term_to_string def  in
+           ((let uu____17673 = FStar_Ident.string_of_lid lident  in
+             d uu____17673);
+            (let uu____17675 = FStar_Ident.string_of_lid lident  in
+             let uu____17677 = FStar_Syntax_Print.term_to_string def  in
              FStar_Util.print2 "Registering top-level definition: %s\n%s\n"
-               uu____17773 uu____17775))
+               uu____17675 uu____17677))
          else ());
         (let fv =
-           let uu____17781 = FStar_Syntax_Util.incr_delta_qualifier def  in
-           FStar_Syntax_Syntax.lid_as_fv lident uu____17781
+           let uu____17683 = FStar_Syntax_Util.incr_delta_qualifier def  in
+           FStar_Syntax_Syntax.lid_as_fv lident uu____17683
              FStar_Pervasives_Native.None
             in
          let lbname = FStar_Util.Inr fv  in
@@ -6526,67 +6472,67 @@ let (mk_toplevel_definition :
            FStar_Syntax_Syntax.mk_sigelt
              (FStar_Syntax_Syntax.Sig_let (lb, [lident]))
             in
-         let uu____17793 =
+         let uu____17695 =
            FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-             FStar_Pervasives_Native.None FStar_Range.dummyRange
+             FStar_Range.dummyRange
             in
-         ((let uu___2086_17795 = sig_ctx  in
+         ((let uu___2086_17697 = sig_ctx  in
            {
              FStar_Syntax_Syntax.sigel =
-               (uu___2086_17795.FStar_Syntax_Syntax.sigel);
+               (uu___2086_17697.FStar_Syntax_Syntax.sigel);
              FStar_Syntax_Syntax.sigrng =
-               (uu___2086_17795.FStar_Syntax_Syntax.sigrng);
+               (uu___2086_17697.FStar_Syntax_Syntax.sigrng);
              FStar_Syntax_Syntax.sigquals =
                [FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen];
              FStar_Syntax_Syntax.sigmeta =
-               (uu___2086_17795.FStar_Syntax_Syntax.sigmeta);
+               (uu___2086_17697.FStar_Syntax_Syntax.sigmeta);
              FStar_Syntax_Syntax.sigattrs =
-               (uu___2086_17795.FStar_Syntax_Syntax.sigattrs);
+               (uu___2086_17697.FStar_Syntax_Syntax.sigattrs);
              FStar_Syntax_Syntax.sigopts =
-               (uu___2086_17795.FStar_Syntax_Syntax.sigopts)
-           }), uu____17793))
+               (uu___2086_17697.FStar_Syntax_Syntax.sigopts)
+           }), uu____17695))
   
 let (check_sigelt_quals :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env  ->
     fun se  ->
-      let visibility uu___11_17813 =
-        match uu___11_17813 with
+      let visibility uu___11_17715 =
+        match uu___11_17715 with
         | FStar_Syntax_Syntax.Private  -> true
-        | uu____17816 -> false  in
-      let reducibility uu___12_17824 =
-        match uu___12_17824 with
+        | uu____17718 -> false  in
+      let reducibility uu___12_17726 =
+        match uu___12_17726 with
         | FStar_Syntax_Syntax.Abstract  -> true
         | FStar_Syntax_Syntax.Irreducible  -> true
         | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen  -> true
         | FStar_Syntax_Syntax.Visible_default  -> true
         | FStar_Syntax_Syntax.Inline_for_extraction  -> true
-        | uu____17831 -> false  in
-      let assumption uu___13_17839 =
-        match uu___13_17839 with
+        | uu____17733 -> false  in
+      let assumption uu___13_17741 =
+        match uu___13_17741 with
         | FStar_Syntax_Syntax.Assumption  -> true
         | FStar_Syntax_Syntax.New  -> true
-        | uu____17843 -> false  in
-      let reification uu___14_17851 =
-        match uu___14_17851 with
+        | uu____17745 -> false  in
+      let reification uu___14_17753 =
+        match uu___14_17753 with
         | FStar_Syntax_Syntax.Reifiable  -> true
-        | FStar_Syntax_Syntax.Reflectable uu____17854 -> true
-        | uu____17856 -> false  in
-      let inferred uu___15_17864 =
-        match uu___15_17864 with
-        | FStar_Syntax_Syntax.Discriminator uu____17866 -> true
-        | FStar_Syntax_Syntax.Projector uu____17868 -> true
-        | FStar_Syntax_Syntax.RecordType uu____17874 -> true
-        | FStar_Syntax_Syntax.RecordConstructor uu____17884 -> true
+        | FStar_Syntax_Syntax.Reflectable uu____17756 -> true
+        | uu____17758 -> false  in
+      let inferred uu___15_17766 =
+        match uu___15_17766 with
+        | FStar_Syntax_Syntax.Discriminator uu____17768 -> true
+        | FStar_Syntax_Syntax.Projector uu____17770 -> true
+        | FStar_Syntax_Syntax.RecordType uu____17776 -> true
+        | FStar_Syntax_Syntax.RecordConstructor uu____17786 -> true
         | FStar_Syntax_Syntax.ExceptionConstructor  -> true
         | FStar_Syntax_Syntax.HasMaskedEffect  -> true
         | FStar_Syntax_Syntax.Effect  -> true
-        | uu____17897 -> false  in
-      let has_eq uu___16_17905 =
-        match uu___16_17905 with
+        | uu____17799 -> false  in
+      let has_eq uu___16_17807 =
+        match uu___16_17807 with
         | FStar_Syntax_Syntax.Noeq  -> true
         | FStar_Syntax_Syntax.Unopteq  -> true
-        | uu____17909 -> false  in
+        | uu____17811 -> false  in
       let quals_combo_ok quals q =
         match q with
         | FStar_Syntax_Syntax.Assumption  ->
@@ -6714,7 +6660,7 @@ let (check_sigelt_quals :
                     ((((reification x) || (inferred x)) || (visibility x)) ||
                        (x = FStar_Syntax_Syntax.TotalEffect))
                       || (x = FStar_Syntax_Syntax.Visible_default)))
-        | FStar_Syntax_Syntax.Reflectable uu____17988 ->
+        | FStar_Syntax_Syntax.Reflectable uu____17890 ->
             FStar_All.pipe_right quals
               (FStar_List.for_all
                  (fun x  ->
@@ -6722,16 +6668,16 @@ let (check_sigelt_quals :
                        (x = FStar_Syntax_Syntax.TotalEffect))
                       || (x = FStar_Syntax_Syntax.Visible_default)))
         | FStar_Syntax_Syntax.Private  -> true
-        | uu____17995 -> true  in
+        | uu____17897 -> true  in
       let check_erasable quals se1 r =
         let lids = FStar_Syntax_Util.lids_of_sigelt se1  in
         let val_exists =
           FStar_All.pipe_right lids
             (FStar_Util.for_some
                (fun l  ->
-                  let uu____18028 =
+                  let uu____17930 =
                     FStar_TypeChecker_Env.try_lookup_val_decl env l  in
-                  FStar_Option.isSome uu____18028))
+                  FStar_Option.isSome uu____17930))
            in
         let val_has_erasable_attr =
           FStar_All.pipe_right lids
@@ -6740,8 +6686,8 @@ let (check_sigelt_quals :
                   let attrs_opt =
                     FStar_TypeChecker_Env.lookup_attrs_of_lid env l  in
                   (FStar_Option.isSome attrs_opt) &&
-                    (let uu____18059 = FStar_Option.get attrs_opt  in
-                     FStar_Syntax_Util.has_attribute uu____18059
+                    (let uu____17961 = FStar_Option.get attrs_opt  in
+                     FStar_Syntax_Util.has_attribute uu____17961
                        FStar_Parser_Const.erasable_attr)))
            in
         let se_has_erasable_attr =
@@ -6769,27 +6715,27 @@ let (check_sigelt_quals :
         if se_has_erasable_attr
         then
           (match se1.FStar_Syntax_Syntax.sigel with
-           | FStar_Syntax_Syntax.Sig_bundle uu____18079 ->
-               let uu____18088 =
-                 let uu____18090 =
+           | FStar_Syntax_Syntax.Sig_bundle uu____17981 ->
+               let uu____17990 =
+                 let uu____17992 =
                    FStar_All.pipe_right quals
                      (FStar_Util.for_some
-                        (fun uu___17_18096  ->
-                           match uu___17_18096 with
+                        (fun uu___17_17998  ->
+                           match uu___17_17998 with
                            | FStar_Syntax_Syntax.Noeq  -> true
-                           | uu____18099 -> false))
+                           | uu____18001 -> false))
                     in
-                 Prims.op_Negation uu____18090  in
-               if uu____18088
+                 Prims.op_Negation uu____17992  in
+               if uu____17990
                then
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_QulifierListNotPermitted,
                      "Incompatible attributes and qualifiers: erasable types do not support decidable equality and must be marked `noeq`")
                    r
                else ()
-           | FStar_Syntax_Syntax.Sig_declare_typ uu____18106 -> ()
-           | FStar_Syntax_Syntax.Sig_fail uu____18113 -> ()
-           | uu____18126 ->
+           | FStar_Syntax_Syntax.Sig_declare_typ uu____18008 -> ()
+           | FStar_Syntax_Syntax.Sig_fail uu____18015 -> ()
+           | uu____18028 ->
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_QulifierListNotPermitted,
                    "Illegal attribute: the `erasable` attribute is only permitted on inductive type definitions")
@@ -6800,68 +6746,68 @@ let (check_sigelt_quals :
           (FStar_List.filter
              (fun x  -> Prims.op_Negation (x = FStar_Syntax_Syntax.Logic)))
          in
-      let uu____18140 =
-        let uu____18142 =
+      let uu____18042 =
+        let uu____18044 =
           FStar_All.pipe_right quals
             (FStar_Util.for_some
-               (fun uu___18_18148  ->
-                  match uu___18_18148 with
+               (fun uu___18_18050  ->
+                  match uu___18_18050 with
                   | FStar_Syntax_Syntax.OnlyName  -> true
-                  | uu____18151 -> false))
+                  | uu____18053 -> false))
            in
-        FStar_All.pipe_right uu____18142 Prims.op_Negation  in
-      if uu____18140
+        FStar_All.pipe_right uu____18044 Prims.op_Negation  in
+      if uu____18042
       then
         let r = FStar_Syntax_Util.range_of_sigelt se  in
         let no_dup_quals =
           FStar_Util.remove_dups (fun x  -> fun y  -> x = y) quals  in
         let err' msg =
-          let uu____18172 =
-            let uu____18178 =
-              let uu____18180 = FStar_Syntax_Print.quals_to_string quals  in
+          let uu____18074 =
+            let uu____18080 =
+              let uu____18082 = FStar_Syntax_Print.quals_to_string quals  in
               FStar_Util.format2
                 "The qualifier list \"[%s]\" is not permissible for this element%s"
-                uu____18180 msg
+                uu____18082 msg
                in
-            (FStar_Errors.Fatal_QulifierListNotPermitted, uu____18178)  in
-          FStar_Errors.raise_error uu____18172 r  in
+            (FStar_Errors.Fatal_QulifierListNotPermitted, uu____18080)  in
+          FStar_Errors.raise_error uu____18074 r  in
         let err msg = err' (Prims.op_Hat ": " msg)  in
-        let err'1 uu____18198 = err' ""  in
+        let err'1 uu____18100 = err' ""  in
         (if (FStar_List.length quals) <> (FStar_List.length no_dup_quals)
          then err "duplicate qualifiers"
          else ();
-         (let uu____18206 =
-            let uu____18208 =
+         (let uu____18108 =
+            let uu____18110 =
               FStar_All.pipe_right quals
                 (FStar_List.for_all (quals_combo_ok quals))
                in
-            Prims.op_Negation uu____18208  in
-          if uu____18206 then err "ill-formed combination" else ());
+            Prims.op_Negation uu____18110  in
+          if uu____18108 then err "ill-formed combination" else ());
          check_erasable quals se r;
          (match se.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_let ((is_rec,uu____18219),uu____18220) ->
-              ((let uu____18232 =
+          | FStar_Syntax_Syntax.Sig_let ((is_rec,uu____18121),uu____18122) ->
+              ((let uu____18134 =
                   is_rec &&
                     (FStar_All.pipe_right quals
                        (FStar_List.contains
                           FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen))
                    in
-                if uu____18232
+                if uu____18134
                 then err "recursive definitions cannot be marked inline"
                 else ());
-               (let uu____18241 =
+               (let uu____18143 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_some
                        (fun x  -> (assumption x) || (has_eq x)))
                    in
-                if uu____18241
+                if uu____18143
                 then
                   err
                     "definitions cannot be assumed or marked with equality qualifiers"
                 else ()))
-          | FStar_Syntax_Syntax.Sig_bundle uu____18252 ->
-              ((let uu____18262 =
-                  let uu____18264 =
+          | FStar_Syntax_Syntax.Sig_bundle uu____18154 ->
+              ((let uu____18164 =
+                  let uu____18166 =
                     FStar_All.pipe_right quals
                       (FStar_Util.for_all
                          (fun x  ->
@@ -6873,43 +6819,43 @@ let (check_sigelt_quals :
                                || (visibility x))
                               || (has_eq x)))
                      in
-                  Prims.op_Negation uu____18264  in
-                if uu____18262 then err'1 () else ());
-               (let uu____18274 =
+                  Prims.op_Negation uu____18166  in
+                if uu____18164 then err'1 () else ());
+               (let uu____18176 =
                   (FStar_All.pipe_right quals
                      (FStar_List.existsb
-                        (fun uu___19_18280  ->
-                           match uu___19_18280 with
+                        (fun uu___19_18182  ->
+                           match uu___19_18182 with
                            | FStar_Syntax_Syntax.Unopteq  -> true
-                           | uu____18283 -> false)))
+                           | uu____18185 -> false)))
                     &&
                     (FStar_Syntax_Util.has_attribute
                        se.FStar_Syntax_Syntax.sigattrs
                        FStar_Parser_Const.erasable_attr)
                    in
-                if uu____18274
+                if uu____18176
                 then
                   err
                     "unopteq is not allowed on an erasable inductives since they don't have decidable equality"
                 else ()))
-          | FStar_Syntax_Syntax.Sig_declare_typ uu____18289 ->
-              let uu____18296 =
+          | FStar_Syntax_Syntax.Sig_declare_typ uu____18191 ->
+              let uu____18198 =
                 FStar_All.pipe_right quals (FStar_Util.for_some has_eq)  in
-              if uu____18296 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_assume uu____18304 ->
-              let uu____18311 =
-                let uu____18313 =
+              if uu____18198 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_assume uu____18206 ->
+              let uu____18213 =
+                let uu____18215 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x  ->
                           (visibility x) ||
                             (x = FStar_Syntax_Syntax.Assumption)))
                    in
-                Prims.op_Negation uu____18313  in
-              if uu____18311 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_new_effect uu____18323 ->
-              let uu____18324 =
-                let uu____18326 =
+                Prims.op_Negation uu____18215  in
+              if uu____18213 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_new_effect uu____18225 ->
+              let uu____18226 =
+                let uu____18228 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x  ->
@@ -6918,18 +6864,18 @@ let (check_sigelt_quals :
                              || (visibility x))
                             || (reification x)))
                    in
-                Prims.op_Negation uu____18326  in
-              if uu____18324 then err'1 () else ()
-          | FStar_Syntax_Syntax.Sig_effect_abbrev uu____18336 ->
-              let uu____18349 =
-                let uu____18351 =
+                Prims.op_Negation uu____18228  in
+              if uu____18226 then err'1 () else ()
+          | FStar_Syntax_Syntax.Sig_effect_abbrev uu____18238 ->
+              let uu____18251 =
+                let uu____18253 =
                   FStar_All.pipe_right quals
                     (FStar_Util.for_all
                        (fun x  -> (inferred x) || (visibility x)))
                    in
-                Prims.op_Negation uu____18351  in
-              if uu____18349 then err'1 () else ()
-          | uu____18361 -> ()))
+                Prims.op_Negation uu____18253  in
+              if uu____18251 then err'1 () else ()
+          | uu____18263 -> ()))
       else ()
   
 let (must_erase_for_extraction :
@@ -6937,13 +6883,13 @@ let (must_erase_for_extraction :
   fun g  ->
     fun t  ->
       let rec descend env t1 =
-        let uu____18400 =
-          let uu____18401 = FStar_Syntax_Subst.compress t1  in
-          uu____18401.FStar_Syntax_Syntax.n  in
-        match uu____18400 with
-        | FStar_Syntax_Syntax.Tm_arrow uu____18405 ->
-            let uu____18420 = FStar_Syntax_Util.arrow_formals_comp t1  in
-            (match uu____18420 with
+        let uu____18302 =
+          let uu____18303 = FStar_Syntax_Subst.compress t1  in
+          uu____18303.FStar_Syntax_Syntax.n  in
+        match uu____18302 with
+        | FStar_Syntax_Syntax.Tm_arrow uu____18307 ->
+            let uu____18322 = FStar_Syntax_Util.arrow_formals_comp t1  in
+            (match uu____18322 with
              | (bs,c) ->
                  let env1 = FStar_TypeChecker_Env.push_binders env bs  in
                  (FStar_Syntax_Util.is_ghost_effect
@@ -6952,16 +6898,16 @@ let (must_erase_for_extraction :
                    ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
                       (aux env1 (FStar_Syntax_Util.comp_result c))))
         | FStar_Syntax_Syntax.Tm_refine
-            ({ FStar_Syntax_Syntax.ppname = uu____18429;
-               FStar_Syntax_Syntax.index = uu____18430;
-               FStar_Syntax_Syntax.sort = t2;_},uu____18432)
+            ({ FStar_Syntax_Syntax.ppname = uu____18331;
+               FStar_Syntax_Syntax.index = uu____18332;
+               FStar_Syntax_Syntax.sort = t2;_},uu____18334)
             -> aux env t2
-        | FStar_Syntax_Syntax.Tm_app (head,uu____18441) -> descend env head
-        | FStar_Syntax_Syntax.Tm_uinst (head,uu____18467) -> descend env head
+        | FStar_Syntax_Syntax.Tm_app (head,uu____18343) -> descend env head
+        | FStar_Syntax_Syntax.Tm_uinst (head,uu____18369) -> descend env head
         | FStar_Syntax_Syntax.Tm_fvar fv ->
             FStar_TypeChecker_Env.fv_has_attr env fv
               FStar_Parser_Const.must_erase_for_extraction_attr
-        | uu____18473 -> false
+        | uu____18375 -> false
       
       and aux env t1 =
         let t2 =
@@ -6980,15 +6926,15 @@ let (must_erase_for_extraction :
         let res =
           (FStar_TypeChecker_Env.non_informative env t2) || (descend env t2)
            in
-        (let uu____18483 =
+        (let uu____18385 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Extraction")
             in
-         if uu____18483
+         if uu____18385
          then
-           let uu____18488 = FStar_Syntax_Print.term_to_string t2  in
+           let uu____18390 = FStar_Syntax_Print.term_to_string t2  in
            FStar_Util.print2 "must_erase=%s: %s\n"
-             (if res then "true" else "false") uu____18488
+             (if res then "true" else "false") uu____18390
          else ());
         res
        in aux g t
@@ -7011,49 +6957,49 @@ let (fresh_effect_repr :
             fun u  ->
               fun a_tm  ->
                 let fail t =
-                  let uu____18553 =
+                  let uu____18455 =
                     FStar_TypeChecker_Err.unexpected_signature_for_monad env
                       eff_name t
                      in
-                  FStar_Errors.raise_error uu____18553 r  in
-                let uu____18563 =
+                  FStar_Errors.raise_error uu____18455 r  in
+                let uu____18465 =
                   FStar_TypeChecker_Env.inst_tscheme signature_ts  in
-                match uu____18563 with
-                | (uu____18572,signature) ->
-                    let uu____18574 =
-                      let uu____18575 = FStar_Syntax_Subst.compress signature
+                match uu____18465 with
+                | (uu____18474,signature) ->
+                    let uu____18476 =
+                      let uu____18477 = FStar_Syntax_Subst.compress signature
                          in
-                      uu____18575.FStar_Syntax_Syntax.n  in
-                    (match uu____18574 with
-                     | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18583) ->
+                      uu____18477.FStar_Syntax_Syntax.n  in
+                    (match uu____18476 with
+                     | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18485) ->
                          let bs1 = FStar_Syntax_Subst.open_binders bs  in
                          (match bs1 with
                           | a::bs2 ->
-                              let uu____18631 =
+                              let uu____18533 =
                                 FStar_TypeChecker_Env.uvars_for_binders env
                                   bs2
                                   [FStar_Syntax_Syntax.NT
                                      ((FStar_Pervasives_Native.fst a), a_tm)]
                                   (fun b  ->
-                                     let uu____18647 =
+                                     let uu____18549 =
                                        FStar_Syntax_Print.binder_to_string b
                                         in
-                                     let uu____18649 =
+                                     let uu____18551 =
                                        FStar_Ident.string_of_lid eff_name  in
-                                     let uu____18651 =
+                                     let uu____18553 =
                                        FStar_Range.string_of_range r  in
                                      FStar_Util.format3
                                        "uvar for binder %s when creating a fresh repr for %s at %s"
-                                       uu____18647 uu____18649 uu____18651) r
+                                       uu____18549 uu____18551 uu____18553) r
                                  in
-                              (match uu____18631 with
+                              (match uu____18533 with
                                | (is,g) ->
-                                   let uu____18664 =
+                                   let uu____18566 =
                                      match repr_ts_opt with
                                      | FStar_Pervasives_Native.None  ->
                                          let eff_c =
-                                           let uu____18666 =
-                                             let uu____18667 =
+                                           let uu____18568 =
+                                             let uu____18569 =
                                                FStar_List.map
                                                  FStar_Syntax_Syntax.as_arg
                                                  is
@@ -7066,54 +7012,46 @@ let (fresh_effect_repr :
                                                FStar_Syntax_Syntax.result_typ
                                                  = a_tm;
                                                FStar_Syntax_Syntax.effect_args
-                                                 = uu____18667;
+                                                 = uu____18569;
                                                FStar_Syntax_Syntax.flags = []
                                              }  in
                                            FStar_Syntax_Syntax.mk_Comp
-                                             uu____18666
+                                             uu____18568
                                             in
-                                         let uu____18686 =
-                                           let uu____18693 =
-                                             let uu____18694 =
-                                               let uu____18709 =
-                                                 let uu____18718 =
-                                                   FStar_Syntax_Syntax.null_binder
-                                                     FStar_Syntax_Syntax.t_unit
-                                                    in
-                                                 [uu____18718]  in
-                                               (uu____18709, eff_c)  in
-                                             FStar_Syntax_Syntax.Tm_arrow
-                                               uu____18694
-                                              in
-                                           FStar_Syntax_Syntax.mk uu____18693
+                                         let uu____18588 =
+                                           let uu____18589 =
+                                             let uu____18604 =
+                                               let uu____18613 =
+                                                 FStar_Syntax_Syntax.null_binder
+                                                   FStar_Syntax_Syntax.t_unit
+                                                  in
+                                               [uu____18613]  in
+                                             (uu____18604, eff_c)  in
+                                           FStar_Syntax_Syntax.Tm_arrow
+                                             uu____18589
                                             in
-                                         uu____18686
-                                           FStar_Pervasives_Native.None r
+                                         FStar_Syntax_Syntax.mk uu____18588 r
                                      | FStar_Pervasives_Native.Some repr_ts
                                          ->
                                          let repr =
-                                           let uu____18749 =
+                                           let uu____18644 =
                                              FStar_TypeChecker_Env.inst_tscheme_with
                                                repr_ts [u]
                                               in
-                                           FStar_All.pipe_right uu____18749
+                                           FStar_All.pipe_right uu____18644
                                              FStar_Pervasives_Native.snd
                                             in
-                                         let uu____18758 =
-                                           let uu____18763 =
-                                             FStar_List.map
-                                               FStar_Syntax_Syntax.as_arg
-                                               (a_tm :: is)
-                                              in
-                                           FStar_Syntax_Syntax.mk_Tm_app repr
-                                             uu____18763
+                                         let uu____18653 =
+                                           FStar_List.map
+                                             FStar_Syntax_Syntax.as_arg (a_tm
+                                             :: is)
                                             in
-                                         uu____18758
-                                           FStar_Pervasives_Native.None r
+                                         FStar_Syntax_Syntax.mk_Tm_app repr
+                                           uu____18653 r
                                       in
-                                   (uu____18664, g))
-                          | uu____18772 -> fail signature)
-                     | uu____18773 -> fail signature)
+                                   (uu____18566, g))
+                          | uu____18662 -> fail signature)
+                     | uu____18663 -> fail signature)
   
 let (fresh_effect_repr_en :
   FStar_TypeChecker_Env.env ->
@@ -7128,16 +7066,16 @@ let (fresh_effect_repr_en :
       fun eff_name  ->
         fun u  ->
           fun a_tm  ->
-            let uu____18804 =
+            let uu____18694 =
               FStar_All.pipe_right eff_name
                 (FStar_TypeChecker_Env.get_effect_decl env)
                in
-            FStar_All.pipe_right uu____18804
+            FStar_All.pipe_right uu____18694
               (fun ed  ->
-                 let uu____18812 =
+                 let uu____18702 =
                    FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr  in
                  fresh_effect_repr env r eff_name
-                   ed.FStar_Syntax_Syntax.signature uu____18812 u a_tm)
+                   ed.FStar_Syntax_Syntax.signature uu____18702 u a_tm)
   
 let (layered_effect_indices_as_binders :
   FStar_TypeChecker_Env.env ->
@@ -7153,29 +7091,29 @@ let (layered_effect_indices_as_binders :
         fun sig_ts  ->
           fun u  ->
             fun a_tm  ->
-              let uu____18848 =
+              let uu____18738 =
                 FStar_TypeChecker_Env.inst_tscheme_with sig_ts [u]  in
-              match uu____18848 with
-              | (uu____18853,sig_tm) ->
+              match uu____18738 with
+              | (uu____18743,sig_tm) ->
                   let fail t =
-                    let uu____18861 =
+                    let uu____18751 =
                       FStar_TypeChecker_Err.unexpected_signature_for_monad
                         env eff_name t
                        in
-                    FStar_Errors.raise_error uu____18861 r  in
-                  let uu____18867 =
-                    let uu____18868 = FStar_Syntax_Subst.compress sig_tm  in
-                    uu____18868.FStar_Syntax_Syntax.n  in
-                  (match uu____18867 with
-                   | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18872) ->
+                    FStar_Errors.raise_error uu____18751 r  in
+                  let uu____18757 =
+                    let uu____18758 = FStar_Syntax_Subst.compress sig_tm  in
+                    uu____18758.FStar_Syntax_Syntax.n  in
+                  (match uu____18757 with
+                   | FStar_Syntax_Syntax.Tm_arrow (bs,uu____18762) ->
                        let bs1 = FStar_Syntax_Subst.open_binders bs  in
                        (match bs1 with
-                        | (a',uu____18895)::bs2 ->
+                        | (a',uu____18785)::bs2 ->
                             FStar_All.pipe_right bs2
                               (FStar_Syntax_Subst.subst_binders
                                  [FStar_Syntax_Syntax.NT (a', a_tm)])
-                        | uu____18917 -> fail sig_tm)
-                   | uu____18918 -> fail sig_tm)
+                        | uu____18807 -> fail sig_tm)
+                   | uu____18808 -> fail sig_tm)
   
 let (lift_tf_layered_effect :
   FStar_Ident.lident ->
@@ -7188,217 +7126,217 @@ let (lift_tf_layered_effect :
     fun lift_ts  ->
       fun env  ->
         fun c  ->
-          (let uu____18949 =
+          (let uu____18839 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffects")
               in
-           if uu____18949
+           if uu____18839
            then
-             let uu____18954 = FStar_Syntax_Print.comp_to_string c  in
-             let uu____18956 = FStar_Syntax_Print.lid_to_string tgt  in
+             let uu____18844 = FStar_Syntax_Print.comp_to_string c  in
+             let uu____18846 = FStar_Syntax_Print.lid_to_string tgt  in
              FStar_Util.print2 "Lifting comp %s to layered effect %s {\n"
-               uu____18954 uu____18956
+               uu____18844 uu____18846
            else ());
           (let r = FStar_TypeChecker_Env.get_range env  in
            let ct = FStar_Syntax_Util.comp_to_comp_typ c  in
-           let uu____18963 =
-             let uu____18974 =
+           let uu____18853 =
+             let uu____18864 =
                FStar_List.hd ct.FStar_Syntax_Syntax.comp_univs  in
-             let uu____18975 =
+             let uu____18865 =
                FStar_All.pipe_right ct.FStar_Syntax_Syntax.effect_args
                  (FStar_List.map FStar_Pervasives_Native.fst)
                 in
-             (uu____18974, (ct.FStar_Syntax_Syntax.result_typ), uu____18975)
+             (uu____18864, (ct.FStar_Syntax_Syntax.result_typ), uu____18865)
               in
-           match uu____18963 with
+           match uu____18853 with
            | (u,a,c_is) ->
-               let uu____19023 =
+               let uu____18913 =
                  FStar_TypeChecker_Env.inst_tscheme_with lift_ts [u]  in
-               (match uu____19023 with
-                | (uu____19032,lift_t) ->
+               (match uu____18913 with
+                | (uu____18922,lift_t) ->
                     let lift_t_shape_error s =
-                      let uu____19043 =
+                      let uu____18933 =
                         FStar_Ident.string_of_lid
                           ct.FStar_Syntax_Syntax.effect_name
                          in
-                      let uu____19045 = FStar_Ident.string_of_lid tgt  in
-                      let uu____19047 =
+                      let uu____18935 = FStar_Ident.string_of_lid tgt  in
+                      let uu____18937 =
                         FStar_Syntax_Print.term_to_string lift_t  in
                       FStar_Util.format4
                         "Lift from %s to %s has unexpected shape, reason: %s (lift:%s)"
-                        uu____19043 uu____19045 s uu____19047
+                        uu____18933 uu____18935 s uu____18937
                        in
-                    let uu____19050 =
-                      let uu____19083 =
-                        let uu____19084 = FStar_Syntax_Subst.compress lift_t
+                    let uu____18940 =
+                      let uu____18973 =
+                        let uu____18974 = FStar_Syntax_Subst.compress lift_t
                            in
-                        uu____19084.FStar_Syntax_Syntax.n  in
-                      match uu____19083 with
+                        uu____18974.FStar_Syntax_Syntax.n  in
+                      match uu____18973 with
                       | FStar_Syntax_Syntax.Tm_arrow (bs,c1) when
                           (FStar_List.length bs) >= (Prims.of_int (2)) ->
-                          let uu____19148 =
+                          let uu____19038 =
                             FStar_Syntax_Subst.open_comp bs c1  in
-                          (match uu____19148 with
+                          (match uu____19038 with
                            | (a_b::bs1,c2) ->
-                               let uu____19208 =
+                               let uu____19098 =
                                  FStar_All.pipe_right bs1
                                    (FStar_List.splitAt
                                       ((FStar_List.length bs1) -
                                          Prims.int_one))
                                   in
-                               (a_b, uu____19208, c2))
-                      | uu____19296 ->
-                          let uu____19297 =
-                            let uu____19303 =
+                               (a_b, uu____19098, c2))
+                      | uu____19186 ->
+                          let uu____19187 =
+                            let uu____19193 =
                               lift_t_shape_error
                                 "either not an arrow or not enough binders"
                                in
                             (FStar_Errors.Fatal_UnexpectedEffect,
-                              uu____19303)
+                              uu____19193)
                              in
-                          FStar_Errors.raise_error uu____19297 r
+                          FStar_Errors.raise_error uu____19187 r
                        in
-                    (match uu____19050 with
+                    (match uu____18940 with
                      | (a_b,(rest_bs,f_b::[]),lift_c) ->
-                         let uu____19421 =
-                           let uu____19428 =
-                             let uu____19429 =
-                               let uu____19430 =
-                                 let uu____19437 =
+                         let uu____19311 =
+                           let uu____19318 =
+                             let uu____19319 =
+                               let uu____19320 =
+                                 let uu____19327 =
                                    FStar_All.pipe_right a_b
                                      FStar_Pervasives_Native.fst
                                     in
-                                 (uu____19437, a)  in
-                               FStar_Syntax_Syntax.NT uu____19430  in
-                             [uu____19429]  in
+                                 (uu____19327, a)  in
+                               FStar_Syntax_Syntax.NT uu____19320  in
+                             [uu____19319]  in
                            FStar_TypeChecker_Env.uvars_for_binders env
-                             rest_bs uu____19428
+                             rest_bs uu____19318
                              (fun b  ->
-                                let uu____19454 =
+                                let uu____19344 =
                                   FStar_Syntax_Print.binder_to_string b  in
-                                let uu____19456 =
+                                let uu____19346 =
                                   FStar_Ident.string_of_lid
                                     ct.FStar_Syntax_Syntax.effect_name
                                    in
-                                let uu____19458 =
+                                let uu____19348 =
                                   FStar_Ident.string_of_lid tgt  in
-                                let uu____19460 =
+                                let uu____19350 =
                                   FStar_Range.string_of_range r  in
                                 FStar_Util.format4
                                   "implicit var for binder %s of %s~>%s at %s"
-                                  uu____19454 uu____19456 uu____19458
-                                  uu____19460) r
+                                  uu____19344 uu____19346 uu____19348
+                                  uu____19350) r
                             in
-                         (match uu____19421 with
+                         (match uu____19311 with
                           | (rest_bs_uvars,g) ->
-                              ((let uu____19474 =
+                              ((let uu____19364 =
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.debug env)
                                     (FStar_Options.Other "LayeredEffects")
                                    in
-                                if uu____19474
+                                if uu____19364
                                 then
-                                  let uu____19479 =
+                                  let uu____19369 =
                                     FStar_List.fold_left
                                       (fun s  ->
                                          fun u1  ->
-                                           let uu____19488 =
-                                             let uu____19490 =
+                                           let uu____19378 =
+                                             let uu____19380 =
                                                FStar_Syntax_Print.term_to_string
                                                  u1
                                                 in
-                                             Prims.op_Hat ";;;;" uu____19490
+                                             Prims.op_Hat ";;;;" uu____19380
                                               in
-                                           Prims.op_Hat s uu____19488) ""
+                                           Prims.op_Hat s uu____19378) ""
                                       rest_bs_uvars
                                      in
                                   FStar_Util.print1 "Introduced uvars: %s\n"
-                                    uu____19479
+                                    uu____19369
                                 else ());
                                (let substs =
                                   FStar_List.map2
                                     (fun b  ->
                                        fun t  ->
-                                         let uu____19521 =
-                                           let uu____19528 =
+                                         let uu____19411 =
+                                           let uu____19418 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst
                                               in
-                                           (uu____19528, t)  in
-                                         FStar_Syntax_Syntax.NT uu____19521)
+                                           (uu____19418, t)  in
+                                         FStar_Syntax_Syntax.NT uu____19411)
                                     (a_b :: rest_bs) (a :: rest_bs_uvars)
                                    in
                                 let guard_f =
                                   let f_sort =
-                                    let uu____19547 =
+                                    let uu____19437 =
                                       FStar_All.pipe_right
                                         (FStar_Pervasives_Native.fst f_b).FStar_Syntax_Syntax.sort
                                         (FStar_Syntax_Subst.subst substs)
                                        in
-                                    FStar_All.pipe_right uu____19547
+                                    FStar_All.pipe_right uu____19437
                                       FStar_Syntax_Subst.compress
                                      in
                                   let f_sort_is =
-                                    let uu____19553 =
+                                    let uu____19443 =
                                       FStar_TypeChecker_Env.is_layered_effect
                                         env
                                         ct.FStar_Syntax_Syntax.effect_name
                                        in
-                                    effect_args_from_repr f_sort uu____19553
+                                    effect_args_from_repr f_sort uu____19443
                                       r
                                      in
                                   FStar_List.fold_left2
                                     (fun g1  ->
                                        fun i1  ->
                                          fun i2  ->
-                                           let uu____19562 =
+                                           let uu____19452 =
                                              FStar_TypeChecker_Rel.teq env i1
                                                i2
                                               in
                                            FStar_TypeChecker_Env.conj_guard
-                                             g1 uu____19562)
+                                             g1 uu____19452)
                                     FStar_TypeChecker_Env.trivial_guard c_is
                                     f_sort_is
                                    in
                                 let lift_ct =
-                                  let uu____19564 =
+                                  let uu____19454 =
                                     FStar_All.pipe_right lift_c
                                       (FStar_Syntax_Subst.subst_comp substs)
                                      in
-                                  FStar_All.pipe_right uu____19564
+                                  FStar_All.pipe_right uu____19454
                                     FStar_Syntax_Util.comp_to_comp_typ
                                    in
                                 let is =
-                                  let uu____19568 =
+                                  let uu____19458 =
                                     FStar_TypeChecker_Env.is_layered_effect
                                       env tgt
                                      in
                                   effect_args_from_repr
                                     lift_ct.FStar_Syntax_Syntax.result_typ
-                                    uu____19568 r
+                                    uu____19458 r
                                    in
                                 let fml =
-                                  let uu____19573 =
-                                    let uu____19578 =
+                                  let uu____19463 =
+                                    let uu____19468 =
                                       FStar_List.hd
                                         lift_ct.FStar_Syntax_Syntax.comp_univs
                                        in
-                                    let uu____19579 =
-                                      let uu____19580 =
+                                    let uu____19469 =
+                                      let uu____19470 =
                                         FStar_List.hd
                                           lift_ct.FStar_Syntax_Syntax.effect_args
                                          in
-                                      FStar_Pervasives_Native.fst uu____19580
+                                      FStar_Pervasives_Native.fst uu____19470
                                        in
-                                    (uu____19578, uu____19579)  in
-                                  match uu____19573 with
+                                    (uu____19468, uu____19469)  in
+                                  match uu____19463 with
                                   | (u1,wp) ->
                                       FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                         env u1
                                         lift_ct.FStar_Syntax_Syntax.result_typ
                                         wp FStar_Range.dummyRange
                                    in
-                                (let uu____19606 =
+                                (let uu____19496 =
                                    (FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "LayeredEffects"))
@@ -7407,17 +7345,17 @@ let (lift_tf_layered_effect :
                                         (FStar_TypeChecker_Env.debug env)
                                         FStar_Options.Extreme)
                                     in
-                                 if uu____19606
+                                 if uu____19496
                                  then
-                                   let uu____19612 =
+                                   let uu____19502 =
                                      FStar_Syntax_Print.term_to_string fml
                                       in
                                    FStar_Util.print1 "Guard for lift is: %s"
-                                     uu____19612
+                                     uu____19502
                                  else ());
                                 (let c1 =
-                                   let uu____19618 =
-                                     let uu____19619 =
+                                   let uu____19508 =
+                                     let uu____19509 =
                                        FStar_All.pipe_right is
                                          (FStar_List.map
                                             FStar_Syntax_Syntax.as_arg)
@@ -7428,42 +7366,42 @@ let (lift_tf_layered_effect :
                                        FStar_Syntax_Syntax.effect_name = tgt;
                                        FStar_Syntax_Syntax.result_typ = a;
                                        FStar_Syntax_Syntax.effect_args =
-                                         uu____19619;
+                                         uu____19509;
                                        FStar_Syntax_Syntax.flags = []
                                      }  in
-                                   FStar_Syntax_Syntax.mk_Comp uu____19618
+                                   FStar_Syntax_Syntax.mk_Comp uu____19508
                                     in
-                                 (let uu____19643 =
+                                 (let uu____19533 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "LayeredEffects")
                                      in
-                                  if uu____19643
+                                  if uu____19533
                                   then
-                                    let uu____19648 =
+                                    let uu____19538 =
                                       FStar_Syntax_Print.comp_to_string c1
                                        in
                                     FStar_Util.print1 "} Lifted comp: %s\n"
-                                      uu____19648
+                                      uu____19538
                                   else ());
-                                 (let uu____19653 =
-                                    let uu____19654 =
+                                 (let uu____19543 =
+                                    let uu____19544 =
                                       FStar_TypeChecker_Env.conj_guard g
                                         guard_f
                                        in
-                                    let uu____19655 =
+                                    let uu____19545 =
                                       FStar_TypeChecker_Env.guard_of_guard_formula
                                         (FStar_TypeChecker_Common.NonTrivial
                                            fml)
                                        in
                                     FStar_TypeChecker_Env.conj_guard
-                                      uu____19654 uu____19655
+                                      uu____19544 uu____19545
                                      in
-                                  (c1, uu____19653)))))))))
+                                  (c1, uu____19543)))))))))
   
 let lift_tf_layered_effect_term :
-  'uuuuuu19669 .
-    'uuuuuu19669 ->
+  'uuuuuu19559 .
+    'uuuuuu19559 ->
       FStar_Syntax_Syntax.sub_eff ->
         FStar_Syntax_Syntax.universe ->
           FStar_Syntax_Syntax.typ ->
@@ -7475,70 +7413,70 @@ let lift_tf_layered_effect_term :
         fun a  ->
           fun e  ->
             let lift =
-              let uu____19698 =
-                let uu____19703 =
+              let uu____19588 =
+                let uu____19593 =
                   FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift
                     FStar_Util.must
                    in
-                FStar_All.pipe_right uu____19703
+                FStar_All.pipe_right uu____19593
                   (fun ts  -> FStar_TypeChecker_Env.inst_tscheme_with ts [u])
                  in
-              FStar_All.pipe_right uu____19698 FStar_Pervasives_Native.snd
+              FStar_All.pipe_right uu____19588 FStar_Pervasives_Native.snd
                in
             let rest_bs =
               let lift_t =
                 FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
                   FStar_Util.must
                  in
-              let uu____19746 =
-                let uu____19747 =
-                  let uu____19750 =
+              let uu____19636 =
+                let uu____19637 =
+                  let uu____19640 =
                     FStar_All.pipe_right lift_t FStar_Pervasives_Native.snd
                      in
-                  FStar_All.pipe_right uu____19750
+                  FStar_All.pipe_right uu____19640
                     FStar_Syntax_Subst.compress
                    in
-                uu____19747.FStar_Syntax_Syntax.n  in
-              match uu____19746 with
-              | FStar_Syntax_Syntax.Tm_arrow (uu____19773::bs,uu____19775)
+                uu____19637.FStar_Syntax_Syntax.n  in
+              match uu____19636 with
+              | FStar_Syntax_Syntax.Tm_arrow (uu____19663::bs,uu____19665)
                   when (FStar_List.length bs) >= Prims.int_one ->
-                  let uu____19815 =
+                  let uu____19705 =
                     FStar_All.pipe_right bs
                       (FStar_List.splitAt
                          ((FStar_List.length bs) - Prims.int_one))
                      in
-                  FStar_All.pipe_right uu____19815
+                  FStar_All.pipe_right uu____19705
                     FStar_Pervasives_Native.fst
-              | uu____19921 ->
-                  let uu____19922 =
-                    let uu____19928 =
-                      let uu____19930 =
+              | uu____19811 ->
+                  let uu____19812 =
+                    let uu____19818 =
+                      let uu____19820 =
                         FStar_Syntax_Print.tscheme_to_string lift_t  in
                       FStar_Util.format1
                         "lift_t tscheme %s is not an arrow with enough binders"
-                        uu____19930
+                        uu____19820
                        in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu____19928)  in
-                  FStar_Errors.raise_error uu____19922
+                    (FStar_Errors.Fatal_UnexpectedEffect, uu____19818)  in
+                  FStar_Errors.raise_error uu____19812
                     (FStar_Pervasives_Native.snd lift_t).FStar_Syntax_Syntax.pos
                in
             let args =
-              let uu____19957 = FStar_Syntax_Syntax.as_arg a  in
-              let uu____19966 =
-                let uu____19977 =
+              let uu____19847 = FStar_Syntax_Syntax.as_arg a  in
+              let uu____19856 =
+                let uu____19867 =
                   FStar_All.pipe_right rest_bs
                     (FStar_List.map
-                       (fun uu____20013  ->
+                       (fun uu____19903  ->
                           FStar_Syntax_Syntax.as_arg
                             FStar_Syntax_Syntax.unit_const))
                    in
-                let uu____20020 =
-                  let uu____20031 = FStar_Syntax_Syntax.as_arg e  in
-                  [uu____20031]  in
-                FStar_List.append uu____19977 uu____20020  in
-              uu____19957 :: uu____19966  in
+                let uu____19910 =
+                  let uu____19921 = FStar_Syntax_Syntax.as_arg e  in
+                  [uu____19921]  in
+                FStar_List.append uu____19867 uu____19910  in
+              uu____19847 :: uu____19856  in
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_app (lift, args))
-              FStar_Pervasives_Native.None e.FStar_Syntax_Syntax.pos
+              e.FStar_Syntax_Syntax.pos
   
 let (get_field_projector_name :
   FStar_TypeChecker_Env.env ->
@@ -7547,40 +7485,40 @@ let (get_field_projector_name :
   fun env  ->
     fun datacon  ->
       fun index  ->
-        let uu____20102 = FStar_TypeChecker_Env.lookup_datacon env datacon
+        let uu____19992 = FStar_TypeChecker_Env.lookup_datacon env datacon
            in
-        match uu____20102 with
-        | (uu____20107,t) ->
+        match uu____19992 with
+        | (uu____19997,t) ->
             let err n =
-              let uu____20117 =
-                let uu____20123 =
-                  let uu____20125 = FStar_Ident.string_of_lid datacon  in
-                  let uu____20127 = FStar_Util.string_of_int n  in
-                  let uu____20129 = FStar_Util.string_of_int index  in
+              let uu____20007 =
+                let uu____20013 =
+                  let uu____20015 = FStar_Ident.string_of_lid datacon  in
+                  let uu____20017 = FStar_Util.string_of_int n  in
+                  let uu____20019 = FStar_Util.string_of_int index  in
                   FStar_Util.format3
                     "Data constructor %s does not have enough binders (has %s, tried %s)"
-                    uu____20125 uu____20127 uu____20129
+                    uu____20015 uu____20017 uu____20019
                    in
-                (FStar_Errors.Fatal_UnexpectedDataConstructor, uu____20123)
+                (FStar_Errors.Fatal_UnexpectedDataConstructor, uu____20013)
                  in
-              let uu____20133 = FStar_TypeChecker_Env.get_range env  in
-              FStar_Errors.raise_error uu____20117 uu____20133  in
-            let uu____20134 =
-              let uu____20135 = FStar_Syntax_Subst.compress t  in
-              uu____20135.FStar_Syntax_Syntax.n  in
-            (match uu____20134 with
-             | FStar_Syntax_Syntax.Tm_arrow (bs,uu____20139) ->
+              let uu____20023 = FStar_TypeChecker_Env.get_range env  in
+              FStar_Errors.raise_error uu____20007 uu____20023  in
+            let uu____20024 =
+              let uu____20025 = FStar_Syntax_Subst.compress t  in
+              uu____20025.FStar_Syntax_Syntax.n  in
+            (match uu____20024 with
+             | FStar_Syntax_Syntax.Tm_arrow (bs,uu____20029) ->
                  let bs1 =
                    FStar_All.pipe_right bs
                      (FStar_List.filter
-                        (fun uu____20194  ->
-                           match uu____20194 with
-                           | (uu____20202,q) ->
+                        (fun uu____20084  ->
+                           match uu____20084 with
+                           | (uu____20092,q) ->
                                (match q with
                                 | FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Implicit (true )) ->
                                     false
-                                | uu____20211 -> true)))
+                                | uu____20101 -> true)))
                     in
                  if (FStar_List.length bs1) <= index
                  then err (FStar_List.length bs1)
@@ -7588,7 +7526,7 @@ let (get_field_projector_name :
                    (let b = FStar_List.nth bs1 index  in
                     FStar_Syntax_Util.mk_field_projector_name datacon
                       (FStar_Pervasives_Native.fst b) index)
-             | uu____20245 -> err Prims.int_zero)
+             | uu____20135 -> err Prims.int_zero)
   
 let (get_mlift_for_subeff :
   FStar_TypeChecker_Env.env ->
@@ -7596,24 +7534,24 @@ let (get_mlift_for_subeff :
   =
   fun env  ->
     fun sub  ->
-      let uu____20258 =
+      let uu____20148 =
         (FStar_TypeChecker_Env.is_layered_effect env
            sub.FStar_Syntax_Syntax.source)
           ||
           (FStar_TypeChecker_Env.is_layered_effect env
              sub.FStar_Syntax_Syntax.target)
          in
-      if uu____20258
+      if uu____20148
       then
-        let uu____20261 =
-          let uu____20274 =
+        let uu____20151 =
+          let uu____20164 =
             FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
               FStar_Util.must
              in
-          lift_tf_layered_effect sub.FStar_Syntax_Syntax.target uu____20274
+          lift_tf_layered_effect sub.FStar_Syntax_Syntax.target uu____20164
            in
         {
-          FStar_TypeChecker_Env.mlift_wp = uu____20261;
+          FStar_TypeChecker_Env.mlift_wp = uu____20151;
           FStar_TypeChecker_Env.mlift_term =
             (FStar_Pervasives_Native.Some
                (lift_tf_layered_effect_term env sub))
@@ -7621,91 +7559,86 @@ let (get_mlift_for_subeff :
       else
         (let mk_mlift_wp ts env1 c =
            let ct = FStar_Syntax_Util.comp_to_comp_typ c  in
-           let uu____20309 =
+           let uu____20199 =
              FStar_TypeChecker_Env.inst_tscheme_with ts
                ct.FStar_Syntax_Syntax.comp_univs
               in
-           match uu____20309 with
-           | (uu____20318,lift_t) ->
+           match uu____20199 with
+           | (uu____20208,lift_t) ->
                let wp = FStar_List.hd ct.FStar_Syntax_Syntax.effect_args  in
-               let uu____20337 =
-                 let uu____20338 =
-                   let uu___2462_20339 = ct  in
-                   let uu____20340 =
-                     let uu____20351 =
-                       let uu____20360 =
-                         let uu____20361 =
-                           let uu____20368 =
-                             let uu____20369 =
-                               let uu____20386 =
-                                 let uu____20397 =
-                                   FStar_Syntax_Syntax.as_arg
-                                     ct.FStar_Syntax_Syntax.result_typ
-                                    in
-                                 [uu____20397; wp]  in
-                               (lift_t, uu____20386)  in
-                             FStar_Syntax_Syntax.Tm_app uu____20369  in
-                           FStar_Syntax_Syntax.mk uu____20368  in
-                         uu____20361 FStar_Pervasives_Native.None
+               let uu____20227 =
+                 let uu____20228 =
+                   let uu___2462_20229 = ct  in
+                   let uu____20230 =
+                     let uu____20241 =
+                       let uu____20250 =
+                         let uu____20251 =
+                           let uu____20252 =
+                             let uu____20269 =
+                               let uu____20280 =
+                                 FStar_Syntax_Syntax.as_arg
+                                   ct.FStar_Syntax_Syntax.result_typ
+                                  in
+                               [uu____20280; wp]  in
+                             (lift_t, uu____20269)  in
+                           FStar_Syntax_Syntax.Tm_app uu____20252  in
+                         FStar_Syntax_Syntax.mk uu____20251
                            (FStar_Pervasives_Native.fst wp).FStar_Syntax_Syntax.pos
                           in
-                       FStar_All.pipe_right uu____20360
+                       FStar_All.pipe_right uu____20250
                          FStar_Syntax_Syntax.as_arg
                         in
-                     [uu____20351]  in
+                     [uu____20241]  in
                    {
                      FStar_Syntax_Syntax.comp_univs =
-                       (uu___2462_20339.FStar_Syntax_Syntax.comp_univs);
+                       (uu___2462_20229.FStar_Syntax_Syntax.comp_univs);
                      FStar_Syntax_Syntax.effect_name =
                        (sub.FStar_Syntax_Syntax.target);
                      FStar_Syntax_Syntax.result_typ =
-                       (uu___2462_20339.FStar_Syntax_Syntax.result_typ);
-                     FStar_Syntax_Syntax.effect_args = uu____20340;
+                       (uu___2462_20229.FStar_Syntax_Syntax.result_typ);
+                     FStar_Syntax_Syntax.effect_args = uu____20230;
                      FStar_Syntax_Syntax.flags =
-                       (uu___2462_20339.FStar_Syntax_Syntax.flags)
+                       (uu___2462_20229.FStar_Syntax_Syntax.flags)
                    }  in
-                 FStar_Syntax_Syntax.mk_Comp uu____20338  in
-               (uu____20337, FStar_TypeChecker_Common.trivial_guard)
+                 FStar_Syntax_Syntax.mk_Comp uu____20228  in
+               (uu____20227, FStar_TypeChecker_Common.trivial_guard)
             in
          let mk_mlift_term ts u r e =
-           let uu____20497 = FStar_TypeChecker_Env.inst_tscheme_with ts [u]
+           let uu____20380 = FStar_TypeChecker_Env.inst_tscheme_with ts [u]
               in
-           match uu____20497 with
-           | (uu____20504,lift_t) ->
-               let uu____20506 =
-                 let uu____20513 =
-                   let uu____20514 =
-                     let uu____20531 =
-                       let uu____20542 = FStar_Syntax_Syntax.as_arg r  in
-                       let uu____20551 =
-                         let uu____20562 =
-                           FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun
-                            in
-                         let uu____20571 =
-                           let uu____20582 = FStar_Syntax_Syntax.as_arg e  in
-                           [uu____20582]  in
-                         uu____20562 :: uu____20571  in
-                       uu____20542 :: uu____20551  in
-                     (lift_t, uu____20531)  in
-                   FStar_Syntax_Syntax.Tm_app uu____20514  in
-                 FStar_Syntax_Syntax.mk uu____20513  in
-               uu____20506 FStar_Pervasives_Native.None
-                 e.FStar_Syntax_Syntax.pos
+           match uu____20380 with
+           | (uu____20387,lift_t) ->
+               let uu____20389 =
+                 let uu____20390 =
+                   let uu____20407 =
+                     let uu____20418 = FStar_Syntax_Syntax.as_arg r  in
+                     let uu____20427 =
+                       let uu____20438 =
+                         FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.tun
+                          in
+                       let uu____20447 =
+                         let uu____20458 = FStar_Syntax_Syntax.as_arg e  in
+                         [uu____20458]  in
+                       uu____20438 :: uu____20447  in
+                     uu____20418 :: uu____20427  in
+                   (lift_t, uu____20407)  in
+                 FStar_Syntax_Syntax.Tm_app uu____20390  in
+               FStar_Syntax_Syntax.mk uu____20389 e.FStar_Syntax_Syntax.pos
             in
-         let uu____20635 =
-           let uu____20648 =
+         let uu____20511 =
+           let uu____20524 =
              FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift_wp
                FStar_Util.must
               in
-           FStar_All.pipe_right uu____20648 mk_mlift_wp  in
+           FStar_All.pipe_right uu____20524 mk_mlift_wp  in
          {
-           FStar_TypeChecker_Env.mlift_wp = uu____20635;
+           FStar_TypeChecker_Env.mlift_wp = uu____20511;
            FStar_TypeChecker_Env.mlift_term =
              (match sub.FStar_Syntax_Syntax.lift with
               | FStar_Pervasives_Native.None  ->
                   FStar_Pervasives_Native.Some
-                    ((fun uu____20684  ->
-                        fun uu____20685  -> fun e  -> FStar_Util.return_all e))
+                    ((fun uu____20560  ->
+                        fun uu____20561  -> fun e  -> FStar_Util.return_all e))
               | FStar_Pervasives_Native.Some ts ->
                   FStar_Pervasives_Native.Some (mk_mlift_term ts))
          })
@@ -7716,10 +7649,10 @@ let (update_env_sub_eff :
   =
   fun env  ->
     fun sub  ->
-      let uu____20708 = get_mlift_for_subeff env sub  in
+      let uu____20584 = get_mlift_for_subeff env sub  in
       FStar_TypeChecker_Env.update_effect_lattice env
         sub.FStar_Syntax_Syntax.source sub.FStar_Syntax_Syntax.target
-        uu____20708
+        uu____20584
   
 let (update_env_polymonadic_bind :
   FStar_TypeChecker_Env.env ->

--- a/src/reflection/FStar.Reflection.Basic.fs
+++ b/src/reflection/FStar.Reflection.Basic.fs
@@ -137,7 +137,7 @@ let rec inspect_ln (t:term) : term_view =
         // expose n-ary lambdas buy unary ones.
         let (a, q) = last args in
         let q' = inspect_aqual q in
-        Tv_App (S.mk_Tm_app hd (init args) None t.pos, (a, q')) // TODO: The range and tk are probably wrong. Fix
+        Tv_App (U.mk_app hd (init args), (a, q'))
 
     | Tm_abs ([], _, _) ->
         failwith "inspect_ln: empty arguments on Tm_abs"
@@ -146,7 +146,7 @@ let rec inspect_ln (t:term) : term_view =
         let body =
             match bs with
             | [] -> t
-            | bs -> S.mk (Tm_abs (bs, t, k)) None t.pos
+            | bs -> S.mk (Tm_abs (bs, t, k)) t.pos
         in
         Tv_Abs (b, body)
 
@@ -305,30 +305,30 @@ let pack_ln (tv:term_view) : term =
         U.mk_app l [(r, q')]
 
     | Tv_Abs (b, t) ->
-        mk (Tm_abs ([b], t, None)) None t.pos // TODO: effect?
+        mk (Tm_abs ([b], t, None)) t.pos // TODO: effect?
 
     | Tv_Arrow (b, c) ->
-        mk (Tm_arrow ([b], c)) None c.pos
+        mk (Tm_arrow ([b], c)) c.pos
 
     | Tv_Type () ->
         U.ktype
 
     | Tv_Refine (bv, t) ->
-        mk (Tm_refine (bv, t)) None t.pos
+        mk (Tm_refine (bv, t)) t.pos
 
     | Tv_Const c ->
-        S.mk (Tm_constant (pack_const c)) None Range.dummyRange
+        S.mk (Tm_constant (pack_const c)) Range.dummyRange
 
     | Tv_Uvar (u, ctx_u_s) ->
-      S.mk (Tm_uvar ctx_u_s) None Range.dummyRange
+      S.mk (Tm_uvar ctx_u_s) Range.dummyRange
 
     | Tv_Let (false, attrs, bv, t1, t2) ->
         let lb = U.mk_letbinding (BU.Inl bv) [] bv.sort PC.effect_Tot_lid t1 attrs Range.dummyRange in
-        S.mk (Tm_let ((false, [lb]), t2)) None Range.dummyRange
+        S.mk (Tm_let ((false, [lb]), t2)) Range.dummyRange
 
     | Tv_Let (true, attrs, bv, t1, t2) ->
         let lb = U.mk_letbinding (BU.Inl bv) [] bv.sort PC.effect_Tot_lid t1 attrs Range.dummyRange in
-        S.mk (Tm_let ((true, [lb]), t2)) None Range.dummyRange
+        S.mk (Tm_let ((true, [lb]), t2)) Range.dummyRange
 
     | Tv_Match (t, brs) ->
         let wrap v = {v=v;p=Range.dummyRange} in
@@ -341,16 +341,16 @@ let pack_ln (tv:term_view) : term =
             | Pat_Dot_Term (bv, t) -> wrap <| Pat_dot_term (bv, t)
         in
         let brs = List.map (function (pat, t) -> (pack_pat pat, None, t)) brs in
-        S.mk (Tm_match (t, brs)) None Range.dummyRange
+        S.mk (Tm_match (t, brs)) Range.dummyRange
 
     | Tv_AscribedT(e, t, tacopt) ->
-        S.mk (Tm_ascribed(e, (BU.Inl t, tacopt), None)) None Range.dummyRange
+        S.mk (Tm_ascribed(e, (BU.Inl t, tacopt), None)) Range.dummyRange
 
     | Tv_AscribedC(e, c, tacopt) ->
-        S.mk (Tm_ascribed(e, (BU.Inr c, tacopt), None)) None Range.dummyRange
+        S.mk (Tm_ascribed(e, (BU.Inr c, tacopt), None)) Range.dummyRange
 
     | Tv_Unknown ->
-        S.mk Tm_unknown None Range.dummyRange
+        S.mk Tm_unknown Range.dummyRange
 
 let compare_bv (x:bv) (y:bv) : order =
     let n = S.order_bv x y in

--- a/src/reflection/FStar.Reflection.Embeddings.fs
+++ b/src/reflection/FStar.Reflection.Embeddings.fs
@@ -101,7 +101,7 @@ let rec mapM_opt (f : ('a -> option<'b>)) (l : list<'a>) : option<list<'b>> =
 let e_term_aq aq =
     let embed_term (rng:Range.range) (t:term) : term =
         let qi = { qkind = Quote_static; antiquotes = aq } in
-        S.mk (Tm_quoted (t, qi)) None rng
+        S.mk (Tm_quoted (t, qi)) rng
     in
     let rec unembed_term w (t:term) : option<term> =
         let apply_antiquotes (t:term) (aq:antiquotations) : option<term> =
@@ -130,7 +130,7 @@ let e_aqualv =
         | Data.Q_Implicit -> ref_Q_Implicit.t
         | Data.Q_Meta t   ->
             S.mk_Tm_app ref_Q_Meta.t [S.as_arg (embed e_term rng t)]
-                        None Range.dummyRange
+                        Range.dummyRange
         in { r with pos = rng }
     in
     let unembed_aqualv w (t : term) : option<aqualv> =
@@ -207,20 +207,20 @@ let e_const =
 
         | C_Int i ->
             S.mk_Tm_app ref_C_Int.t [S.as_arg (U.exp_int (Z.string_of_big_int i))]
-                        None Range.dummyRange
+                        Range.dummyRange
         | C_String s ->
             S.mk_Tm_app ref_C_String.t [S.as_arg (embed e_string rng s)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         | C_Range r ->
             S.mk_Tm_app ref_C_Range.t [S.as_arg (embed e_range rng r)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         | C_Reify -> ref_C_Reify.t
 
         | C_Reflect ns ->
             S.mk_Tm_app ref_C_Reflect.t [S.as_arg (embed e_string_list rng ns)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         in { r with pos = rng }
     in
@@ -267,17 +267,17 @@ let rec e_pattern' () =
     let rec embed_pattern (rng:Range.range) (p : pattern) : term =
         match p with
         | Pat_Constant c ->
-            S.mk_Tm_app ref_Pat_Constant.t [S.as_arg (embed e_const rng c)] None rng
+            S.mk_Tm_app ref_Pat_Constant.t [S.as_arg (embed e_const rng c)] rng
         | Pat_Cons (fv, ps) ->
-            S.mk_Tm_app ref_Pat_Cons.t [S.as_arg (embed e_fv rng fv); S.as_arg (embed (e_list (e_tuple2 (e_pattern' ()) e_bool)) rng ps)] None rng
+            S.mk_Tm_app ref_Pat_Cons.t [S.as_arg (embed e_fv rng fv); S.as_arg (embed (e_list (e_tuple2 (e_pattern' ()) e_bool)) rng ps)] rng
         | Pat_Var bv ->
-            S.mk_Tm_app ref_Pat_Var.t [S.as_arg (embed e_bv rng bv)] None rng
+            S.mk_Tm_app ref_Pat_Var.t [S.as_arg (embed e_bv rng bv)] rng
         | Pat_Wild bv ->
-            S.mk_Tm_app ref_Pat_Wild.t [S.as_arg (embed e_bv rng bv)] None rng
+            S.mk_Tm_app ref_Pat_Wild.t [S.as_arg (embed e_bv rng bv)] rng
         | Pat_Dot_Term (bv, t) ->
             S.mk_Tm_app ref_Pat_Dot_Term.t [S.as_arg (embed e_bv rng bv);
                                             S.as_arg (embed e_term rng t)]
-                        None rng
+                        rng
     in
     let rec unembed_pattern w (t : term) : option<pattern> =
         let t = U.unascribe t in
@@ -327,45 +327,45 @@ let e_term_view_aq aq =
         match t with
         | Tv_FVar fv ->
             S.mk_Tm_app ref_Tv_FVar.t [S.as_arg (embed e_fv rng fv)]
-                        None rng
+                        rng
 
         | Tv_BVar fv ->
             S.mk_Tm_app ref_Tv_BVar.t [S.as_arg (embed e_bv rng fv)]
-                        None rng
+                        rng
 
         | Tv_Var bv ->
             S.mk_Tm_app ref_Tv_Var.t [S.as_arg (embed e_bv rng bv)]
-                        None rng
+                        rng
 
         | Tv_App (hd, a) ->
             S.mk_Tm_app ref_Tv_App.t [S.as_arg (embed (e_term_aq aq) rng hd); S.as_arg (embed (e_argv_aq aq) rng a)]
-                        None rng
+                        rng
 
         | Tv_Abs (b, t) ->
             S.mk_Tm_app ref_Tv_Abs.t [S.as_arg (embed e_binder rng b); S.as_arg (embed (e_term_aq aq) rng t)]
-                        None rng
+                        rng
 
         | Tv_Arrow (b, c) ->
             S.mk_Tm_app ref_Tv_Arrow.t [S.as_arg (embed e_binder rng b); S.as_arg (embed e_comp rng c)]
-                        None rng
+                        rng
 
         | Tv_Type u ->
             S.mk_Tm_app ref_Tv_Type.t [S.as_arg (embed e_unit rng ())]
-                        None rng
+                        rng
 
         | Tv_Refine (bv, t) ->
             S.mk_Tm_app ref_Tv_Refine.t [S.as_arg (embed e_bv rng bv); S.as_arg (embed (e_term_aq aq) rng t)]
-                        None rng
+                        rng
 
         | Tv_Const c ->
             S.mk_Tm_app ref_Tv_Const.t [S.as_arg (embed e_const rng c)]
-                        None rng
+                        rng
 
         | Tv_Uvar (u, d) ->
             S.mk_Tm_app ref_Tv_Uvar.t
                         [S.as_arg (embed e_int rng u);
                          S.as_arg (U.mk_lazy (u,d) U.t_ctx_uvar_and_sust Lazy_uvar None)]
-                        None rng
+                        rng
 
         | Tv_Let (r, attrs, b, t1, t2) ->
             S.mk_Tm_app ref_Tv_Let.t [S.as_arg (embed e_bool rng r);
@@ -373,26 +373,26 @@ let e_term_view_aq aq =
                                       S.as_arg (embed e_bv rng b);
                                       S.as_arg (embed (e_term_aq aq) rng t1);
                                       S.as_arg (embed (e_term_aq aq) rng t2)]
-                        None rng
+                        rng
 
         | Tv_Match (t, brs) ->
             S.mk_Tm_app ref_Tv_Match.t [S.as_arg (embed (e_term_aq aq) rng t);
                                         S.as_arg (embed (e_list (e_branch_aq aq)) rng brs)]
-                        None rng
+                        rng
 
         | Tv_AscribedT (e, t, tacopt) ->
             S.mk_Tm_app ref_Tv_AscT.t
                         [S.as_arg (embed (e_term_aq aq) rng e);
                          S.as_arg (embed (e_term_aq aq) rng t);
                          S.as_arg (embed (e_option (e_term_aq aq)) rng tacopt)]
-                        None rng
+                        rng
 
         | Tv_AscribedC (e, c, tacopt) ->
             S.mk_Tm_app ref_Tv_AscC.t
                         [S.as_arg (embed (e_term_aq aq) rng e);
                          S.as_arg (embed e_comp rng c);
                          S.as_arg (embed (e_option (e_term_aq aq)) rng tacopt)]
-                        None rng
+                        rng
 
         | Tv_Unknown ->
             { ref_Tv_Unknown.t with pos = rng }
@@ -504,7 +504,7 @@ let e_bv_view =
         S.mk_Tm_app ref_Mk_bv.t [S.as_arg (embed e_string rng bvv.bv_ppname);
                                  S.as_arg (embed e_int    rng bvv.bv_index);
                                  S.as_arg (embed e_term   rng bvv.bv_sort)]
-                    None rng
+                    rng
     in
     let unembed_bv_view w (t : term) : option<bv_view> =
         let t = U.unascribe t in
@@ -529,23 +529,23 @@ let e_comp_view =
         | C_Total (t, md) ->
             S.mk_Tm_app ref_C_Total.t [S.as_arg (embed e_term rng t);
                                        S.as_arg (embed (e_option e_term) rng md)]
-                        None rng
+                        rng
 
         | C_GTotal (t, md) ->
             S.mk_Tm_app ref_C_GTotal.t [S.as_arg (embed e_term rng t);
                                        S.as_arg (embed (e_option e_term) rng md)]
-                        None rng
+                        rng
 
         | C_Lemma (pre, post, pats) ->
             S.mk_Tm_app ref_C_Lemma.t [S.as_arg (embed e_term rng pre); S.as_arg (embed e_term rng post); S.as_arg (embed e_term rng pats)]
-                        None rng
+                        rng
 
         | C_Eff (us, eff, res, args) ->
             S.mk_Tm_app ref_C_Eff.t
                 [ S.as_arg (embed e_unit rng ()) (* TODO *)
                 ; S.as_arg (embed e_string_list rng eff)
                 ; S.as_arg (embed e_term rng res)
-                ; S.as_arg (embed (e_list e_argv) rng args)] None rng
+                ; S.as_arg (embed (e_list e_argv) rng args)] rng
 
 
     in
@@ -646,13 +646,13 @@ let e_sigelt_view =
                             S.as_arg (embed e_univ_names rng univs);
                             S.as_arg (embed e_term rng ty);
                             S.as_arg (embed e_term rng t)]
-                        None rng
+                        rng
 
         | Sg_Constructor (nm, ty) ->
             S.mk_Tm_app ref_Sg_Constructor.t
                         [S.as_arg (embed e_string_list rng nm);
                             S.as_arg (embed e_term rng ty)]
-                        None rng
+                        rng
 
         | Sg_Inductive (nm, univs, bs, t, dcs) ->
             S.mk_Tm_app ref_Sg_Inductive.t
@@ -661,7 +661,7 @@ let e_sigelt_view =
                             S.as_arg (embed e_binders rng bs);
                             S.as_arg (embed e_term rng t);
                             S.as_arg (embed (e_list e_string_list)  rng dcs)]
-                        None rng
+                        rng
 
         | Unk ->
             { ref_Unk.t with pos = rng }
@@ -703,10 +703,10 @@ let e_exp =
         | Unit    -> ref_E_Unit.t
         | Var i ->
             S.mk_Tm_app ref_E_Var.t [S.as_arg (U.exp_int (Z.string_of_big_int i))]
-                        None Range.dummyRange
+                        Range.dummyRange
         | Mult (e1, e2) ->
             S.mk_Tm_app ref_E_Mult.t [S.as_arg (embed_exp rng e1); S.as_arg (embed_exp rng e2)]
-                        None Range.dummyRange
+                        Range.dummyRange
         in { r with pos = rng }
     in
     let rec unembed_exp w (t: term) : option<exp> =
@@ -761,30 +761,30 @@ let e_qualifier =
         | RD.OnlyName                         -> ref_qual_OnlyName.t
         | RD.Reflectable l ->
             S.mk_Tm_app ref_qual_Reflectable.t [S.as_arg (embed e_lid rng l)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         | RD.Discriminator l ->
             S.mk_Tm_app ref_qual_Discriminator.t [S.as_arg (embed e_lid rng l)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         | RD.Action l ->
             S.mk_Tm_app ref_qual_Action.t [S.as_arg (embed e_lid rng l)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         | RD.Projector (l, i) ->
             S.mk_Tm_app ref_qual_Projector.t [S.as_arg (embed e_lid rng l);
                                               S.as_arg (embed e_ident rng i)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         | RD.RecordType (ids1, ids2) ->
             S.mk_Tm_app ref_qual_RecordType.t [S.as_arg (embed (e_list e_ident) rng ids1);
                                                S.as_arg (embed (e_list e_ident) rng ids2)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         | RD.RecordConstructor (ids1, ids2) ->
             S.mk_Tm_app ref_qual_RecordConstructor.t [S.as_arg (embed (e_list e_ident) rng ids1);
                                                       S.as_arg (embed (e_list e_ident) rng ids2)]
-                        None Range.dummyRange
+                        Range.dummyRange
 
         in { r with pos = rng }
     in
@@ -894,7 +894,7 @@ let e_qualifiers = e_list e_qualifier
 let unfold_lazy_bv  (i : lazyinfo) : term =
     let bv : bv = undyn i.blob in
     S.mk_Tm_app fstar_refl_pack_bv.t [S.as_arg (embed e_bv_view i.rng (inspect_bv bv))]
-                None i.rng
+                i.rng
 
 (* TODO: non-uniform *)
 let unfold_lazy_binder (i : lazyinfo) : term =
@@ -902,17 +902,17 @@ let unfold_lazy_binder (i : lazyinfo) : term =
     let bv, aq = inspect_binder binder in
     S.mk_Tm_app fstar_refl_pack_binder.t [S.as_arg (embed e_bv i.rng bv);
                                         S.as_arg (embed e_aqualv i.rng aq)]
-                None i.rng
+                i.rng
 
 let unfold_lazy_fvar (i : lazyinfo) : term =
     let fv : fv = undyn i.blob in
     S.mk_Tm_app fstar_refl_pack_fv.t [S.as_arg (embed (e_list e_string) i.rng (inspect_fv fv))]
-                None i.rng
+                i.rng
 
 let unfold_lazy_comp (i : lazyinfo) : term =
     let comp : comp = undyn i.blob in
     S.mk_Tm_app fstar_refl_pack_comp.t [S.as_arg (embed e_comp_view i.rng (inspect_comp comp))]
-                None i.rng
+                i.rng
 
 let unfold_lazy_env (i : lazyinfo) : term =
     (* Not needed, metaprograms never see concrete environments. *)
@@ -925,4 +925,4 @@ let unfold_lazy_optionstate (i : lazyinfo) : term =
 let unfold_lazy_sigelt (i : lazyinfo) : term =
     let sigelt : sigelt = undyn i.blob in
     S.mk_Tm_app fstar_refl_pack_sigelt.t [S.as_arg (embed e_sigelt_view i.rng (inspect_sigelt sigelt))]
-                None i.rng
+                i.rng

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fs
@@ -640,7 +640,7 @@ let encode_top_level_let :
       let formals, extra_formals = BU.first_N nbinders formals in
       let subst = List.map2 (fun (formal, _) (binder, _) -> NT(formal, S.bv_to_name binder)) formals binders in
       let extra_formals = extra_formals |> List.map (fun (x, i) -> {x with sort=SS.subst subst x.sort}, i) |> U.name_binders in
-      let body = Syntax.extend_app_n (SS.compress body) (snd <| U.args_of_binders extra_formals) None body.pos in
+      let body = Syntax.extend_app_n (SS.compress body) (snd <| U.args_of_binders extra_formals) body.pos in
       binders@extra_formals, body
     in
 
@@ -1048,7 +1048,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
             let close_effect_params tm =
               match ed.binders with
               | [] -> tm
-              | _ -> S.mk (Tm_abs(ed.binders, tm, Some (U.mk_residual_comp Const.effect_Tot_lid None [TOTAL]))) None tm.pos
+              | _ -> S.mk (Tm_abs(ed.binders, tm, Some (U.mk_residual_comp Const.effect_Tot_lid None [TOTAL]))) tm.pos
             in
 
             let encode_action env (a:S.action) =
@@ -1215,7 +1215,6 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                  (S.mk_Tm_app
                    (S.fvar t (Delta_constant_at_level 0) None)
                    (snd (U.args_of_binders tps))
-                   None
                    (Ident.range_of_lid t))
                  k
              in
@@ -1299,7 +1298,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
           let k =
             match tps with
             | [] -> k
-            | _ -> S.mk (Tm_arrow (tps, S.mk_Total k)) None k.pos
+            | _ -> S.mk (Tm_arrow (tps, S.mk_Total k)) k.pos
           in
           let k = norm_before_encoding env k in
           U.arrow_formals k

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fs
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fs
@@ -1012,7 +1012,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
             let e0 = TcUtil.reify_body_with_arg env.tcenv [] head (List.hd args_e) in
             if Env.debug env.tcenv <| Options.Other "SMTEncodingReify"
             then BU.print1 "Result of normalization %s\n" (Print.term_to_string e0);
-            let e = S.mk_Tm_app (TcUtil.remove_reify e0) (List.tl args_e) None t0.pos in
+            let e = S.mk_Tm_app (TcUtil.remove_reify e0) (List.tl args_e) t0.pos in
             encode_term e env
 
         | Tm_constant (Const_reflect _), [(arg, _)] ->
@@ -1316,7 +1316,7 @@ and encode_let
 
 and encode_match (e:S.term) (pats:list<S.branch>) (default_case:term) (env:env_t)
                  (encode_br:S.term -> env_t -> (term * decls_t)) : term * decls_t =
-    let scrsym, scr', env = gen_term_var env (S.null_bv (S.mk S.Tm_unknown None Range.dummyRange)) in
+    let scrsym, scr', env = gen_term_var env (S.null_bv (S.mk S.Tm_unknown Range.dummyRange)) in
     let scr, decls = encode_term e env in
     let match_tm, decls =
       let encode_branch b (else_case, decls) =
@@ -1567,12 +1567,12 @@ and encode_formula (phi:typ) (env:env_t) : (term * decls_t)  = (* expects phi to
               begin match SE.unembed SE.e_range r false SE.id_norm_cb,
                           SE.unembed SE.e_string msg false SE.id_norm_cb with
               | Some r, Some s ->
-                let phi = S.mk (Tm_meta(phi,  Meta_labeled(s, r, false))) None r in
+                let phi = S.mk (Tm_meta(phi,  Meta_labeled(s, r, false))) r in
                 fallback phi
 
               (* If we could not unembed the position, still use the string *)
               | None, Some s ->
-                let phi = S.mk (Tm_meta(phi,  Meta_labeled(s, phi.pos, false))) None phi.pos in
+                let phi = S.mk (Tm_meta(phi,  Meta_labeled(s, phi.pos, false))) phi.pos in
                 fallback phi
 
               | _ ->

--- a/src/syntax/FStar.Syntax.DsEnv.fs
+++ b/src/syntax/FStar.Syntax.DsEnv.fs
@@ -547,7 +547,7 @@ let try_lookup_name any_val exclude_interf env (lid:lident) : option<foundname> 
                  let dd = delta_depth_of_declaration lid quals in
                  begin match BU.find_map quals (function Reflectable refl_monad -> Some refl_monad | _ -> None) with //this is really a M?.reflect
                  | Some refl_monad ->
-                        let refl_const = S.mk (Tm_constant (FStar.Const.Const_reflect refl_monad)) None occurrence_range in
+                        let refl_const = S.mk (Tm_constant (FStar.Const.Const_reflect refl_monad)) occurrence_range in
                         Some (Term_name (refl_const, se.sigattrs))
                  | _ ->
                    Some (Term_name(fvar lid dd (fv_qual_of_se se), se.sigattrs)) //NS delta: ok
@@ -1051,7 +1051,7 @@ let finish env modul =
                   BU.smap_remove (sigmap env) (string_of_lid lid);
                   if not (List.contains Private quals)
                   then //it's only abstract; add it back to the environment as an abstract type
-                       let sigel = Sig_declare_typ(lid, univ_names, S.mk (Tm_arrow(binders, S.mk_Total typ)) None (Ident.range_of_lid lid)) in
+                       let sigel = Sig_declare_typ(lid, univ_names, S.mk (Tm_arrow(binders, S.mk_Total typ)) (Ident.range_of_lid lid)) in
                        let se = {se with sigel=sigel; sigquals=Assumption::quals} in
                        BU.smap_add (sigmap env) (string_of_lid lid) (se, false)
                 | _ -> ())

--- a/src/syntax/FStar.Syntax.Embeddings.fs
+++ b/src/syntax/FStar.Syntax.Embeddings.fs
@@ -101,7 +101,6 @@ let lazy_embed (pa:printer<'a>) (et:emb_typ) rng ta (x:'a) (f:unit -> term) =
                         ltyp=S.tun;
                         rng=rng;
                         lkind=Lazy_embedding (et, thunk)}))
-               None
                rng
 
 let lazy_unembed (pa:printer<'a>) (et:emb_typ) (x:term) (ta:term) (f:term -> option<'a>) : option<'a> =
@@ -262,7 +261,6 @@ let e_string =
     let emb_t_string = ET_app(PC.string_lid |> Ident.string_of_lid, []) in
     let em (s:string) (rng:range) _topt _norm : term =
         S.mk (Tm_constant(FStar.Const.Const_string(s, rng)))
-             None
              rng
     in
     let un (t0:term) (w:bool) _norm : option<string> =
@@ -284,7 +282,7 @@ let e_string =
 let e_option (ea : embedding<'a>) =
     let t_option_a =
         let t_opt = U.fvar_const PC.option_lid in
-        S.mk_Tm_app t_opt [S.as_arg ea.typ] None Range.dummyRange
+        S.mk_Tm_app t_opt [S.as_arg ea.typ] Range.dummyRange
     in
     let emb_t_option_a =
         ET_app(PC.option_lid |> Ident.string_of_lid, [ea.emb_typ])
@@ -304,7 +302,7 @@ let e_option (ea : embedding<'a>) =
                 | None ->
                   S.mk_Tm_app (S.mk_Tm_uinst (S.tdataconstr PC.none_lid) [U_zero])
                               [S.iarg (type_of ea)]
-                              None rng
+                              rng
                 | Some a ->
                   let shadow_a = map_shadow topt (fun t ->
                     let v = Ident.mk_ident ("v", rng) in
@@ -312,12 +310,11 @@ let e_option (ea : embedding<'a>) =
                     let some_v_tm = S.fv_to_tm (lid_as_fv some_v delta_equational None) in
                     S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                                 [S.iarg (type_of ea); S.as_arg t]
-                                None
                                 rng)
                   in
                   S.mk_Tm_app (S.mk_Tm_uinst (S.tdataconstr PC.some_lid) [U_zero])
                               [S.iarg (type_of ea); S.as_arg (embed ea a rng shadow_a norm)]
-                              None rng)
+                              rng)
     in
     let un (t0:term) (w:bool) norm : option<option<'a>> =
         let t = U.unmeta_safe t0 in
@@ -348,7 +345,7 @@ let e_tuple2 (ea:embedding<'a>) (eb:embedding<'b>) =
     let t_pair_a_b =
         let t_tup2 = U.fvar_const PC.lid_tuple2 in
         S.mk_Tm_app t_tup2 [S.as_arg ea.typ; S.as_arg eb.typ]
-                    None Range.dummyRange
+                    Range.dummyRange
     in
     let emb_t_pair_a_b =
         ET_app(PC.lid_tuple2 |> Ident.string_of_lid, [ea.emb_typ; eb.emb_typ])
@@ -371,7 +368,6 @@ let e_tuple2 (ea:embedding<'a>) (eb:embedding<'b>) =
                                 [S.iarg (type_of ea);
                                  S.iarg (type_of eb);
                                  S.as_arg ab]
-                                None
                                 rng
                 in
                 let shadow_a = map_shadow topt (proj 1) in
@@ -381,7 +377,6 @@ let e_tuple2 (ea:embedding<'a>) (eb:embedding<'b>) =
                              S.iarg (type_of eb);
                              S.as_arg (embed ea (fst x) rng shadow_a norm);
                              S.as_arg (embed eb (snd x) rng shadow_b norm)]
-                            None
                             rng)
     in
     let un (t0:term) (w:bool) norm : option<('a * 'b)> =
@@ -414,7 +409,7 @@ let e_either (ea:embedding<'a>) (eb:embedding<'b>) =
     let t_sum_a_b =
         let t_either = U.fvar_const PC.either_lid in
         S.mk_Tm_app t_either [S.as_arg ea.typ; S.as_arg eb.typ]
-                    None Range.dummyRange
+                    Range.dummyRange
     in
     let emb_t_sum_a_b =
         ET_app(PC.either_lid |> Ident.string_of_lid, [ea.emb_typ; eb.emb_typ])
@@ -441,14 +436,12 @@ let e_either (ea:embedding<'a>) (eb:embedding<'b>) =
                   let some_v_tm = S.fv_to_tm (lid_as_fv some_v delta_equational None) in
                   S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                               [S.iarg (type_of ea); S.iarg (type_of eb); S.as_arg t]
-                              None
                               rng)
                 in
                 S.mk_Tm_app (S.mk_Tm_uinst (S.tdataconstr PC.inl_lid) [U_zero;U_zero])
                             [S.iarg (type_of ea);
                              S.iarg (type_of eb);
                              S.as_arg (embed ea a rng shadow_a norm)]
-                            None
                             rng)
              | BU.Inr b ->
                 (fun () ->
@@ -458,14 +451,12 @@ let e_either (ea:embedding<'a>) (eb:embedding<'b>) =
                   let some_v_tm = S.fv_to_tm (lid_as_fv some_v delta_equational None) in
                   S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                               [S.iarg (type_of ea); S.iarg (type_of eb); S.as_arg t]
-                              None
                               rng)
                 in
                 S.mk_Tm_app (S.mk_Tm_uinst (S.tdataconstr PC.inr_lid) [U_zero;U_zero])
                             [S.iarg (type_of ea);
                              S.iarg (type_of eb);
                              S.as_arg (embed eb b rng shadow_b norm)]
-                            None
                             rng)
              )
     in
@@ -500,7 +491,7 @@ let e_either (ea:embedding<'a>) (eb:embedding<'b>) =
 let e_list (ea:embedding<'a>) =
     let t_list_a =
         let t_list = U.fvar_const PC.list_lid in
-        S.mk_Tm_app t_list [S.as_arg ea.typ] None Range.dummyRange
+        S.mk_Tm_app t_list [S.as_arg ea.typ] Range.dummyRange
     in
     let emb_t_list_a =
         ET_app(PC.list_lid |> Ident.string_of_lid, [ea.emb_typ])
@@ -521,7 +512,6 @@ let e_list (ea:embedding<'a>) =
                 | [] ->
                   S.mk_Tm_app (S.mk_Tm_uinst (S.tdataconstr PC.nil_lid) [U_zero]) //NS: the universe here is bogus
                               [t]
-                              None
                               rng
                 | hd::tl ->
                   let cons =
@@ -534,7 +524,6 @@ let e_list (ea:embedding<'a>) =
                     S.mk_Tm_app (S.mk_Tm_uinst proj_tm [U_zero])
                                 [S.iarg (type_of ea);
                                  S.as_arg cons_tm]
-                                None
                                 rng
                   in
                   let shadow_hd = map_shadow shadow_l (proj "hd") in
@@ -543,7 +532,6 @@ let e_list (ea:embedding<'a>) =
                               [t;
                                S.as_arg (embed ea hd rng shadow_hd norm);
                                S.as_arg (em tl rng shadow_tl norm)]
-                              None
                               rng)
     in
     let rec un (t0:term) (w:bool) norm : option<list<'a>> =
@@ -644,13 +632,13 @@ let e_norm_step =
                     steps_Reify
                 | UnfoldOnly l ->
                     S.mk_Tm_app steps_UnfoldOnly [S.as_arg (embed (e_list e_string) l rng None norm)]
-                                None rng
+                                rng
                 | UnfoldFully l ->
                     S.mk_Tm_app steps_UnfoldFully [S.as_arg (embed (e_list e_string) l rng None norm)]
-                                None rng
+                                rng
                 | UnfoldAttr l ->
                     S.mk_Tm_app steps_UnfoldAttr [S.as_arg (embed (e_list e_string) l rng None norm)]
-                                None rng
+                                rng
                 )
     in
     let un (t0:term) (w:bool) norm : option<norm_step> =
@@ -706,7 +694,7 @@ let e_norm_step =
 
 let e_range =
     let em (r:range) (rng:range) _shadow _norm : term =
-        S.mk (Tm_constant (C.Const_range r)) None rng
+        S.mk (Tm_constant (C.Const_range r)) rng
     in
     let un (t0:term) (w:bool) _norm : option<range> =
         let t = U.unmeta_safe t0 in
@@ -733,7 +721,7 @@ let e_arrow (ea:embedding<'a>) (eb:embedding<'b>) : embedding<('a -> 'b)> =
     let t_arrow =
         S.mk (Tm_arrow([S.null_bv ea.typ, None],
                         S.mk_Total eb.typ))
-              None Range.dummyRange
+              Range.dummyRange
     in
     let emb_t_arr_a_b = ET_fun(ea.emb_typ, eb.emb_typ) in
     let printer (f:'a -> 'b) = "<fun>" in
@@ -785,7 +773,7 @@ let e_arrow (ea:embedding<'a>) (eb:embedding<'b>) : embedding<('a -> 'b)> =
                               (Print.term_to_string f)
                               (BU.stack_dump());
                     let a_tm = embed ea a f.pos None norm in
-                    let b_tm = norm (BU.Inr (S.mk_Tm_app f [S.as_arg a_tm] None f.pos)) in
+                    let b_tm = norm (BU.Inr (S.mk_Tm_app f [S.as_arg a_tm] f.pos)) in
                     match unembed eb b_tm w norm with
                     | None -> raise Unembedding_failure
                     | Some b -> b
@@ -811,7 +799,7 @@ let arrow_as_prim_step_1 (ea:embedding<'a>) (eb:embedding<'b>)
         let _tvar_args, rest_args = List.splitAt n_tvars args in
         let x, _ = List.hd rest_args in //arity mismatches are handled by code that dispatches here
         let shadow_app =
-            Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (BU.Inl fv_lid)) args None rng))
+            Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (BU.Inl fv_lid)) args rng))
         in
         match
             (BU.map_opt
@@ -832,7 +820,7 @@ let arrow_as_prim_step_2 (ea:embedding<'a>) (eb:embedding<'b>) (ec:embedding<'c>
         let x, _ = List.hd rest_args in //arity mismatches are handled by code that dispatches here
         let y, _ = List.hd (List.tl rest_args) in
         let shadow_app =
-            Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (BU.Inl fv_lid)) args None rng))
+            Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (BU.Inl fv_lid)) args rng))
         in
         match
             (BU.bind_opt (unembed ea x true norm) (fun x ->
@@ -855,7 +843,7 @@ let arrow_as_prim_step_3 (ea:embedding<'a>) (eb:embedding<'b>)
         let y, _ = List.hd (List.tl rest_args) in
         let z, _ = List.hd (List.tl (List.tl rest_args)) in
         let shadow_app =
-            Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (BU.Inl fv_lid)) args None rng))
+            Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (BU.Inl fv_lid)) args rng))
         in
         match
             (BU.bind_opt (unembed ea x true norm) (fun x ->

--- a/src/syntax/FStar.Syntax.InstFV.fs
+++ b/src/syntax/FStar.Syntax.InstFV.fs
@@ -28,7 +28,7 @@ type inst_t = list<(lident * universes)>
 
 
 
-let mk t s = S.mk s None t.pos
+let mk t s = S.mk s t.pos
 
 let rec inst (s:term -> fv -> term) t =
     let t = SS.compress t in

--- a/src/syntax/FStar.Syntax.Print.fs
+++ b/src/syntax/FStar.Syntax.Print.fs
@@ -759,7 +759,7 @@ let rec sigelt_to_string (x: sigelt) =
       | Sig_sub_effect (se) -> sub_eff_to_string se
       | Sig_effect_abbrev(l, univs, tps, c, flags) ->
         if (Options.print_universes())
-        then let univs, t = Subst.open_univ_vars univs (mk (Tm_arrow(tps, c)) None Range.dummyRange) in
+        then let univs, t = Subst.open_univ_vars univs (mk (Tm_arrow(tps, c)) Range.dummyRange) in
              let tps, c = match (Subst.compress t).n with
                 | Tm_arrow(bs, c) -> bs, c
                 | _ -> failwith "impossible" in

--- a/src/syntax/FStar.Syntax.Resugar.fs
+++ b/src/syntax/FStar.Syntax.Resugar.fs
@@ -1307,7 +1307,7 @@ let resugar_sigelt' env se : option<A.decl> =
     if (se.sigquals |> BU.for_some (function S.Projector(_,_) | S.Discriminator _ -> true | _ -> false)) then
       None
     else
-      let mk e = S.mk e None se.sigrng in
+      let mk e = S.mk e se.sigrng in
       let dummy = mk Tm_unknown in
       let desugared_let = mk (Tm_let(lbs, dummy)) in
       let t = resugar_term' env desugared_let in

--- a/src/syntax/FStar.Syntax.Subst.fs
+++ b/src/syntax/FStar.Syntax.Subst.fs
@@ -218,7 +218,7 @@ let rec subst' (s:subst_ts) t =
         apply_until_some_then_map (subst_nm a) (fst s) subst_tail t0
 
     | Tm_type u ->
-        mk (Tm_type (subst_univ (fst s) u)) None (mk_range t0.pos s)
+        mk (Tm_type (subst_univ (fst s) u)) (mk_range t0.pos s)
 
     | _ ->
       //NS: 04/12/2018
@@ -341,7 +341,7 @@ let compose_uvar_subst (u:ctx_uvar) (s0:subst_ts) (s:subst_ts) : subst_ts =
 
 let rec push_subst s t =
     //makes a syntax node, setting it's use range as appropriate from s
-    let mk t' = Syntax.mk t' None (mk_range t.pos s) in
+    let mk t' = Syntax.mk t' (mk_range t.pos s) in
     match t.n with
     | Tm_delayed _ -> failwith "Impossible"
 

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -514,8 +514,6 @@ val mod_name: modul -> lident
 
 type path = list<string>
 type subst_t = list<subst_elt>
-type mk_t_a<'a> = option<unit> -> range -> syntax<'a>
-type mk_t = mk_t_a<term'>
 
 val contains_reflectable:  list<qualifier> -> bool
 
@@ -523,22 +521,22 @@ val withsort: 'a -> withinfo_t<'a>
 val withinfo: 'a -> Range.range -> withinfo_t<'a>
 
 (* Constructors for each term form; NO HASH CONSING; just makes all the auxiliary data at each node *)
-val mk: 'a -> Tot<mk_t_a<'a>>
+val mk: 'a -> range -> syntax<'a>
 
 val mk_lb :         (lbname * list<univ_name> * lident * typ * term * list<attribute> * range) -> letbinding
 val default_sigmeta: sig_metadata
 val mk_sigelt:      sigelt' -> sigelt // FIXME check uses
-val mk_Tm_app:      term -> args -> Tot<mk_t>
+val mk_Tm_app:      term -> args -> range -> term
 
-(* This raise an exception if the term is not a Tm_fvar,
+(* This raises an exception if the term is not a Tm_fvar,
  * use with care. It has to be an Tm_fvar *immediately*,
  * there is no solving of Tm_delayed nor Tm_uvar. If it's
  * possible that it is not a Tm_fvar, which can be the case
  * for non-typechecked terms, just use `mk`. *)
 val mk_Tm_uinst:    term -> universes -> term
 
-val extend_app:     term -> arg -> Tot<mk_t>
-val extend_app_n:   term -> args -> Tot<mk_t>
+val extend_app:     term -> arg -> range -> term
+val extend_app_n:   term -> args -> range -> term
 val mk_Tm_delayed:  (term * subst_ts) -> Range.range -> term
 val mk_Total:       typ -> comp
 val mk_GTotal:      typ -> comp

--- a/src/syntax/FStar.Syntax.Util.fs
+++ b/src/syntax/FStar.Syntax.Util.fs
@@ -77,7 +77,7 @@ let name_binders binders =
             else b)
 
 let name_function_binders t = match t.n with
-    | Tm_arrow(binders, comp) -> mk (Tm_arrow(name_binders binders, comp)) None t.pos
+    | Tm_arrow(binders, comp) -> mk (Tm_arrow(name_binders binders, comp)) t.pos
     | _ -> t
 
 let null_binders_of_tks (tks:list<(typ * aqual)>) : binders =
@@ -403,7 +403,7 @@ let rec unascribe e =
 
 let rec ascribe t k = match t.n with
   | Tm_ascribed (t', _, _) -> ascribe t' k
-  | _ -> mk (Tm_ascribed(t, k, None)) None t.pos
+  | _ -> mk (Tm_ascribed(t, k, None)) t.pos
 
 let unfold_lazy i = must !lazy_chooser i.lkind i
 
@@ -452,11 +452,11 @@ let mk_lazy (t : 'a) (typ : typ) (k : lazy_kind) (r : option<range>) : term =
         ltyp   = typ;
         rng   = rng;
       } in
-    mk (Tm_lazy i) None rng
+    mk (Tm_lazy i) rng
 
 let canon_app t =
     let hd, args = head_and_args' (unascribe t) in
-    mk_Tm_app hd args None t.pos
+    mk_Tm_app hd args t.pos
 
 (* ---------------------------------------------------------------------- *)
 (* <eq_tm> Syntactic equality of zero-order terms                         *)
@@ -754,7 +754,7 @@ let mk_app f args =
   | [] -> f
   | _ ->
       let r = range_of_args args f.pos in
-      mk (Tm_app(f, args)) None r
+      mk (Tm_app(f, args)) r
 
 let mk_app_binders f bs =
     mk_app f (List.map (fun (bv, aq) -> (bv_to_name bv, aq)) bs)
@@ -845,13 +845,13 @@ let abs bs t lopt =
     let body = compress (Subst.close bs t) in
     match body.n with
         | Tm_abs(bs', t, lopt') ->  //AR: if the body is an Tm_abs, we can combine the binders and use lopt', ignoring lopt, since lopt will be Tot (non-informative anyway)
-          mk (Tm_abs(close_binders bs@bs', t, close_lopt lopt')) None t.pos
+          mk (Tm_abs(close_binders bs@bs', t, close_lopt lopt')) t.pos
         | _ ->
-          mk (Tm_abs(close_binders bs, body, close_lopt lopt)) None t.pos
+          mk (Tm_abs(close_binders bs, body, close_lopt lopt)) t.pos
 
 let arrow bs c = match bs with
   | [] -> comp_result c
-  | _ -> mk (Tm_arrow(close_binders bs, Subst.close_comp bs c)) None c.pos
+  | _ -> mk (Tm_arrow(close_binders bs, Subst.close_comp bs c)) c.pos
 
 let flat_arrow bs c =
   let t = arrow bs c in
@@ -860,7 +860,7 @@ let flat_arrow bs c =
     begin match c.n with
         | Total (tres, _) ->
           begin match (Subst.compress tres).n with
-               | Tm_arrow(bs', c') -> mk (Tm_arrow(bs@bs', c')) None t.pos
+               | Tm_arrow(bs', c') -> mk (Tm_arrow(bs@bs', c')) t.pos
                | _ -> t
           end
         | _ -> t
@@ -878,7 +878,7 @@ let rec canon_arrow t =
       flat_arrow bs c
   | _ -> t
 
-let refine b t = mk (Tm_refine(b, Subst.close [mk_binder b] t)) None (Range.union_ranges (range_of_bv b) t.pos)
+let refine b t = mk (Tm_refine(b, Subst.close [mk_binder b] t)) (Range.union_ranges (range_of_bv b) t.pos)
 let branch b = Subst.close_branch b
 
 (*
@@ -989,7 +989,7 @@ let remove_inacc (t:term) : term =
     let bs, c = arrow_formals_comp_ln t in
     match bs with
     | [] -> t
-    | _ -> mk (Tm_arrow (List.map no_acc bs, c)) None t.pos
+    | _ -> mk (Tm_arrow (List.map no_acc bs, c)) t.pos
 
 let mk_letbinding (lbname : either<bv,fv>) univ_vars typ eff def lbattrs pos =
     {lbname=lbname;
@@ -1090,13 +1090,13 @@ let is_builtin_tactic md =
 (*********************** Constructors of common terms  **************************)
 (********************************************************************************)
 
-let ktype  : term = mk (Tm_type(U_unknown)) None dummyRange
-let ktype0 : term = mk (Tm_type(U_zero)) None dummyRange
+let ktype  : term = mk (Tm_type(U_unknown)) dummyRange
+let ktype0 : term = mk (Tm_type(U_zero)) dummyRange
 
 //Type(u), where u is a new universe unification variable
 let type_u () : typ * universe =
     let u = U_unif <| Unionfind.univ_fresh Range.dummyRange in
-    mk (Tm_type u) None dummyRange, u
+    mk (Tm_type u) dummyRange, u
 
 // works on anything, really
 let attr_eq a a' =
@@ -1108,16 +1108,15 @@ let attr_substitute =
     mk (Tm_fvar (lid_as_fv (lid_of_path ["FStar"; "Pervasives"; "Substitute"] Range.dummyRange)
                            delta_constant
                            None))
-       None
        Range.dummyRange
 
-let exp_true_bool : term = mk (Tm_constant (Const_bool true)) None dummyRange
-let exp_false_bool : term = mk (Tm_constant (Const_bool false)) None dummyRange
-let exp_unit : term = mk (Tm_constant (Const_unit)) None dummyRange
+let exp_true_bool : term = mk (Tm_constant (Const_bool true)) dummyRange
+let exp_false_bool : term = mk (Tm_constant (Const_bool false)) dummyRange
+let exp_unit : term = mk (Tm_constant (Const_unit)) dummyRange
 (* Makes an (unbounded) integer from its string repr. *)
-let exp_int s : term = mk (Tm_constant (Const_int (s,None))) None dummyRange
-let exp_char c : term = mk (Tm_constant (Const_char c)) None dummyRange
-let exp_string s : term = mk (Tm_constant (Const_string (s, dummyRange))) None dummyRange
+let exp_int s : term = mk (Tm_constant (Const_int (s,None))) dummyRange
+let exp_char c : term = mk (Tm_constant (Const_char c)) dummyRange
+let exp_string s : term = mk (Tm_constant (Const_string (s, dummyRange))) dummyRange
 
 let fvar_const l = fvar l delta_constant None
 let tand    = fvar_const PC.and_lid
@@ -1140,9 +1139,9 @@ let t_ctx_uvar_and_sust = fvar_const PC.ctx_uvar_and_subst_lid
 
 let mk_conj_opt phi1 phi2 = match phi1 with
   | None -> Some phi2
-  | Some phi1 -> Some (mk (Tm_app(tand, [as_arg phi1; as_arg phi2])) None (Range.union_ranges phi1.pos phi2.pos))
-let mk_binop op_t phi1 phi2 = mk (Tm_app(op_t, [as_arg phi1; as_arg phi2])) None (Range.union_ranges phi1.pos phi2.pos)
-let mk_neg phi = mk (Tm_app(t_not, [as_arg phi])) None phi.pos
+  | Some phi1 -> Some (mk (Tm_app(tand, [as_arg phi1; as_arg phi2])) (Range.union_ranges phi1.pos phi2.pos))
+let mk_binop op_t phi1 phi2 = mk (Tm_app(op_t, [as_arg phi1; as_arg phi2])) (Range.union_ranges phi1.pos phi2.pos)
+let mk_neg phi = mk (Tm_app(t_not, [as_arg phi])) phi.pos
 let mk_conj phi1 phi2 = mk_binop tand phi1 phi2
 let mk_conj_l phi = match phi with
     | [] -> fvar PC.true_lid delta_constant None //NS delta: wrong, see a t_true
@@ -1153,7 +1152,7 @@ let mk_disj_l phi = match phi with
     | hd::tl -> List.fold_right mk_disj tl hd
 let mk_imp phi1 phi2 : term = mk_binop timp phi1 phi2
 let mk_iff phi1 phi2 : term = mk_binop tiff phi1 phi2
-let b2t e = mk (Tm_app(b2t_v, [as_arg e])) None e.pos//implicitly coerce a boolean to a type
+let b2t e = mk (Tm_app(b2t_v, [as_arg e])) e.pos//implicitly coerce a boolean to a type
 let unb2t (e:term) : option<term> =
     let hd, args = head_and_args e in
     match (compress hd).n, args with
@@ -1174,23 +1173,23 @@ let mk_disj_simp t1 t2 =
     else mk_disj t1 t2
 
 let teq = fvar_const PC.eq2_lid
-let mk_untyped_eq2 e1 e2 = mk (Tm_app(teq, [as_arg e1; as_arg e2])) None (Range.union_ranges e1.pos e2.pos)
+let mk_untyped_eq2 e1 e2 = mk (Tm_app(teq, [as_arg e1; as_arg e2])) (Range.union_ranges e1.pos e2.pos)
 let mk_eq2 (u:universe) (t:typ) (e1:term) (e2:term) : term =
     let eq_inst = mk_Tm_uinst teq [u] in
-    mk (Tm_app(eq_inst, [iarg t; as_arg e1; as_arg e2])) None (Range.union_ranges e1.pos e2.pos)
+    mk (Tm_app(eq_inst, [iarg t; as_arg e1; as_arg e2])) (Range.union_ranges e1.pos e2.pos)
 
 let mk_has_type t x t' =
     let t_has_type = fvar_const PC.has_type_lid in //TODO: Fix the U_zeroes below!
-    let t_has_type = mk (Tm_uinst(t_has_type, [U_zero; U_zero])) None dummyRange in
-    mk (Tm_app(t_has_type, [iarg t; as_arg x; as_arg t'])) None dummyRange
+    let t_has_type = mk (Tm_uinst(t_has_type, [U_zero; U_zero])) dummyRange in
+    mk (Tm_app(t_has_type, [iarg t; as_arg x; as_arg t'])) dummyRange
 
 let mk_with_type u t e =
     let t_with_type = fvar PC.with_type_lid delta_equational None in
-    let t_with_type = mk (Tm_uinst(t_with_type, [u])) None dummyRange in
-    mk (Tm_app(t_with_type, [iarg t; as_arg e])) None dummyRange
+    let t_with_type = mk (Tm_uinst(t_with_type, [u])) dummyRange in
+    mk (Tm_app(t_with_type, [iarg t; as_arg e])) dummyRange
 
 let lex_t    = fvar_const PC.lex_t_lid
-let lex_top :term = mk (Tm_uinst (fvar PC.lextop_lid delta_constant (Some Data_ctor), [U_zero])) None dummyRange //NS delta: ok
+let lex_top :term = mk (Tm_uinst (fvar PC.lextop_lid delta_constant (Some Data_ctor), [U_zero])) dummyRange //NS delta: ok
 let lex_pair = fvar PC.lexcons_lid delta_constant (Some Data_ctor) //NS delta: ok
 let tforall  = fvar PC.forall_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
 let t_haseq   = fvar PC.haseq_lid delta_constant None //NS delta: wrong Delta_abstract (Delta_constant_at_level 0)?
@@ -1213,7 +1212,7 @@ let residual_comp_of_comp (c:comp) = {
 
 let mk_forall_aux fa x body =
   mk (Tm_app(fa, [ iarg (x.sort);
-                   as_arg (abs [mk_binder x] body (Some (residual_tot ktype0)))])) None dummyRange
+                   as_arg (abs [mk_binder x] body (Some (residual_tot ktype0)))])) dummyRange
 
 let mk_forall_no_univ (x:bv) (body:typ) : typ =
   mk_forall_aux tforall x body
@@ -1233,7 +1232,7 @@ let is_wild_pat p =
 let if_then_else b t1 t2 =
     let then_branch = (withinfo (Pat_constant (Const_bool true)) t1.pos, None, t1) in
     let else_branch = (withinfo (Pat_constant (Const_bool false)) t2.pos, None, t2) in
-    mk (Tm_match(b, [then_branch; else_branch])) None (Range.union_ranges b.pos (Range.union_ranges t1.pos t2.pos))
+    mk (Tm_match(b, [then_branch; else_branch])) (Range.union_ranges b.pos (Range.union_ranges t1.pos t2.pos))
 
 //////////////////////////////////////////////////////////////////////////////////////
 // Operations on squashed and other irrelevant/sub-singleton types
@@ -1520,12 +1519,12 @@ let action_as_lb eff_lid a pos =
 
 (* Some reification utilities *)
 let mk_reify t =
-    let reify_ = mk (Tm_constant(FStar.Const.Const_reify)) None t.pos in
-    mk (Tm_app(reify_, [as_arg t])) None t.pos
+    let reify_ = mk (Tm_constant(FStar.Const.Const_reify)) t.pos in
+    mk (Tm_app(reify_, [as_arg t])) t.pos
 
 let mk_reflect t =
-    let reflect_ = mk (Tm_constant(FStar.Const.Const_reflect (Ident.lid_of_str "Bogus.Effect"))) None t.pos in
-    mk (Tm_app(reflect_, [as_arg t])) None t.pos
+    let reflect_ = mk (Tm_constant(FStar.Const.Const_reflect (Ident.lid_of_str "Bogus.Effect"))) t.pos in
+    mk (Tm_app(reflect_, [as_arg t])) t.pos
 
 (* Some utilities for clients who wish to build top-level bindings and keep
  * their delta-qualifiers correct (e.g. dmff). *)
@@ -1575,9 +1574,9 @@ let dm4f_lid ed name : lident =
     lid_of_path p' Range.dummyRange
 
 let mk_list (typ:term) (rng:range) (l:list<term>) : term =
-    let ctor l = mk (Tm_fvar (lid_as_fv l delta_constant (Some Data_ctor))) None rng in
-    let cons args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.cons_lid) [U_zero]) args None pos in
-    let nil  args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.nil_lid)  [U_zero]) args None pos in
+    let ctor l = mk (Tm_fvar (lid_as_fv l delta_constant (Some Data_ctor))) rng in
+    let cons args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.cons_lid) [U_zero]) args pos in
+    let nil  args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.nil_lid)  [U_zero]) args pos in
     List.fold_right (fun t a -> cons [iarg typ; as_arg t; as_arg a] t.pos) l (nil [iarg typ] rng)
 
 // Some generic equalities
@@ -2080,7 +2079,7 @@ let smt_lemma_as_forall (t:term) (universe_of_binders: binders -> list<universe>
     in
     (* Postcondition is thunked, c.f. #57 *)
     let post = unthunk_lemma_post post in
-    let body = mk (Tm_meta (mk_imp pre post, Meta_pattern (binders_to_names binders, patterns))) None t.pos in
+    let body = mk (Tm_meta (mk_imp pre post, Meta_pattern (binders_to_names binders, patterns))) t.pos in
     let quant =
       List.fold_right2
         (fun b u out -> mk_forall u (fst b) out)

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -499,7 +499,7 @@ let intro_rec () : tac<(binder * binder)> =
              let lb = U.mk_letbinding (Inl bv) [] (goal_type goal) PC.effect_Tot_lid (U.abs [b] u None) [] Range.dummyRange in
              let body = S.bv_to_name bv in
              let lbs, body = SS.close_let_rec [lb] body in
-             let tm = mk (Tm_let ((true, lbs), body)) None (goal_witness goal).pos in
+             let tm = mk (Tm_let ((true, lbs), body)) (goal_witness goal).pos in
              bind (set_solution goal tm) (fun () ->
              bind (replace_cur (bnorm_goal ({ goal with goal_ctx_uvar=ctx_uvar_u}))) (fun _ ->
              ret (S.mk_binder bv, b))))
@@ -972,7 +972,7 @@ let revert () : tac<unit> =
     | Some (x, env') ->
         let typ' = U.arrow [(x, None)] (mk_Total (goal_type goal)) in
         bind (new_uvar "revert" env' typ') (fun (r, u_r) ->
-        bind (set_solution goal (S.mk_Tm_app r [S.as_arg (S.bv_to_name x)] None (goal_type goal).pos)) (fun () ->
+        bind (set_solution goal (S.mk_Tm_app r [S.as_arg (S.bv_to_name x)] (goal_type goal).pos)) (fun () ->
         let g = mk_goal env' u_r goal.opts goal.is_guard goal.label in
         replace_cur g)))
 
@@ -1366,7 +1366,7 @@ let t_destruct (s_tm : term) : tac<list<(fv * Z.t)>> = wrap_err "destruct" <|
                         fail "impossible: not a ctor")
                  c_lids) (fun goal_brs ->
       let goals, brs, infos = List.unzip3 goal_brs in
-      let w = mk (Tm_match (s_tm, brs)) None s_tm.pos in
+      let w = mk (Tm_match (s_tm, brs)) s_tm.pos in
       bind (solve' g w) (fun () ->
       bind (add_goals goals) (fun () ->
       ret infos)))))
@@ -1413,7 +1413,7 @@ let rec inspect (t:term) : tac<term_view> = wrap_err "inspect" (
         // expose n-ary lambdas buy unary ones.
         let (a, q) = last args in
         let q' = inspect_aqual q in
-        ret <| Tv_App (S.mk_Tm_app hd (init args) None t.pos, (a, q')) // TODO: The range and tk are probably wrong. Fix
+        ret <| Tv_App (S.mk_Tm_app hd (init args) t.pos, (a, q')) // TODO: The range and tk are probably wrong. Fix
 
     | Tm_abs ([], _, _) ->
         failwith "empty arguments on Tm_abs"
@@ -1533,19 +1533,19 @@ let pack (tv:term_view) : tac<term> =
         ret <| U.refine bv t
 
     | Tv_Const c ->
-        ret <| S.mk (Tm_constant (pack_const c)) None Range.dummyRange
+        ret <| S.mk (Tm_constant (pack_const c)) Range.dummyRange
 
     | Tv_Uvar (_u, ctx_u_s) ->
-        ret <| S.mk (Tm_uvar ctx_u_s) None Range.dummyRange
+        ret <| S.mk (Tm_uvar ctx_u_s) Range.dummyRange
 
     | Tv_Let (false, attrs, bv, t1, t2) ->
         let lb = U.mk_letbinding (BU.Inl bv) [] bv.sort PC.effect_Tot_lid t1 attrs Range.dummyRange in
-        ret <| S.mk (Tm_let ((false, [lb]), SS.close [S.mk_binder bv] t2)) None Range.dummyRange
+        ret <| S.mk (Tm_let ((false, [lb]), SS.close [S.mk_binder bv] t2)) Range.dummyRange
 
     | Tv_Let (true, attrs, bv, t1, t2) ->
         let lb = U.mk_letbinding (BU.Inl bv) [] bv.sort PC.effect_Tot_lid t1 attrs Range.dummyRange in
         let lbs, body = SS.close_let_rec [lb] t2 in
-        ret <| S.mk (Tm_let ((true, lbs), body)) None Range.dummyRange
+        ret <| S.mk (Tm_let ((true, lbs), body)) Range.dummyRange
 
     | Tv_Match (t, brs) ->
         let wrap v = {v=v;p=Range.dummyRange} in
@@ -1559,16 +1559,16 @@ let pack (tv:term_view) : tac<term> =
         in
         let brs = List.map (function (pat, t) -> (pack_pat pat, None, t)) brs in
         let brs = List.map SS.close_branch brs in
-        ret <| S.mk (Tm_match (t, brs)) None Range.dummyRange
+        ret <| S.mk (Tm_match (t, brs)) Range.dummyRange
 
     | Tv_AscribedT(e, t, tacopt) ->
-        ret <| S.mk (Tm_ascribed(e, (BU.Inl t, tacopt), None)) None Range.dummyRange
+        ret <| S.mk (Tm_ascribed(e, (BU.Inl t, tacopt), None)) Range.dummyRange
 
     | Tv_AscribedC(e, c, tacopt) ->
-        ret <| S.mk (Tm_ascribed(e, (BU.Inr c, tacopt), None)) None Range.dummyRange
+        ret <| S.mk (Tm_ascribed(e, (BU.Inr c, tacopt), None)) Range.dummyRange
 
     | Tv_Unknown ->
-        ret <| S.mk Tm_unknown None Range.dummyRange
+        ret <| S.mk Tm_unknown Range.dummyRange
 
 let lget (ty:term) (k:string) : tac<term> = wrap_err "lget" <|
     bind get (fun ps ->

--- a/src/tactics/FStar.Tactics.Embedding.fs
+++ b/src/tactics/FStar.Tactics.Embedding.fs
@@ -206,14 +206,14 @@ let e_exn : embedding<exn> =
         | TacticFailure s ->
             S.mk_Tm_app fstar_tactics_TacticFailure.t
                 [S.as_arg (embed e_string rng s)]
-                None rng
+                rng
         | EExn t ->
             { t with pos = rng }
         | e ->
             let s = "uncaught exception: " ^ (BU.message_of_exn e) in
             S.mk_Tm_app fstar_tactics_TacticFailure.t
                 [S.as_arg (embed e_string rng s)]
-                None rng
+                rng
     in
     let unembed_exn (t:term) w _ : option<exn> =
         match hd'_and_args t with
@@ -266,13 +266,13 @@ let e_result (ea : embedding<'a>)  =
                  [S.iarg (type_of ea);
                   S.as_arg (embed ea rng a);
                   S.as_arg (embed e_proofstate rng ps)]
-                 None rng
+                 rng
         | Failed (e, ps) ->
           S.mk_Tm_app (S.mk_Tm_uinst fstar_tactics_Failed.t [U_zero])
                  [S.iarg (type_of ea);
                   S.as_arg (embed e_exn rng e);
                   S.as_arg (embed e_proofstate rng ps)]
-                 None rng
+                 rng
     in
     let unembed_result (t:term) w _ : option<__result<'a>> =
         match hd'_and_args t with

--- a/src/tactics/FStar.Tactics.Hooks.fs
+++ b/src/tactics/FStar.Tactics.Hooks.fs
@@ -289,7 +289,7 @@ let preprocess (env:Env.env) (goal:term) : list<(Env.env * term * O.optionstate)
 let synthesize (env:Env.env) (typ:typ) (tau:term) : term =
     // Don't run the tactic (and end with a magic) when nosynth is set, cf. issue #73 in fstar-mode.el
     if env.nosynth
-    then mk_Tm_app (TcUtil.fvar_const env PC.magic_lid) [S.as_arg U.exp_unit] None typ.pos
+    then mk_Tm_app (TcUtil.fvar_const env PC.magic_lid) [S.as_arg U.exp_unit] typ.pos
     else begin
     tacdbg := Env.debug env (O.Other "Tac");
 

--- a/src/tactics/FStar.Tactics.Interpreter.fs
+++ b/src/tactics/FStar.Tactics.Interpreter.fs
@@ -83,7 +83,6 @@ let unembed_tactic_0 (eb:embedding<'b>) (embedded_tac_b:term) (ncb:norm_cb) : ta
 
     let tm = S.mk_Tm_app embedded_tac_b
                          [S.as_arg (embed E.e_proofstate rng proof_state ncb)]
-                          None
                           rng in
 
 
@@ -142,7 +141,7 @@ let unembed_tactic_1 (ea:embedding<'a>) (er:embedding<'r>) (f:term) (ncb:norm_cb
     fun x ->
       let rng = FStar.Range.dummyRange  in
       let x_tm = embed ea rng x ncb in
-      let app = S.mk_Tm_app f [as_arg x_tm] None rng in
+      let app = S.mk_Tm_app f [as_arg x_tm] rng in
       unembed_tactic_0 er app ncb
 
 let unembed_tactic_nbe_1 (ea:NBET.embedding<'a>) (er:NBET.embedding<'r>) (cb:NBET.nbe_cbs) (f:NBET.t) : 'a -> tac<'r> =
@@ -452,7 +451,7 @@ let unembed_tactic_1_alt (ea:embedding<'a>) (er:embedding<'r>) (f:term) (ncb:nor
     Some (fun x ->
       let rng = FStar.Range.dummyRange  in
       let x_tm = embed ea rng x ncb in
-      let app = S.mk_Tm_app f [as_arg x_tm] None rng in
+      let app = S.mk_Tm_app f [as_arg x_tm] rng in
       unembed_tactic_0 er app ncb)
 
 let e_tactic_1_alt (ea: embedding<'a>) (er:embedding<'r>): embedding<('a -> (proofstate -> __result<'r>))> =

--- a/src/tactics/FStar.Tactics.Types.fs
+++ b/src/tactics/FStar.Tactics.Types.fs
@@ -37,7 +37,7 @@ type goal = {
 }
 let goal_env g = g.goal_main_env
 let goal_witness g =
-    FStar.Syntax.Syntax.mk (Tm_uvar (g.goal_ctx_uvar, ([], NoUseRange))) None Range.dummyRange
+    FStar.Syntax.Syntax.mk (Tm_uvar (g.goal_ctx_uvar, ([], NoUseRange))) Range.dummyRange
 let goal_type g = g.goal_ctx_uvar.ctx_uvar_typ
 
 let goal_with_type g t =

--- a/src/tests/FStar.Tests.Norm.fs
+++ b/src/tests/FStar.Tests.Norm.fs
@@ -41,28 +41,28 @@ let let_ x e e' : term = app (U.abs [b x] e' None) [e]
 let mk_let x e e' : term =
     let e' = FStar.Syntax.Subst.subst [NM(x, 0)] e' in
     mk (Tm_let((false, [{lbname=BU.Inl x; lbunivs=[]; lbtyp=tun; lbdef=e; lbeff=Const.effect_Tot_lid; lbattrs=[];lbpos=dummyRange}]), e'))
-                           None dummyRange
+                           dummyRange
 
 let lid x = lid_of_path ["Test"; x] dummyRange
 let znat_l = S.lid_as_fv (lid "Z") delta_constant (Some Data_ctor)
 let snat_l = S.lid_as_fv (lid "S") delta_constant (Some Data_ctor)
-let tm_fv fv = mk (Tm_fvar fv) None dummyRange
+let tm_fv fv = mk (Tm_fvar fv) dummyRange
 let znat : term = tm_fv znat_l
-let snat s      = mk (Tm_app(tm_fv snat_l, [as_arg s])) None dummyRange
+let snat s      = mk (Tm_app(tm_fv snat_l, [as_arg s])) dummyRange
 let pat p = withinfo p dummyRange
 let snat_type = tm_fv (S.lid_as_fv (lid "snat") delta_constant None)
 open FStar.Syntax.Subst
 module SS=FStar.Syntax.Subst
 let mk_match h branches =
     let branches = branches |> List.map U.branch in
-    mk (Tm_match(h, branches)) None dummyRange
+    mk (Tm_match(h, branches)) dummyRange
 let pred_nat s  =
     let zbranch = pat (Pat_cons(znat_l, [])),
                   None,
                   znat in
     let sbranch = pat (Pat_cons(snat_l, [pat (Pat_var x), false])),
                   None,
-                  mk (Tm_bvar({x with index=0})) None dummyRange in
+                  mk (Tm_bvar({x with index=0})) dummyRange in
     mk_match s [zbranch;sbranch]
 let minus_nat t1 t2 =
     let minus = m in
@@ -77,7 +77,7 @@ let minus_nat t1 t2 =
     let lb = {lbname=BU.Inl minus; lbeff=lid_of_path ["Pure"] dummyRange; lbunivs=[]; lbtyp=tun;
               lbdef=subst [NM(minus, 0)] (U.abs [b x; b y] (mk_match (nm y) [zbranch; sbranch]) None);
               lbattrs=[]; lbpos=dummyRange} in
-    mk (Tm_let((true, [lb]), subst [NM(minus, 0)] (app (nm minus) [t1; t2]))) None dummyRange
+    mk (Tm_let((true, [lb]), subst [NM(minus, 0)] (app (nm minus) [t1; t2]))) dummyRange
 let encode_nat n =
     let rec aux out n =
         if n=0 then out

--- a/src/tests/FStar.Tests.Util.fs
+++ b/src/tests/FStar.Tests.Util.fs
@@ -28,9 +28,9 @@ let y = gen_bv "y" None S.tun
 let n = gen_bv "n" None S.tun
 let h = gen_bv "h" None S.tun
 let m = gen_bv "m" None S.tun
-let tm t = mk t None dummyRange
+let tm t = mk t dummyRange
 let nm x = bv_to_name x
-let app x ts = mk (Tm_app(x, List.map as_arg ts)) None dummyRange
+let app x ts = mk (Tm_app(x, List.map as_arg ts)) dummyRange
 
 let rec term_eq' t1 t2 =
     let t1 = SS.compress t1 in
@@ -62,10 +62,10 @@ let rec term_eq' t1 t2 =
       | Tm_abs(xs, t, _), Tm_abs(ys, u, _) ->
         if List.length xs > List.length ys
         then let xs, xs' = BU.first_N (List.length ys) xs in
-             let t1 = mk (Tm_abs(xs, mk (Tm_abs(xs', t, None)) None t1.pos, None)) None t1.pos in
+             let t1 = mk (Tm_abs(xs, mk (Tm_abs(xs', t, None)) t1.pos, None)) t1.pos in
              term_eq' t1 t2
         else let ys, ys' = BU.first_N (List.length xs) ys in
-             let t2 = mk (Tm_abs(ys, mk (Tm_abs(ys', u, None)) None t2.pos, None)) None t2.pos in
+             let t2 = mk (Tm_abs(ys, mk (Tm_abs(ys', u, None)) t2.pos, None)) t2.pos in
              term_eq' t1 t2
       | Tm_arrow(xs, c), Tm_arrow(ys, d) -> binders_eq xs ys && comp_eq c d
       | Tm_refine(x, t), Tm_refine(y, u) -> term_eq' x.sort y.sort && term_eq' t u

--- a/src/typechecker/FStar.TypeChecker.Cfg.fs
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fs
@@ -297,7 +297,6 @@ let embed_simple (emb:EMB.embedding<'a>) (r:Range.range) (x:'a) : term =
     EMB.embed emb x r None EMB.id_norm_cb
 let try_unembed_simple (emb:EMB.embedding<'a>) (x:term) : option<'a> =
     EMB.unembed emb x false EMB.id_norm_cb
-let mk t r = mk t None r
 let built_in_primitive_steps : prim_step_set =
     let arg_as_int    (a:arg) = fst a |> try_unembed_simple EMB.e_int in
     let arg_as_bool   (a:arg) = fst a |> try_unembed_simple EMB.e_bool in
@@ -737,7 +736,7 @@ let built_in_primitive_steps : prim_step_set =
         let int_as_bounded r int_to_t n =
             let c = embed_simple EMB.e_int r n in
             let int_to_t = S.fv_to_tm int_to_t in
-            S.mk_Tm_app int_to_t [S.as_arg c] None r
+            S.mk_Tm_app int_to_t [S.as_arg c] r
         in
         let add_sub_mul_v =
           (bounded_signed_int_types @ bounded_unsigned_int_types)

--- a/src/typechecker/FStar.TypeChecker.Common.fs
+++ b/src/typechecker/FStar.TypeChecker.Common.fs
@@ -80,7 +80,7 @@ module C = FStar.Parser.Const
 
 let mk_by_tactic tac f =
     let t_by_tactic = S.mk_Tm_uinst (tabbrev C.by_tactic_lid) [U_zero] in
-    S.mk_Tm_app t_by_tactic [S.as_arg tac; S.as_arg f] None Range.dummyRange
+    S.mk_Tm_app t_by_tactic [S.as_arg tac; S.as_arg f] Range.dummyRange
 
 let rec delta_depth_greater_than l m = match l, m with
     | Delta_equational_at_level i, Delta_equational_at_level j -> i > j
@@ -463,7 +463,7 @@ let simplify (debug:bool) (tm:term) : term =
         in
         let head, args = U.head_and_args t in
         let args = List.map maybe_un_auto_squash_arg args in
-        S.mk_Tm_app head args None t.pos
+        S.mk_Tm_app head args t.pos
     in
     let rec clearly_inhabited (ty : typ) : bool =
         match (U.unmeta ty).n with

--- a/src/typechecker/FStar.TypeChecker.DMFF.fs
+++ b/src/typechecker/FStar.TypeChecker.DMFF.fs
@@ -115,7 +115,7 @@ let gen_wps_for_free
   if Env.debug env (Options.Other "ED") then
     d (BU.format1 "Gamma is %s\n" (Print.binders_to_string ", " gamma));
   let unknown = S.tun in
-  let mk x = mk x None Range.dummyRange in
+  let mk x = mk x Range.dummyRange in
 
   // The [register] function accumulates the top-level definitions that are
   // generated in the course of producing WP combinators
@@ -319,7 +319,7 @@ let gen_wps_for_free
   let ret_tot_type = Some (U.residual_tot U.ktype) in
   let ret_gtot_type = Some (TcComm.residual_comp_of_lcomp (TcComm.lcomp_of_comp <| S.mk_GTotal U.ktype)) in
   let mk_forall (x: S.bv) (body: S.term): S.term =
-    S.mk (Tm_app (U.tforall, [ S.as_arg (U.abs [ S.mk_binder x ] body ret_tot_type)])) None Range.dummyRange
+    S.mk (Tm_app (U.tforall, [ S.as_arg (U.abs [ S.mk_binder x ] body ret_tot_type)])) Range.dummyRange
   in
 
   (* For each (target) type t, we define a binary relation in t called ≤_t.
@@ -538,7 +538,7 @@ let rec mk_star_to_type mk env a =
 // [Tm_abs] case to account for parameterized types
 
 and star_type' env t =
-  let mk x = mk x None t.pos in
+  let mk x = mk x t.pos in
   let mk_star_to_type = mk_star_to_type mk in
   //BU.print1 "[debug]: star_type' %s\n" (Print.term_to_string t);
   let t = SS.compress t in
@@ -776,7 +776,7 @@ let rec is_C (t: typ): bool =
 // This function assumes [e] has been starred already and returns:
 //   [fun (p: t* -> Type) -> p e]
 let mk_return env (t: typ) (e: term) =
-  let mk x = mk x None e.pos in
+  let mk x = mk x e.pos in
   let p_type = mk_star_to_type mk env t in
   let p = S.gen_bv "p'" None p_type in
   let body = mk (Tm_app (S.bv_to_name p, [ e, S.as_implicit false ])) in
@@ -883,7 +883,7 @@ let rec check (env: env) (e: term) (context_nm: nm): nm * term * term =
 
 and infer (env: env) (e: term): nm * term * term =
   // BU.print1 "[debug]: infer %s\n" (Print.term_to_string e);
-  let mk x = mk x None e.pos in
+  let mk x = mk x e.pos in
   let normalize = N.normalize [ Env.Beta; Env.Eager_unfolding; Env.UnfoldUntil S.delta_constant; Env.EraseUniverses ] env.tcenv in
   match (SS.compress e).n with
   | Tm_bvar bv ->
@@ -1131,7 +1131,7 @@ and infer (env: env) (e: term): nm * term * term =
       failwith (BU.format1 "[infer]: Tm_unknown %s" (Print.term_to_string e))
 
 and mk_match env e0 branches f =
-  let mk x = mk x None e0.pos in
+  let mk x = mk x e0.pos in
 
   // TODO: automatically [bind] when the scrutinee is monadic?
   let _, s_e0, u_e0 = check_n env e0 in
@@ -1196,7 +1196,7 @@ and mk_match env e0 branches f =
 and mk_let (env: env_) (binding: letbinding) (e2: term)
     (proceed: env_ -> term -> nm * term * term)
     (ensure_m: env_ -> term -> term * term * term) =
-  let mk x = mk x None e2.pos in
+  let mk x = mk x e2.pos in
   let e1 = binding.lbdef in
   // This is [let x = e1 in e2]. Open [x] in [e2].
   let x = BU.left binding.lbname in
@@ -1242,13 +1242,13 @@ and mk_let (env: env_) (binding: letbinding) (e2: term)
 
 
 and check_n (env: env_) (e: term): typ * term * term =
-  let mn = N (mk Tm_unknown None e.pos) in
+  let mn = N (mk Tm_unknown e.pos) in
   match check env e mn with
   | N t, s_e, u_e -> t, s_e, u_e
   | _ -> failwith "[check_n]: impossible"
 
 and check_m (env: env_) (e: term): typ * term * term =
-  let mn = M (mk Tm_unknown None e.pos) in
+  let mn = M (mk Tm_unknown e.pos) in
   match check env e mn with
   | M t, s_e, u_e -> t, s_e, u_e
   | _ -> failwith "[check_m]: impossible"
@@ -1273,7 +1273,7 @@ and type_of_comp t = U.comp_result t
 and trans_F_ (env: env_) (c: typ) (wp: term): term =
   if not (is_C c) then
     raise_error (Error_UnexpectedDM4FType, BU.format1 "Not a DM4F C-type: %s" (Print.term_to_string c)) c.pos;
-  let mk x = mk x None c.pos in
+  let mk x = mk x c.pos in
   match (SS.compress c).n with
   | Tm_app (head, args) ->
       // It's a product, the only form of [Tm_app] allowed.
@@ -1400,7 +1400,7 @@ let cps_and_elaborate (env:FStar.TypeChecker.Env.env) (ed:S.eff_decl)
     let t, comp, _ = TcTerm.tc_term env t in
     t, comp
   in
-  let mk x = mk x None signature.pos in
+  let mk x = mk x signature.pos in
 
   // TODO: check that [_comp] is [Tot Type]
   let repr, _comp = open_and_check env [] (ed |> U.get_eff_repr |> must |> snd) in
@@ -1497,7 +1497,7 @@ let cps_and_elaborate (env:FStar.TypeChecker.Env.env) (ed:S.eff_decl)
         in
 
         (* fun b1 wp -> (fun bs@bs'-> wp (fun b2 -> body $$ Type0) $$ Type0) $$ wp_a *)
-        let body = mk_Tm_app (S.bv_to_name wp) [U.abs [b2] body what', None] None ed_range in
+        let body = mk_Tm_app (S.bv_to_name wp) [U.abs [b2] body what', None] ed_range in
         U.abs ([ b1; S.mk_binder wp ])
               (U.abs (bs) body what)
               (Some rc_gtot)

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -1207,7 +1207,7 @@ let effect_repr_aux only_reifiable env c u_res =
       let res_typ = c.result_typ in
       let repr = inst_effect_fun_with [u_res] env ed ts in
       check_partial_application effect_name c.effect_args;
-      Some (S.mk (Tm_app (repr, ((res_typ |> S.as_arg)::c.effect_args))) None (get_range env))
+      Some (S.mk (Tm_app (repr, ((res_typ |> S.as_arg)::c.effect_args))) (get_range env))
 
 let effect_repr env c u_res : option<term> = effect_repr_aux false env c u_res
 
@@ -1669,7 +1669,7 @@ let def_check_guard_wf rng msg env g =
 
 let apply_guard g e = match g.guard_f with
   | Trivial -> g
-  | NonTrivial f -> {g with guard_f=NonTrivial <| mk (Tm_app(f, [as_arg e])) None f.pos}
+  | NonTrivial f -> {g with guard_f=NonTrivial <| mk (Tm_app(f, [as_arg e])) f.pos}
 
 let map_guard g map = match g.guard_f with
   | Trivial -> g
@@ -1722,7 +1722,7 @@ let close_guard env binders g =
 let new_implicit_var_aux reason r env k should_check meta =
     match U.destruct k FStar.Parser.Const.range_of_lid with
      | Some [_; (tm, _)] ->
-       let t = S.mk (S.Tm_constant (FStar.Const.Const_range tm.pos)) None tm.pos in
+       let t = S.mk (S.Tm_constant (FStar.Const.Const_range tm.pos)) tm.pos in
        t, [], trivial_guard
 
      | _ ->
@@ -1739,7 +1739,7 @@ let new_implicit_var_aux reason r env k should_check meta =
           ctx_uvar_meta=meta;
       } in
       check_uvar_ctx_invariant reason r true gamma binders;
-      let t = mk (Tm_uvar (ctx_uvar, ([], NoUseRange))) None r in
+      let t = mk (Tm_uvar (ctx_uvar, ([], NoUseRange))) r in
       let imp = { imp_reason = reason
                 ; imp_tm     = t
                 ; imp_uvar   = ctx_uvar
@@ -1795,11 +1795,11 @@ let pure_precondition_for_trivial_post env u t wp r =
     S.mk_Tm_app
       post
       [t |> S.as_arg]
-      None r in
+      r in
   S.mk_Tm_app
     wp
     [trivial_post |> S.as_arg]
-    None r
+    r
 
 
 (* <Move> this out of here *)

--- a/src/typechecker/FStar.TypeChecker.PatternUtils.fs
+++ b/src/typechecker/FStar.TypeChecker.PatternUtils.fs
@@ -150,7 +150,7 @@ let pat_as_exp (introduce_bv_uvars:bool)
                 | FStar.Const.Const_int(repr, Some sw) ->
                   FStar.ToSyntax.ToSyntax.desugar_machine_integer env.dsenv repr sw p.p
                 | _ ->
-                  mk (Tm_constant c) None p.p
+                  mk (Tm_constant c) p.p
              in
              ([], [], [], env, e, trivial_guard, p)
 
@@ -164,12 +164,12 @@ let pat_as_exp (introduce_bv_uvars:bool)
 
            | Pat_wild x ->
              let x, g, env = intro_bv env x in
-             let e = mk (Tm_name x) None p.p in
+             let e = mk (Tm_name x) p.p in
              ([x], [], [x], env, e, g, p)
 
            | Pat_var x ->
              let x, g, env = intro_bv env x in
-             let e = mk (Tm_name x) None p.p in
+             let e = mk (Tm_name x) p.p in
              ([x], [x], [], env, e, g, p)
 
            | Pat_cons(fv, pats) ->
@@ -182,7 +182,7 @@ let pat_as_exp (introduce_bv_uvars:bool)
                     (b'::b, a'::a, w'::w, env, arg::args, conj_guard guard guard', (pat, imp)::pats))
                ([], [], [], env, [], trivial_guard, [])
              in
-             let e = mk_Tm_app (Syntax.fv_to_tm fv) (args |> List.rev) None p.p in
+             let e = mk_Tm_app (Syntax.fv_to_tm fv) (args |> List.rev) p.p in
              (List.rev b |> List.flatten,
               List.rev a |> List.flatten,
               List.rev w |> List.flatten,

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -103,7 +103,7 @@ let new_uvar reason wl r gamma binders k should_check meta : ctx_uvar * term * w
          ctx_uvar_meta=meta;
        } in
     check_uvar_ctx_invariant reason r true gamma binders;
-    let t = mk (Tm_uvar (ctx_uvar, ([], NoUseRange))) None r in
+    let t = mk (Tm_uvar (ctx_uvar, ([], NoUseRange))) r in
     let imp = { imp_reason = reason
               ; imp_tm     = t
               ; imp_uvar   = ctx_uvar
@@ -403,7 +403,7 @@ let new_problem wl env lhs rel rhs (subject:option<bv>) loc reason =
   let lg =
     match subject with
     | None -> lg
-    | Some x -> S.mk_Tm_app lg [S.as_arg <| S.bv_to_name x] None loc
+    | Some x -> S.mk_Tm_app lg [S.as_arg <| S.bv_to_name x] loc
   in
   let prob =
    {
@@ -625,7 +625,7 @@ let force_refinement (t_base, refopt) : term =
     let y, phi = match refopt with
         | Some (y, phi) -> y, phi
         | None -> trivial_refinement t_base in
-    mk (Tm_refine(y, phi)) None t_base.pos
+    mk (Tm_refine(y, phi)) t_base.pos
 
 (* ------------------------------------------------ *)
 (* </normalization>                                 *)
@@ -744,13 +744,13 @@ let ensure_no_uvar_subst (t0:term) (wl:worklist)
 
         (* Solve the old variable *)
         let args_sol = List.map (fun (x, i) -> S.bv_to_name x, i) dom_binders in
-        let sol = S.mk_Tm_app t_v args_sol None t0.pos in
+        let sol = S.mk_Tm_app t_v args_sol t0.pos in
         U.set_uvar uv.ctx_uvar_head sol;
 
         (* Make a term for the new uvar, applied to the substitutions of
          * the abstracted arguments, plus all the original arguments. *)
         let args_sol_s = List.map (fun (a, i) -> SS.subst' s a, i) args_sol in
-        let t = S.mk_Tm_app t_v (args_sol_s @ args) None t0.pos in
+        let t = S.mk_Tm_app t_v (args_sol_s @ args) t0.pos in
         t, wl
       end
     | _ ->
@@ -1930,7 +1930,7 @@ and imitate_arrow (orig:prob) (env:Env.env) (wl:worklist)
                   | None ->
                     U.type_u()
                   | Some univ ->
-                    S.mk (Tm_type univ) None t.pos, univ
+                    S.mk (Tm_type univ) t.pos, univ
               in
               let _, u, wl = copy_uvar u_lhs (bs_lhs@bs) k wl in
               f u (Some univ), wl
@@ -2113,7 +2113,7 @@ and solve_t_flex_rigid_eq env (orig:prob) wl
         //    (Print.term_to_string rhs);
         let rhs_hd, args = U.head_and_args rhs in
         let args_rhs, last_arg_rhs = BU.prefix args in
-        let rhs' = S.mk_Tm_app rhs_hd args_rhs None rhs.pos in
+        let rhs' = S.mk_Tm_app rhs_hd args_rhs rhs.pos in
         //if Env.debug env <| Options.Other "Rel"
         //then printfn "imitate_app 2:\n\trhs'=%s\n\tlast_arg_rhs=%s\n"
         //            (Print.term_to_string rhs')
@@ -2130,7 +2130,7 @@ and solve_t_flex_rigid_eq env (orig:prob) wl
         //then printfn "imitate_app 3:\n\tlhs'=%s\n\tlast_arg_lhs=%s\n"
         //            (Print.term_to_string lhs')
         //            (Print.term_to_string lhs'_last_arg);
-        let sol = [TERM(u_lhs, U.abs bs_lhs (S.mk_Tm_app lhs' [S.as_arg lhs'_last_arg] None t_lhs.pos)
+        let sol = [TERM(u_lhs, U.abs bs_lhs (S.mk_Tm_app lhs' [S.as_arg lhs'_last_arg] t_lhs.pos)
                                             (Some (U.residual_tot t_res_lhs)))]
         in
         let sub_probs, wl =
@@ -2270,7 +2270,7 @@ and solve_t_flex_flex env orig wl (lhs:flex_t) (rhs:flex_t) : solution =
                                          wl range gamma_w ctx_w (U.arrow zs (S.mk_Total t_res_lhs))
                                          Strict
                                          None in
-                 let w_app = S.mk_Tm_app w (List.map (fun (z, _) -> S.as_arg (S.bv_to_name z)) zs) None w.pos in
+                 let w_app = S.mk_Tm_app w (List.map (fun (z, _) -> S.as_arg (S.bv_to_name z)) zs) w.pos in
                  let _ =
                     if Env.debug env <| Options.Other "Rel"
                     then BU.print "flex-flex quasi:\n\t\
@@ -2708,7 +2708,7 @@ and solve_t' (env:Env.env) (problem:tprob) (wl:worklist) : solution =
       | Tm_arrow(bs1, c1), Tm_arrow(bs2, c2) ->
         let mk_c c = function
             | [] -> c
-            | bs -> mk_Total(mk (Tm_arrow(bs, c)) None c.pos) in
+            | bs -> mk_Total(mk (Tm_arrow(bs, c)) c.pos) in
 
         let (bs1, c1), (bs2, c2) =
             match_num_binders (bs1, mk_c c1) (bs2, mk_c c2) in
@@ -2723,7 +2723,7 @@ and solve_t' (env:Env.env) (problem:tprob) (wl:worklist) : solution =
       | Tm_abs(bs1, tbody1, lopt1), Tm_abs(bs2, tbody2, lopt2) ->
         let mk_t t l = function
             | [] -> t
-            | bs -> mk (Tm_abs(bs, t, l)) None t.pos in
+            | bs -> mk (Tm_abs(bs, t, l)) t.pos in
         let (bs1, tbody1), (bs2, tbody2) =
             match_num_binders (bs1, mk_t tbody1 lopt1) (bs2, mk_t tbody2 lopt2) in
         solve_binders env bs1 bs2 orig wl
@@ -3071,9 +3071,9 @@ and solve_c (env:Env.env) (problem:problem<comp>) (wl:worklist) : solution =
              let univ_sub_probs, wl =
                List.fold_left2 (fun (univ_sub_probs, wl) u1 u2 ->
                  let p, wl = sub_prob wl
-                   (S.mk (S.Tm_type u1) None Range.dummyRange)
+                   (S.mk (S.Tm_type u1) Range.dummyRange)
                    EQ
-                   (S.mk (S.Tm_type u2) None Range.dummyRange)
+                   (S.mk (S.Tm_type u2) Range.dummyRange)
                    "effect universes" in
                  (univ_sub_probs@[p]), wl) ([], wl) c1_comp.comp_univs c2_comp.comp_univs in
              let ret_sub_prob, wl = sub_prob wl c1_comp.result_typ EQ c2_comp.result_typ "effect ret type" in
@@ -3327,13 +3327,13 @@ and solve_c (env:Env.env) (problem:problem<comp>) (wl:worklist) : solution =
                                      | Some t -> t in
                                    mk (Tm_app (inst_effect_fun_with [c1_univ] env c2_decl trivial,
                                                [as_arg c1.result_typ;
-                                                wpc1_2])) None r
+                                                wpc1_2])) r
                               else let c2_univ = env.universe_of env c2.result_typ in
                                    let stronger = c2_decl |> U.get_stronger_vc_combinator in
                                    mk (Tm_app(inst_effect_fun_with [c2_univ] env c2_decl stronger,
                                               [as_arg c2.result_typ;
                                                as_arg wpc2;
-                                               wpc1_2])) None r in
+                                               wpc1_2])) r in
                       if debug env <| Options.Other "Rel" then
                           BU.print1 "WP guard (simplifed) is (%s)\n" (Print.term_to_string (N.normalize [Env.Iota; Env.Eager_unfolding; Env.Primops; Env.Simplify] env g));
                       let base_prob, wl = sub_prob wl c1.result_typ problem.relation c2.result_typ "result type" in

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -105,7 +105,7 @@ let tc_lex_t env ses quals lids =
             && lid_equals lex_cons PC.lexcons_lid) ->
 
         let u = S.new_univ_name (Some r) in
-        let t = mk (Tm_type(U_name u)) None r in
+        let t = mk (Tm_type(U_name u)) r in
         let t = Subst.close_univ_vars [u] t in
         let tc = { sigel = Sig_inductive_typ(lex_t, [u], [], t, [], [PC.lextop_lid; PC.lexcons_lid]);
                    sigquals = [];
@@ -115,7 +115,7 @@ let tc_lex_t env ses quals lids =
                    sigopts = None; } in
 
         let utop = S.new_univ_name (Some r1) in
-        let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r1) delta_constant None, [U_name utop])) None r1 in
+        let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r1) delta_constant None, [U_name utop])) r1 in
         let lex_top_t = Subst.close_univ_vars [utop] lex_top_t in
         let dc_lextop = { sigel = Sig_datacon(lex_top, [utop], lex_top_t, PC.lex_t_lid, 0, []);
                           sigquals = [];
@@ -127,10 +127,10 @@ let tc_lex_t env ses quals lids =
         let ucons1 = S.new_univ_name (Some r2) in
         let ucons2 = S.new_univ_name (Some r2) in
         let lex_cons_t =
-            let a = S.new_bv (Some r2) (mk (Tm_type(U_name ucons1)) None r2) in
+            let a = S.new_bv (Some r2) (mk (Tm_type(U_name ucons1)) r2) in
             let hd = S.new_bv (Some r2) (S.bv_to_name a) in
-            let tl = S.new_bv (Some r2) (mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r2) delta_constant None, [U_name ucons2])) None r2) in
-            let res = mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r2) delta_constant None, [U_max [U_name ucons1; U_name ucons2]])) None r2 in
+            let tl = S.new_bv (Some r2) (mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r2) delta_constant None, [U_name ucons2])) r2) in
+            let res = mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r2) delta_constant None, [U_max [U_name ucons1; U_name ucons2]])) r2 in
             U.arrow [(a, Some S.imp_tag); (hd, None); (tl, None)] (S.mk_Total res) in
         let lex_cons_t = Subst.close_univ_vars [ucons1;ucons2]  lex_cons_t in
         let dc_lexcons = { sigel = Sig_datacon(lex_cons, [ucons1;ucons2], lex_cons_t, PC.lex_t_lid, 0, []);
@@ -605,7 +605,7 @@ let tc_decl' env0 se: list<sigelt> * list<sigelt> * Env.env =
                  //     (BU.format2 "Parameter name %s doesn't match name %s used in val declaration"
                  //                  (text_of_id body_bv.ppname) (text_of_id val_bv.ppname));
                  (val_bv, aqual)) :: rename_binders bt vt in
-          Syntax.mk (Tm_arrow(rename_binders def_bs val_bs, c)) None r end
+          Syntax.mk (Tm_arrow(rename_binders def_bs val_bs, c)) r end
         | _ -> typ in
       { lb with lbtyp = rename_in_typ lb.lbdef lb.lbtyp } in
 
@@ -627,7 +627,7 @@ let tc_decl' env0 se: list<sigelt> * list<sigelt> * Env.env =
                 | Tm_unknown -> lb.lbdef
                 | _ ->
                   (* If there are two type ascriptions we check that they are compatible *)
-                  mk (Tm_ascribed (lb.lbdef, (Inl lb.lbtyp, None), None)) None lb.lbdef.pos
+                  mk (Tm_ascribed (lb.lbdef, (Inl lb.lbtyp, None), None)) lb.lbdef.pos
               in
               if lb.lbunivs <> [] && List.length lb.lbunivs <> List.length uvs
               then raise_error (Errors.Fatal_IncoherentInlineUniverse, ("Inline universes are incoherent with annotation from val declaration")) r;
@@ -675,7 +675,7 @@ let tc_decl' env0 se: list<sigelt> * list<sigelt> * Env.env =
     (* / preprocess_with *)
 
     (* 2. Turn the top-level lb into a Tm_let with a unit body *)
-    let e = mk (Tm_let((fst lbs, lbs'), mk (Tm_constant (Const_unit)) None r)) None r in
+    let e = mk (Tm_let((fst lbs, lbs'), mk (Tm_constant (Const_unit)) r)) r in
 
     (* 3. Type-check the Tm_let and convert it back to Sig_let *)
     let env' = { env with top_level = true; generalize = should_generalize } in
@@ -1086,7 +1086,7 @@ let check_exports env (modul:modul) exports : unit =
           if not (se.sigquals |> List.contains Private)
           then ses |> List.iter check_sigelt
         | Sig_inductive_typ (l, univs, binders, typ, _, _) ->
-          let t = S.mk (Tm_arrow(binders, S.mk_Total typ)) None se.sigrng in
+          let t = S.mk (Tm_arrow(binders, S.mk_Total typ)) se.sigrng in
           check_term l univs t
         | Sig_datacon(l , univs, t, _, _, _) ->
           check_term l univs t
@@ -1100,7 +1100,7 @@ let check_exports env (modul:modul) exports : unit =
                check_term fv.fv_name.v lb.lbunivs lb.lbtyp)
         | Sig_effect_abbrev(l, univs, binders, comp, flags) ->
           if not (se.sigquals |> List.contains Private)
-          then let arrow = S.mk (Tm_arrow(binders, comp)) None se.sigrng in
+          then let arrow = S.mk (Tm_arrow(binders, comp)) se.sigrng in
                check_term l univs arrow
         | Sig_assume _
         | Sig_new_effect _
@@ -1146,8 +1146,8 @@ let extract_interface (en:env) (m:modul) :modul =
       | [] -> t
       | _  ->
         (match t.n with
-         | Tm_arrow (bs', c ) -> mk (Tm_arrow (bs@bs', c)) None r  //flattening arrows?
-         | _ -> mk (Tm_arrow (bs, mk_Total t)) None r)  //Total ok?
+         | Tm_arrow (bs', c ) -> mk (Tm_arrow (bs@bs', c)) r  //flattening arrows?
+         | _ -> mk (Tm_arrow (bs, mk_Total t)) r)  //Total ok?
     in
 
     match s.sigel with

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fs
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fs
@@ -134,7 +134,7 @@ let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
                   //the type of each datacon is already a function with the type params as arguments
                   //need to map the prefix of bs corresponding to params to the tps of the inductive
                   let _, bs' = BU.first_N ntps bs in
-                  let t = mk (Tm_arrow(bs', res)) None t.pos in
+                  let t = mk (Tm_arrow(bs', res)) t.pos in
                   let subst = tps |> List.mapi (fun i (x, _) -> DB(ntps - (1 + i), x)) in
 (*open*)          let bs, c = U.arrow_formals_comp (SS.subst subst t) in
                   (* check that c is a Tot computation, reject it otherwise
@@ -154,7 +154,7 @@ let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
                 (Print.term_to_string result);
 
          let arguments, env', us = tc_tparams env arguments in
-         let type_u_tc = S.mk (Tm_type u_tc) None result.pos in
+         let type_u_tc = S.mk (Tm_type u_tc) result.pos in
          let env' = Env.set_expected_typ env' type_u_tc in
          let result, res_lcomp = tc_trivial_guard env' result in
          let head, args = U.head_and_args result in
@@ -190,7 +190,7 @@ let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
               if List.length _uvs = List.length tuvs then
                 List.fold_left2 (fun g u1 u2 ->
                   //unify the two
-                  Env.conj_guard g (Rel.teq env' (mk (Tm_type u1) None Range.dummyRange) (mk (Tm_type (U_name u2)) None Range.dummyRange))
+                  Env.conj_guard g (Rel.teq env' (mk (Tm_type u1) Range.dummyRange) (mk (Tm_type (U_name u2)) Range.dummyRange))
                 ) Env.trivial_guard tuvs _uvs
               else Errors.raise_error (Errors.Fatal_UnexpectedConstructorType,
                                        "Length of annotated universes does not match inferred universes")
@@ -252,7 +252,7 @@ let generalize_and_inst_within (env:env_t) (tcs:list<(sigelt * universe)>) (data
                   let tps, rest = BU.first_N (List.length tps) binders in
                   let t = match rest with
                     | [] -> U.comp_result c
-                    | _ -> mk (Tm_arrow(rest, c)) None x.sort.pos
+                    | _ -> mk (Tm_arrow(rest, c)) x.sort.pos
                   in
                   tps, t
                 | _ -> [], ty
@@ -598,28 +598,28 @@ let get_optimized_haseq_axiom (en:env) (ty:sigelt) (usubst:list<subst_elt>) (us:
   //term for unapplied inductive type, making a Tm_uinst, otherwise there are unresolved universe variables, may be that's fine ?
   let ind = mk_Tm_uinst (S.fvar lid delta_constant None) (List.map (fun u -> U_name u) us) in
   //apply the bs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
-  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) bs) None Range.dummyRange in
+  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) bs) Range.dummyRange in
   //apply the ibs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
-  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) ibs) None Range.dummyRange in
+  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) ibs) Range.dummyRange in
   //haseq of ind
-  let haseq_ind = mk_Tm_app U.t_haseq [S.as_arg ind] None Range.dummyRange in
+  let haseq_ind = mk_Tm_app U.t_haseq [S.as_arg ind] Range.dummyRange in
   //haseq of all binders in bs, we will add only those binders x:t for which t <: Type u for some fresh universe variable u
   //we want to avoid the case of binders such as (x:nat), as hasEq x is not well-typed
   let bs' = List.filter (fun b ->
     Rel.subtype_nosmt_force en (fst b).sort  (fst (U.type_u ()))
   ) bs in
-  let haseq_bs = List.fold_left (fun (t:term) (b:binder) -> U.mk_conj t (mk_Tm_app U.t_haseq [S.as_arg (S.bv_to_name (fst b))] None Range.dummyRange)) U.t_true bs' in
+  let haseq_bs = List.fold_left (fun (t:term) (b:binder) -> U.mk_conj t (mk_Tm_app U.t_haseq [S.as_arg (S.bv_to_name (fst b))] Range.dummyRange)) U.t_true bs' in
   //implication
   let fml = U.mk_imp haseq_bs haseq_ind in
   //attach pattern -- is this the right place ?
   let fml = { fml with n = Tm_meta (fml, Meta_pattern(binders_to_names ibs, [[S.as_arg haseq_ind]])) } in
   //fold right with ibs, close and add a forall b
   //we are setting the qualifier of the binder to None explicitly, we don't want to make forall binder implicit etc. ?
-  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app U.tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] None Range.dummyRange) ibs fml in
+  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app U.tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] Range.dummyRange) ibs fml in
 
   //fold right with bs, close and add a forall b
   //we are setting the qualifier of the binder to None explicitly, we don't want to make forall binder implicit etc. ?
-  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app U.tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] None Range.dummyRange) bs fml in
+  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app U.tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] Range.dummyRange) bs fml in
 
   let axiom_lid = get_haseq_axiom_lid lid in
   axiom_lid, fml, bs, ibs, haseq_bs
@@ -640,7 +640,7 @@ let optimized_haseq_soundness_for_data (ty_lid:lident) (data:sigelt) (usubst:lis
     let dbs = SS.open_binders dbs in
     //fold on dbs, add haseq of its sort to the guard
     let cond = List.fold_left (fun (t:term) (b:binder) ->
-      let haseq_b = mk_Tm_app U.t_haseq [S.as_arg (fst b).sort] None Range.dummyRange in
+      let haseq_b = mk_Tm_app U.t_haseq [S.as_arg (fst b).sort] Range.dummyRange in
       //label the haseq predicate so that we get a proper error message if the assertion fails
       let sort_range = (fst b).sort.pos in
       let haseq_b = TcUtil.label
@@ -651,7 +651,7 @@ let optimized_haseq_soundness_for_data (ty_lid:lident) (data:sigelt) (usubst:lis
       U.mk_conj t haseq_b) U.t_true dbs
     in
     //fold right over dbs and add a forall for each binder in dbs
-    List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] None Range.dummyRange) dbs cond
+    List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] Range.dummyRange) dbs cond
   | _                -> U.t_true
 
 //this is the folding function for tcs
@@ -783,14 +783,14 @@ let unoptimized_haseq_data (usubst:list<subst_elt>) (bs:binders) (haseq_ind:term
     //cond is the conjunct of the hasEq of all the data constructor arguments
     let cond = List.fold_left (fun (t:term) (b:binder) ->
       let sort = (fst b).sort in
-      let haseq_sort = mk_Tm_app U.t_haseq [S.as_arg (fst b).sort] None Range.dummyRange in
+      let haseq_sort = mk_Tm_app U.t_haseq [S.as_arg (fst b).sort] Range.dummyRange in
       let haseq_sort = if is_mutual sort then U.mk_imp haseq_ind haseq_sort else haseq_sort in
       U.mk_conj t haseq_sort) U.t_true dbs
     in
 
             //fold right with dbs, close and add a forall b
                 //we are setting the qualifier of the binder to None explicitly, we don't want to make forall binder implicit etc. ?
-            let cond = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] None Range.dummyRange) dbs cond in
+            let cond = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] Range.dummyRange) dbs cond in
 
             //new accumulator is old one /\ cond
             U.mk_conj acc cond
@@ -823,11 +823,11 @@ let unoptimized_haseq_ty (all_datas_in_the_bundle:list<sigelt>) (mutuals:list<li
   //term for unapplied inductive type, making a Tm_uinst, otherwise there are unresolved universe variables, may be that's fine ?
   let ind = mk_Tm_uinst (S.fvar lid delta_constant None) (List.map (fun u -> U_name u) us) in
   //apply the bs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
-  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) bs) None Range.dummyRange in
+  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) bs) Range.dummyRange in
   //apply the ibs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
-  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) ibs) None Range.dummyRange in
+  let ind = mk_Tm_app ind (List.map (fun (bv, aq) -> S.bv_to_name bv, aq) ibs) Range.dummyRange in
   //haseq of ind applied to all bs and ibs
-  let haseq_ind = mk_Tm_app U.t_haseq [S.as_arg ind] None Range.dummyRange in
+  let haseq_ind = mk_Tm_app U.t_haseq [S.as_arg ind] Range.dummyRange in
 
 
   //filter out data constructors for this type constructor
@@ -848,10 +848,10 @@ let unoptimized_haseq_ty (all_datas_in_the_bundle:list<sigelt>) (mutuals:list<li
 
   //fold right with ibs, close and add a forall b
   //we are setting the qualifier of the binder to None explicitly, we don't want to make forall binder implicit etc. ?
-  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] None Range.dummyRange) ibs fml in
+  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] Range.dummyRange) ibs fml in
   //fold right with bs, close and add a forall b
   //we are setting the qualifier of the binder to None explicitly, we don't want to make forall binder implicit etc. ?
-  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] None Range.dummyRange) bs fml in
+  let fml = List.fold_right (fun (b:binder) (t:term) -> mk_Tm_app tforall [ S.as_arg (U.abs [(fst b, None)] (SS.close [b] t) None) ] Range.dummyRange) bs fml in
 
   //new accumulator is old accumulator /\ fml
   U.mk_conj acc fml
@@ -1023,7 +1023,7 @@ let check_inductive_well_typedness (env:env_t) (ses:list<sigelt>) (quals:list<qu
                   let body =
                       match binders with
                       | [] -> typ
-                      | _ -> S.mk (Tm_arrow(binders, S.mk_Total typ)) None se.sigrng in
+                      | _ -> S.mk (Tm_arrow(binders, S.mk_Total typ)) se.sigrng in
                   (univs, body)
               in
               if List.length univs = List.length (fst expected_typ)
@@ -1066,9 +1066,9 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
     let inst_univs = List.map (fun u -> U_name u) uvs in
     let tps = inductive_tps in //List.map2 (fun (x,_) (_,imp) -> ({x,imp)) implicit_tps inductive_tps in
     let arg_typ =
-        let inst_tc = S.mk (Tm_uinst (S.fv_to_tm (S.lid_as_fv tc delta_constant None), inst_univs)) None p in
+        let inst_tc = S.mk (Tm_uinst (S.fv_to_tm (S.lid_as_fv tc delta_constant None), inst_univs)) p in
         let args = tps@indices |> List.map (fun (x, imp) -> S.bv_to_name x,imp) in
-        S.mk_Tm_app inst_tc args None p
+        S.mk_Tm_app inst_tc args p
     in
     let unrefined_arg_binder = S.mk_binder (projectee arg_typ) in
     let arg_binder =
@@ -1078,7 +1078,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
              let x = S.new_bv (Some p) arg_typ in
              let sort =
                  let disc_fvar = S.fvar (Ident.set_lid_range disc_name p) (Delta_equational_at_level 1) None in
-                 U.refine x (U.b2t (S.mk_Tm_app (S.mk_Tm_uinst disc_fvar inst_univs) [as_arg <| S.bv_to_name x] None p))
+                 U.refine x (U.b2t (S.mk_Tm_app (S.mk_Tm_uinst disc_fvar inst_univs) [as_arg <| S.bv_to_name x] p))
              in
              S.mk_binder ({projectee arg_typ with sort = sort})
     in
@@ -1148,7 +1148,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                         let pat_true = pos (S.Pat_cons (S.lid_as_fv lid delta_constant (Some fvq), arg_pats)), None, U.exp_true_bool in
                         let pat_false = pos (Pat_wild (S.new_bv None tun)), None, U.exp_false_bool in
                         let arg_exp = S.bv_to_name (fst unrefined_arg_binder) in
-                        mk (Tm_match(arg_exp, [U.branch pat_true ; U.branch pat_false])) None p
+                        mk (Tm_match(arg_exp, [U.branch pat_true ; U.branch pat_false])) p
                 in
                 let dd =
                     if quals |> List.contains S.Abstract
@@ -1187,7 +1187,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
     let subst = fields |> List.mapi (fun i (a, _) ->
             let field_name = U.mk_field_projector_name lid a i in
             let field_proj_tm = mk_Tm_uinst (S.fv_to_tm (S.lid_as_fv field_name (Delta_equational_at_level 1) None)) inst_univs in
-            let proj = mk_Tm_app field_proj_tm [arg] None p in
+            let proj = mk_Tm_app field_proj_tm [arg] p in
             NT(a, proj))
     in
 
@@ -1247,7 +1247,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   else pos (Pat_wild (S.gen_bv (text_of_id x.ppname) None tun)), b)
               in
               let pat = pos (S.Pat_cons (S.lid_as_fv lid delta_constant (Some fvq), arg_pats)), None, S.bv_to_name projection in
-              let body = mk (Tm_match(arg_exp, [U.branch pat])) None p in
+              let body = mk (Tm_match(arg_exp, [U.branch pat])) p in
               let imp = U.abs binders body None in
               let dd =
                   if quals |> List.contains S.Abstract

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -52,7 +52,7 @@ let no_inst env = {env with Env.instantiate_imp=false}
 let mk_lex_list vs =
     List.fold_right (fun v tl ->
         let r = if tl.pos = Range.dummyRange then v.pos else Range.union_ranges v.pos tl.pos in
-        mk_Tm_app lex_pair [as_arg v; as_arg tl] None r)
+        mk_Tm_app lex_pair [as_arg v; as_arg tl] r)
     vs lex_top
 let is_eq = function
     | Some Equality -> true
@@ -408,7 +408,7 @@ let guard_letrecs env actuals expected_c : list<(lbname*typ*univ_names)> =
                   let formals = formals |> List.map (fun (x, imp) -> if S.is_null_bv x then (S.new_bv (Some (S.range_of_bv x)) x.sort, imp) else x,imp) in
         (*open*)  let formals, c = SS.open_comp formals c in
                   let dec = decreases_clause formals c in
-                  let precedes = mk_Tm_app precedes [as_arg dec; as_arg previous_dec] None r in
+                  let precedes = mk_Tm_app precedes [as_arg dec; as_arg previous_dec] r in
                   let precedes = TcUtil.label "Could not prove termination of this recursive call" r precedes in
                   let bs, (last, imp) = BU.prefix formals in
                   let last = {last with sort=U.refine last precedes} in
@@ -531,9 +531,9 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
                            z in
         let qi = { qi with antiquotes = List.map (fun ((bv, _), bv') ->
                                             (bv, S.bv_to_name bv')) z } in
-        let nq = mk (Tm_quoted (qt, qi)) None top.pos in
+        let nq = mk (Tm_quoted (qt, qi)) top.pos in
         let e = List.fold_left (fun t lb -> mk (Tm_let ((false, [lb]),
-                                                        SS.close [S.mk_binder (projl lb.lbname)] t)) None top.pos) nq lbs in
+                                                        SS.close [S.mk_binder (projl lb.lbname)] t)) top.pos) nq lbs in
         tc_maybe_toplevel_term env e
 
     (* A static quote is of type `term`, as long as its antiquotations are too *)
@@ -547,7 +547,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
                                     ((bv, tm)::aqs_rev, Env.conj_guard g guard)) aqs ([], Env.trivial_guard) in
         let qi = { qi with antiquotes = List.rev aqs_rev } in
 
-        let tm = mk (Tm_quoted (qt, qi)) None top.pos in
+        let tm = mk (Tm_quoted (qt, qi)) top.pos in
         value_check_expected_typ env tm (Inl S.t_term) guard
 
     | Quote_dynamic ->
@@ -556,11 +556,11 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
         (* Typechecked the quoted term just to elaborate it *)
         let env', _ = Env.clear_expected_typ env in
         let qt, _, _ = tc_term ({ env' with lax = true }) qt in
-        let t = mk (Tm_quoted (qt, qi)) None top.pos in
+        let t = mk (Tm_quoted (qt, qi)) top.pos in
 
         let t, lc, g = value_check_expected_typ env top (Inr (TcComm.lcomp_of_comp c)) Env.trivial_guard in
         let t = mk (Tm_meta(t, Meta_monadic_lift (Const.effect_PURE_lid, Const.effect_TAC_lid, S.t_term)))
-                   None t.pos in
+                   t.pos in
         t, lc, g
     end
 
@@ -574,7 +574,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
   | Tm_meta(e, Meta_desugared Meta_smt_pat) ->
     let e, c, g = tc_tot_or_gtot_term env e in
     let g = {g with guard_f=Trivial} in //VC's in SMT patterns are irrelevant
-    mk (Tm_meta (e, Meta_desugared Meta_smt_pat)) None top.pos, c, g  //AR: keeping the pats as meta for the second phase. smtencoding does an unmeta.
+    mk (Tm_meta (e, Meta_desugared Meta_smt_pat)) top.pos, c, g  //AR: keeping the pats as meta for the second phase. smtencoding does an unmeta.
 
   | Tm_meta(e, Meta_pattern(names, pats)) ->
     let t, u = U.type_u () in
@@ -589,7 +589,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
         let env, _ = Env.clear_expected_typ env in
         tc_smt_pats env pats in
     let g' = {g' with guard_f=Trivial} in //The pattern may have some VCs associated with it, but these are irrelevant.
-    mk (Tm_meta(e, Meta_pattern(names, pats))) None top.pos,
+    mk (Tm_meta(e, Meta_pattern(names, pats))) top.pos,
     c,
     Env.conj_guard g g' //but don't drop g' altogether, since it also contains unification constraints
 
@@ -606,13 +606,13 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
             then [U.inline_let_attr]
             else []
           in
-          let e = mk (Tm_let((false, [mk_lb (x, [], c1.eff_name, t_unit, e1, attrs, e1.pos)]), e2)) None e.pos in
+          let e = mk (Tm_let((false, [mk_lb (x, [], c1.eff_name, t_unit, e1, attrs, e1.pos)]), e2)) e.pos in
           let e = TcUtil.maybe_monadic env e c.eff_name c.res_typ in
-          let e = mk (Tm_meta(e, Meta_desugared Sequence)) None top.pos in
+          let e = mk (Tm_meta(e, Meta_desugared Sequence)) top.pos in
           e, c, Env.conj_guard g1 g2
         | _ ->
           let e, c, g = tc_term env e in
-          let e = mk (Tm_meta(e, Meta_desugared Sequence)) None top.pos in
+          let e = mk (Tm_meta(e, Meta_desugared Sequence)) top.pos in
           e, c, g
     end
 
@@ -624,7 +624,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
 
   | Tm_meta(e, m) ->
     let e, c, g = tc_term env e in
-    let e = mk (Tm_meta(e, m)) None top.pos in
+    let e = mk (Tm_meta(e, m)) top.pos in
     e, c, g
 
   (*
@@ -661,7 +661,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     let repr = Env.effect_repr env0 (expected_ct |> S.mk_Comp) u_c |> must in
 
     // e <: Tot repr
-    let e = S.mk (Tm_ascribed (e, (Inr (S.mk_Total' repr (Some u_c)), None), None)) None e.pos in
+    let e = S.mk (Tm_ascribed (e, (Inr (S.mk_Total' repr (Some u_c)), None), None)) e.pos in
 
     if Env.debug env0 <| Options.Extreme
     then BU.print1 "Typechecking ascribed reflect, inner ascribed term: %s\n"
@@ -677,9 +677,9 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     //reconstruct (M.reflect e) < M a is
     let top =
       let r = top.pos in
-      let tm = mk (Tm_constant (Const_reflect effect_lid)) None r in
-      let tm = mk (Tm_app (tm, [e, aqual])) None r in
-      mk (Tm_ascribed (tm, (Inr expected_c, _tacopt), expected_c |> U.comp_effect_name |> Some)) None r in
+      let tm = mk (Tm_constant (Const_reflect effect_lid)) r in
+      let tm = mk (Tm_app (tm, [e, aqual])) r in
+      mk (Tm_ascribed (tm, (Inr expected_c, _tacopt), expected_c |> U.comp_effect_name |> Some)) r in
 
     //check the expected type in the env, if present
     let top, c, g_env = comp_check_expected_typ env top (expected_c |> TcComm.lcomp_of_comp) in
@@ -695,7 +695,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
       let e, expected_c, g'' = check_expected_effect env0 (Some expected_c) (e, c') in
       e, expected_c, Env.conj_guard g_c' g'' in
     let topt, gtac = tc_tactic_opt env0 topt in
-    let e = mk (Tm_ascribed(e, (Inr expected_c, topt), Some (U.comp_effect_name expected_c))) None top.pos in  //AR: this used to be Inr t_res, which meant it lost annotation for the second phase
+    let e = mk (Tm_ascribed(e, (Inr expected_c, topt), Some (U.comp_effect_name expected_c))) top.pos in  //AR: this used to be Inr t_res, which meant it lost annotation for the second phase
     let lc = TcComm.lcomp_of_comp expected_c in
     let f = Env.conj_guard g (Env.conj_guard g' g'') in
     let e, c, f2 = comp_check_expected_typ env e lc in
@@ -709,7 +709,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     let e, c, g = tc_term (Env.set_expected_typ env t) e in
     //NS: Maybe redundant strengthen
     let c, f = TcUtil.strengthen_precondition (Some (fun () -> return_all Err.ill_kinded_type)) (Env.set_range env t.pos) e c f in
-    let e, c, f2 = comp_check_expected_typ env (mk (Tm_ascribed(e, (Inl t, topt), Some c.eff_name)) None top.pos) c in
+    let e, c, f2 = comp_check_expected_typ env (mk (Tm_ascribed(e, (Inl t, topt), Some c.eff_name)) top.pos) c in
     let final_guard = Env.conj_guard f (Env.conj_guard g f2) in
     let final_guard = wrap_guard_with_tactic_opt topt final_guard in
     e, c, Env.conj_guard final_guard gtac
@@ -720,22 +720,22 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
   | Tm_app({n=Tm_constant (Const_reflect _)}, a::hd::rest) ->
     let rest = hd::rest in //no 'as' clauses in F* yet, so we need to do this ugliness
     let unary_op, _ = U.head_and_args top in
-    let head = mk (Tm_app(unary_op, [a])) None (Range.union_ranges unary_op.pos (fst a).pos) in
-    let t = mk (Tm_app(head, rest)) None top.pos in
+    let head = mk (Tm_app(unary_op, [a])) (Range.union_ranges unary_op.pos (fst a).pos) in
+    let t = mk (Tm_app(head, rest)) top.pos in
     tc_term env t
 
   (* Binary operators *)
   | Tm_app({n=Tm_constant Const_set_range_of}, a1::a2::hd::rest) ->
     let rest = hd::rest in //no 'as' clauses in F* yet, so we need to do this ugliness
     let unary_op, _ = U.head_and_args top in
-    let head = mk (Tm_app(unary_op, [a1; a2])) None (Range.union_ranges unary_op.pos (fst a1).pos) in
-    let t = mk (Tm_app(head, rest)) None top.pos in
+    let head = mk (Tm_app(unary_op, [a1; a2])) (Range.union_ranges unary_op.pos (fst a1).pos) in
+    let t = mk (Tm_app(head, rest)) top.pos in
     tc_term env t
 
   | Tm_app({n=Tm_constant Const_range_of}, [(e, None)]) ->
     let e, c, g = tc_term (fst <| Env.clear_expected_typ env) e in
     let head, _ = U.head_and_args top in
-    mk (Tm_app (head, [(e, None)])) None top.pos, (TcComm.lcomp_of_comp <| mk_Total (tabbrev Const.range_lid)), g
+    mk (Tm_app (head, [(e, None)])) top.pos, (TcComm.lcomp_of_comp <| mk_Total (tabbrev Const.range_lid)), g
 
   | Tm_app({n=Tm_constant Const_set_range_of}, (t, None)::(r, None)::[]) ->
     let head, _ = U.head_and_args top in
@@ -743,7 +743,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     let er, _, gr = tc_term env' r in
     let t, tt, gt = tc_term env t in
     let g = Env.conj_guard gr gt in
-    mk_Tm_app head [S.as_arg t; S.as_arg r] None top.pos, tt, g
+    mk_Tm_app head [S.as_arg t; S.as_arg r] top.pos, tt, g
 
   | Tm_app({n=Tm_constant Const_range_of}, _)
   | Tm_app({n=Tm_constant Const_set_range_of}, _) ->
@@ -761,7 +761,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     if not (is_user_reifiable_effect env ef) then
         raise_error (Errors.Fatal_EffectCannotBeReified, (BU.format1 "Effect %s cannot be reified" (string_of_lid ef))) e.pos;
     let repr = Env.reify_comp env c u_c in
-    let e = mk (Tm_app(reify_op, [(e, aqual)])) None top.pos in
+    let e = mk (Tm_app(reify_op, [(e, aqual)])) top.pos in
     let c =
         if is_total_effect env ef || ef |> Env.norm_eff_name env |> Env.is_layered_effect env
         then S.mk_Total repr |> TcComm.lcomp_of_comp
@@ -826,11 +826,11 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
         flags=[]
       }) |> TcComm.lcomp_of_comp in
 
-      let e = mk (Tm_app(reflect_op, [(e, aqual)])) None top.pos in
+      let e = mk (Tm_app(reflect_op, [(e, aqual)])) top.pos in
 
       let e, c, g' = comp_check_expected_typ env e c in
 
-      let e = S.mk (Tm_meta(e, Meta_monadic(c.eff_name, c.res_typ))) None e.pos in
+      let e = S.mk (Tm_meta(e, Meta_monadic(c.eff_name, c.res_typ))) e.pos in
 
       e, c, Env.conj_guards [g_e; g_repr; g_a; g_eq; g']
     end
@@ -976,10 +976,10 @@ and tc_match (env : Env.env) (top : term) : term * lcomp * guard_t =
         let branches = t_eqns |> List.map (fun ((pat, wopt, br), _, eff_label, _, _, _, _) ->
               (pat, wopt, TcUtil.maybe_lift env br eff_label cres.eff_name res_t))
         in
-        let e = mk (Tm_match(scrutinee, branches)) None top.pos in
+        let e = mk (Tm_match(scrutinee, branches)) top.pos in
         let e = TcUtil.maybe_monadic env e cres.eff_name cres.res_typ in
         //The ascription with the result type is useful for re-checking a term, translating it to Lean etc.
-        mk (Tm_ascribed(e, (Inl cres.res_typ, None), Some cres.eff_name)) None e.pos
+        mk (Tm_ascribed(e, (Inl cres.res_typ, None), Some cres.eff_name)) e.pos
       in
       //see issue #594: if the scrutinee is impure, then explicitly sequence it with an impure let binding
       //                to protect it from the normalizer optimizing it away
@@ -989,7 +989,7 @@ and tc_match (env : Env.env) (top : term) : term * lcomp * guard_t =
         (* generate a let binding for e1 *)
         let e_match = mk_match (S.bv_to_name guard_x) in
         let lb = U.mk_letbinding (Inl guard_x) [] c1.res_typ (Env.norm_eff_name env c1.eff_name) e1 [] e1.pos in
-        let e = mk (Tm_let((false, [lb]), SS.close [S.mk_binder guard_x] e_match)) None top.pos in
+        let e = mk (Tm_let((false, [lb]), SS.close [S.mk_binder guard_x] e_match)) top.pos in
         TcUtil.maybe_monadic env e cres.eff_name cres.res_typ
     in
     if debug env Options.Extreme
@@ -1126,7 +1126,7 @@ and tc_value env (e:term) : term
             | U_unif u'' -> UF.univ_change u'' u
             | _ -> failwith "Impossible") us' us;
     Env.insert_fv_info env fv t;
-    let e = S.mk_Tm_uinst (mk (Tm_fvar fv) None e.pos) us in
+    let e = S.mk_Tm_uinst (mk (Tm_fvar fv) e.pos) us in
     check_instantiated_fvar env fv.fv_name fv.fv_qual e t
 
   (* not an fvar, fail *)
@@ -1147,12 +1147,12 @@ and tc_value env (e:term) : term
             (Range.string_of_use_range range)
             (Print.term_to_string t);
     Env.insert_fv_info env fv t;
-    let e = S.mk_Tm_uinst (mk (Tm_fvar fv) None e.pos) us in
+    let e = S.mk_Tm_uinst (mk (Tm_fvar fv) e.pos) us in
     check_instantiated_fvar env fv.fv_name fv.fv_qual e t
 
   | Tm_constant c ->
     let t = tc_constant env top.pos c in
-    let e = mk (Tm_constant c) None e.pos in
+    let e = mk (Tm_constant c) e.pos in
     value_check_expected_typ env e (Inl t) Env.trivial_guard
 
   | Tm_arrow(bs, c) ->
@@ -1169,15 +1169,15 @@ and tc_value env (e:term) : term
     (* taking the maximum of the universes of the computation and of all binders *)
     let u = S.U_max (uc::us) in
     (* create a universe of level u *)
-    let t = mk (Tm_type u) None top.pos in
+    let t = mk (Tm_type u) top.pos in
     let g = Env.conj_guard g (Env.close_guard_univs us bs f) in
     let g = TcUtil.close_guard_implicits env false bs g in
     value_check_expected_typ env0 e (Inl t) g
 
   | Tm_type u ->
     let u = tc_universe env u in
-    let t = mk (Tm_type(S.U_succ u)) None top.pos in
-    let e = mk (Tm_type u) None top.pos in
+    let t = mk (Tm_type(S.U_succ u)) top.pos in
+    let e = mk (Tm_type u) top.pos in
     value_check_expected_typ env e (Inl t) Env.trivial_guard
 
   | Tm_refine(x, phi) ->
@@ -1192,7 +1192,7 @@ and tc_value env (e:term) : term
     let phi, _, f2 = tc_check_tot_or_gtot_term env phi t_phi
       "refinement formula must be pure or ghost" in
     let e = {U.refine (fst x) phi with pos=top.pos} in
-    let t = mk (Tm_type u) None top.pos in
+    let t = mk (Tm_type u) top.pos in
     let g = Env.conj_guard f1 (Env.close_guard_univs [u] [x] f2) in
     let g = TcUtil.close_guard_implicits env false [x] g in
     value_check_expected_typ env0 e (Inl t) g
@@ -1270,8 +1270,8 @@ and tc_comp env c : comp                                      (* checked version
       let head = S.fvar c.effect_name delta_constant None in
       let head = match c.comp_univs with
          | [] -> head
-         | us -> S.mk (Tm_uinst(head, us)) None c0.pos in
-      let tc = mk_Tm_app head ((as_arg c.result_typ)::c.effect_args) None c.result_typ.pos in
+         | us -> S.mk (Tm_uinst(head, us)) c0.pos in
+      let tc = mk_Tm_app head ((as_arg c.result_typ)::c.effect_args) c.result_typ.pos in
       let tc, _, f = tc_check_tot_or_gtot_term env tc S.teff "" in
       let head, args = U.head_and_args tc in
       let comp_univs = match (SS.compress head).n with
@@ -1579,7 +1579,7 @@ and tc_abs env (top:term) (bs:binders) (body:term) : term * lcomp * guard_t =
           Env.clear_expected_typ envbody |> fst,
           S.mk
             (Tm_ascribed (body, (Inr (c_opt |> must), None), None))
-            None Range.dummyRange,
+            Range.dummyRange,
           false
         else 
           envbody,
@@ -1753,7 +1753,7 @@ and check_application_args env head (chead:comp) ghead args expected_topt : term
                                            || TcUtil.should_not_inline_lc lc)
                             arg_comps_rev)
         in
-        let term = S.mk_Tm_app head (List.rev arg_rets_rev) None head.pos in
+        let term = S.mk_Tm_app head (List.rev arg_rets_rev) head.pos in
         if TcComm.is_pure_or_ghost_lcomp cres
         && (head_is_pure_and_some_arg_is_effectful)
             // || Option.isSome (Env.expected_typ env))
@@ -1803,7 +1803,7 @@ and check_application_args env head (chead:comp) ghead args expected_topt : term
          (* If the head is shortcutting we cannot hoist its arguments *)
          (* Leaving it `as is` is a little dubious, it would fail whenever we try to reify it *)
          let args = List.fold_left (fun args (arg, _, _) -> arg::args) [] arg_comps_rev in
-         let app = mk_Tm_app head args None r in
+         let app = mk_Tm_app head args r in
          let app = TcUtil.maybe_lift env app cres.eff_name comp.eff_name comp.res_typ in
          TcUtil.maybe_monadic env app comp.eff_name comp.res_typ
 
@@ -1848,15 +1848,15 @@ and check_application_args env head (chead:comp) ghead args expected_topt : term
           (* 3. We apply the (non-monadic) head to the non-monadic arguments, lift the *)
           (*    result to comp and then bind each monadic arguments to close over the *)
           (*    variables introduces at step 2. *)
-          let app = mk_Tm_app head args None r in
+          let app = mk_Tm_app head args r in
           let app = TcUtil.maybe_lift env app cres.eff_name comp.eff_name comp.res_typ in
           let app = TcUtil.maybe_monadic env app comp.eff_name comp.res_typ in
           let bind_lifted_args e = function
             | None -> e
             | Some (x, m, t, e1) ->
               let lb = U.mk_letbinding (Inl x) [] t m e1 [] e1.pos in
-              let letbinding = mk (Tm_let ((false, [lb]), SS.close [S.mk_binder x] e)) None e.pos in
-              mk (Tm_meta(letbinding, Meta_monadic(m, comp.res_typ))) None e.pos
+              let letbinding = mk (Tm_let ((false, [lb]), SS.close [S.mk_binder x] e)) e.pos in
+              mk (Tm_meta(letbinding, Meta_monadic(m, comp.res_typ))) e.pos
           in
           List.fold_left bind_lifted_args app lifted_args
       in
@@ -2087,7 +2087,7 @@ and check_short_circuit_args env head chead g_head args expected_topt : term * l
                           || (not (TcComm.is_total_lcomp c)
                               && not (TcUtil.is_pure_effect env c.eff_name)) in
                 seen@[as_arg e], Env.conj_guard guard g, ghost) ([], g_head, false) args bs in
-          let e = mk_Tm_app head args None r  in
+          let e = mk_Tm_app head args r  in
           let c = if ghost then S.mk_GTotal res_t |> TcComm.lcomp_of_comp else TcComm.lcomp_of_comp c in
           //NS: maybe redundant strengthen
           // let c, g = c, guard in
@@ -2134,7 +2134,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
                  | None -> t
                  | Some head_def_ts ->
                    let _, head_def = Env.inst_tscheme_with head_def_ts us in
-                   let t' = S.mk_Tm_app head_def args None t.pos in
+                   let t' = S.mk_Tm_app head_def args t.pos in
                    let t' = N.normalize [Env.Beta; Env.Iota] env t' in
                    aux false t'
         in
@@ -2218,7 +2218,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
             match formals, args with
             | [], [] ->
               let head = S.mk_Tm_uinst head us in
-              let pat_e = S.mk_Tm_app head args_out None e.pos in
+              let pat_e = S.mk_Tm_app head args_out e.pos in
               pat_e, SS.subst subst t, bvs, guard, erasable
             | (f, _)::formals, (a, imp_a)::args ->
               let t_f = SS.subst subst f.sort in
@@ -2281,10 +2281,10 @@ and tc_pat env (pat_t:typ) (p0:pat) :
           let x_b = S.gen_bv "x" None t |> S.mk_binder in
           let tm = S.mk_Tm_app
             disc
-            [x_b |> fst |> S.bv_to_name |> S.as_arg] None Range.dummyRange in
+            [x_b |> fst |> S.bv_to_name |> S.as_arg] Range.dummyRange in
           let tm = S.mk_Tm_app
             inner_t
-            [tm |> S.as_arg] None Range.dummyRange in
+            [tm |> S.as_arg] Range.dummyRange in
           U.abs [x_b] tm None in
 
         match p.v with
@@ -2526,7 +2526,7 @@ and tc_eqn scrutinee env branch
                         | None -> []  // We don't use the discriminator if we are typechecking it
                         | _ ->
                             let disc = S.fvar discriminator (Delta_equational_at_level 1) None in
-                            let disc = mk_Tm_app disc [as_arg scrutinee_tm] None scrutinee_tm.pos in
+                            let disc = mk_Tm_app disc [as_arg scrutinee_tm] scrutinee_tm.pos in
                             [U.mk_eq2 U_zero U.t_bool disc U.exp_true_bool]
                 else []
             in
@@ -2594,7 +2594,7 @@ and tc_eqn scrutinee env branch
                                   None //no projector, e.g., because we are actually typechecking the projector itself
                                 | _ ->
                                   let proj = S.fvar (Ident.set_lid_range projector f.p) (Delta_equational_at_level 1) None in
-                                  Some (mk_Tm_app proj [as_arg (force_scrutinee())] None f.p)
+                                  Some (mk_Tm_app proj [as_arg (force_scrutinee())] f.p)
                             in
                             build_branch_guard scrutinee_tm pi ei) |>
                         List.flatten
@@ -2725,7 +2725,7 @@ and tc_eqn scrutinee env branch
 
           //first apply the pat_bv_tms to the scrutinee term
           let pat_bv_tms = pat_bv_tms |> List.map (fun pat_bv_tm ->
-            mk_Tm_app pat_bv_tm [scrutinee_tm |> S.as_arg] None Range.dummyRange
+            mk_Tm_app pat_bv_tm [scrutinee_tm |> S.as_arg] Range.dummyRange
           ) in
 
           let pat_bv_tms =
@@ -2817,7 +2817,7 @@ and check_top_level_let env e =
                 if ok
                 then e2, c1
                 else (Errors.log_issue (Env.get_range env) Err.top_level_effect;
-                      mk (Tm_meta(e2, Meta_desugared Masked_effect)) None e2.pos, c1) //and tag it as masking an effect
+                      mk (Tm_meta(e2, Meta_desugared Masked_effect)) e2.pos, c1) //and tag it as masking an effect
             else //even if we're not verifying, still need to solve remaining unification/subtyping constraints
                  let _ = Rel.force_trivial_guard env g1 in
                  let comp1, g_comp1 = TcComm.lcomp_comp c1 in
@@ -2826,7 +2826,7 @@ and check_top_level_let env e =
                  let e2 = if Util.is_pure_comp c
                           then e2
                           else (Errors.log_issue (Env.get_range env) Err.top_level_effect;
-                                mk (Tm_meta(e2, Meta_desugared Masked_effect)) None e2.pos) in
+                                mk (Tm_meta(e2, Meta_desugared Masked_effect)) e2.pos) in
                  e2, c
          in
 
@@ -2870,19 +2870,19 @@ and check_top_level_let env e =
                   mk_Tm_app
                     (inst_effect_fun_with [ S.U_zero ] env c1_eff_decl ret)
                     [S.as_arg S.t_unit; S.as_arg S.unit_const]
-                    None e2.pos in
+                    e2.pos in
 
                 (* wp = M.bind wp_c1 (fun _ -> wp2) *)
                 let wp =
                   let bind = c1_eff_decl |> U.get_bind_vc_combinator in
                   mk_Tm_app
                     (inst_effect_fun_with (c1_comp_typ.comp_univs @ [S.U_zero]) env c1_eff_decl bind)
-                    [ S.as_arg <| S.mk (S.Tm_constant (FStar.Const.Const_range lb.lbpos)) None lb.lbpos;
+                    [ S.as_arg <| S.mk (S.Tm_constant (FStar.Const.Const_range lb.lbpos)) lb.lbpos;
                       S.as_arg <| c1_comp_typ.result_typ;
                       S.as_arg S.t_unit;
                       S.as_arg c1_wp;
                       S.as_arg <| U.abs [null_binder c1_comp_typ.result_typ] wp2 (Some (U.mk_residual_comp Const.effect_Tot_lid None [TOTAL])) ]
-                    None lb.lbpos in
+                    lb.lbpos in
                 mk_Comp ({
                   comp_univs=[S.U_zero];
                   effect_name=c1_comp_typ.effect_name;
@@ -2893,7 +2893,6 @@ and check_top_level_let env e =
 
 (*close*)let lb = U.close_univs_and_mk_letbinding None lb.lbname univ_vars (U.comp_result c1) (U.comp_effect_name c1) e1 lb.lbattrs lb.lbpos in
          mk (Tm_let((false, [lb]), e2))
-            None
             e.pos,
          TcComm.lcomp_of_comp cres,
          Env.trivial_guard
@@ -2985,7 +2984,7 @@ and check_inner_let env e =
        let e1 = TcUtil.maybe_lift env e1 c1.eff_name cres.eff_name c1.res_typ in
        let e2 = TcUtil.maybe_lift env e2 c2.eff_name cres.eff_name c2.res_typ in
        let lb = U.mk_letbinding (Inl x) [] c1.res_typ cres.eff_name e1 attrs lb.lbpos in
-       let e = mk (Tm_let((false, [lb]), SS.close xb e2)) None e.pos in
+       let e = mk (Tm_let((false, [lb]), SS.close xb e2)) e.pos in
        let e = TcUtil.maybe_monadic env e cres.eff_name cres.res_typ in
 
        //AR: for layered effects, solve any deferred constraints first
@@ -3064,7 +3063,7 @@ and check_top_level_let_rec env top =
 
 (*close*) let lbs, e2 = SS.close_let_rec lbs e2 in
           Rel.discharge_guard env g_lbs |> Rel.force_trivial_guard env;
-          mk (Tm_let((true, lbs), e2)) None top.pos,
+          mk (Tm_let((true, lbs), e2)) top.pos,
           cres,
           Env.trivial_guard
 
@@ -3111,7 +3110,7 @@ and check_inner_let_rec env top =
           in
 
 (*close*) let lbs, e2 = SS.close_let_rec lbs e2 in
-          let e = mk (Tm_let((true, lbs), e2)) None top.pos in
+          let e = mk (Tm_let((true, lbs), e2)) top.pos in
 
           begin match topt with
               | Some _ -> e, cres, guard //we have an annotation
@@ -3466,7 +3465,7 @@ let rec universe_of_aux env e =
    | Tm_ascribed(_, (Inl t, _), _) -> t
    | Tm_ascribed(_, (Inr c, _), _) -> U.comp_result c
    //also easy, since we can quickly recompute the type
-   | Tm_type u -> S.mk (Tm_type (U_succ u)) None e.pos
+   | Tm_type u -> S.mk (Tm_type (U_succ u)) e.pos
    | Tm_quoted _ -> U.ktype0
    | Tm_constant sc -> tc_constant env e.pos sc
    //slightly subtle, since fv is a type-scheme; instantiate it with us
@@ -3491,7 +3490,7 @@ let rec universe_of_aux env e =
         level_of_type env res (universe_of_aux env res) in
      let u_c = c |> TcUtil.universe_of_comp env u_res in
      let u = N.normalize_universe env (S.U_max (u_c::us)) in
-     S.mk (Tm_type u) None e.pos
+     S.mk (Tm_type u) e.pos
    //See the comment at the top of this function; we just compute the universe of hd's result type
    | Tm_app(hd, args) ->
      let rec type_of_head retry hd args =
@@ -3566,7 +3565,7 @@ let tc_tparams env0 (tps:binders) : (binders * Env.env * universes) =
     Returns (Some k), if it can find k quickly
 *)
 let rec type_of_well_typed_term (env:env) (t:term) : option<typ> =
-  let mk_tm_type u = S.mk (Tm_type u) None t.pos in
+  let mk_tm_type u = S.mk (Tm_type u) t.pos in
   let t = SS.compress t in
   match t.n with
   | Tm_delayed _
@@ -3606,7 +3605,7 @@ let rec type_of_well_typed_term (env:env) (t:term) : option<typ> =
     in
     BU.bind_opt mk_comp (fun f ->
     BU.bind_opt (universe_of_well_typed_term env tbody) (fun u ->
-    Some (S.mk (Tm_arrow(bs, f tbody (Some u))) None t.pos)))
+    Some (S.mk (Tm_arrow(bs, f tbody (Some u))) t.pos)))
 
   | Tm_arrow(bs, c) ->
     let bs, c = SS.open_comp bs c in
@@ -3638,16 +3637,16 @@ let rec type_of_well_typed_term (env:env) (t:term) : option<typ> =
   | Tm_app({n=Tm_constant Const_range_of}, a::hd::rest) ->
     let rest = hd::rest in //no 'as' clauses in F* yet, so we need to do this ugliness
     let unary_op, _ = U.head_and_args t in
-    let head = mk (Tm_app(unary_op, [a])) None (Range.union_ranges unary_op.pos (fst a).pos) in
-    let t = mk (Tm_app(head, rest)) None t.pos in
+    let head = mk (Tm_app(unary_op, [a])) (Range.union_ranges unary_op.pos (fst a).pos) in
+    let t = mk (Tm_app(head, rest)) t.pos in
     type_of_well_typed_term env t
 
   (* Binary operators *)
   | Tm_app({n=Tm_constant Const_set_range_of}, a1::a2::hd::rest) ->
     let rest = hd::rest in //no 'as' clauses in F* yet, so we need to do this ugliness
     let unary_op, _ = U.head_and_args t in
-    let head = mk (Tm_app(unary_op, [a1; a2])) None (Range.union_ranges unary_op.pos (fst a1).pos) in
-    let t = mk (Tm_app(head, rest)) None t.pos in
+    let head = mk (Tm_app(unary_op, [a1; a2])) (Range.union_ranges unary_op.pos (fst a1).pos) in
+    let t = mk (Tm_app(head, rest)) t.pos in
     type_of_well_typed_term env t
 
   | Tm_app({n=Tm_constant Const_range_of}, [_]) ->
@@ -3666,7 +3665,7 @@ let rec type_of_well_typed_term (env:env) (t:term) : option<typ> =
         let bs_t_opt =
           if n_args < n_bs
           then let bs, rest = BU.first_N n_args bs in
-               let t = S.mk (Tm_arrow (rest, c)) None t_hd.pos in
+               let t = S.mk (Tm_arrow (rest, c)) t_hd.pos in
                let bs, c = SS.open_comp bs (S.mk_Total t) in
                Some (bs, U.comp_result c)
           else if n_args = n_bs

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -689,4 +689,4 @@ let labeled (r: range) (msg: string) (b: Type) : Type = b
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 24
+let __cache_version_number__ = 25


### PR DESCRIPTION
Just a cleanup. This touches pretty much every file, but the changes are dead easy, so if this conflicts with some other PR we should favor the other.