### PR TITLE
Resolving single valued implicits in the unifier

### DIFF
--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -2333,5 +2333,6 @@ let (t_either_of : term -> term -> term) =
         uu____10279 :: uu____10288  in
       mk_Tm_app uu____10276 uu____10278 FStar_Range.dummyRange
   
-let (unit_const : term) =
-  mk (Tm_constant FStar_Const.Const_unit) FStar_Range.dummyRange 
+let (unit_const_with_range : FStar_Range.range -> term) =
+  fun r  -> mk (Tm_constant FStar_Const.Const_unit) r 
+let (unit_const : term) = unit_const_with_range FStar_Range.dummyRange 

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -12714,7 +12714,7 @@ let (try_solve_single_valued_implicits :
         match uu____32176 with
         | (ctx_u,r) ->
             let t_norm =
-              FStar_TypeChecker_Normalize.normalize_refinement
+              FStar_TypeChecker_Normalize.normalize
                 FStar_TypeChecker_Normalize.whnf_steps env
                 ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
                in

--- a/src/syntax/FStar.Syntax.Syntax.fs
+++ b/src/syntax/FStar.Syntax.Syntax.fs
@@ -747,4 +747,6 @@ let t_list_of t = mk_Tm_app (mk_Tm_uinst (tabbrev PC.list_lid) [U_zero]) [as_arg
 let t_option_of t = mk_Tm_app (mk_Tm_uinst (tabbrev PC.option_lid) [U_zero]) [as_arg t] Range.dummyRange
 let t_tuple2_of t1 t2 = mk_Tm_app (mk_Tm_uinst (tabbrev PC.lid_tuple2) [U_zero;U_zero]) [as_arg t1; as_arg t2] Range.dummyRange
 let t_either_of t1 t2 = mk_Tm_app (mk_Tm_uinst (tabbrev PC.either_lid) [U_zero;U_zero]) [as_arg t1; as_arg t2] Range.dummyRange
-let unit_const = mk (Tm_constant FStar.Const.Const_unit) Range.dummyRange
+
+let unit_const_with_range r = mk (Tm_constant FStar.Const.Const_unit) r
+let unit_const = unit_const_with_range Range.dummyRange

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -644,4 +644,6 @@ val t_list_of       : term -> term
 val t_option_of     : term -> term
 val t_tuple2_of     : term -> term -> term
 val t_either_of     : term -> term -> term
-val unit_const      : term
+
+val unit_const_with_range : Range.range -> term
+val unit_const            : term

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -3876,7 +3876,7 @@ let try_solve_single_valued_implicits env (imps:Env.implicits) : Env.implicits *
   let imp_value imp : option<term> =
     let ctx_u, r = imp.imp_uvar, imp.imp_range in
 
-    let t_norm = N.normalize_refinement N.whnf_steps env ctx_u.ctx_uvar_typ in
+    let t_norm = N.normalize N.whnf_steps env ctx_u.ctx_uvar_typ in
     
     match (SS.compress t_norm).n with
     | Tm_fvar fv when S.fv_eq_lid fv Const.unit_lid ->

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -3887,14 +3887,12 @@ let try_solve_single_valued_implicits env (imps:Env.implicits) : Env.implicits *
 
   in
 
-  let tx = UF.new_transaction () in
-
-  let b = List.fold_left (fun b imp ->
-    match imp_value imp with
-    | Some tm -> commit ([TERM (imp.imp_uvar, tm)]); true
-    | None -> b) false imps in
-
-  UF.commit tx;
+  let b = List.fold_left (fun b imp ->  //check that the imp is still unsolved
+    if UF.find imp.imp_uvar.ctx_uvar_head |> is_none
+    then match imp_value imp with
+         | Some tm -> commit ([TERM (imp.imp_uvar, tm)]); true
+         | None -> b
+    else b) false imps in
 
   imps, b
   

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -3847,6 +3847,57 @@ let teq_nosmt (env:env) (t1:typ) (t2:typ) : option<guard_t> =
   | None -> None
   | Some g -> discharge_guard' None env g false
 
+(*
+ * Solve the uni-valued implicits
+ *
+ * For now we handle only unit and unit refinement typed implicits,
+ *   we can later extend it to single constructor inductives
+ *
+ * This function gets the unresolved implicits from the main resolve_implicits'
+ *   function
+ *
+ * It only sets the value of the implicit's ctx uvar in the UF graph
+ * -- leaving their typechecking to resolve_implicits'
+ *
+ * E.g. for a ?u:squash phi, this will only set ?u=unit in the UF graph,
+ *   and, as usual, resolve_implicits' will check that G |= phi
+ *
+ * It returns a boolean (true if at least one implicit was solved)
+ *   and the set of new implicits, right now this set is same as imps,
+ *   for inductives, this may later include implicits for pattern variables
+ *)
+ 
+let try_solve_single_valued_implicits env (imps:Env.implicits) : Env.implicits * bool =
+  (*
+   * Get the value of the implicit imp
+   * Going forward, it can also return new implicits for the pattern variables
+   *   (cf. the comment above about extending it to inductives)
+   *)
+  let imp_value imp : option<term> =
+    let ctx_u, r = imp.imp_uvar, imp.imp_range in
+
+    let t_norm = N.normalize_refinement N.whnf_steps env ctx_u.ctx_uvar_typ in
+    
+    match (SS.compress t_norm).n with
+    | Tm_fvar fv when S.fv_eq_lid fv Const.unit_lid ->
+      r |> S.unit_const_with_range |> Some
+    | Tm_refine (b, _) when U.is_unit b.sort ->
+      r |> S.unit_const_with_range |> Some
+    | _ -> None
+
+  in
+
+  let tx = UF.new_transaction () in
+
+  let b = List.fold_left (fun b imp ->
+    match imp_value imp with
+    | Some tm -> commit ([TERM (imp.imp_uvar, tm)]); true
+    | None -> b) false imps in
+
+  UF.commit tx;
+
+  imps, b
+  
 let resolve_implicits' env must_total forcelax g =
   let rec unresolved ctx_u =
     match (Unionfind.find ctx_u.ctx_uvar_head) with
@@ -3869,7 +3920,12 @@ let resolve_implicits' env must_total forcelax g =
   let rec until_fixpoint (acc: Env.implicits * bool) (implicits:Env.implicits) : Env.implicits =
     let out, changed = acc in
     match implicits with
-    | [] -> if not changed then out else until_fixpoint ([], false) out
+    | [] ->
+      if not changed
+      then let out, changed = try_solve_single_valued_implicits env out in
+           if changed then until_fixpoint ([], false) out
+           else out
+      else until_fixpoint ([], false) out
     | hd::tl ->
           let { imp_reason = reason; imp_tm = tm; imp_uvar = ctx_u; imp_range = r } = hd in
           if ctx_u.ctx_uvar_should_check = Allow_unresolved

--- a/tests/micro-benchmarks/Unit1.UnificationTests.fst
+++ b/tests/micro-benchmarks/Unit1.UnificationTests.fst
@@ -71,3 +71,16 @@ let test_unit_valued_implicits0 () : PURE unit (fun p -> some_predicate /\ p ())
 [@@ expect_failure [19]]
 let test_unit_valued_implicits1 () : PURE unit (fun p -> p ()) = some_f _
 
+// test two refinements
+assume val some_other_predicate : prop
+assume val some_g (_:(_:unit{some_predicate}){some_other_predicate}) : unit
+
+[@@ expect_failure [19]]
+let test_unit_valued_implicits2 () : PURE unit (fun p -> p ()) = some_g _
+
+[@@ expect_failure [19]]
+let test_unit_valued_implicits3 ()
+: PURE unit (fun p -> some_predicate /\ p ()) = some_g _
+
+let test_unit_valued_implicits4 ()
+: PURE unit (fun p -> some_predicate /\ some_other_predicate /\ p ()) = some_g _

--- a/tests/micro-benchmarks/Unit1.UnificationTests.fst
+++ b/tests/micro-benchmarks/Unit1.UnificationTests.fst
@@ -56,3 +56,18 @@ let h_923 (g: u_923 ()) : Tot p_923 =
 unfold let buf_760 (a:Type0) = l:list a { l == [] }
 val test_760 : a:Type0 -> Tot (buf_760 a)
 let test_760 a = admit #(buf_760 a) ()
+
+
+(***** tests for unit valued implicits *****)
+
+assume val some_predicate : prop
+assume val some_f (#_:squash some_predicate) (#_:unit) (_:unit) : unit
+
+let test_unit_valued_implicits0 () : PURE unit (fun p -> some_predicate /\ p ()) =
+  some_f _
+
+// make sure that we are not dropping the guard
+
+[@@ expect_failure [19]]
+let test_unit_valued_implicits1 () : PURE unit (fun p -> p ()) = some_f _
+


### PR DESCRIPTION
Patch for solving single-valued implicits in the unifier as discussed. The implementation for now only supports `unit`, but adding other single constructor inductives shouldn't be too hard. I can do it some time later.