### PR TITLE
Removing the restriction for the totality check and lifts on layered effects to relate to the underlying representation type

### DIFF
--- a/src/fstar/FStar.CheckedFiles.fs
+++ b/src/fstar/FStar.CheckedFiles.fs
@@ -42,7 +42,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It need to be kept in sync with prims.fst
  *)
-let cache_version_number = 26
+let cache_version_number = 27
 
 type tc_result = {
   checked_module: Syntax.modul; //persisted

--- a/src/ocaml-output/FStar_CheckedFiles.ml
+++ b/src/ocaml-output/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (26))
+let (cache_version_number : Prims.int) = (Prims.of_int (27))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -1259,32 +1259,28 @@ let (layered_eff_combinators_to_string :
           let uu____3816 = tscheme_to_string ts_ty in
           FStar_Util.format2 "(%s) : (%s)" uu____3814 uu____3816 in
     let uu____3819 =
-      let uu____3823 =
-        FStar_Ident.string_of_lid combs.FStar_Syntax_Syntax.l_base_effect in
+      let uu____3823 = to_str combs.FStar_Syntax_Syntax.l_repr in
       let uu____3825 =
-        let uu____3829 = to_str combs.FStar_Syntax_Syntax.l_repr in
+        let uu____3829 = to_str combs.FStar_Syntax_Syntax.l_return in
         let uu____3831 =
-          let uu____3835 = to_str combs.FStar_Syntax_Syntax.l_return in
+          let uu____3835 = to_str combs.FStar_Syntax_Syntax.l_bind in
           let uu____3837 =
-            let uu____3841 = to_str combs.FStar_Syntax_Syntax.l_bind in
+            let uu____3841 = to_str combs.FStar_Syntax_Syntax.l_subcomp in
             let uu____3843 =
-              let uu____3847 = to_str combs.FStar_Syntax_Syntax.l_subcomp in
-              let uu____3849 =
-                let uu____3853 =
-                  to_str combs.FStar_Syntax_Syntax.l_if_then_else in
-                [uu____3853] in
-              uu____3847 :: uu____3849 in
+              let uu____3847 =
+                to_str combs.FStar_Syntax_Syntax.l_if_then_else in
+              [uu____3847] in
             uu____3841 :: uu____3843 in
           uu____3835 :: uu____3837 in
         uu____3829 :: uu____3831 in
       uu____3823 :: uu____3825 in
     FStar_Util.format
-      "{\nl_base_effect = %s\n; l_repr = %s\n; l_return = %s\n; l_bind = %s\n; l_subcomp = %s\n; l_if_then_else = %s\n\n  }\n"
+      "{\n; l_repr = %s\n; l_return = %s\n; l_bind = %s\n; l_subcomp = %s\n; l_if_then_else = %s\n\n  }\n"
       uu____3819
 let (eff_combinators_to_string :
   FStar_Syntax_Syntax.eff_combinators -> Prims.string) =
-  fun uu___14_3869 ->
-    match uu___14_3869 with
+  fun uu___14_3862 ->
+    match uu___14_3862 with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
         wp_eff_combinators_to_string combs
     | FStar_Syntax_Syntax.DM4F_eff combs ->
@@ -1301,10 +1297,10 @@ let (eff_decl_to_string' :
     fun r ->
       fun q ->
         fun ed ->
-          let uu____3902 =
-            let uu____3904 = FStar_Options.ugly () in
-            Prims.op_Negation uu____3904 in
-          if uu____3902
+          let uu____3895 =
+            let uu____3897 = FStar_Options.ugly () in
+            Prims.op_Negation uu____3897 in
+          if uu____3895
           then
             let d = FStar_Syntax_Resugar.resugar_eff_decl r q ed in
             let d1 = FStar_Parser_ToDocument.decl_to_document d in
@@ -1312,48 +1308,48 @@ let (eff_decl_to_string' :
               (Prims.of_int (100)) d1
           else
             (let actions_to_string actions =
-               let uu____3925 =
+               let uu____3918 =
                  FStar_All.pipe_right actions
                    (FStar_List.map action_to_string) in
-               FStar_All.pipe_right uu____3925 (FStar_String.concat ",\n\t") in
+               FStar_All.pipe_right uu____3918 (FStar_String.concat ",\n\t") in
              let eff_name =
-               let uu____3942 = FStar_Syntax_Util.is_layered ed in
-               if uu____3942 then "layered_effect" else "new_effect" in
-             let uu____3950 =
-               let uu____3954 =
-                 let uu____3958 =
-                   let uu____3962 =
+               let uu____3935 = FStar_Syntax_Util.is_layered ed in
+               if uu____3935 then "layered_effect" else "new_effect" in
+             let uu____3943 =
+               let uu____3947 =
+                 let uu____3951 =
+                   let uu____3955 =
                      lid_to_string ed.FStar_Syntax_Syntax.mname in
-                   let uu____3964 =
-                     let uu____3968 =
-                       let uu____3970 =
+                   let uu____3957 =
+                     let uu____3961 =
+                       let uu____3963 =
                          univ_names_to_string ed.FStar_Syntax_Syntax.univs in
-                       FStar_All.pipe_left enclose_universes uu____3970 in
-                     let uu____3974 =
-                       let uu____3978 =
+                       FStar_All.pipe_left enclose_universes uu____3963 in
+                     let uu____3967 =
+                       let uu____3971 =
                          binders_to_string " " ed.FStar_Syntax_Syntax.binders in
-                       let uu____3981 =
-                         let uu____3985 =
+                       let uu____3974 =
+                         let uu____3978 =
                            tscheme_to_string ed.FStar_Syntax_Syntax.signature in
-                         let uu____3987 =
-                           let uu____3991 =
+                         let uu____3980 =
+                           let uu____3984 =
                              eff_combinators_to_string
                                ed.FStar_Syntax_Syntax.combinators in
-                           let uu____3993 =
-                             let uu____3997 =
+                           let uu____3986 =
+                             let uu____3990 =
                                actions_to_string
                                  ed.FStar_Syntax_Syntax.actions in
-                             [uu____3997] in
-                           uu____3991 :: uu____3993 in
-                         uu____3985 :: uu____3987 in
-                       uu____3978 :: uu____3981 in
-                     uu____3968 :: uu____3974 in
-                   uu____3962 :: uu____3964 in
-                 (if for_free then "_for_free " else "") :: uu____3958 in
-               eff_name :: uu____3954 in
+                             [uu____3990] in
+                           uu____3984 :: uu____3986 in
+                         uu____3978 :: uu____3980 in
+                       uu____3971 :: uu____3974 in
+                     uu____3961 :: uu____3967 in
+                   uu____3955 :: uu____3957 in
+                 (if for_free then "_for_free " else "") :: uu____3951 in
+               eff_name :: uu____3947 in
              FStar_Util.format
                "%s%s { %s%s %s : %s \n  %s\nand effect_actions\n\t%s\n}\n"
-               uu____3950)
+               uu____3943)
 let (eff_decl_to_string :
   Prims.bool -> FStar_Syntax_Syntax.eff_decl -> Prims.string) =
   fun for_free ->
@@ -1363,15 +1359,15 @@ let (sub_eff_to_string : FStar_Syntax_Syntax.sub_eff -> Prims.string) =
     let tsopt_to_string ts_opt =
       if FStar_Util.is_some ts_opt
       then
-        let uu____4049 = FStar_All.pipe_right ts_opt FStar_Util.must in
-        FStar_All.pipe_right uu____4049 tscheme_to_string
+        let uu____4042 = FStar_All.pipe_right ts_opt FStar_Util.must in
+        FStar_All.pipe_right uu____4042 tscheme_to_string
       else "<None>" in
-    let uu____4056 = lid_to_string se.FStar_Syntax_Syntax.source in
-    let uu____4058 = lid_to_string se.FStar_Syntax_Syntax.target in
-    let uu____4060 = tsopt_to_string se.FStar_Syntax_Syntax.lift in
-    let uu____4062 = tsopt_to_string se.FStar_Syntax_Syntax.lift_wp in
+    let uu____4049 = lid_to_string se.FStar_Syntax_Syntax.source in
+    let uu____4051 = lid_to_string se.FStar_Syntax_Syntax.target in
+    let uu____4053 = tsopt_to_string se.FStar_Syntax_Syntax.lift in
+    let uu____4055 = tsopt_to_string se.FStar_Syntax_Syntax.lift_wp in
     FStar_Util.format4 "sub_effect %s ~> %s : lift = %s ;; lift_wp = %s"
-      uu____4056 uu____4058 uu____4060 uu____4062
+      uu____4049 uu____4051 uu____4053 uu____4055
 let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun x ->
     let basic =
@@ -1395,192 +1391,192 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
       | FStar_Syntax_Syntax.Sig_pragma (FStar_Syntax_Syntax.PopOptions) ->
           "#pop-options"
       | FStar_Syntax_Syntax.Sig_inductive_typ
-          (lid, univs, tps, k, uu____4097, uu____4098) ->
+          (lid, univs, tps, k, uu____4090, uu____4091) ->
           let quals_str = quals_to_string' x.FStar_Syntax_Syntax.sigquals in
           let binders_str = binders_to_string " " tps in
           let term_str = term_to_string k in
-          let uu____4114 = FStar_Options.print_universes () in
-          if uu____4114
+          let uu____4107 = FStar_Options.print_universes () in
+          if uu____4107
           then
-            let uu____4118 = FStar_Ident.string_of_lid lid in
-            let uu____4120 = univ_names_to_string univs in
-            FStar_Util.format5 "%stype %s<%s> %s : %s" quals_str uu____4118
-              uu____4120 binders_str term_str
+            let uu____4111 = FStar_Ident.string_of_lid lid in
+            let uu____4113 = univ_names_to_string univs in
+            FStar_Util.format5 "%stype %s<%s> %s : %s" quals_str uu____4111
+              uu____4113 binders_str term_str
           else
-            (let uu____4125 = FStar_Ident.string_of_lid lid in
-             FStar_Util.format4 "%stype %s %s : %s" quals_str uu____4125
+            (let uu____4118 = FStar_Ident.string_of_lid lid in
+             FStar_Util.format4 "%stype %s %s : %s" quals_str uu____4118
                binders_str term_str)
       | FStar_Syntax_Syntax.Sig_datacon
-          (lid, univs, t, uu____4131, uu____4132, uu____4133) ->
-          let uu____4140 = FStar_Options.print_universes () in
-          if uu____4140
+          (lid, univs, t, uu____4124, uu____4125, uu____4126) ->
+          let uu____4133 = FStar_Options.print_universes () in
+          if uu____4133
           then
-            let uu____4144 = univ_names_to_string univs in
-            let uu____4146 = FStar_Ident.string_of_lid lid in
-            let uu____4148 = term_to_string t in
-            FStar_Util.format3 "datacon<%s> %s : %s" uu____4144 uu____4146
-              uu____4148
+            let uu____4137 = univ_names_to_string univs in
+            let uu____4139 = FStar_Ident.string_of_lid lid in
+            let uu____4141 = term_to_string t in
+            FStar_Util.format3 "datacon<%s> %s : %s" uu____4137 uu____4139
+              uu____4141
           else
-            (let uu____4153 = FStar_Ident.string_of_lid lid in
-             let uu____4155 = term_to_string t in
-             FStar_Util.format2 "datacon %s : %s" uu____4153 uu____4155)
+            (let uu____4146 = FStar_Ident.string_of_lid lid in
+             let uu____4148 = term_to_string t in
+             FStar_Util.format2 "datacon %s : %s" uu____4146 uu____4148)
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) ->
-          let uu____4161 = quals_to_string' x.FStar_Syntax_Syntax.sigquals in
-          let uu____4163 = FStar_Ident.string_of_lid lid in
-          let uu____4165 =
-            let uu____4167 = FStar_Options.print_universes () in
-            if uu____4167
+          let uu____4154 = quals_to_string' x.FStar_Syntax_Syntax.sigquals in
+          let uu____4156 = FStar_Ident.string_of_lid lid in
+          let uu____4158 =
+            let uu____4160 = FStar_Options.print_universes () in
+            if uu____4160
             then
-              let uu____4171 = univ_names_to_string univs in
-              FStar_Util.format1 "<%s>" uu____4171
+              let uu____4164 = univ_names_to_string univs in
+              FStar_Util.format1 "<%s>" uu____4164
             else "" in
-          let uu____4177 = term_to_string t in
-          FStar_Util.format4 "%sval %s %s : %s" uu____4161 uu____4163
-            uu____4165 uu____4177
+          let uu____4170 = term_to_string t in
+          FStar_Util.format4 "%sval %s %s : %s" uu____4154 uu____4156
+            uu____4158 uu____4170
       | FStar_Syntax_Syntax.Sig_assume (lid, us, f) ->
-          let uu____4183 = FStar_Options.print_universes () in
-          if uu____4183
+          let uu____4176 = FStar_Options.print_universes () in
+          if uu____4176
           then
-            let uu____4187 = FStar_Ident.string_of_lid lid in
-            let uu____4189 = univ_names_to_string us in
-            let uu____4191 = term_to_string f in
-            FStar_Util.format3 "val %s<%s> : %s" uu____4187 uu____4189
-              uu____4191
+            let uu____4180 = FStar_Ident.string_of_lid lid in
+            let uu____4182 = univ_names_to_string us in
+            let uu____4184 = term_to_string f in
+            FStar_Util.format3 "val %s<%s> : %s" uu____4180 uu____4182
+              uu____4184
           else
-            (let uu____4196 = FStar_Ident.string_of_lid lid in
-             let uu____4198 = term_to_string f in
-             FStar_Util.format2 "val %s : %s" uu____4196 uu____4198)
-      | FStar_Syntax_Syntax.Sig_let (lbs, uu____4202) ->
+            (let uu____4189 = FStar_Ident.string_of_lid lid in
+             let uu____4191 = term_to_string f in
+             FStar_Util.format2 "val %s : %s" uu____4189 uu____4191)
+      | FStar_Syntax_Syntax.Sig_let (lbs, uu____4195) ->
           lbs_to_string x.FStar_Syntax_Syntax.sigquals lbs
-      | FStar_Syntax_Syntax.Sig_bundle (ses, uu____4208) ->
-          let uu____4217 =
-            let uu____4219 = FStar_List.map sigelt_to_string ses in
-            FStar_All.pipe_right uu____4219 (FStar_String.concat "\n") in
-          Prims.op_Hat "(* Sig_bundle *)" uu____4217
+      | FStar_Syntax_Syntax.Sig_bundle (ses, uu____4201) ->
+          let uu____4210 =
+            let uu____4212 = FStar_List.map sigelt_to_string ses in
+            FStar_All.pipe_right uu____4212 (FStar_String.concat "\n") in
+          Prims.op_Hat "(* Sig_bundle *)" uu____4210
       | FStar_Syntax_Syntax.Sig_fail (errs, lax, ses) ->
-          let uu____4245 = FStar_Util.string_of_bool lax in
-          let uu____4247 =
+          let uu____4238 = FStar_Util.string_of_bool lax in
+          let uu____4240 =
             FStar_Common.string_of_list FStar_Util.string_of_int errs in
-          let uu____4250 =
-            let uu____4252 = FStar_List.map sigelt_to_string ses in
-            FStar_All.pipe_right uu____4252 (FStar_String.concat "\n") in
+          let uu____4243 =
+            let uu____4245 = FStar_List.map sigelt_to_string ses in
+            FStar_All.pipe_right uu____4245 (FStar_String.concat "\n") in
           FStar_Util.format3 "(* Sig_fail %s %s *)\n%s\n(* / Sig_fail*)\n"
-            uu____4245 uu____4247 uu____4250
+            uu____4238 uu____4240 uu____4243
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____4264 = FStar_Syntax_Util.is_dm4f ed in
-          eff_decl_to_string' uu____4264 x.FStar_Syntax_Syntax.sigrng
+          let uu____4257 = FStar_Syntax_Util.is_dm4f ed in
+          eff_decl_to_string' uu____4257 x.FStar_Syntax_Syntax.sigrng
             x.FStar_Syntax_Syntax.sigquals ed
       | FStar_Syntax_Syntax.Sig_sub_effect se -> sub_eff_to_string se
       | FStar_Syntax_Syntax.Sig_effect_abbrev (l, univs, tps, c, flags) ->
-          let uu____4276 = FStar_Options.print_universes () in
-          if uu____4276
+          let uu____4269 = FStar_Options.print_universes () in
+          if uu____4269
           then
-            let uu____4280 =
-              let uu____4285 =
+            let uu____4273 =
+              let uu____4278 =
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (tps, c))
                   FStar_Range.dummyRange in
-              FStar_Syntax_Subst.open_univ_vars univs uu____4285 in
-            (match uu____4280 with
+              FStar_Syntax_Subst.open_univ_vars univs uu____4278 in
+            (match uu____4273 with
              | (univs1, t) ->
-                 let uu____4299 =
-                   let uu____4304 =
-                     let uu____4305 = FStar_Syntax_Subst.compress t in
-                     uu____4305.FStar_Syntax_Syntax.n in
-                   match uu____4304 with
+                 let uu____4292 =
+                   let uu____4297 =
+                     let uu____4298 = FStar_Syntax_Subst.compress t in
+                     uu____4298.FStar_Syntax_Syntax.n in
+                   match uu____4297 with
                    | FStar_Syntax_Syntax.Tm_arrow (bs, c1) -> (bs, c1)
-                   | uu____4334 -> failwith "impossible" in
-                 (match uu____4299 with
+                   | uu____4327 -> failwith "impossible" in
+                 (match uu____4292 with
                   | (tps1, c1) ->
-                      let uu____4343 = sli l in
-                      let uu____4345 = univ_names_to_string univs1 in
-                      let uu____4347 = binders_to_string " " tps1 in
-                      let uu____4350 = comp_to_string c1 in
-                      FStar_Util.format4 "effect %s<%s> %s = %s" uu____4343
-                        uu____4345 uu____4347 uu____4350))
+                      let uu____4336 = sli l in
+                      let uu____4338 = univ_names_to_string univs1 in
+                      let uu____4340 = binders_to_string " " tps1 in
+                      let uu____4343 = comp_to_string c1 in
+                      FStar_Util.format4 "effect %s<%s> %s = %s" uu____4336
+                        uu____4338 uu____4340 uu____4343))
           else
-            (let uu____4355 = sli l in
-             let uu____4357 = binders_to_string " " tps in
-             let uu____4360 = comp_to_string c in
-             FStar_Util.format3 "effect %s %s = %s" uu____4355 uu____4357
-               uu____4360)
+            (let uu____4348 = sli l in
+             let uu____4350 = binders_to_string " " tps in
+             let uu____4353 = comp_to_string c in
+             FStar_Util.format3 "effect %s %s = %s" uu____4348 uu____4350
+               uu____4353)
       | FStar_Syntax_Syntax.Sig_splice (lids, t) ->
-          let uu____4369 =
-            let uu____4371 = FStar_List.map FStar_Ident.string_of_lid lids in
-            FStar_All.pipe_left (FStar_String.concat "; ") uu____4371 in
-          let uu____4381 = term_to_string t in
-          FStar_Util.format2 "splice[%s] (%s)" uu____4369 uu____4381
+          let uu____4362 =
+            let uu____4364 = FStar_List.map FStar_Ident.string_of_lid lids in
+            FStar_All.pipe_left (FStar_String.concat "; ") uu____4364 in
+          let uu____4374 = term_to_string t in
+          FStar_Util.format2 "splice[%s] (%s)" uu____4362 uu____4374
       | FStar_Syntax_Syntax.Sig_polymonadic_bind (m, n, p, t, ty) ->
-          let uu____4389 = FStar_Ident.string_of_lid m in
-          let uu____4391 = FStar_Ident.string_of_lid n in
-          let uu____4393 = FStar_Ident.string_of_lid p in
-          let uu____4395 = tscheme_to_string t in
-          let uu____4397 = tscheme_to_string ty in
+          let uu____4382 = FStar_Ident.string_of_lid m in
+          let uu____4384 = FStar_Ident.string_of_lid n in
+          let uu____4386 = FStar_Ident.string_of_lid p in
+          let uu____4388 = tscheme_to_string t in
+          let uu____4390 = tscheme_to_string ty in
           FStar_Util.format5 "polymonadic_bind (%s, %s) |> %s = (%s, %s)"
-            uu____4389 uu____4391 uu____4393 uu____4395 uu____4397 in
+            uu____4382 uu____4384 uu____4386 uu____4388 uu____4390 in
     match x.FStar_Syntax_Syntax.sigattrs with
     | [] -> Prims.op_Hat "[@ ]" (Prims.op_Hat "\n" basic)
-    | uu____4403 ->
-        let uu____4406 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs in
-        Prims.op_Hat uu____4406 (Prims.op_Hat "\n" basic)
+    | uu____4396 ->
+        let uu____4399 = attrs_to_string x.FStar_Syntax_Syntax.sigattrs in
+        Prims.op_Hat uu____4399 (Prims.op_Hat "\n" basic)
 let (format_error : FStar_Range.range -> Prims.string -> Prims.string) =
   fun r ->
     fun msg ->
-      let uu____4423 = FStar_Range.string_of_range r in
-      FStar_Util.format2 "%s: %s\n" uu____4423 msg
+      let uu____4416 = FStar_Range.string_of_range r in
+      FStar_Util.format2 "%s: %s\n" uu____4416 msg
 let (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun x ->
     match x.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_let
-        ((uu____4434,
+        ((uu____4427,
           { FStar_Syntax_Syntax.lbname = lb;
-            FStar_Syntax_Syntax.lbunivs = uu____4436;
+            FStar_Syntax_Syntax.lbunivs = uu____4429;
             FStar_Syntax_Syntax.lbtyp = t;
-            FStar_Syntax_Syntax.lbeff = uu____4438;
-            FStar_Syntax_Syntax.lbdef = uu____4439;
-            FStar_Syntax_Syntax.lbattrs = uu____4440;
-            FStar_Syntax_Syntax.lbpos = uu____4441;_}::[]),
-         uu____4442)
+            FStar_Syntax_Syntax.lbeff = uu____4431;
+            FStar_Syntax_Syntax.lbdef = uu____4432;
+            FStar_Syntax_Syntax.lbattrs = uu____4433;
+            FStar_Syntax_Syntax.lbpos = uu____4434;_}::[]),
+         uu____4435)
         ->
-        let uu____4465 = lbname_to_string lb in
-        let uu____4467 = term_to_string t in
-        FStar_Util.format2 "let %s : %s" uu____4465 uu____4467
-    | uu____4470 ->
-        let uu____4471 =
+        let uu____4458 = lbname_to_string lb in
+        let uu____4460 = term_to_string t in
+        FStar_Util.format2 "let %s : %s" uu____4458 uu____4460
+    | uu____4463 ->
+        let uu____4464 =
           FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt x)
             (FStar_List.map (fun l -> FStar_Ident.string_of_lid l)) in
-        FStar_All.pipe_right uu____4471 (FStar_String.concat ", ")
+        FStar_All.pipe_right uu____4464 (FStar_String.concat ", ")
 let (tag_of_sigelt : FStar_Syntax_Syntax.sigelt -> Prims.string) =
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
-    | FStar_Syntax_Syntax.Sig_inductive_typ uu____4497 -> "Sig_inductive_typ"
-    | FStar_Syntax_Syntax.Sig_bundle uu____4515 -> "Sig_bundle"
-    | FStar_Syntax_Syntax.Sig_datacon uu____4525 -> "Sig_datacon"
-    | FStar_Syntax_Syntax.Sig_declare_typ uu____4542 -> "Sig_declare_typ"
-    | FStar_Syntax_Syntax.Sig_let uu____4550 -> "Sig_let"
-    | FStar_Syntax_Syntax.Sig_assume uu____4558 -> "Sig_assume"
-    | FStar_Syntax_Syntax.Sig_new_effect uu____4566 -> "Sig_new_effect"
-    | FStar_Syntax_Syntax.Sig_sub_effect uu____4568 -> "Sig_sub_effect"
-    | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4570 -> "Sig_effect_abbrev"
-    | FStar_Syntax_Syntax.Sig_pragma uu____4584 -> "Sig_pragma"
-    | FStar_Syntax_Syntax.Sig_splice uu____4586 -> "Sig_splice"
-    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____4594 ->
+    | FStar_Syntax_Syntax.Sig_inductive_typ uu____4490 -> "Sig_inductive_typ"
+    | FStar_Syntax_Syntax.Sig_bundle uu____4508 -> "Sig_bundle"
+    | FStar_Syntax_Syntax.Sig_datacon uu____4518 -> "Sig_datacon"
+    | FStar_Syntax_Syntax.Sig_declare_typ uu____4535 -> "Sig_declare_typ"
+    | FStar_Syntax_Syntax.Sig_let uu____4543 -> "Sig_let"
+    | FStar_Syntax_Syntax.Sig_assume uu____4551 -> "Sig_assume"
+    | FStar_Syntax_Syntax.Sig_new_effect uu____4559 -> "Sig_new_effect"
+    | FStar_Syntax_Syntax.Sig_sub_effect uu____4561 -> "Sig_sub_effect"
+    | FStar_Syntax_Syntax.Sig_effect_abbrev uu____4563 -> "Sig_effect_abbrev"
+    | FStar_Syntax_Syntax.Sig_pragma uu____4577 -> "Sig_pragma"
+    | FStar_Syntax_Syntax.Sig_splice uu____4579 -> "Sig_splice"
+    | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____4587 ->
         "Sig_polymonadic_bind"
-    | FStar_Syntax_Syntax.Sig_fail uu____4606 -> "Sig_fail"
+    | FStar_Syntax_Syntax.Sig_fail uu____4599 -> "Sig_fail"
 let (modul_to_string : FStar_Syntax_Syntax.modul -> Prims.string) =
   fun m ->
-    let uu____4627 = sli m.FStar_Syntax_Syntax.name in
-    let uu____4629 =
-      let uu____4631 =
+    let uu____4620 = sli m.FStar_Syntax_Syntax.name in
+    let uu____4622 =
+      let uu____4624 =
         FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.declarations in
-      FStar_All.pipe_right uu____4631 (FStar_String.concat "\n") in
-    let uu____4641 =
-      let uu____4643 =
+      FStar_All.pipe_right uu____4624 (FStar_String.concat "\n") in
+    let uu____4634 =
+      let uu____4636 =
         FStar_List.map sigelt_to_string m.FStar_Syntax_Syntax.exports in
-      FStar_All.pipe_right uu____4643 (FStar_String.concat "\n") in
+      FStar_All.pipe_right uu____4636 (FStar_String.concat "\n") in
     FStar_Util.format3
-      "module %s\nDeclarations: [\n%s\n]\nExports: [\n%s\n]\n" uu____4627
-      uu____4629 uu____4641
+      "module %s\nDeclarations: [\n%s\n]\nExports: [\n%s\n]\n" uu____4620
+      uu____4622 uu____4634
 let list_to_string :
   'a . ('a -> Prims.string) -> 'a Prims.list -> Prims.string =
   fun f ->
@@ -1590,13 +1586,13 @@ let list_to_string :
       | x::xs ->
           let strb = FStar_Util.new_string_builder () in
           (FStar_Util.string_builder_append strb "[";
-           (let uu____4693 = f x in
-            FStar_Util.string_builder_append strb uu____4693);
+           (let uu____4686 = f x in
+            FStar_Util.string_builder_append strb uu____4686);
            FStar_List.iter
              (fun x1 ->
                 FStar_Util.string_builder_append strb "; ";
-                (let uu____4702 = f x1 in
-                 FStar_Util.string_builder_append strb uu____4702)) xs;
+                (let uu____4695 = f x1 in
+                 FStar_Util.string_builder_append strb uu____4695)) xs;
            FStar_Util.string_builder_append strb "]";
            FStar_Util.string_of_string_builder strb)
 let set_to_string :
@@ -1609,42 +1605,42 @@ let set_to_string :
       | x::xs ->
           let strb = FStar_Util.new_string_builder () in
           (FStar_Util.string_builder_append strb "{";
-           (let uu____4749 = f x in
-            FStar_Util.string_builder_append strb uu____4749);
+           (let uu____4742 = f x in
+            FStar_Util.string_builder_append strb uu____4742);
            FStar_List.iter
              (fun x1 ->
                 FStar_Util.string_builder_append strb ", ";
-                (let uu____4758 = f x1 in
-                 FStar_Util.string_builder_append strb uu____4758)) xs;
+                (let uu____4751 = f x1 in
+                 FStar_Util.string_builder_append strb uu____4751)) xs;
            FStar_Util.string_builder_append strb "}";
            FStar_Util.string_of_string_builder strb)
 let (bvs_to_string :
   Prims.string -> FStar_Syntax_Syntax.bv Prims.list -> Prims.string) =
   fun sep ->
     fun bvs ->
-      let uu____4780 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs in
-      binders_to_string sep uu____4780
+      let uu____4773 = FStar_List.map FStar_Syntax_Syntax.mk_binder bvs in
+      binders_to_string sep uu____4773
 let rec (emb_typ_to_string : FStar_Syntax_Syntax.emb_typ -> Prims.string) =
-  fun uu___15_4793 ->
-    match uu___15_4793 with
+  fun uu___15_4786 ->
+    match uu___15_4786 with
     | FStar_Syntax_Syntax.ET_abstract -> "abstract"
     | FStar_Syntax_Syntax.ET_app (h, []) -> h
     | FStar_Syntax_Syntax.ET_app (h, args) ->
-        let uu____4809 =
-          let uu____4811 =
-            let uu____4813 =
-              let uu____4815 =
-                let uu____4817 = FStar_List.map emb_typ_to_string args in
-                FStar_All.pipe_right uu____4817 (FStar_String.concat " ") in
-              Prims.op_Hat uu____4815 ")" in
-            Prims.op_Hat " " uu____4813 in
-          Prims.op_Hat h uu____4811 in
-        Prims.op_Hat "(" uu____4809
+        let uu____4802 =
+          let uu____4804 =
+            let uu____4806 =
+              let uu____4808 =
+                let uu____4810 = FStar_List.map emb_typ_to_string args in
+                FStar_All.pipe_right uu____4810 (FStar_String.concat " ") in
+              Prims.op_Hat uu____4808 ")" in
+            Prims.op_Hat " " uu____4806 in
+          Prims.op_Hat h uu____4804 in
+        Prims.op_Hat "(" uu____4802
     | FStar_Syntax_Syntax.ET_fun (a, b) ->
-        let uu____4832 =
-          let uu____4834 = emb_typ_to_string a in
-          let uu____4836 =
-            let uu____4838 = emb_typ_to_string b in
-            Prims.op_Hat ") -> " uu____4838 in
-          Prims.op_Hat uu____4834 uu____4836 in
-        Prims.op_Hat "(" uu____4832
+        let uu____4825 =
+          let uu____4827 = emb_typ_to_string a in
+          let uu____4829 =
+            let uu____4831 = emb_typ_to_string b in
+            Prims.op_Hat ") -> " uu____4831 in
+          Prims.op_Hat uu____4827 uu____4829 in
+        Prims.op_Hat "(" uu____4825

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -17,30 +17,30 @@ type pragma =
   | LightOff [@@deriving yojson,show]
 let (uu___is_SetOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | SetOptions _0 -> true | uu____180 -> false
+    match projectee with | SetOptions _0 -> true | uu____179 -> false
 let (__proj__SetOptions__item___0 : pragma -> Prims.string) =
   fun projectee -> match projectee with | SetOptions _0 -> _0
 let (uu___is_ResetOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | ResetOptions _0 -> true | uu____205 -> false
+    match projectee with | ResetOptions _0 -> true | uu____204 -> false
 let (__proj__ResetOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | ResetOptions _0 -> _0
 let (uu___is_PushOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | PushOptions _0 -> true | uu____236 -> false
+    match projectee with | PushOptions _0 -> true | uu____235 -> false
 let (__proj__PushOptions__item___0 :
   pragma -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | PushOptions _0 -> _0
 let (uu___is_PopOptions : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | PopOptions -> true | uu____263 -> false
+    match projectee with | PopOptions -> true | uu____262 -> false
 let (uu___is_RestartSolver : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | RestartSolver -> true | uu____274 -> false
+    match projectee with | RestartSolver -> true | uu____273 -> false
 let (uu___is_LightOff : pragma -> Prims.bool) =
   fun projectee ->
-    match projectee with | LightOff -> true | uu____285 -> false
+    match projectee with | LightOff -> true | uu____284 -> false
 type 'a memo =
   (('a FStar_Pervasives_Native.option FStar_ST.ref)[@printer
                                                      fun fmt ->
@@ -54,15 +54,15 @@ type emb_typ =
   | ET_app of (Prims.string * emb_typ Prims.list) 
 let (uu___is_ET_abstract : emb_typ -> Prims.bool) =
   fun projectee ->
-    match projectee with | ET_abstract -> true | uu____325 -> false
+    match projectee with | ET_abstract -> true | uu____324 -> false
 let (uu___is_ET_fun : emb_typ -> Prims.bool) =
   fun projectee ->
-    match projectee with | ET_fun _0 -> true | uu____341 -> false
+    match projectee with | ET_fun _0 -> true | uu____340 -> false
 let (__proj__ET_fun__item___0 : emb_typ -> (emb_typ * emb_typ)) =
   fun projectee -> match projectee with | ET_fun _0 -> _0
 let (uu___is_ET_app : emb_typ -> Prims.bool) =
   fun projectee ->
-    match projectee with | ET_app _0 -> true | uu____379 -> false
+    match projectee with | ET_app _0 -> true | uu____378 -> false
 let (__proj__ET_app__item___0 :
   emb_typ -> (Prims.string * emb_typ Prims.list)) =
   fun projectee -> match projectee with | ET_app _0 -> _0
@@ -83,30 +83,30 @@ type universe =
   * version * FStar_Range.range) 
   | U_unknown [@@deriving yojson,show]
 let (uu___is_U_zero : universe -> Prims.bool) =
-  fun projectee -> match projectee with | U_zero -> true | uu____492 -> false
+  fun projectee -> match projectee with | U_zero -> true | uu____491 -> false
 let (uu___is_U_succ : universe -> Prims.bool) =
   fun projectee ->
-    match projectee with | U_succ _0 -> true | uu____504 -> false
+    match projectee with | U_succ _0 -> true | uu____503 -> false
 let (__proj__U_succ__item___0 : universe -> universe) =
   fun projectee -> match projectee with | U_succ _0 -> _0
 let (uu___is_U_max : universe -> Prims.bool) =
   fun projectee ->
-    match projectee with | U_max _0 -> true | uu____525 -> false
+    match projectee with | U_max _0 -> true | uu____524 -> false
 let (__proj__U_max__item___0 : universe -> universe Prims.list) =
   fun projectee -> match projectee with | U_max _0 -> _0
 let (uu___is_U_bvar : universe -> Prims.bool) =
   fun projectee ->
-    match projectee with | U_bvar _0 -> true | uu____551 -> false
+    match projectee with | U_bvar _0 -> true | uu____550 -> false
 let (__proj__U_bvar__item___0 : universe -> Prims.int) =
   fun projectee -> match projectee with | U_bvar _0 -> _0
 let (uu___is_U_name : universe -> Prims.bool) =
   fun projectee ->
-    match projectee with | U_name _0 -> true | uu____573 -> false
+    match projectee with | U_name _0 -> true | uu____572 -> false
 let (__proj__U_name__item___0 : universe -> FStar_Ident.ident) =
   fun projectee -> match projectee with | U_name _0 -> _0
 let (uu___is_U_unif : universe -> Prims.bool) =
   fun projectee ->
-    match projectee with | U_unif _0 -> true | uu____602 -> false
+    match projectee with | U_unif _0 -> true | uu____601 -> false
 let (__proj__U_unif__item___0 :
   universe ->
     (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar * version
@@ -114,7 +114,7 @@ let (__proj__U_unif__item___0 :
   = fun projectee -> match projectee with | U_unif _0 -> _0
 let (uu___is_U_unknown : universe -> Prims.bool) =
   fun projectee ->
-    match projectee with | U_unknown -> true | uu____650 -> false
+    match projectee with | U_unknown -> true | uu____649 -> false
 type univ_name = FStar_Ident.ident[@@deriving yojson,show]
 type universe_uvar =
   (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar * version *
@@ -127,19 +127,19 @@ type quote_kind =
   | Quote_dynamic [@@deriving yojson,show]
 let (uu___is_Quote_static : quote_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Quote_static -> true | uu____675 -> false
+    match projectee with | Quote_static -> true | uu____674 -> false
 let (uu___is_Quote_dynamic : quote_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Quote_dynamic -> true | uu____686 -> false
+    match projectee with | Quote_dynamic -> true | uu____685 -> false
 type maybe_set_use_range =
   | NoUseRange 
   | SomeUseRange of FStar_Range.range [@@deriving yojson,show]
 let (uu___is_NoUseRange : maybe_set_use_range -> Prims.bool) =
   fun projectee ->
-    match projectee with | NoUseRange -> true | uu____702 -> false
+    match projectee with | NoUseRange -> true | uu____701 -> false
 let (uu___is_SomeUseRange : maybe_set_use_range -> Prims.bool) =
   fun projectee ->
-    match projectee with | SomeUseRange _0 -> true | uu____714 -> false
+    match projectee with | SomeUseRange _0 -> true | uu____713 -> false
 let (__proj__SomeUseRange__item___0 :
   maybe_set_use_range -> FStar_Range.range) =
   fun projectee -> match projectee with | SomeUseRange _0 -> _0
@@ -151,20 +151,20 @@ let (uu___is_Delta_constant_at_level : delta_depth -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Delta_constant_at_level _0 -> true
-    | uu____751 -> false
+    | uu____750 -> false
 let (__proj__Delta_constant_at_level__item___0 : delta_depth -> Prims.int) =
   fun projectee -> match projectee with | Delta_constant_at_level _0 -> _0
 let (uu___is_Delta_equational_at_level : delta_depth -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Delta_equational_at_level _0 -> true
-    | uu____774 -> false
+    | uu____773 -> false
 let (__proj__Delta_equational_at_level__item___0 : delta_depth -> Prims.int)
   =
   fun projectee -> match projectee with | Delta_equational_at_level _0 -> _0
 let (uu___is_Delta_abstract : delta_depth -> Prims.bool) =
   fun projectee ->
-    match projectee with | Delta_abstract _0 -> true | uu____796 -> false
+    match projectee with | Delta_abstract _0 -> true | uu____795 -> false
 let (__proj__Delta_abstract__item___0 : delta_depth -> delta_depth) =
   fun projectee -> match projectee with | Delta_abstract _0 -> _0
 type should_check_uvar =
@@ -173,12 +173,12 @@ type should_check_uvar =
   | Strict [@@deriving yojson,show]
 let (uu___is_Allow_unresolved : should_check_uvar -> Prims.bool) =
   fun projectee ->
-    match projectee with | Allow_unresolved -> true | uu____814 -> false
+    match projectee with | Allow_unresolved -> true | uu____813 -> false
 let (uu___is_Allow_untyped : should_check_uvar -> Prims.bool) =
   fun projectee ->
-    match projectee with | Allow_untyped -> true | uu____825 -> false
+    match projectee with | Allow_untyped -> true | uu____824 -> false
 let (uu___is_Strict : should_check_uvar -> Prims.bool) =
-  fun projectee -> match projectee with | Strict -> true | uu____836 -> false
+  fun projectee -> match projectee with | Strict -> true | uu____835 -> false
 type term' =
   | Tm_bvar of bv 
   | Tm_name of bv 
@@ -346,37 +346,37 @@ and arg_qualifier_meta_t =
   | Arg_qualifier_meta_attr of term' syntax 
 let (uu___is_Tm_bvar : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_bvar _0 -> true | uu____1786 -> false
+    match projectee with | Tm_bvar _0 -> true | uu____1785 -> false
 let (__proj__Tm_bvar__item___0 : term' -> bv) =
   fun projectee -> match projectee with | Tm_bvar _0 -> _0
 let (uu___is_Tm_name : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_name _0 -> true | uu____1805 -> false
+    match projectee with | Tm_name _0 -> true | uu____1804 -> false
 let (__proj__Tm_name__item___0 : term' -> bv) =
   fun projectee -> match projectee with | Tm_name _0 -> _0
 let (uu___is_Tm_fvar : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_fvar _0 -> true | uu____1824 -> false
+    match projectee with | Tm_fvar _0 -> true | uu____1823 -> false
 let (__proj__Tm_fvar__item___0 : term' -> fv) =
   fun projectee -> match projectee with | Tm_fvar _0 -> _0
 let (uu___is_Tm_uinst : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_uinst _0 -> true | uu____1849 -> false
+    match projectee with | Tm_uinst _0 -> true | uu____1848 -> false
 let (__proj__Tm_uinst__item___0 : term' -> (term' syntax * universes)) =
   fun projectee -> match projectee with | Tm_uinst _0 -> _0
 let (uu___is_Tm_constant : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_constant _0 -> true | uu____1886 -> false
+    match projectee with | Tm_constant _0 -> true | uu____1885 -> false
 let (__proj__Tm_constant__item___0 : term' -> sconst) =
   fun projectee -> match projectee with | Tm_constant _0 -> _0
 let (uu___is_Tm_type : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_type _0 -> true | uu____1905 -> false
+    match projectee with | Tm_type _0 -> true | uu____1904 -> false
 let (__proj__Tm_type__item___0 : term' -> universe) =
   fun projectee -> match projectee with | Tm_type _0 -> _0
 let (uu___is_Tm_abs : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_abs _0 -> true | uu____1942 -> false
+    match projectee with | Tm_abs _0 -> true | uu____1941 -> false
 let (__proj__Tm_abs__item___0 :
   term' ->
     ((bv * arg_qualifier FStar_Pervasives_Native.option) Prims.list * term'
@@ -384,7 +384,7 @@ let (__proj__Tm_abs__item___0 :
   = fun projectee -> match projectee with | Tm_abs _0 -> _0
 let (uu___is_Tm_arrow : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_arrow _0 -> true | uu____2029 -> false
+    match projectee with | Tm_arrow _0 -> true | uu____2028 -> false
 let (__proj__Tm_arrow__item___0 :
   term' ->
     ((bv * arg_qualifier FStar_Pervasives_Native.option) Prims.list * comp'
@@ -392,12 +392,12 @@ let (__proj__Tm_arrow__item___0 :
   = fun projectee -> match projectee with | Tm_arrow _0 -> _0
 let (uu___is_Tm_refine : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_refine _0 -> true | uu____2096 -> false
+    match projectee with | Tm_refine _0 -> true | uu____2095 -> false
 let (__proj__Tm_refine__item___0 : term' -> (bv * term' syntax)) =
   fun projectee -> match projectee with | Tm_refine _0 -> _0
 let (uu___is_Tm_app : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_app _0 -> true | uu____2149 -> false
+    match projectee with | Tm_app _0 -> true | uu____2148 -> false
 let (__proj__Tm_app__item___0 :
   term' ->
     (term' syntax * (term' syntax * arg_qualifier
@@ -405,7 +405,7 @@ let (__proj__Tm_app__item___0 :
   = fun projectee -> match projectee with | Tm_app _0 -> _0
 let (uu___is_Tm_match : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_match _0 -> true | uu____2238 -> false
+    match projectee with | Tm_match _0 -> true | uu____2237 -> false
 let (__proj__Tm_match__item___0 :
   term' ->
     (term' syntax * (pat' withinfo_t * term' syntax
@@ -413,7 +413,7 @@ let (__proj__Tm_match__item___0 :
   = fun projectee -> match projectee with | Tm_match _0 -> _0
 let (uu___is_Tm_ascribed : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_ascribed _0 -> true | uu____2349 -> false
+    match projectee with | Tm_ascribed _0 -> true | uu____2348 -> false
 let (__proj__Tm_ascribed__item___0 :
   term' ->
     (term' syntax * ((term' syntax, comp' syntax) FStar_Util.either * term'
@@ -422,42 +422,42 @@ let (__proj__Tm_ascribed__item___0 :
   = fun projectee -> match projectee with | Tm_ascribed _0 -> _0
 let (uu___is_Tm_let : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_let _0 -> true | uu____2459 -> false
+    match projectee with | Tm_let _0 -> true | uu____2458 -> false
 let (__proj__Tm_let__item___0 :
   term' -> ((Prims.bool * letbinding Prims.list) * term' syntax)) =
   fun projectee -> match projectee with | Tm_let _0 -> _0
 let (uu___is_Tm_uvar : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_uvar _0 -> true | uu____2529 -> false
+    match projectee with | Tm_uvar _0 -> true | uu____2528 -> false
 let (__proj__Tm_uvar__item___0 :
   term' ->
     (ctx_uvar * (subst_elt Prims.list Prims.list * maybe_set_use_range)))
   = fun projectee -> match projectee with | Tm_uvar _0 -> _0
 let (uu___is_Tm_delayed : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_delayed _0 -> true | uu____2598 -> false
+    match projectee with | Tm_delayed _0 -> true | uu____2597 -> false
 let (__proj__Tm_delayed__item___0 :
   term' ->
     (term' syntax * (subst_elt Prims.list Prims.list * maybe_set_use_range)))
   = fun projectee -> match projectee with | Tm_delayed _0 -> _0
 let (uu___is_Tm_meta : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_meta _0 -> true | uu____2665 -> false
+    match projectee with | Tm_meta _0 -> true | uu____2664 -> false
 let (__proj__Tm_meta__item___0 : term' -> (term' syntax * metadata)) =
   fun projectee -> match projectee with | Tm_meta _0 -> _0
 let (uu___is_Tm_lazy : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_lazy _0 -> true | uu____2702 -> false
+    match projectee with | Tm_lazy _0 -> true | uu____2701 -> false
 let (__proj__Tm_lazy__item___0 : term' -> lazyinfo) =
   fun projectee -> match projectee with | Tm_lazy _0 -> _0
 let (uu___is_Tm_quoted : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_quoted _0 -> true | uu____2727 -> false
+    match projectee with | Tm_quoted _0 -> true | uu____2726 -> false
 let (__proj__Tm_quoted__item___0 : term' -> (term' syntax * quoteinfo)) =
   fun projectee -> match projectee with | Tm_quoted _0 -> _0
 let (uu___is_Tm_unknown : term' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tm_unknown -> true | uu____2763 -> false
+    match projectee with | Tm_unknown -> true | uu____2762 -> false
 let (__proj__Mkctx_uvar__item__ctx_uvar_head :
   ctx_uvar ->
     (term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar *
@@ -518,7 +518,7 @@ let (__proj__Mkctx_uvar__item__ctx_uvar_meta :
         ctx_uvar_meta;_} -> ctx_uvar_meta
 let (uu___is_Ctx_uvar_meta_tac : ctx_uvar_meta_t -> Prims.bool) =
   fun projectee ->
-    match projectee with | Ctx_uvar_meta_tac _0 -> true | uu____3163 -> false
+    match projectee with | Ctx_uvar_meta_tac _0 -> true | uu____3162 -> false
 let (__proj__Ctx_uvar_meta_tac__item___0 :
   ctx_uvar_meta_t -> (FStar_Dyn.dyn * term' syntax)) =
   fun projectee -> match projectee with | Ctx_uvar_meta_tac _0 -> _0
@@ -526,33 +526,33 @@ let (uu___is_Ctx_uvar_meta_attr : ctx_uvar_meta_t -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Ctx_uvar_meta_attr _0 -> true
-    | uu____3202 -> false
+    | uu____3201 -> false
 let (__proj__Ctx_uvar_meta_attr__item___0 : ctx_uvar_meta_t -> term' syntax)
   = fun projectee -> match projectee with | Ctx_uvar_meta_attr _0 -> _0
 let (uu___is_Pat_constant : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_constant _0 -> true | uu____3227 -> false
+    match projectee with | Pat_constant _0 -> true | uu____3226 -> false
 let (__proj__Pat_constant__item___0 : pat' -> sconst) =
   fun projectee -> match projectee with | Pat_constant _0 -> _0
 let (uu___is_Pat_cons : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_cons _0 -> true | uu____3259 -> false
+    match projectee with | Pat_cons _0 -> true | uu____3258 -> false
 let (__proj__Pat_cons__item___0 :
   pat' -> (fv * (pat' withinfo_t * Prims.bool) Prims.list)) =
   fun projectee -> match projectee with | Pat_cons _0 -> _0
 let (uu___is_Pat_var : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_var _0 -> true | uu____3317 -> false
+    match projectee with | Pat_var _0 -> true | uu____3316 -> false
 let (__proj__Pat_var__item___0 : pat' -> bv) =
   fun projectee -> match projectee with | Pat_var _0 -> _0
 let (uu___is_Pat_wild : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_wild _0 -> true | uu____3336 -> false
+    match projectee with | Pat_wild _0 -> true | uu____3335 -> false
 let (__proj__Pat_wild__item___0 : pat' -> bv) =
   fun projectee -> match projectee with | Pat_wild _0 -> _0
 let (uu___is_Pat_dot_term : pat' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Pat_dot_term _0 -> true | uu____3361 -> false
+    match projectee with | Pat_dot_term _0 -> true | uu____3360 -> false
 let (__proj__Pat_dot_term__item___0 : pat' -> (bv * term' syntax)) =
   fun projectee -> match projectee with | Pat_dot_term _0 -> _0
 let (__proj__Mkletbinding__item__lbname :
@@ -622,55 +622,55 @@ let (__proj__Mkcomp_typ__item__flags : comp_typ -> cflag Prims.list) =
     | { comp_univs; effect_name; result_typ; effect_args; flags;_} -> flags
 let (uu___is_Total : comp' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Total _0 -> true | uu____3824 -> false
+    match projectee with | Total _0 -> true | uu____3823 -> false
 let (__proj__Total__item___0 :
   comp' -> (term' syntax * universe FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | Total _0 -> _0
 let (uu___is_GTotal : comp' -> Prims.bool) =
   fun projectee ->
-    match projectee with | GTotal _0 -> true | uu____3875 -> false
+    match projectee with | GTotal _0 -> true | uu____3874 -> false
 let (__proj__GTotal__item___0 :
   comp' -> (term' syntax * universe FStar_Pervasives_Native.option)) =
   fun projectee -> match projectee with | GTotal _0 -> _0
 let (uu___is_Comp : comp' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Comp _0 -> true | uu____3918 -> false
+    match projectee with | Comp _0 -> true | uu____3917 -> false
 let (__proj__Comp__item___0 : comp' -> comp_typ) =
   fun projectee -> match projectee with | Comp _0 -> _0
 let (uu___is_TOTAL : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | TOTAL -> true | uu____3936 -> false
+  fun projectee -> match projectee with | TOTAL -> true | uu____3935 -> false
 let (uu___is_MLEFFECT : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | MLEFFECT -> true | uu____3947 -> false
+    match projectee with | MLEFFECT -> true | uu____3946 -> false
 let (uu___is_LEMMA : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | LEMMA -> true | uu____3958 -> false
+  fun projectee -> match projectee with | LEMMA -> true | uu____3957 -> false
 let (uu___is_RETURN : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | RETURN -> true | uu____3969 -> false
+    match projectee with | RETURN -> true | uu____3968 -> false
 let (uu___is_PARTIAL_RETURN : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | PARTIAL_RETURN -> true | uu____3980 -> false
+    match projectee with | PARTIAL_RETURN -> true | uu____3979 -> false
 let (uu___is_SOMETRIVIAL : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | SOMETRIVIAL -> true | uu____3991 -> false
+    match projectee with | SOMETRIVIAL -> true | uu____3990 -> false
 let (uu___is_TRIVIAL_POSTCONDITION : cflag -> Prims.bool) =
   fun projectee ->
     match projectee with
     | TRIVIAL_POSTCONDITION -> true
-    | uu____4002 -> false
+    | uu____4001 -> false
 let (uu___is_SHOULD_NOT_INLINE : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | SHOULD_NOT_INLINE -> true | uu____4013 -> false
+    match projectee with | SHOULD_NOT_INLINE -> true | uu____4012 -> false
 let (uu___is_CPS : cflag -> Prims.bool) =
-  fun projectee -> match projectee with | CPS -> true | uu____4024 -> false
+  fun projectee -> match projectee with | CPS -> true | uu____4023 -> false
 let (uu___is_DECREASES : cflag -> Prims.bool) =
   fun projectee ->
-    match projectee with | DECREASES _0 -> true | uu____4038 -> false
+    match projectee with | DECREASES _0 -> true | uu____4037 -> false
 let (__proj__DECREASES__item___0 : cflag -> term' syntax) =
   fun projectee -> match projectee with | DECREASES _0 -> _0
 let (uu___is_Meta_pattern : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_pattern _0 -> true | uu____4083 -> false
+    match projectee with | Meta_pattern _0 -> true | uu____4082 -> false
 let (__proj__Meta_pattern__item___0 :
   metadata ->
     (term' syntax Prims.list * (term' syntax * arg_qualifier
@@ -678,77 +678,77 @@ let (__proj__Meta_pattern__item___0 :
   = fun projectee -> match projectee with | Meta_pattern _0 -> _0
 let (uu___is_Meta_named : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_named _0 -> true | uu____4162 -> false
+    match projectee with | Meta_named _0 -> true | uu____4161 -> false
 let (__proj__Meta_named__item___0 : metadata -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Meta_named _0 -> _0
 let (uu___is_Meta_labeled : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_labeled _0 -> true | uu____4189 -> false
+    match projectee with | Meta_labeled _0 -> true | uu____4188 -> false
 let (__proj__Meta_labeled__item___0 :
   metadata -> (Prims.string * FStar_Range.range * Prims.bool)) =
   fun projectee -> match projectee with | Meta_labeled _0 -> _0
 let (uu___is_Meta_desugared : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_desugared _0 -> true | uu____4232 -> false
+    match projectee with | Meta_desugared _0 -> true | uu____4231 -> false
 let (__proj__Meta_desugared__item___0 : metadata -> meta_source_info) =
   fun projectee -> match projectee with | Meta_desugared _0 -> _0
 let (uu___is_Meta_monadic : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_monadic _0 -> true | uu____4257 -> false
+    match projectee with | Meta_monadic _0 -> true | uu____4256 -> false
 let (__proj__Meta_monadic__item___0 :
   metadata -> (monad_name * term' syntax)) =
   fun projectee -> match projectee with | Meta_monadic _0 -> _0
 let (uu___is_Meta_monadic_lift : metadata -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_monadic_lift _0 -> true | uu____4302 -> false
+    match projectee with | Meta_monadic_lift _0 -> true | uu____4301 -> false
 let (__proj__Meta_monadic_lift__item___0 :
   metadata -> (monad_name * monad_name * term' syntax)) =
   fun projectee -> match projectee with | Meta_monadic_lift _0 -> _0
 let (uu___is_Sequence : meta_source_info -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sequence -> true | uu____4344 -> false
+    match projectee with | Sequence -> true | uu____4343 -> false
 let (uu___is_Primop : meta_source_info -> Prims.bool) =
   fun projectee ->
-    match projectee with | Primop -> true | uu____4355 -> false
+    match projectee with | Primop -> true | uu____4354 -> false
 let (uu___is_Masked_effect : meta_source_info -> Prims.bool) =
   fun projectee ->
-    match projectee with | Masked_effect -> true | uu____4366 -> false
+    match projectee with | Masked_effect -> true | uu____4365 -> false
 let (uu___is_Meta_smt_pat : meta_source_info -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta_smt_pat -> true | uu____4377 -> false
+    match projectee with | Meta_smt_pat -> true | uu____4376 -> false
 let (uu___is_Data_ctor : fv_qual -> Prims.bool) =
   fun projectee ->
-    match projectee with | Data_ctor -> true | uu____4388 -> false
+    match projectee with | Data_ctor -> true | uu____4387 -> false
 let (uu___is_Record_projector : fv_qual -> Prims.bool) =
   fun projectee ->
-    match projectee with | Record_projector _0 -> true | uu____4404 -> false
+    match projectee with | Record_projector _0 -> true | uu____4403 -> false
 let (__proj__Record_projector__item___0 :
   fv_qual -> (FStar_Ident.lident * FStar_Ident.ident)) =
   fun projectee -> match projectee with | Record_projector _0 -> _0
 let (uu___is_Record_ctor : fv_qual -> Prims.bool) =
   fun projectee ->
-    match projectee with | Record_ctor _0 -> true | uu____4441 -> false
+    match projectee with | Record_ctor _0 -> true | uu____4440 -> false
 let (__proj__Record_ctor__item___0 :
   fv_qual -> (FStar_Ident.lident * FStar_Ident.ident Prims.list)) =
   fun projectee -> match projectee with | Record_ctor _0 -> _0
 let (uu___is_DB : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | DB _0 -> true | uu____4483 -> false
+  fun projectee -> match projectee with | DB _0 -> true | uu____4482 -> false
 let (__proj__DB__item___0 : subst_elt -> (Prims.int * bv)) =
   fun projectee -> match projectee with | DB _0 -> _0
 let (uu___is_NM : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | NM _0 -> true | uu____4522 -> false
+  fun projectee -> match projectee with | NM _0 -> true | uu____4521 -> false
 let (__proj__NM__item___0 : subst_elt -> (bv * Prims.int)) =
   fun projectee -> match projectee with | NM _0 -> _0
 let (uu___is_NT : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | NT _0 -> true | uu____4562 -> false
+  fun projectee -> match projectee with | NT _0 -> true | uu____4561 -> false
 let (__proj__NT__item___0 : subst_elt -> (bv * term' syntax)) =
   fun projectee -> match projectee with | NT _0 -> _0
 let (uu___is_UN : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | UN _0 -> true | uu____4604 -> false
+  fun projectee -> match projectee with | UN _0 -> true | uu____4603 -> false
 let (__proj__UN__item___0 : subst_elt -> (Prims.int * universe)) =
   fun projectee -> match projectee with | UN _0 -> _0
 let (uu___is_UD : subst_elt -> Prims.bool) =
-  fun projectee -> match projectee with | UD _0 -> true | uu____4643 -> false
+  fun projectee -> match projectee with | UD _0 -> true | uu____4642 -> false
 let (__proj__UD__item___0 : subst_elt -> (univ_name * Prims.int)) =
   fun projectee -> match projectee with | UD _0 -> _0
 let __proj__Mksyntax__item__n : 'a . 'a syntax -> 'a =
@@ -822,77 +822,77 @@ let (__proj__Mklazyinfo__item__rng : lazyinfo -> FStar_Range.range) =
   fun projectee -> match projectee with | { blob; lkind; ltyp; rng;_} -> rng
 let (uu___is_BadLazy : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | BadLazy -> true | uu____5014 -> false
+    match projectee with | BadLazy -> true | uu____5013 -> false
 let (uu___is_Lazy_bv : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_bv -> true | uu____5025 -> false
+    match projectee with | Lazy_bv -> true | uu____5024 -> false
 let (uu___is_Lazy_binder : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_binder -> true | uu____5036 -> false
+    match projectee with | Lazy_binder -> true | uu____5035 -> false
 let (uu___is_Lazy_optionstate : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_optionstate -> true | uu____5047 -> false
+    match projectee with | Lazy_optionstate -> true | uu____5046 -> false
 let (uu___is_Lazy_fvar : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_fvar -> true | uu____5058 -> false
+    match projectee with | Lazy_fvar -> true | uu____5057 -> false
 let (uu___is_Lazy_comp : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_comp -> true | uu____5069 -> false
+    match projectee with | Lazy_comp -> true | uu____5068 -> false
 let (uu___is_Lazy_env : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_env -> true | uu____5080 -> false
+    match projectee with | Lazy_env -> true | uu____5079 -> false
 let (uu___is_Lazy_proofstate : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_proofstate -> true | uu____5091 -> false
+    match projectee with | Lazy_proofstate -> true | uu____5090 -> false
 let (uu___is_Lazy_goal : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_goal -> true | uu____5102 -> false
+    match projectee with | Lazy_goal -> true | uu____5101 -> false
 let (uu___is_Lazy_sigelt : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_sigelt -> true | uu____5113 -> false
+    match projectee with | Lazy_sigelt -> true | uu____5112 -> false
 let (uu___is_Lazy_uvar : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_uvar -> true | uu____5124 -> false
+    match projectee with | Lazy_uvar -> true | uu____5123 -> false
 let (uu___is_Lazy_embedding : lazy_kind -> Prims.bool) =
   fun projectee ->
-    match projectee with | Lazy_embedding _0 -> true | uu____5144 -> false
+    match projectee with | Lazy_embedding _0 -> true | uu____5143 -> false
 let (__proj__Lazy_embedding__item___0 :
   lazy_kind -> (emb_typ * term' syntax FStar_Thunk.t)) =
   fun projectee -> match projectee with | Lazy_embedding _0 -> _0
 let (uu___is_Binding_var : binding -> Prims.bool) =
   fun projectee ->
-    match projectee with | Binding_var _0 -> true | uu____5187 -> false
+    match projectee with | Binding_var _0 -> true | uu____5186 -> false
 let (__proj__Binding_var__item___0 : binding -> bv) =
   fun projectee -> match projectee with | Binding_var _0 -> _0
 let (uu___is_Binding_lid : binding -> Prims.bool) =
   fun projectee ->
-    match projectee with | Binding_lid _0 -> true | uu____5218 -> false
+    match projectee with | Binding_lid _0 -> true | uu____5217 -> false
 let (__proj__Binding_lid__item___0 :
   binding -> (FStar_Ident.lident * (univ_name Prims.list * term' syntax))) =
   fun projectee -> match projectee with | Binding_lid _0 -> _0
 let (uu___is_Binding_univ : binding -> Prims.bool) =
   fun projectee ->
-    match projectee with | Binding_univ _0 -> true | uu____5273 -> false
+    match projectee with | Binding_univ _0 -> true | uu____5272 -> false
 let (__proj__Binding_univ__item___0 : binding -> univ_name) =
   fun projectee -> match projectee with | Binding_univ _0 -> _0
 let (uu___is_Implicit : arg_qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Implicit _0 -> true | uu____5293 -> false
+    match projectee with | Implicit _0 -> true | uu____5292 -> false
 let (__proj__Implicit__item___0 : arg_qualifier -> Prims.bool) =
   fun projectee -> match projectee with | Implicit _0 -> _0
 let (uu___is_Meta : arg_qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Meta _0 -> true | uu____5315 -> false
+    match projectee with | Meta _0 -> true | uu____5314 -> false
 let (__proj__Meta__item___0 : arg_qualifier -> arg_qualifier_meta_t) =
   fun projectee -> match projectee with | Meta _0 -> _0
 let (uu___is_Equality : arg_qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Equality -> true | uu____5333 -> false
+    match projectee with | Equality -> true | uu____5332 -> false
 let (uu___is_Arg_qualifier_meta_tac : arg_qualifier_meta_t -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Arg_qualifier_meta_tac _0 -> true
-    | uu____5347 -> false
+    | uu____5346 -> false
 let (__proj__Arg_qualifier_meta_tac__item___0 :
   arg_qualifier_meta_t -> term' syntax) =
   fun projectee -> match projectee with | Arg_qualifier_meta_tac _0 -> _0
@@ -900,7 +900,7 @@ let (uu___is_Arg_qualifier_meta_attr : arg_qualifier_meta_t -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Arg_qualifier_meta_attr _0 -> true
-    | uu____5374 -> false
+    | uu____5373 -> false
 let (__proj__Arg_qualifier_meta_attr__item___0 :
   arg_qualifier_meta_t -> term' syntax) =
   fun projectee -> match projectee with | Arg_qualifier_meta_attr _0 -> _0
@@ -969,92 +969,92 @@ type qualifier =
   | OnlyName 
 let (uu___is_Assumption : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Assumption -> true | uu____5626 -> false
+    match projectee with | Assumption -> true | uu____5625 -> false
 let (uu___is_New : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | New -> true | uu____5637 -> false
+  fun projectee -> match projectee with | New -> true | uu____5636 -> false
 let (uu___is_Private : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Private -> true | uu____5648 -> false
+    match projectee with | Private -> true | uu____5647 -> false
 let (uu___is_Unfold_for_unification_and_vcgen : qualifier -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Unfold_for_unification_and_vcgen -> true
-    | uu____5659 -> false
+    | uu____5658 -> false
 let (uu___is_Visible_default : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Visible_default -> true | uu____5670 -> false
+    match projectee with | Visible_default -> true | uu____5669 -> false
 let (uu___is_Irreducible : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Irreducible -> true | uu____5681 -> false
+    match projectee with | Irreducible -> true | uu____5680 -> false
 let (uu___is_Abstract : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Abstract -> true | uu____5692 -> false
+    match projectee with | Abstract -> true | uu____5691 -> false
 let (uu___is_Inline_for_extraction : qualifier -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Inline_for_extraction -> true
-    | uu____5703 -> false
+    | uu____5702 -> false
 let (uu___is_NoExtract : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | NoExtract -> true | uu____5714 -> false
+    match projectee with | NoExtract -> true | uu____5713 -> false
 let (uu___is_Noeq : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Noeq -> true | uu____5725 -> false
+  fun projectee -> match projectee with | Noeq -> true | uu____5724 -> false
 let (uu___is_Unopteq : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Unopteq -> true | uu____5736 -> false
+    match projectee with | Unopteq -> true | uu____5735 -> false
 let (uu___is_TotalEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | TotalEffect -> true | uu____5747 -> false
+    match projectee with | TotalEffect -> true | uu____5746 -> false
 let (uu___is_Logic : qualifier -> Prims.bool) =
-  fun projectee -> match projectee with | Logic -> true | uu____5758 -> false
+  fun projectee -> match projectee with | Logic -> true | uu____5757 -> false
 let (uu___is_Reifiable : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Reifiable -> true | uu____5769 -> false
+    match projectee with | Reifiable -> true | uu____5768 -> false
 let (uu___is_Reflectable : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Reflectable _0 -> true | uu____5781 -> false
+    match projectee with | Reflectable _0 -> true | uu____5780 -> false
 let (__proj__Reflectable__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Reflectable _0 -> _0
 let (uu___is_Discriminator : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Discriminator _0 -> true | uu____5800 -> false
+    match projectee with | Discriminator _0 -> true | uu____5799 -> false
 let (__proj__Discriminator__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Discriminator _0 -> _0
 let (uu___is_Projector : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Projector _0 -> true | uu____5823 -> false
+    match projectee with | Projector _0 -> true | uu____5822 -> false
 let (__proj__Projector__item___0 :
   qualifier -> (FStar_Ident.lident * FStar_Ident.ident)) =
   fun projectee -> match projectee with | Projector _0 -> _0
 let (uu___is_RecordType : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | RecordType _0 -> true | uu____5862 -> false
+    match projectee with | RecordType _0 -> true | uu____5861 -> false
 let (__proj__RecordType__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee -> match projectee with | RecordType _0 -> _0
 let (uu___is_RecordConstructor : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | RecordConstructor _0 -> true | uu____5913 -> false
+    match projectee with | RecordConstructor _0 -> true | uu____5912 -> false
 let (__proj__RecordConstructor__item___0 :
   qualifier -> (FStar_Ident.ident Prims.list * FStar_Ident.ident Prims.list))
   = fun projectee -> match projectee with | RecordConstructor _0 -> _0
 let (uu___is_Action : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Action _0 -> true | uu____5956 -> false
+    match projectee with | Action _0 -> true | uu____5955 -> false
 let (__proj__Action__item___0 : qualifier -> FStar_Ident.lident) =
   fun projectee -> match projectee with | Action _0 -> _0
 let (uu___is_ExceptionConstructor : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | ExceptionConstructor -> true | uu____5974 -> false
+    match projectee with | ExceptionConstructor -> true | uu____5973 -> false
 let (uu___is_HasMaskedEffect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | HasMaskedEffect -> true | uu____5985 -> false
+    match projectee with | HasMaskedEffect -> true | uu____5984 -> false
 let (uu___is_Effect : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | Effect -> true | uu____5996 -> false
+    match projectee with | Effect -> true | uu____5995 -> false
 let (uu___is_OnlyName : qualifier -> Prims.bool) =
   fun projectee ->
-    match projectee with | OnlyName -> true | uu____6007 -> false
+    match projectee with | OnlyName -> true | uu____6006 -> false
 type tycon = (FStar_Ident.lident * binders * typ)
 type monad_abbrev = {
   mabbrev: FStar_Ident.lident ;
@@ -1200,65 +1200,54 @@ let (__proj__Mkwp_eff_combinators__item__bind_repr :
         repr; return_repr; bind_repr;_} -> bind_repr
 type layered_eff_combinators =
   {
-  l_base_effect: FStar_Ident.lident ;
   l_repr: (tscheme * tscheme) ;
   l_return: (tscheme * tscheme) ;
   l_bind: (tscheme * tscheme) ;
   l_subcomp: (tscheme * tscheme) ;
   l_if_then_else: (tscheme * tscheme) }
-let (__proj__Mklayered_eff_combinators__item__l_base_effect :
-  layered_eff_combinators -> FStar_Ident.lident) =
-  fun projectee ->
-    match projectee with
-    | { l_base_effect; l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_}
-        -> l_base_effect
 let (__proj__Mklayered_eff_combinators__item__l_repr :
   layered_eff_combinators -> (tscheme * tscheme)) =
   fun projectee ->
     match projectee with
-    | { l_base_effect; l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_}
-        -> l_repr
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_repr
 let (__proj__Mklayered_eff_combinators__item__l_return :
   layered_eff_combinators -> (tscheme * tscheme)) =
   fun projectee ->
     match projectee with
-    | { l_base_effect; l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_}
-        -> l_return
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_return
 let (__proj__Mklayered_eff_combinators__item__l_bind :
   layered_eff_combinators -> (tscheme * tscheme)) =
   fun projectee ->
     match projectee with
-    | { l_base_effect; l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_}
-        -> l_bind
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_bind
 let (__proj__Mklayered_eff_combinators__item__l_subcomp :
   layered_eff_combinators -> (tscheme * tscheme)) =
   fun projectee ->
     match projectee with
-    | { l_base_effect; l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_}
-        -> l_subcomp
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_subcomp
 let (__proj__Mklayered_eff_combinators__item__l_if_then_else :
   layered_eff_combinators -> (tscheme * tscheme)) =
   fun projectee ->
     match projectee with
-    | { l_base_effect; l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_}
-        -> l_if_then_else
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} ->
+        l_if_then_else
 type eff_combinators =
   | Primitive_eff of wp_eff_combinators 
   | DM4F_eff of wp_eff_combinators 
   | Layered_eff of layered_eff_combinators 
 let (uu___is_Primitive_eff : eff_combinators -> Prims.bool) =
   fun projectee ->
-    match projectee with | Primitive_eff _0 -> true | uu____6842 -> false
+    match projectee with | Primitive_eff _0 -> true | uu____6799 -> false
 let (__proj__Primitive_eff__item___0 : eff_combinators -> wp_eff_combinators)
   = fun projectee -> match projectee with | Primitive_eff _0 -> _0
 let (uu___is_DM4F_eff : eff_combinators -> Prims.bool) =
   fun projectee ->
-    match projectee with | DM4F_eff _0 -> true | uu____6861 -> false
+    match projectee with | DM4F_eff _0 -> true | uu____6818 -> false
 let (__proj__DM4F_eff__item___0 : eff_combinators -> wp_eff_combinators) =
   fun projectee -> match projectee with | DM4F_eff _0 -> _0
 let (uu___is_Layered_eff : eff_combinators -> Prims.bool) =
   fun projectee ->
-    match projectee with | Layered_eff _0 -> true | uu____6880 -> false
+    match projectee with | Layered_eff _0 -> true | uu____6837 -> false
 let (__proj__Layered_eff__item___0 :
   eff_combinators -> layered_eff_combinators) =
   fun projectee -> match projectee with | Layered_eff _0 -> _0
@@ -1364,7 +1353,7 @@ and sigelt =
   sigopts: FStar_Options.optionstate FStar_Pervasives_Native.option }
 let (uu___is_Sig_inductive_typ : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_inductive_typ _0 -> true | uu____7403 -> false
+    match projectee with | Sig_inductive_typ _0 -> true | uu____7360 -> false
 let (__proj__Sig_inductive_typ__item___0 :
   sigelt' ->
     (FStar_Ident.lident * univ_names * binders * typ * FStar_Ident.lident
@@ -1372,13 +1361,13 @@ let (__proj__Sig_inductive_typ__item___0 :
   = fun projectee -> match projectee with | Sig_inductive_typ _0 -> _0
 let (uu___is_Sig_bundle : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_bundle _0 -> true | uu____7478 -> false
+    match projectee with | Sig_bundle _0 -> true | uu____7435 -> false
 let (__proj__Sig_bundle__item___0 :
   sigelt' -> (sigelt Prims.list * FStar_Ident.lident Prims.list)) =
   fun projectee -> match projectee with | Sig_bundle _0 -> _0
 let (uu___is_Sig_datacon : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_datacon _0 -> true | uu____7536 -> false
+    match projectee with | Sig_datacon _0 -> true | uu____7493 -> false
 let (__proj__Sig_datacon__item___0 :
   sigelt' ->
     (FStar_Ident.lident * univ_names * typ * FStar_Ident.lident * Prims.int *
@@ -1386,47 +1375,47 @@ let (__proj__Sig_datacon__item___0 :
   = fun projectee -> match projectee with | Sig_datacon _0 -> _0
 let (uu___is_Sig_declare_typ : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_declare_typ _0 -> true | uu____7606 -> false
+    match projectee with | Sig_declare_typ _0 -> true | uu____7563 -> false
 let (__proj__Sig_declare_typ__item___0 :
   sigelt' -> (FStar_Ident.lident * univ_names * typ)) =
   fun projectee -> match projectee with | Sig_declare_typ _0 -> _0
 let (uu___is_Sig_let : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_let _0 -> true | uu____7649 -> false
+    match projectee with | Sig_let _0 -> true | uu____7606 -> false
 let (__proj__Sig_let__item___0 :
   sigelt' -> (letbindings * FStar_Ident.lident Prims.list)) =
   fun projectee -> match projectee with | Sig_let _0 -> _0
 let (uu___is_Sig_assume : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_assume _0 -> true | uu____7692 -> false
+    match projectee with | Sig_assume _0 -> true | uu____7649 -> false
 let (__proj__Sig_assume__item___0 :
   sigelt' -> (FStar_Ident.lident * univ_names * formula)) =
   fun projectee -> match projectee with | Sig_assume _0 -> _0
 let (uu___is_Sig_new_effect : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_new_effect _0 -> true | uu____7729 -> false
+    match projectee with | Sig_new_effect _0 -> true | uu____7686 -> false
 let (__proj__Sig_new_effect__item___0 : sigelt' -> eff_decl) =
   fun projectee -> match projectee with | Sig_new_effect _0 -> _0
 let (uu___is_Sig_sub_effect : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_sub_effect _0 -> true | uu____7748 -> false
+    match projectee with | Sig_sub_effect _0 -> true | uu____7705 -> false
 let (__proj__Sig_sub_effect__item___0 : sigelt' -> sub_eff) =
   fun projectee -> match projectee with | Sig_sub_effect _0 -> _0
 let (uu___is_Sig_effect_abbrev : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_effect_abbrev _0 -> true | uu____7779 -> false
+    match projectee with | Sig_effect_abbrev _0 -> true | uu____7736 -> false
 let (__proj__Sig_effect_abbrev__item___0 :
   sigelt' ->
     (FStar_Ident.lident * univ_names * binders * comp * cflag Prims.list))
   = fun projectee -> match projectee with | Sig_effect_abbrev _0 -> _0
 let (uu___is_Sig_pragma : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_pragma _0 -> true | uu____7834 -> false
+    match projectee with | Sig_pragma _0 -> true | uu____7791 -> false
 let (__proj__Sig_pragma__item___0 : sigelt' -> pragma) =
   fun projectee -> match projectee with | Sig_pragma _0 -> _0
 let (uu___is_Sig_splice : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_splice _0 -> true | uu____7859 -> false
+    match projectee with | Sig_splice _0 -> true | uu____7816 -> false
 let (__proj__Sig_splice__item___0 :
   sigelt' -> (FStar_Ident.lident Prims.list * term)) =
   fun projectee -> match projectee with | Sig_splice _0 -> _0
@@ -1434,7 +1423,7 @@ let (uu___is_Sig_polymonadic_bind : sigelt' -> Prims.bool) =
   fun projectee ->
     match projectee with
     | Sig_polymonadic_bind _0 -> true
-    | uu____7906 -> false
+    | uu____7863 -> false
 let (__proj__Sig_polymonadic_bind__item___0 :
   sigelt' ->
     (FStar_Ident.lident * FStar_Ident.lident * FStar_Ident.lident * tscheme *
@@ -1442,7 +1431,7 @@ let (__proj__Sig_polymonadic_bind__item___0 :
   = fun projectee -> match projectee with | Sig_polymonadic_bind _0 -> _0
 let (uu___is_Sig_fail : sigelt' -> Prims.bool) =
   fun projectee ->
-    match projectee with | Sig_fail _0 -> true | uu____7967 -> false
+    match projectee with | Sig_fail _0 -> true | uu____7924 -> false
 let (__proj__Sig_fail__item___0 :
   sigelt' -> (Prims.int Prims.list * Prims.bool * sigelt Prims.list)) =
   fun projectee -> match projectee with | Sig_fail _0 -> _0
@@ -1500,10 +1489,10 @@ type subst_t = subst_elt Prims.list
 let (contains_reflectable : qualifier Prims.list -> Prims.bool) =
   fun l ->
     FStar_Util.for_some
-      (fun uu___0_8226 ->
-         match uu___0_8226 with
-         | Reflectable uu____8228 -> true
-         | uu____8230 -> false) l
+      (fun uu___0_8183 ->
+         match uu___0_8183 with
+         | Reflectable uu____8185 -> true
+         | uu____8187 -> false) l
 let withinfo : 'a . 'a -> FStar_Range.range -> 'a withinfo_t =
   fun v -> fun r -> { v; p = r }
 let withsort : 'a . 'a -> 'a withinfo_t =
@@ -1517,22 +1506,22 @@ let (order_bv : bv -> bv -> Prims.int) =
   fun x ->
     fun y ->
       let i =
-        let uu____8292 = FStar_Ident.string_of_id x.ppname in
-        let uu____8294 = FStar_Ident.string_of_id y.ppname in
-        FStar_String.compare uu____8292 uu____8294 in
+        let uu____8249 = FStar_Ident.string_of_id x.ppname in
+        let uu____8251 = FStar_Ident.string_of_id y.ppname in
+        FStar_String.compare uu____8249 uu____8251 in
       if i = Prims.int_zero then x.index - y.index else i
 let (order_ident : FStar_Ident.ident -> FStar_Ident.ident -> Prims.int) =
   fun x ->
     fun y ->
-      let uu____8314 = FStar_Ident.string_of_id x in
-      let uu____8316 = FStar_Ident.string_of_id y in
-      FStar_String.compare uu____8314 uu____8316
+      let uu____8271 = FStar_Ident.string_of_id x in
+      let uu____8273 = FStar_Ident.string_of_id y in
+      FStar_String.compare uu____8271 uu____8273
 let (order_fv : FStar_Ident.lident -> FStar_Ident.lident -> Prims.int) =
   fun x ->
     fun y ->
-      let uu____8330 = FStar_Ident.string_of_lid x in
-      let uu____8332 = FStar_Ident.string_of_lid y in
-      FStar_String.compare uu____8330 uu____8332
+      let uu____8287 = FStar_Ident.string_of_lid x in
+      let uu____8289 = FStar_Ident.string_of_lid y in
+      FStar_String.compare uu____8287 uu____8289
 let (range_of_lbname : lbname -> FStar_Range.range) =
   fun l ->
     match l with
@@ -1543,73 +1532,73 @@ let (range_of_bv : bv -> FStar_Range.range) =
 let (set_range_of_bv : bv -> FStar_Range.range -> bv) =
   fun x ->
     fun r ->
-      let uu___419_8359 = x in
-      let uu____8360 = FStar_Ident.set_id_range r x.ppname in
+      let uu___416_8316 = x in
+      let uu____8317 = FStar_Ident.set_id_range r x.ppname in
       {
-        ppname = uu____8360;
-        index = (uu___419_8359.index);
-        sort = (uu___419_8359.sort)
+        ppname = uu____8317;
+        index = (uu___416_8316.index);
+        sort = (uu___416_8316.sort)
       }
 let (on_antiquoted : (term -> term) -> quoteinfo -> quoteinfo) =
   fun f ->
     fun qi ->
       let aq =
         FStar_List.map
-          (fun uu____8396 ->
-             match uu____8396 with
-             | (bv1, t) -> let uu____8407 = f t in (bv1, uu____8407))
+          (fun uu____8353 ->
+             match uu____8353 with
+             | (bv1, t) -> let uu____8364 = f t in (bv1, uu____8364))
           qi.antiquotes in
-      let uu___427_8408 = qi in
-      { qkind = (uu___427_8408.qkind); antiquotes = aq }
+      let uu___424_8365 = qi in
+      { qkind = (uu___424_8365.qkind); antiquotes = aq }
 let (lookup_aq : bv -> antiquotations -> term FStar_Pervasives_Native.option)
   =
   fun bv1 ->
     fun aq ->
-      let uu____8424 =
+      let uu____8381 =
         FStar_List.tryFind
-          (fun uu____8442 ->
-             match uu____8442 with | (bv', uu____8451) -> bv_eq bv1 bv') aq in
-      match uu____8424 with
-      | FStar_Pervasives_Native.Some (uu____8458, e) ->
+          (fun uu____8399 ->
+             match uu____8399 with | (bv', uu____8408) -> bv_eq bv1 bv') aq in
+      match uu____8381 with
+      | FStar_Pervasives_Native.Some (uu____8415, e) ->
           FStar_Pervasives_Native.Some e
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
 let syn :
-  'uuuuuu8489 'uuuuuu8490 'uuuuuu8491 .
-    'uuuuuu8489 ->
-      'uuuuuu8490 ->
-        ('uuuuuu8490 -> 'uuuuuu8489 -> 'uuuuuu8491) -> 'uuuuuu8491
+  'uuuuuu8446 'uuuuuu8447 'uuuuuu8448 .
+    'uuuuuu8446 ->
+      'uuuuuu8447 ->
+        ('uuuuuu8447 -> 'uuuuuu8446 -> 'uuuuuu8448) -> 'uuuuuu8448
   = fun p -> fun k -> fun f -> f k p
 let mk_fvs :
-  'uuuuuu8522 .
-    unit -> 'uuuuuu8522 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8531 -> FStar_Util.mk_ref FStar_Pervasives_Native.None
+  'uuuuuu8479 .
+    unit -> 'uuuuuu8479 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8488 -> FStar_Util.mk_ref FStar_Pervasives_Native.None
 let mk_uvs :
-  'uuuuuu8539 .
-    unit -> 'uuuuuu8539 FStar_Pervasives_Native.option FStar_ST.ref
-  = fun uu____8548 -> FStar_Util.mk_ref FStar_Pervasives_Native.None
+  'uuuuuu8496 .
+    unit -> 'uuuuuu8496 FStar_Pervasives_Native.option FStar_ST.ref
+  = fun uu____8505 -> FStar_Util.mk_ref FStar_Pervasives_Native.None
 let (new_bv_set : unit -> bv FStar_Util.set) =
-  fun uu____8558 -> FStar_Util.new_set order_bv
+  fun uu____8515 -> FStar_Util.new_set order_bv
 let (new_id_set : unit -> FStar_Ident.ident FStar_Util.set) =
-  fun uu____8568 -> FStar_Util.new_set order_ident
+  fun uu____8525 -> FStar_Util.new_set order_ident
 let (new_fv_set : unit -> FStar_Ident.lident FStar_Util.set) =
-  fun uu____8578 -> FStar_Util.new_set order_fv
+  fun uu____8535 -> FStar_Util.new_set order_fv
 let (order_univ_name : univ_name -> univ_name -> Prims.int) =
   fun x ->
     fun y ->
-      let uu____8593 = FStar_Ident.string_of_id x in
-      let uu____8595 = FStar_Ident.string_of_id y in
-      FStar_String.compare uu____8593 uu____8595
+      let uu____8550 = FStar_Ident.string_of_id x in
+      let uu____8552 = FStar_Ident.string_of_id y in
+      FStar_String.compare uu____8550 uu____8552
 let (new_universe_names_set : unit -> univ_name FStar_Util.set) =
-  fun uu____8604 -> FStar_Util.new_set order_univ_name
+  fun uu____8561 -> FStar_Util.new_set order_univ_name
 let (eq_binding : binding -> binding -> Prims.bool) =
   fun b1 ->
     fun b2 ->
       match (b1, b2) with
       | (Binding_var bv1, Binding_var bv2) -> bv_eq bv1 bv2
-      | (Binding_lid (lid1, uu____8623), Binding_lid (lid2, uu____8625)) ->
+      | (Binding_lid (lid1, uu____8580), Binding_lid (lid2, uu____8582)) ->
           FStar_Ident.lid_equals lid1 lid2
       | (Binding_univ u1, Binding_univ u2) -> FStar_Ident.ident_equals u1 u2
-      | uu____8660 -> false
+      | uu____8617 -> false
 let (no_names : freenames) = new_bv_set ()
 let (no_fvars : FStar_Ident.lident FStar_Util.set) = new_fv_set ()
 let (no_universe_names : univ_name FStar_Util.set) =
@@ -1621,30 +1610,30 @@ let (list_of_freenames : freenames -> bv Prims.list) =
 let mk : 'a . 'a -> FStar_Range.range -> 'a syntax =
   fun t ->
     fun r ->
-      let uu____8713 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
-      { n = t; pos = r; vars = uu____8713 }
+      let uu____8670 = FStar_Util.mk_ref FStar_Pervasives_Native.None in
+      { n = t; pos = r; vars = uu____8670 }
 let (bv_to_tm : bv -> term) =
-  fun bv1 -> let uu____8724 = range_of_bv bv1 in mk (Tm_bvar bv1) uu____8724
+  fun bv1 -> let uu____8681 = range_of_bv bv1 in mk (Tm_bvar bv1) uu____8681
 let (bv_to_name : bv -> term) =
-  fun bv1 -> let uu____8731 = range_of_bv bv1 in mk (Tm_name bv1) uu____8731
+  fun bv1 -> let uu____8688 = range_of_bv bv1 in mk (Tm_name bv1) uu____8688
 let (binders_to_names : binders -> term Prims.list) =
   fun bs ->
     FStar_All.pipe_right bs
       (FStar_List.map
-         (fun uu____8761 ->
-            match uu____8761 with | (x, uu____8769) -> bv_to_name x))
+         (fun uu____8718 ->
+            match uu____8718 with | (x, uu____8726) -> bv_to_name x))
 let (mk_Tm_app : term -> args -> FStar_Range.range -> term) =
   fun t1 ->
     fun args1 ->
       fun p ->
-        match args1 with | [] -> t1 | uu____8792 -> mk (Tm_app (t1, args1)) p
+        match args1 with | [] -> t1 | uu____8749 -> mk (Tm_app (t1, args1)) p
 let (mk_Tm_uinst : term -> universes -> term) =
   fun t ->
     fun us ->
       match t.n with
-      | Tm_fvar uu____8818 ->
+      | Tm_fvar uu____8775 ->
           (match us with | [] -> t | us1 -> mk (Tm_uinst (t, us1)) t.pos)
-      | uu____8822 -> failwith "Unexpected universe instantiation"
+      | uu____8779 -> failwith "Unexpected universe instantiation"
 let (extend_app_n : term -> args -> FStar_Range.range -> term) =
   fun t ->
     fun args' ->
@@ -1652,7 +1641,7 @@ let (extend_app_n : term -> args -> FStar_Range.range -> term) =
         match t.n with
         | Tm_app (head, args1) ->
             mk_Tm_app head (FStar_List.append args1 args') r
-        | uu____8874 -> mk_Tm_app t args' r
+        | uu____8831 -> mk_Tm_app t args' r
 let (extend_app : term -> arg -> FStar_Range.range -> term) =
   fun t -> fun arg1 -> fun r -> extend_app_n t [arg1] r
 let (mk_Tm_delayed : (term * subst_ts) -> FStar_Range.range -> term) =
@@ -1670,8 +1659,8 @@ let (mk_lb :
   (lbname * univ_name Prims.list * FStar_Ident.lident * typ * term *
     attribute Prims.list * FStar_Range.range) -> letbinding)
   =
-  fun uu____9005 ->
-    match uu____9005 with
+  fun uu____8962 ->
+    match uu____8962 with
     | (x, univs, eff, t, e, attrs, pos) ->
         {
           lbname = x;
@@ -1716,9 +1705,9 @@ let (is_teff : term -> Prims.bool) =
   fun t ->
     match t.n with
     | Tm_constant (FStar_Const.Const_effect) -> true
-    | uu____9105 -> false
+    | uu____9062 -> false
 let (is_type : term -> Prims.bool) =
-  fun t -> match t.n with | Tm_type uu____9115 -> true | uu____9117 -> false
+  fun t -> match t.n with | Tm_type uu____9072 -> true | uu____9074 -> false
 let (null_id : FStar_Ident.ident) =
   FStar_Ident.mk_ident ("_", FStar_Range.dummyRange)
 let (null_bv : term -> bv) =
@@ -1726,76 +1715,76 @@ let (null_bv : term -> bv) =
 let (mk_binder : bv -> binder) = fun a -> (a, FStar_Pervasives_Native.None)
 let (null_binder : term -> binder) =
   fun t ->
-    let uu____9143 = null_bv t in (uu____9143, FStar_Pervasives_Native.None)
+    let uu____9100 = null_bv t in (uu____9100, FStar_Pervasives_Native.None)
 let (imp_tag : arg_qualifier) = Implicit false
 let (iarg : term -> arg) =
   fun t -> (t, (FStar_Pervasives_Native.Some imp_tag))
 let (as_arg : term -> arg) = fun t -> (t, FStar_Pervasives_Native.None)
 let (is_null_bv : bv -> Prims.bool) =
   fun b ->
-    let uu____9175 = FStar_Ident.string_of_id b.ppname in
-    let uu____9177 = FStar_Ident.string_of_id null_id in
-    uu____9175 = uu____9177
+    let uu____9132 = FStar_Ident.string_of_id b.ppname in
+    let uu____9134 = FStar_Ident.string_of_id null_id in
+    uu____9132 = uu____9134
 let (is_null_binder : binder -> Prims.bool) =
   fun b -> is_null_bv (FStar_Pervasives_Native.fst b)
 let (is_top_level : letbinding Prims.list -> Prims.bool) =
-  fun uu___1_9197 ->
-    match uu___1_9197 with
-    | { lbname = FStar_Util.Inr uu____9201; lbunivs = uu____9202;
-        lbtyp = uu____9203; lbeff = uu____9204; lbdef = uu____9205;
-        lbattrs = uu____9206; lbpos = uu____9207;_}::uu____9208 -> true
-    | uu____9222 -> false
+  fun uu___1_9154 ->
+    match uu___1_9154 with
+    | { lbname = FStar_Util.Inr uu____9158; lbunivs = uu____9159;
+        lbtyp = uu____9160; lbeff = uu____9161; lbdef = uu____9162;
+        lbattrs = uu____9163; lbpos = uu____9164;_}::uu____9165 -> true
+    | uu____9179 -> false
 let (freenames_of_binders : binders -> freenames) =
   fun bs ->
     FStar_List.fold_right
-      (fun uu____9244 ->
+      (fun uu____9201 ->
          fun out ->
-           match uu____9244 with
-           | (x, uu____9257) -> FStar_Util.set_add x out) bs no_names
+           match uu____9201 with
+           | (x, uu____9214) -> FStar_Util.set_add x out) bs no_names
 let (binders_of_list : bv Prims.list -> binders) =
   fun fvs ->
     FStar_All.pipe_right fvs
       (FStar_List.map (fun t -> (t, FStar_Pervasives_Native.None)))
 let (binders_of_freenames : freenames -> binders) =
   fun fvs ->
-    let uu____9290 = FStar_Util.set_elements fvs in
-    FStar_All.pipe_right uu____9290 binders_of_list
+    let uu____9247 = FStar_Util.set_elements fvs in
+    FStar_All.pipe_right uu____9247 binders_of_list
 let (is_implicit : aqual -> Prims.bool) =
-  fun uu___2_9301 ->
-    match uu___2_9301 with
-    | FStar_Pervasives_Native.Some (Implicit uu____9303) -> true
-    | uu____9306 -> false
+  fun uu___2_9258 ->
+    match uu___2_9258 with
+    | FStar_Pervasives_Native.Some (Implicit uu____9260) -> true
+    | uu____9263 -> false
 let (is_implicit_or_meta : aqual -> Prims.bool) =
-  fun uu___3_9314 ->
-    match uu___3_9314 with
-    | FStar_Pervasives_Native.Some (Implicit uu____9316) -> true
-    | FStar_Pervasives_Native.Some (Meta uu____9319) -> true
-    | uu____9321 -> false
+  fun uu___3_9271 ->
+    match uu___3_9271 with
+    | FStar_Pervasives_Native.Some (Implicit uu____9273) -> true
+    | FStar_Pervasives_Native.Some (Meta uu____9276) -> true
+    | uu____9278 -> false
 let (as_implicit : Prims.bool -> aqual) =
-  fun uu___4_9329 ->
-    if uu___4_9329
+  fun uu___4_9286 ->
+    if uu___4_9286
     then FStar_Pervasives_Native.Some imp_tag
     else FStar_Pervasives_Native.None
 let (pat_bvs : pat -> bv Prims.list) =
   fun p ->
     let rec aux b p1 =
       match p1.v with
-      | Pat_dot_term uu____9367 -> b
-      | Pat_constant uu____9374 -> b
+      | Pat_dot_term uu____9324 -> b
+      | Pat_constant uu____9331 -> b
       | Pat_wild x -> x :: b
       | Pat_var x -> x :: b
-      | Pat_cons (uu____9377, pats) ->
+      | Pat_cons (uu____9334, pats) ->
           FStar_List.fold_left
             (fun b1 ->
-               fun uu____9411 ->
-                 match uu____9411 with | (p2, uu____9424) -> aux b1 p2) b
+               fun uu____9368 ->
+                 match uu____9368 with | (p2, uu____9381) -> aux b1 p2) b
             pats in
-    let uu____9431 = aux [] p in
-    FStar_All.pipe_left FStar_List.rev uu____9431
+    let uu____9388 = aux [] p in
+    FStar_All.pipe_left FStar_List.rev uu____9388
 let (range_of_ropt :
   FStar_Range.range FStar_Pervasives_Native.option -> FStar_Range.range) =
-  fun uu___5_9445 ->
-    match uu___5_9445 with
+  fun uu___5_9402 ->
+    match uu___5_9402 with
     | FStar_Pervasives_Native.None -> FStar_Range.dummyRange
     | FStar_Pervasives_Native.Some r -> r
 let (gen_bv :
@@ -1806,42 +1795,42 @@ let (gen_bv :
     fun r ->
       fun t ->
         let id = FStar_Ident.mk_ident (s, (range_of_ropt r)) in
-        let uu____9485 = FStar_Ident.next_id () in
-        { ppname = id; index = uu____9485; sort = t }
+        let uu____9442 = FStar_Ident.next_id () in
+        { ppname = id; index = uu____9442; sort = t }
 let (new_bv : FStar_Range.range FStar_Pervasives_Native.option -> typ -> bv)
   = fun ropt -> fun t -> gen_bv FStar_Ident.reserved_prefix ropt t
 let (freshen_bv : bv -> bv) =
   fun bv1 ->
-    let uu____9508 = is_null_bv bv1 in
-    if uu____9508
+    let uu____9465 = is_null_bv bv1 in
+    if uu____9465
     then
-      let uu____9511 =
-        let uu____9514 = range_of_bv bv1 in
-        FStar_Pervasives_Native.Some uu____9514 in
-      new_bv uu____9511 bv1.sort
+      let uu____9468 =
+        let uu____9471 = range_of_bv bv1 in
+        FStar_Pervasives_Native.Some uu____9471 in
+      new_bv uu____9468 bv1.sort
     else
-      (let uu___613_9517 = bv1 in
-       let uu____9518 = FStar_Ident.next_id () in
+      (let uu___610_9474 = bv1 in
+       let uu____9475 = FStar_Ident.next_id () in
        {
-         ppname = (uu___613_9517.ppname);
-         index = uu____9518;
-         sort = (uu___613_9517.sort)
+         ppname = (uu___610_9474.ppname);
+         index = uu____9475;
+         sort = (uu___610_9474.sort)
        })
 let (freshen_binder : binder -> binder) =
   fun b ->
-    let uu____9526 = b in
-    match uu____9526 with
-    | (bv1, aq) -> let uu____9533 = freshen_bv bv1 in (uu____9533, aq)
+    let uu____9483 = b in
+    match uu____9483 with
+    | (bv1, aq) -> let uu____9490 = freshen_bv bv1 in (uu____9490, aq)
 let (new_univ_name :
   FStar_Range.range FStar_Pervasives_Native.option -> univ_name) =
   fun ropt ->
     let id = FStar_Ident.next_id () in
-    let uu____9548 =
-      let uu____9554 =
-        let uu____9556 = FStar_Util.string_of_int id in
-        Prims.op_Hat FStar_Ident.reserved_prefix uu____9556 in
-      (uu____9554, (range_of_ropt ropt)) in
-    FStar_Ident.mk_ident uu____9548
+    let uu____9505 =
+      let uu____9511 =
+        let uu____9513 = FStar_Util.string_of_int id in
+        Prims.op_Hat FStar_Ident.reserved_prefix uu____9513 in
+      (uu____9511, (range_of_ropt ropt)) in
+    FStar_Ident.mk_ident uu____9505
 let (lbname_eq :
   (bv, FStar_Ident.lident) FStar_Util.either ->
     (bv, FStar_Ident.lident) FStar_Util.either -> Prims.bool)
@@ -1851,7 +1840,7 @@ let (lbname_eq :
       match (l1, l2) with
       | (FStar_Util.Inl x, FStar_Util.Inl y) -> bv_eq x y
       | (FStar_Util.Inr l, FStar_Util.Inr m) -> FStar_Ident.lid_equals l m
-      | uu____9616 -> false
+      | uu____9573 -> false
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun fv1 ->
     fun fv2 -> FStar_Ident.lid_equals (fv1.fv_name).v (fv2.fv_name).v
@@ -1860,12 +1849,12 @@ let (fv_eq_lid : fv -> FStar_Ident.lident -> Prims.bool) =
 let (set_bv_range : bv -> FStar_Range.range -> bv) =
   fun bv1 ->
     fun r ->
-      let uu___640_9665 = bv1 in
-      let uu____9666 = FStar_Ident.set_id_range r bv1.ppname in
+      let uu___637_9622 = bv1 in
+      let uu____9623 = FStar_Ident.set_id_range r bv1.ppname in
       {
-        ppname = uu____9666;
-        index = (uu___640_9665.index);
-        sort = (uu___640_9665.sort)
+        ppname = uu____9623;
+        index = (uu___637_9622.index);
+        sort = (uu___637_9622.sort)
       }
 let (lid_as_fv :
   FStar_Ident.lident ->
@@ -1874,69 +1863,69 @@ let (lid_as_fv :
   fun l ->
     fun dd ->
       fun dq ->
-        let uu____9687 =
-          let uu____9688 = FStar_Ident.range_of_lid l in
-          withinfo l uu____9688 in
-        { fv_name = uu____9687; fv_delta = dd; fv_qual = dq }
+        let uu____9644 =
+          let uu____9645 = FStar_Ident.range_of_lid l in
+          withinfo l uu____9645 in
+        { fv_name = uu____9644; fv_delta = dd; fv_qual = dq }
 let (fv_to_tm : fv -> term) =
   fun fv1 ->
-    let uu____9695 = FStar_Ident.range_of_lid (fv1.fv_name).v in
-    mk (Tm_fvar fv1) uu____9695
+    let uu____9652 = FStar_Ident.range_of_lid (fv1.fv_name).v in
+    mk (Tm_fvar fv1) uu____9652
 let (fvar :
   FStar_Ident.lident ->
     delta_depth -> fv_qual FStar_Pervasives_Native.option -> term)
   =
   fun l ->
     fun dd ->
-      fun dq -> let uu____9716 = lid_as_fv l dd dq in fv_to_tm uu____9716
+      fun dq -> let uu____9673 = lid_as_fv l dd dq in fv_to_tm uu____9673
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv1 -> (fv1.fv_name).v
 let (range_of_fv : fv -> FStar_Range.range) =
   fun fv1 ->
-    let uu____9729 = lid_of_fv fv1 in FStar_Ident.range_of_lid uu____9729
+    let uu____9686 = lid_of_fv fv1 in FStar_Ident.range_of_lid uu____9686
 let (set_range_of_fv : fv -> FStar_Range.range -> fv) =
   fun fv1 ->
     fun r ->
-      let uu___653_9741 = fv1 in
-      let uu____9742 =
-        let uu___655_9743 = fv1.fv_name in
-        let uu____9744 =
-          let uu____9745 = lid_of_fv fv1 in
-          FStar_Ident.set_lid_range uu____9745 r in
-        { v = uu____9744; p = (uu___655_9743.p) } in
+      let uu___650_9698 = fv1 in
+      let uu____9699 =
+        let uu___652_9700 = fv1.fv_name in
+        let uu____9701 =
+          let uu____9702 = lid_of_fv fv1 in
+          FStar_Ident.set_lid_range uu____9702 r in
+        { v = uu____9701; p = (uu___652_9700.p) } in
       {
-        fv_name = uu____9742;
-        fv_delta = (uu___653_9741.fv_delta);
-        fv_qual = (uu___653_9741.fv_qual)
+        fv_name = uu____9699;
+        fv_delta = (uu___650_9698.fv_delta);
+        fv_qual = (uu___650_9698.fv_qual)
       }
 let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
   fun l ->
     fun s ->
       FStar_List.existsb
-        (fun uu___6_9771 ->
-           match uu___6_9771 with
-           | { n = Tm_constant (FStar_Const.Const_string (data, uu____9776));
-               pos = uu____9777; vars = uu____9778;_} when data = s -> true
-           | uu____9785 -> false) l
+        (fun uu___6_9728 ->
+           match uu___6_9728 with
+           | { n = Tm_constant (FStar_Const.Const_string (data, uu____9733));
+               pos = uu____9734; vars = uu____9735;_} when data = s -> true
+           | uu____9742 -> false) l
 let rec (eq_pat : pat -> pat -> Prims.bool) =
   fun p1 ->
     fun p2 ->
       match ((p1.v), (p2.v)) with
       | (Pat_constant c1, Pat_constant c2) -> FStar_Const.eq_const c1 c2
       | (Pat_cons (fv1, as1), Pat_cons (fv2, as2)) ->
-          let uu____9844 = fv_eq fv1 fv2 in
-          if uu____9844
+          let uu____9801 = fv_eq fv1 fv2 in
+          if uu____9801
           then
-            let uu____9849 = FStar_List.zip as1 as2 in
-            FStar_All.pipe_right uu____9849
+            let uu____9806 = FStar_List.zip as1 as2 in
+            FStar_All.pipe_right uu____9806
               (FStar_List.for_all
-                 (fun uu____9916 ->
-                    match uu____9916 with
+                 (fun uu____9873 ->
+                    match uu____9873 with
                     | ((p11, b1), (p21, b2)) -> (b1 = b2) && (eq_pat p11 p21)))
           else false
-      | (Pat_var uu____9954, Pat_var uu____9955) -> true
-      | (Pat_wild uu____9957, Pat_wild uu____9958) -> true
+      | (Pat_var uu____9911, Pat_var uu____9912) -> true
+      | (Pat_wild uu____9914, Pat_wild uu____9915) -> true
       | (Pat_dot_term (bv1, t1), Pat_dot_term (bv2, t2)) -> true
-      | (uu____9973, uu____9974) -> false
+      | (uu____9930, uu____9931) -> false
 let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero
 let (delta_equational : delta_depth) =
   Delta_equational_at_level Prims.int_zero
@@ -1944,21 +1933,21 @@ let (fvconst : FStar_Ident.lident -> fv) =
   fun l -> lid_as_fv l delta_constant FStar_Pervasives_Native.None
 let (tconst : FStar_Ident.lident -> term) =
   fun l ->
-    let uu____9992 = let uu____9993 = fvconst l in Tm_fvar uu____9993 in
-    mk uu____9992 FStar_Range.dummyRange
+    let uu____9949 = let uu____9950 = fvconst l in Tm_fvar uu____9950 in
+    mk uu____9949 FStar_Range.dummyRange
 let (tabbrev : FStar_Ident.lident -> term) =
   fun l ->
-    let uu____10000 =
-      let uu____10001 =
+    let uu____9957 =
+      let uu____9958 =
         lid_as_fv l (Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None in
-      Tm_fvar uu____10001 in
-    mk uu____10000 FStar_Range.dummyRange
+      Tm_fvar uu____9958 in
+    mk uu____9957 FStar_Range.dummyRange
 let (tdataconstr : FStar_Ident.lident -> term) =
   fun l ->
-    let uu____10009 =
+    let uu____9966 =
       lid_as_fv l delta_constant (FStar_Pervasives_Native.Some Data_ctor) in
-    fv_to_tm uu____10009
+    fv_to_tm uu____9966
 let (t_unit : term) = tconst FStar_Parser_Const.unit_lid
 let (t_bool : term) = tconst FStar_Parser_Const.bool_lid
 let (t_int : term) = tconst FStar_Parser_Const.int_lid
@@ -1980,57 +1969,57 @@ let (t_norm_step : term) = tconst FStar_Parser_Const.norm_step_lid
 let (t_tac_of : term -> term -> term) =
   fun a ->
     fun b ->
-      let uu____10039 =
-        let uu____10040 = tabbrev FStar_Parser_Const.tac_lid in
-        mk_Tm_uinst uu____10040 [U_zero; U_zero] in
-      let uu____10041 =
-        let uu____10042 = as_arg a in
-        let uu____10051 = let uu____10062 = as_arg b in [uu____10062] in
-        uu____10042 :: uu____10051 in
-      mk_Tm_app uu____10039 uu____10041 FStar_Range.dummyRange
+      let uu____9996 =
+        let uu____9997 = tabbrev FStar_Parser_Const.tac_lid in
+        mk_Tm_uinst uu____9997 [U_zero; U_zero] in
+      let uu____9998 =
+        let uu____9999 = as_arg a in
+        let uu____10008 = let uu____10019 = as_arg b in [uu____10019] in
+        uu____9999 :: uu____10008 in
+      mk_Tm_app uu____9996 uu____9998 FStar_Range.dummyRange
 let (t_tactic_of : term -> term) =
   fun t ->
-    let uu____10101 =
-      let uu____10102 = tabbrev FStar_Parser_Const.tactic_lid in
-      mk_Tm_uinst uu____10102 [U_zero] in
-    let uu____10103 = let uu____10104 = as_arg t in [uu____10104] in
-    mk_Tm_app uu____10101 uu____10103 FStar_Range.dummyRange
+    let uu____10058 =
+      let uu____10059 = tabbrev FStar_Parser_Const.tactic_lid in
+      mk_Tm_uinst uu____10059 [U_zero] in
+    let uu____10060 = let uu____10061 = as_arg t in [uu____10061] in
+    mk_Tm_app uu____10058 uu____10060 FStar_Range.dummyRange
 let (t_tactic_unit : term) = t_tactic_of t_unit
 let (t_list_of : term -> term) =
   fun t ->
-    let uu____10136 =
-      let uu____10137 = tabbrev FStar_Parser_Const.list_lid in
-      mk_Tm_uinst uu____10137 [U_zero] in
-    let uu____10138 = let uu____10139 = as_arg t in [uu____10139] in
-    mk_Tm_app uu____10136 uu____10138 FStar_Range.dummyRange
+    let uu____10093 =
+      let uu____10094 = tabbrev FStar_Parser_Const.list_lid in
+      mk_Tm_uinst uu____10094 [U_zero] in
+    let uu____10095 = let uu____10096 = as_arg t in [uu____10096] in
+    mk_Tm_app uu____10093 uu____10095 FStar_Range.dummyRange
 let (t_option_of : term -> term) =
   fun t ->
-    let uu____10170 =
-      let uu____10171 = tabbrev FStar_Parser_Const.option_lid in
-      mk_Tm_uinst uu____10171 [U_zero] in
-    let uu____10172 = let uu____10173 = as_arg t in [uu____10173] in
-    mk_Tm_app uu____10170 uu____10172 FStar_Range.dummyRange
+    let uu____10127 =
+      let uu____10128 = tabbrev FStar_Parser_Const.option_lid in
+      mk_Tm_uinst uu____10128 [U_zero] in
+    let uu____10129 = let uu____10130 = as_arg t in [uu____10130] in
+    mk_Tm_app uu____10127 uu____10129 FStar_Range.dummyRange
 let (t_tuple2_of : term -> term -> term) =
   fun t1 ->
     fun t2 ->
-      let uu____10209 =
-        let uu____10210 = tabbrev FStar_Parser_Const.lid_tuple2 in
-        mk_Tm_uinst uu____10210 [U_zero; U_zero] in
-      let uu____10211 =
-        let uu____10212 = as_arg t1 in
-        let uu____10221 = let uu____10232 = as_arg t2 in [uu____10232] in
-        uu____10212 :: uu____10221 in
-      mk_Tm_app uu____10209 uu____10211 FStar_Range.dummyRange
+      let uu____10166 =
+        let uu____10167 = tabbrev FStar_Parser_Const.lid_tuple2 in
+        mk_Tm_uinst uu____10167 [U_zero; U_zero] in
+      let uu____10168 =
+        let uu____10169 = as_arg t1 in
+        let uu____10178 = let uu____10189 = as_arg t2 in [uu____10189] in
+        uu____10169 :: uu____10178 in
+      mk_Tm_app uu____10166 uu____10168 FStar_Range.dummyRange
 let (t_either_of : term -> term -> term) =
   fun t1 ->
     fun t2 ->
-      let uu____10276 =
-        let uu____10277 = tabbrev FStar_Parser_Const.either_lid in
-        mk_Tm_uinst uu____10277 [U_zero; U_zero] in
-      let uu____10278 =
-        let uu____10279 = as_arg t1 in
-        let uu____10288 = let uu____10299 = as_arg t2 in [uu____10299] in
-        uu____10279 :: uu____10288 in
-      mk_Tm_app uu____10276 uu____10278 FStar_Range.dummyRange
+      let uu____10233 =
+        let uu____10234 = tabbrev FStar_Parser_Const.either_lid in
+        mk_Tm_uinst uu____10234 [U_zero; U_zero] in
+      let uu____10235 =
+        let uu____10236 = as_arg t1 in
+        let uu____10245 = let uu____10256 = as_arg t2 in [uu____10256] in
+        uu____10236 :: uu____10245 in
+      mk_Tm_app uu____10233 uu____10235 FStar_Range.dummyRange
 let (unit_const : term) =
   mk (Tm_constant FStar_Const.Const_unit) FStar_Range.dummyRange

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -4273,8 +4273,6 @@ let (apply_layered_eff_combinators :
       let uu____19851 = map_tuple combs.FStar_Syntax_Syntax.l_subcomp in
       let uu____19856 = map_tuple combs.FStar_Syntax_Syntax.l_if_then_else in
       {
-        FStar_Syntax_Syntax.l_base_effect =
-          (combs.FStar_Syntax_Syntax.l_base_effect);
         FStar_Syntax_Syntax.l_repr = uu____19836;
         FStar_Syntax_Syntax.l_return = uu____19841;
         FStar_Syntax_Syntax.l_bind = uu____19846;
@@ -4455,13 +4453,3 @@ let (get_stronger_repr :
             FStar_Pervasives_Native.fst in
         FStar_All.pipe_right uu____20090
           (fun uu____20097 -> FStar_Pervasives_Native.Some uu____20097)
-let (get_layered_effect_base :
-  FStar_Syntax_Syntax.eff_decl ->
-    FStar_Ident.lident FStar_Pervasives_Native.option)
-  =
-  fun ed ->
-    match ed.FStar_Syntax_Syntax.combinators with
-    | FStar_Syntax_Syntax.Layered_eff combs ->
-        FStar_All.pipe_right combs.FStar_Syntax_Syntax.l_base_effect
-          (fun uu____20111 -> FStar_Pervasives_Native.Some uu____20111)
-    | uu____20112 -> FStar_Pervasives_Native.None

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -6441,125 +6441,121 @@ let rec (desugar_effect :
                                                 ((us, t), dummy_tscheme) in
                                           let uu____26059 =
                                             let uu____26060 =
-                                              FStar_Ident.lid_of_str "" in
-                                            let uu____26062 =
-                                              let uu____26067 = lookup "repr" in
+                                              let uu____26065 = lookup "repr" in
                                               FStar_All.pipe_right
-                                                uu____26067 to_comb in
-                                            let uu____26085 =
-                                              let uu____26090 =
+                                                uu____26065 to_comb in
+                                            let uu____26083 =
+                                              let uu____26088 =
                                                 lookup "return" in
                                               FStar_All.pipe_right
-                                                uu____26090 to_comb in
-                                            let uu____26108 =
-                                              let uu____26113 = lookup "bind" in
+                                                uu____26088 to_comb in
+                                            let uu____26106 =
+                                              let uu____26111 = lookup "bind" in
                                               FStar_All.pipe_right
-                                                uu____26113 to_comb in
-                                            let uu____26131 =
-                                              let uu____26136 =
+                                                uu____26111 to_comb in
+                                            let uu____26129 =
+                                              let uu____26134 =
                                                 lookup "subcomp" in
                                               FStar_All.pipe_right
-                                                uu____26136 to_comb in
-                                            let uu____26154 =
-                                              let uu____26159 =
+                                                uu____26134 to_comb in
+                                            let uu____26152 =
+                                              let uu____26157 =
                                                 lookup "if_then_else" in
                                               FStar_All.pipe_right
-                                                uu____26159 to_comb in
+                                                uu____26157 to_comb in
                                             {
-                                              FStar_Syntax_Syntax.l_base_effect
-                                                = uu____26060;
                                               FStar_Syntax_Syntax.l_repr =
-                                                uu____26062;
+                                                uu____26060;
                                               FStar_Syntax_Syntax.l_return =
-                                                uu____26085;
+                                                uu____26083;
                                               FStar_Syntax_Syntax.l_bind =
-                                                uu____26108;
+                                                uu____26106;
                                               FStar_Syntax_Syntax.l_subcomp =
-                                                uu____26131;
+                                                uu____26129;
                                               FStar_Syntax_Syntax.l_if_then_else
-                                                = uu____26154
+                                                = uu____26152
                                             } in
                                           FStar_Syntax_Syntax.Layered_eff
                                             uu____26059)
                                        else
                                          (let rr =
                                             FStar_Util.for_some
-                                              (fun uu___27_26182 ->
-                                                 match uu___27_26182 with
+                                              (fun uu___27_26180 ->
+                                                 match uu___27_26180 with
                                                  | FStar_Syntax_Syntax.Reifiable
                                                      -> true
                                                  | FStar_Syntax_Syntax.Reflectable
-                                                     uu____26185 -> true
-                                                 | uu____26187 -> false)
+                                                     uu____26183 -> true
+                                                 | uu____26185 -> false)
                                               qualifiers in
-                                          let uu____26189 =
-                                            let uu____26190 =
+                                          let uu____26187 =
+                                            let uu____26188 =
                                               lookup "return_wp" in
-                                            let uu____26192 =
+                                            let uu____26190 =
                                               lookup "bind_wp" in
-                                            let uu____26194 =
+                                            let uu____26192 =
                                               lookup "stronger" in
-                                            let uu____26196 =
+                                            let uu____26194 =
                                               lookup "if_then_else" in
-                                            let uu____26198 = lookup "ite_wp" in
-                                            let uu____26200 =
+                                            let uu____26196 = lookup "ite_wp" in
+                                            let uu____26198 =
                                               lookup "close_wp" in
-                                            let uu____26202 =
+                                            let uu____26200 =
                                               lookup "trivial" in
-                                            let uu____26204 =
+                                            let uu____26202 =
                                               if rr
                                               then
-                                                let uu____26210 =
+                                                let uu____26208 =
                                                   lookup "repr" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26210
+                                                  uu____26208
                                               else
                                                 FStar_Pervasives_Native.None in
-                                            let uu____26214 =
+                                            let uu____26212 =
                                               if rr
                                               then
-                                                let uu____26220 =
+                                                let uu____26218 =
                                                   lookup "return" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26220
+                                                  uu____26218
                                               else
                                                 FStar_Pervasives_Native.None in
-                                            let uu____26224 =
+                                            let uu____26222 =
                                               if rr
                                               then
-                                                let uu____26230 =
+                                                let uu____26228 =
                                                   lookup "bind" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____26230
+                                                  uu____26228
                                               else
                                                 FStar_Pervasives_Native.None in
                                             {
                                               FStar_Syntax_Syntax.ret_wp =
-                                                uu____26190;
+                                                uu____26188;
                                               FStar_Syntax_Syntax.bind_wp =
-                                                uu____26192;
+                                                uu____26190;
                                               FStar_Syntax_Syntax.stronger =
-                                                uu____26194;
+                                                uu____26192;
                                               FStar_Syntax_Syntax.if_then_else
-                                                = uu____26196;
+                                                = uu____26194;
                                               FStar_Syntax_Syntax.ite_wp =
-                                                uu____26198;
+                                                uu____26196;
                                               FStar_Syntax_Syntax.close_wp =
-                                                uu____26200;
+                                                uu____26198;
                                               FStar_Syntax_Syntax.trivial =
-                                                uu____26202;
+                                                uu____26200;
                                               FStar_Syntax_Syntax.repr =
-                                                uu____26204;
+                                                uu____26202;
                                               FStar_Syntax_Syntax.return_repr
-                                                = uu____26214;
+                                                = uu____26212;
                                               FStar_Syntax_Syntax.bind_repr =
-                                                uu____26224
+                                                uu____26222
                                             } in
                                           FStar_Syntax_Syntax.Primitive_eff
-                                            uu____26189) in
+                                            uu____26187) in
                                    let sigel =
-                                     let uu____26235 =
-                                       let uu____26236 =
+                                     let uu____26233 =
+                                       let uu____26234 =
                                          FStar_List.map (desugar_term env2)
                                            attrs in
                                        {
@@ -6575,10 +6571,10 @@ let rec (desugar_effect :
                                          FStar_Syntax_Syntax.actions =
                                            actions1;
                                          FStar_Syntax_Syntax.eff_attrs =
-                                           uu____26236
+                                           uu____26234
                                        } in
                                      FStar_Syntax_Syntax.Sig_new_effect
-                                       uu____26235 in
+                                       uu____26233 in
                                    let se =
                                      {
                                        FStar_Syntax_Syntax.sigel = sigel;
@@ -6599,12 +6595,12 @@ let rec (desugar_effect :
                                        (FStar_List.fold_left
                                           (fun env4 ->
                                              fun a ->
-                                               let uu____26253 =
+                                               let uu____26251 =
                                                  FStar_Syntax_Util.action_as_lb
                                                    mname a
                                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                                                FStar_Syntax_DsEnv.push_sigelt
-                                                 env4 uu____26253) env3) in
+                                                 env4 uu____26251) env3) in
                                    let env5 =
                                      push_reflect_effect env4 qualifiers
                                        mname d.FStar_Parser_AST.drange in
@@ -6631,50 +6627,50 @@ and (desugar_redefine_effect :
               fun defn ->
                 let env0 = env in
                 let env1 = FStar_Syntax_DsEnv.enter_monad_scope env eff_name in
-                let uu____26276 = desugar_binders env1 eff_binders in
-                match uu____26276 with
+                let uu____26274 = desugar_binders env1 eff_binders in
+                match uu____26274 with
                 | (env2, binders) ->
-                    let uu____26313 =
-                      let uu____26324 = head_and_args defn in
-                      match uu____26324 with
+                    let uu____26311 =
+                      let uu____26322 = head_and_args defn in
+                      match uu____26322 with
                       | (head, args) ->
                           let lid =
                             match head.FStar_Parser_AST.tm with
                             | FStar_Parser_AST.Name l -> l
-                            | uu____26361 ->
-                                let uu____26362 =
-                                  let uu____26368 =
-                                    let uu____26370 =
-                                      let uu____26372 =
+                            | uu____26359 ->
+                                let uu____26360 =
+                                  let uu____26366 =
+                                    let uu____26368 =
+                                      let uu____26370 =
                                         FStar_Parser_AST.term_to_string head in
-                                      Prims.op_Hat uu____26372 " not found" in
-                                    Prims.op_Hat "Effect " uu____26370 in
+                                      Prims.op_Hat uu____26370 " not found" in
+                                    Prims.op_Hat "Effect " uu____26368 in
                                   (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____26368) in
-                                FStar_Errors.raise_error uu____26362
+                                    uu____26366) in
+                                FStar_Errors.raise_error uu____26360
                                   d.FStar_Parser_AST.drange in
                           let ed =
                             FStar_Syntax_DsEnv.fail_or env2
                               (FStar_Syntax_DsEnv.try_lookup_effect_defn env2)
                               lid in
-                          let uu____26378 =
+                          let uu____26376 =
                             match FStar_List.rev args with
-                            | (last_arg, uu____26408)::args_rev ->
-                                let uu____26420 =
-                                  let uu____26421 = unparen last_arg in
-                                  uu____26421.FStar_Parser_AST.tm in
-                                (match uu____26420 with
+                            | (last_arg, uu____26406)::args_rev ->
+                                let uu____26418 =
+                                  let uu____26419 = unparen last_arg in
+                                  uu____26419.FStar_Parser_AST.tm in
+                                (match uu____26418 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
-                                 | uu____26449 -> ([], args))
-                            | uu____26458 -> ([], args) in
-                          (match uu____26378 with
+                                 | uu____26447 -> ([], args))
+                            | uu____26456 -> ([], args) in
+                          (match uu____26376 with
                            | (cattributes, args1) ->
-                               let uu____26501 = desugar_args env2 args1 in
-                               let uu____26502 =
+                               let uu____26499 = desugar_args env2 args1 in
+                               let uu____26500 =
                                  desugar_attributes env2 cattributes in
-                               (lid, ed, uu____26501, uu____26502)) in
-                    (match uu____26313 with
+                               (lid, ed, uu____26499, uu____26500)) in
+                    (match uu____26311 with
                      | (ed_lid, ed, args, cattributes) ->
                          let binders1 =
                            FStar_Syntax_Subst.close_binders binders in
@@ -6688,65 +6684,65 @@ and (desugar_redefine_effect :
                                 "Unexpected number of arguments to effect constructor")
                               defn.FStar_Parser_AST.range
                           else ();
-                          (let uu____26542 =
+                          (let uu____26540 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
                                FStar_Syntax_Syntax.t_unit in
-                           match uu____26542 with
-                           | (ed_binders, uu____26556, ed_binders_opening) ->
-                               let sub' shift_n uu____26575 =
-                                 match uu____26575 with
+                           match uu____26540 with
+                           | (ed_binders, uu____26554, ed_binders_opening) ->
+                               let sub' shift_n uu____26573 =
+                                 match uu____26573 with
                                  | (us, x) ->
                                      let x1 =
-                                       let uu____26590 =
+                                       let uu____26588 =
                                          FStar_Syntax_Subst.shift_subst
                                            (shift_n + (FStar_List.length us))
                                            ed_binders_opening in
-                                       FStar_Syntax_Subst.subst uu____26590 x in
+                                       FStar_Syntax_Subst.subst uu____26588 x in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
                                          ed_binders args in
-                                     let uu____26594 =
-                                       let uu____26595 =
+                                     let uu____26592 =
+                                       let uu____26593 =
                                          FStar_Syntax_Subst.subst s x1 in
-                                       (us, uu____26595) in
+                                       (us, uu____26593) in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____26594 in
+                                       binders1 uu____26592 in
                                let sub = sub' Prims.int_zero in
                                let mname =
                                  FStar_Syntax_DsEnv.qualify env0 eff_name in
                                let ed1 =
-                                 let uu____26616 =
+                                 let uu____26614 =
                                    sub ed.FStar_Syntax_Syntax.signature in
-                                 let uu____26617 =
+                                 let uu____26615 =
                                    FStar_Syntax_Util.apply_eff_combinators
                                      sub ed.FStar_Syntax_Syntax.combinators in
-                                 let uu____26618 =
+                                 let uu____26616 =
                                    FStar_List.map
                                      (fun action ->
                                         let nparam =
                                           FStar_List.length
                                             action.FStar_Syntax_Syntax.action_params in
-                                        let uu____26634 =
+                                        let uu____26632 =
                                           FStar_Syntax_DsEnv.qualify env2
                                             action.FStar_Syntax_Syntax.action_unqualified_name in
-                                        let uu____26635 =
-                                          let uu____26636 =
+                                        let uu____26633 =
+                                          let uu____26634 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_defn)) in
                                           FStar_Pervasives_Native.snd
-                                            uu____26636 in
-                                        let uu____26651 =
-                                          let uu____26652 =
+                                            uu____26634 in
+                                        let uu____26649 =
+                                          let uu____26650 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_typ)) in
                                           FStar_Pervasives_Native.snd
-                                            uu____26652 in
+                                            uu____26650 in
                                         {
                                           FStar_Syntax_Syntax.action_name =
-                                            uu____26634;
+                                            uu____26632;
                                           FStar_Syntax_Syntax.action_unqualified_name
                                             =
                                             (action.FStar_Syntax_Syntax.action_unqualified_name);
@@ -6755,9 +6751,9 @@ and (desugar_redefine_effect :
                                           FStar_Syntax_Syntax.action_params =
                                             (action.FStar_Syntax_Syntax.action_params);
                                           FStar_Syntax_Syntax.action_defn =
-                                            uu____26635;
+                                            uu____26633;
                                           FStar_Syntax_Syntax.action_typ =
-                                            uu____26651
+                                            uu____26649
                                         }) ed.FStar_Syntax_Syntax.actions in
                                  {
                                    FStar_Syntax_Syntax.mname = mname;
@@ -6767,25 +6763,25 @@ and (desugar_redefine_effect :
                                      (ed.FStar_Syntax_Syntax.univs);
                                    FStar_Syntax_Syntax.binders = binders1;
                                    FStar_Syntax_Syntax.signature =
-                                     uu____26616;
+                                     uu____26614;
                                    FStar_Syntax_Syntax.combinators =
-                                     uu____26617;
-                                   FStar_Syntax_Syntax.actions = uu____26618;
+                                     uu____26615;
+                                   FStar_Syntax_Syntax.actions = uu____26616;
                                    FStar_Syntax_Syntax.eff_attrs =
                                      (ed.FStar_Syntax_Syntax.eff_attrs)
                                  } in
                                let se =
-                                 let uu____26668 =
-                                   let uu____26671 =
+                                 let uu____26666 =
+                                   let uu____26669 =
                                      trans_qual1
                                        (FStar_Pervasives_Native.Some mname) in
-                                   FStar_List.map uu____26671 quals in
+                                   FStar_List.map uu____26669 quals in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ed1);
                                    FStar_Syntax_Syntax.sigrng =
                                      (d.FStar_Parser_AST.drange);
-                                   FStar_Syntax_Syntax.sigquals = uu____26668;
+                                   FStar_Syntax_Syntax.sigquals = uu____26666;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = [];
@@ -6801,23 +6797,23 @@ and (desugar_redefine_effect :
                                    (FStar_List.fold_left
                                       (fun env4 ->
                                          fun a ->
-                                           let uu____26686 =
+                                           let uu____26684 =
                                              FStar_Syntax_Util.action_as_lb
                                                mname a
                                                (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                                            FStar_Syntax_DsEnv.push_sigelt
-                                             env4 uu____26686) env3) in
+                                             env4 uu____26684) env3) in
                                let env5 =
-                                 let uu____26688 =
+                                 let uu____26686 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
                                         FStar_Parser_AST.Reflectable) in
-                                 if uu____26688
+                                 if uu____26686
                                  then
                                    let reflect_lid =
-                                     let uu____26695 =
+                                     let uu____26693 =
                                        FStar_Ident.id_of_text "reflect" in
-                                     FStar_All.pipe_right uu____26695
+                                     FStar_All.pipe_right uu____26693
                                        (FStar_Syntax_DsEnv.qualify monad_env) in
                                    let quals1 =
                                      [FStar_Syntax_Syntax.Assumption;
@@ -6850,52 +6846,52 @@ and (desugar_decl_aux :
       let no_fail_attrs ats =
         FStar_List.filter
           (fun at ->
-             let uu____26728 = get_fail_attr1 false at in
-             FStar_Option.isNone uu____26728) ats in
+             let uu____26726 = get_fail_attr1 false at in
+             FStar_Option.isNone uu____26726) ats in
       let env0 =
-        let uu____26749 = FStar_Syntax_DsEnv.snapshot env in
-        FStar_All.pipe_right uu____26749 FStar_Pervasives_Native.snd in
+        let uu____26747 = FStar_Syntax_DsEnv.snapshot env in
+        FStar_All.pipe_right uu____26747 FStar_Pervasives_Native.snd in
       let attrs = FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs in
-      let uu____26764 =
-        let uu____26771 = get_fail_attr false attrs in
-        match uu____26771 with
+      let uu____26762 =
+        let uu____26769 = get_fail_attr false attrs in
+        match uu____26769 with
         | FStar_Pervasives_Native.Some (expected_errs, lax) ->
             let d1 =
-              let uu___3396_26808 = d in
+              let uu___3396_26806 = d in
               {
-                FStar_Parser_AST.d = (uu___3396_26808.FStar_Parser_AST.d);
+                FStar_Parser_AST.d = (uu___3396_26806.FStar_Parser_AST.d);
                 FStar_Parser_AST.drange =
-                  (uu___3396_26808.FStar_Parser_AST.drange);
+                  (uu___3396_26806.FStar_Parser_AST.drange);
                 FStar_Parser_AST.quals =
-                  (uu___3396_26808.FStar_Parser_AST.quals);
+                  (uu___3396_26806.FStar_Parser_AST.quals);
                 FStar_Parser_AST.attrs = []
               } in
-            let uu____26809 =
+            let uu____26807 =
               FStar_Errors.catch_errors
-                (fun uu____26827 ->
+                (fun uu____26825 ->
                    FStar_Options.with_saved_options
-                     (fun uu____26833 -> desugar_decl_noattrs env d1)) in
-            (match uu____26809 with
+                     (fun uu____26831 -> desugar_decl_noattrs env d1)) in
+            (match uu____26807 with
              | (errs, r) ->
                  (match (errs, r) with
                   | ([], FStar_Pervasives_Native.Some (env1, ses)) ->
                       let ses1 =
                         FStar_List.map
                           (fun se ->
-                             let uu___3411_26893 = se in
-                             let uu____26894 = no_fail_attrs attrs in
+                             let uu___3411_26891 = se in
+                             let uu____26892 = no_fail_attrs attrs in
                              {
                                FStar_Syntax_Syntax.sigel =
-                                 (uu___3411_26893.FStar_Syntax_Syntax.sigel);
+                                 (uu___3411_26891.FStar_Syntax_Syntax.sigel);
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___3411_26893.FStar_Syntax_Syntax.sigrng);
+                                 (uu___3411_26891.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___3411_26893.FStar_Syntax_Syntax.sigquals);
+                                 (uu___3411_26891.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___3411_26893.FStar_Syntax_Syntax.sigmeta);
-                               FStar_Syntax_Syntax.sigattrs = uu____26894;
+                                 (uu___3411_26891.FStar_Syntax_Syntax.sigmeta);
+                               FStar_Syntax_Syntax.sigattrs = uu____26892;
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___3411_26893.FStar_Syntax_Syntax.sigopts)
+                                 (uu___3411_26891.FStar_Syntax_Syntax.sigopts)
                              }) ses in
                       let se =
                         {
@@ -6921,118 +6917,118 @@ and (desugar_decl_aux :
                       if expected_errs = []
                       then (env0, [])
                       else
-                        (let uu____26947 =
+                        (let uu____26945 =
                            FStar_Errors.find_multiset_discrepancy
                              expected_errs errnos in
-                         match uu____26947 with
+                         match uu____26945 with
                          | FStar_Pervasives_Native.None -> (env0, [])
                          | FStar_Pervasives_Native.Some (e, n1, n2) ->
                              (FStar_List.iter FStar_Errors.print_issue errs1;
-                              (let uu____26996 =
-                                 let uu____27002 =
-                                   let uu____27004 =
+                              (let uu____26994 =
+                                 let uu____27000 =
+                                   let uu____27002 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int expected_errs in
-                                   let uu____27007 =
+                                   let uu____27005 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int errnos in
-                                   let uu____27010 =
+                                   let uu____27008 =
                                      FStar_Util.string_of_int e in
-                                   let uu____27012 =
+                                   let uu____27010 =
                                      FStar_Util.string_of_int n2 in
-                                   let uu____27014 =
+                                   let uu____27012 =
                                      FStar_Util.string_of_int n1 in
                                    FStar_Util.format5
                                      "This top-level definition was expected to raise error codes %s, but it raised %s (at desugaring time). Error #%s was raised %s times, instead of %s."
-                                     uu____27004 uu____27007 uu____27010
-                                     uu____27012 uu____27014 in
-                                 (FStar_Errors.Error_DidNotFail, uu____27002) in
+                                     uu____27002 uu____27005 uu____27008
+                                     uu____27010 uu____27012 in
+                                 (FStar_Errors.Error_DidNotFail, uu____27000) in
                                FStar_Errors.log_issue
-                                 d1.FStar_Parser_AST.drange uu____26996);
+                                 d1.FStar_Parser_AST.drange uu____26994);
                               (env0, [])))))
         | FStar_Pervasives_Native.None -> desugar_decl_noattrs env d in
-      match uu____26764 with
+      match uu____26762 with
       | (env1, sigelts) ->
           let rec val_attrs ses =
             match ses with
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-                  uu____27052;
-                FStar_Syntax_Syntax.sigrng = uu____27053;
-                FStar_Syntax_Syntax.sigquals = uu____27054;
-                FStar_Syntax_Syntax.sigmeta = uu____27055;
-                FStar_Syntax_Syntax.sigattrs = uu____27056;
-                FStar_Syntax_Syntax.sigopts = uu____27057;_}::[] ->
-                let uu____27070 =
-                  let uu____27073 = FStar_List.hd sigelts in
-                  FStar_Syntax_Util.lids_of_sigelt uu____27073 in
-                FStar_All.pipe_right uu____27070
+                  uu____27050;
+                FStar_Syntax_Syntax.sigrng = uu____27051;
+                FStar_Syntax_Syntax.sigquals = uu____27052;
+                FStar_Syntax_Syntax.sigmeta = uu____27053;
+                FStar_Syntax_Syntax.sigattrs = uu____27054;
+                FStar_Syntax_Syntax.sigopts = uu____27055;_}::[] ->
+                let uu____27068 =
+                  let uu____27071 = FStar_List.hd sigelts in
+                  FStar_Syntax_Util.lids_of_sigelt uu____27071 in
+                FStar_All.pipe_right uu____27068
                   (FStar_List.collect
                      (fun nm ->
-                        let uu____27081 =
+                        let uu____27079 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm in
-                        FStar_Pervasives_Native.snd uu____27081))
+                        FStar_Pervasives_Native.snd uu____27079))
             | {
                 FStar_Syntax_Syntax.sigel =
-                  FStar_Syntax_Syntax.Sig_inductive_typ uu____27094;
-                FStar_Syntax_Syntax.sigrng = uu____27095;
-                FStar_Syntax_Syntax.sigquals = uu____27096;
-                FStar_Syntax_Syntax.sigmeta = uu____27097;
-                FStar_Syntax_Syntax.sigattrs = uu____27098;
-                FStar_Syntax_Syntax.sigopts = uu____27099;_}::uu____27100 ->
-                let uu____27125 =
-                  let uu____27128 = FStar_List.hd sigelts in
-                  FStar_Syntax_Util.lids_of_sigelt uu____27128 in
-                FStar_All.pipe_right uu____27125
+                  FStar_Syntax_Syntax.Sig_inductive_typ uu____27092;
+                FStar_Syntax_Syntax.sigrng = uu____27093;
+                FStar_Syntax_Syntax.sigquals = uu____27094;
+                FStar_Syntax_Syntax.sigmeta = uu____27095;
+                FStar_Syntax_Syntax.sigattrs = uu____27096;
+                FStar_Syntax_Syntax.sigopts = uu____27097;_}::uu____27098 ->
+                let uu____27123 =
+                  let uu____27126 = FStar_List.hd sigelts in
+                  FStar_Syntax_Util.lids_of_sigelt uu____27126 in
+                FStar_All.pipe_right uu____27123
                   (FStar_List.collect
                      (fun nm ->
-                        let uu____27136 =
+                        let uu____27134 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm in
-                        FStar_Pervasives_Native.snd uu____27136))
+                        FStar_Pervasives_Native.snd uu____27134))
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_fail
                   (_errs, _lax, ses1);
-                FStar_Syntax_Syntax.sigrng = uu____27152;
-                FStar_Syntax_Syntax.sigquals = uu____27153;
-                FStar_Syntax_Syntax.sigmeta = uu____27154;
-                FStar_Syntax_Syntax.sigattrs = uu____27155;
-                FStar_Syntax_Syntax.sigopts = uu____27156;_}::[] ->
+                FStar_Syntax_Syntax.sigrng = uu____27150;
+                FStar_Syntax_Syntax.sigquals = uu____27151;
+                FStar_Syntax_Syntax.sigmeta = uu____27152;
+                FStar_Syntax_Syntax.sigattrs = uu____27153;
+                FStar_Syntax_Syntax.sigopts = uu____27154;_}::[] ->
                 FStar_List.collect (fun se -> val_attrs [se]) ses1
-            | uu____27177 -> [] in
+            | uu____27175 -> [] in
           let attrs1 =
-            let uu____27183 = val_attrs sigelts in
-            FStar_List.append attrs uu____27183 in
-          let uu____27186 =
+            let uu____27181 = val_attrs sigelts in
+            FStar_List.append attrs uu____27181 in
+          let uu____27184 =
             FStar_List.map
               (fun sigelt ->
-                 let uu___3471_27190 = sigelt in
+                 let uu___3471_27188 = sigelt in
                  {
                    FStar_Syntax_Syntax.sigel =
-                     (uu___3471_27190.FStar_Syntax_Syntax.sigel);
+                     (uu___3471_27188.FStar_Syntax_Syntax.sigel);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___3471_27190.FStar_Syntax_Syntax.sigrng);
+                     (uu___3471_27188.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___3471_27190.FStar_Syntax_Syntax.sigquals);
+                     (uu___3471_27188.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___3471_27190.FStar_Syntax_Syntax.sigmeta);
+                     (uu___3471_27188.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs = attrs1;
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___3471_27190.FStar_Syntax_Syntax.sigopts)
+                     (uu___3471_27188.FStar_Syntax_Syntax.sigopts)
                  }) sigelts in
-          (env1, uu____27186)
+          (env1, uu____27184)
 and (desugar_decl :
   env_t -> FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts)) =
   fun env ->
     fun d ->
-      let uu____27197 = desugar_decl_aux env d in
-      match uu____27197 with
+      let uu____27195 = desugar_decl_aux env d in
+      match uu____27195 with
       | (env1, ses) ->
-          let uu____27208 =
+          let uu____27206 =
             FStar_All.pipe_right ses
               (FStar_List.map generalize_annotated_univs) in
-          (env1, uu____27208)
+          (env1, uu____27206)
 and (desugar_decl_noattrs :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts))
@@ -7060,47 +7056,47 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Open lid ->
           let env1 = FStar_Syntax_DsEnv.push_namespace env lid in (env1, [])
       | FStar_Parser_AST.Friend lid ->
-          let uu____27240 = FStar_Syntax_DsEnv.iface env in
-          if uu____27240
+          let uu____27238 = FStar_Syntax_DsEnv.iface env in
+          if uu____27238
           then
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FriendInterface,
                 "'friend' declarations are not allowed in interfaces")
               d.FStar_Parser_AST.drange
           else
-            (let uu____27255 =
-               let uu____27257 =
-                 let uu____27259 = FStar_Syntax_DsEnv.dep_graph env in
-                 let uu____27260 = FStar_Syntax_DsEnv.current_module env in
-                 FStar_Parser_Dep.module_has_interface uu____27259
-                   uu____27260 in
-               Prims.op_Negation uu____27257 in
-             if uu____27255
+            (let uu____27253 =
+               let uu____27255 =
+                 let uu____27257 = FStar_Syntax_DsEnv.dep_graph env in
+                 let uu____27258 = FStar_Syntax_DsEnv.current_module env in
+                 FStar_Parser_Dep.module_has_interface uu____27257
+                   uu____27258 in
+               Prims.op_Negation uu____27255 in
+             if uu____27253
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_FriendInterface,
                    "'friend' declarations are not allowed in modules that lack interfaces")
                  d.FStar_Parser_AST.drange
              else
-               (let uu____27274 =
-                  let uu____27276 =
-                    let uu____27278 = FStar_Syntax_DsEnv.dep_graph env in
-                    FStar_Parser_Dep.module_has_interface uu____27278 lid in
-                  Prims.op_Negation uu____27276 in
-                if uu____27274
+               (let uu____27272 =
+                  let uu____27274 =
+                    let uu____27276 = FStar_Syntax_DsEnv.dep_graph env in
+                    FStar_Parser_Dep.module_has_interface uu____27276 lid in
+                  Prims.op_Negation uu____27274 in
+                if uu____27272
                 then
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_FriendInterface,
                       "'friend' declarations cannot refer to modules that lack interfaces")
                     d.FStar_Parser_AST.drange
                 else
-                  (let uu____27292 =
-                     let uu____27294 =
-                       let uu____27296 = FStar_Syntax_DsEnv.dep_graph env in
-                       FStar_Parser_Dep.deps_has_implementation uu____27296
+                  (let uu____27290 =
+                     let uu____27292 =
+                       let uu____27294 = FStar_Syntax_DsEnv.dep_graph env in
+                       FStar_Parser_Dep.deps_has_implementation uu____27294
                          lid in
-                     Prims.op_Negation uu____27294 in
-                   if uu____27292
+                     Prims.op_Negation uu____27292 in
+                   if uu____27290
                    then
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FriendInterface,
@@ -7110,8 +7106,8 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Include lid ->
           let env1 = FStar_Syntax_DsEnv.push_include env lid in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x, l) ->
-          let uu____27314 = FStar_Syntax_DsEnv.push_module_abbrev env x l in
-          (uu____27314, [])
+          let uu____27312 = FStar_Syntax_DsEnv.push_module_abbrev env x l in
+          (uu____27312, [])
       | FStar_Parser_AST.Tycon (is_effect, typeclass, tcs) ->
           let quals = d.FStar_Parser_AST.quals in
           let quals1 =
@@ -7122,75 +7118,75 @@ and (desugar_decl_noattrs :
             if typeclass
             then
               match tcs with
-              | (FStar_Parser_AST.TyconRecord uu____27343)::[] ->
+              | (FStar_Parser_AST.TyconRecord uu____27341)::[] ->
                   FStar_Parser_AST.Noeq :: quals1
-              | uu____27362 ->
+              | uu____27360 ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Error_BadClassDecl,
                       "Ill-formed `class` declaration: definition must be a record type")
                     d.FStar_Parser_AST.drange
             else quals1 in
-          let uu____27371 =
-            let uu____27376 =
+          let uu____27369 =
+            let uu____27374 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals2 in
-            desugar_tycon env d uu____27376 tcs in
-          (match uu____27371 with
+            desugar_tycon env d uu____27374 tcs in
+          (match uu____27369 with
            | (env1, ses) ->
                let mkclass lid =
                  let r = FStar_Ident.range_of_lid lid in
-                 let uu____27394 =
-                   let uu____27395 =
-                     let uu____27402 =
-                       let uu____27403 = tun_r r in
+                 let uu____27392 =
+                   let uu____27393 =
+                     let uu____27400 =
+                       let uu____27401 = tun_r r in
                        FStar_Syntax_Syntax.new_bv
-                         (FStar_Pervasives_Native.Some r) uu____27403 in
-                     FStar_Syntax_Syntax.mk_binder uu____27402 in
-                   [uu____27395] in
-                 let uu____27416 =
-                   let uu____27419 =
+                         (FStar_Pervasives_Native.Some r) uu____27401 in
+                     FStar_Syntax_Syntax.mk_binder uu____27400 in
+                   [uu____27393] in
+                 let uu____27414 =
+                   let uu____27417 =
                      FStar_Syntax_Syntax.tabbrev
                        FStar_Parser_Const.mk_class_lid in
-                   let uu____27422 =
-                     let uu____27433 =
-                       let uu____27442 =
-                         let uu____27443 = FStar_Ident.string_of_lid lid in
-                         FStar_Syntax_Util.exp_string uu____27443 in
-                       FStar_Syntax_Syntax.as_arg uu____27442 in
-                     [uu____27433] in
-                   FStar_Syntax_Util.mk_app uu____27419 uu____27422 in
-                 FStar_Syntax_Util.abs uu____27394 uu____27416
+                   let uu____27420 =
+                     let uu____27431 =
+                       let uu____27440 =
+                         let uu____27441 = FStar_Ident.string_of_lid lid in
+                         FStar_Syntax_Util.exp_string uu____27441 in
+                       FStar_Syntax_Syntax.as_arg uu____27440 in
+                     [uu____27431] in
+                   FStar_Syntax_Util.mk_app uu____27417 uu____27420 in
+                 FStar_Syntax_Util.abs uu____27392 uu____27414
                    FStar_Pervasives_Native.None in
                let get_meths se =
                  let rec get_fname quals3 =
                    match quals3 with
                    | (FStar_Syntax_Syntax.Projector
-                       (uu____27483, id))::uu____27485 ->
+                       (uu____27481, id))::uu____27483 ->
                        FStar_Pervasives_Native.Some id
-                   | uu____27488::quals4 -> get_fname quals4
+                   | uu____27486::quals4 -> get_fname quals4
                    | [] -> FStar_Pervasives_Native.None in
-                 let uu____27492 = get_fname se.FStar_Syntax_Syntax.sigquals in
-                 match uu____27492 with
+                 let uu____27490 = get_fname se.FStar_Syntax_Syntax.sigquals in
+                 match uu____27490 with
                  | FStar_Pervasives_Native.None -> []
                  | FStar_Pervasives_Native.Some id ->
-                     let uu____27498 = FStar_Syntax_DsEnv.qualify env1 id in
-                     [uu____27498] in
+                     let uu____27496 = FStar_Syntax_DsEnv.qualify env1 id in
+                     [uu____27496] in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_bundle (ses1, uu____27519) ->
+                 | FStar_Syntax_Syntax.Sig_bundle (ses1, uu____27517) ->
                      FStar_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid, uu____27529, uu____27530, uu____27531,
-                      uu____27532, uu____27533)
+                     (lid, uu____27527, uu____27528, uu____27529,
+                      uu____27530, uu____27531)
                      ->
-                     let uu____27542 =
-                       let uu____27543 =
-                         let uu____27544 =
-                           let uu____27551 = mkclass lid in
-                           (meths, uu____27551) in
-                         FStar_Syntax_Syntax.Sig_splice uu____27544 in
+                     let uu____27540 =
+                       let uu____27541 =
+                         let uu____27542 =
+                           let uu____27549 = mkclass lid in
+                           (meths, uu____27549) in
+                         FStar_Syntax_Syntax.Sig_splice uu____27542 in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____27543;
+                         FStar_Syntax_Syntax.sigel = uu____27541;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
@@ -7200,8 +7196,8 @@ and (desugar_decl_noattrs :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        } in
-                     [uu____27542]
-                 | uu____27554 -> [] in
+                     [uu____27540]
+                 | uu____27552 -> [] in
                let extra =
                  if typeclass
                  then
@@ -7218,36 +7214,36 @@ and (desugar_decl_noattrs :
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
                | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27588;
-                    FStar_Parser_AST.prange = uu____27589;_},
-                  uu____27590)::[] -> false
+                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____27586;
+                    FStar_Parser_AST.prange = uu____27587;_},
+                  uu____27588)::[] -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                      uu____27600;
-                    FStar_Parser_AST.prange = uu____27601;_},
-                  uu____27602)::[] -> false
+                      uu____27598;
+                    FStar_Parser_AST.prange = uu____27599;_},
+                  uu____27600)::[] -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatOp
-                           uu____27618;
-                         FStar_Parser_AST.prange = uu____27619;_},
-                       uu____27620);
-                    FStar_Parser_AST.prange = uu____27621;_},
-                  uu____27622)::[] -> false
+                           uu____27616;
+                         FStar_Parser_AST.prange = uu____27617;_},
+                       uu____27618);
+                    FStar_Parser_AST.prange = uu____27619;_},
+                  uu____27620)::[] -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           uu____27644;
-                         FStar_Parser_AST.prange = uu____27645;_},
-                       uu____27646);
-                    FStar_Parser_AST.prange = uu____27647;_},
-                  uu____27648)::[] -> false
-               | (p, uu____27677)::[] ->
-                   let uu____27686 = is_app_pattern p in
-                   Prims.op_Negation uu____27686
-               | uu____27688 -> false) in
+                           uu____27642;
+                         FStar_Parser_AST.prange = uu____27643;_},
+                       uu____27644);
+                    FStar_Parser_AST.prange = uu____27645;_},
+                  uu____27646)::[] -> false
+               | (p, uu____27675)::[] ->
+                   let uu____27684 = is_app_pattern p in
+                   Prims.op_Negation uu____27684
+               | uu____27686 -> false) in
           if Prims.op_Negation expand_toplevel_pattern
           then
             let lets1 =
@@ -7261,17 +7257,17 @@ and (desugar_decl_noattrs :
                         (FStar_Parser_AST.Const FStar_Const.Const_unit)
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
                 d.FStar_Parser_AST.drange FStar_Parser_AST.Expr in
-            let uu____27763 = desugar_term_maybe_top true env as_inner_let in
-            (match uu____27763 with
+            let uu____27761 = desugar_term_maybe_top true env as_inner_let in
+            (match uu____27761 with
              | (ds_lets, aq) ->
                  (check_no_aq aq;
-                  (let uu____27776 =
-                     let uu____27777 =
+                  (let uu____27774 =
+                     let uu____27775 =
                        FStar_All.pipe_left FStar_Syntax_Subst.compress
                          ds_lets in
-                     uu____27777.FStar_Syntax_Syntax.n in
-                   match uu____27776 with
-                   | FStar_Syntax_Syntax.Tm_let (lbs, uu____27787) ->
+                     uu____27775.FStar_Syntax_Syntax.n in
+                   match uu____27774 with
+                   | FStar_Syntax_Syntax.Tm_let (lbs, uu____27785) ->
                        let fvs =
                          FStar_All.pipe_right
                            (FStar_Pervasives_Native.snd lbs)
@@ -7279,50 +7275,50 @@ and (desugar_decl_noattrs :
                               (fun lb ->
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname)) in
-                       let uu____27818 =
+                       let uu____27816 =
                          FStar_List.fold_right
                            (fun fv ->
-                              fun uu____27843 ->
-                                match uu____27843 with
+                              fun uu____27841 ->
+                                match uu____27841 with
                                 | (qs, ats) ->
-                                    let uu____27870 =
+                                    let uu____27868 =
                                       FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                         env
                                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                    (match uu____27870 with
+                                    (match uu____27868 with
                                      | (qs', ats') ->
                                          ((FStar_List.append qs' qs),
                                            (FStar_List.append ats' ats))))
                            fvs ([], []) in
-                       (match uu____27818 with
+                       (match uu____27816 with
                         | (val_quals, val_attrs) ->
                             let quals1 =
                               match quals with
-                              | uu____27924::uu____27925 ->
+                              | uu____27922::uu____27923 ->
                                   FStar_List.map
                                     (trans_qual1 FStar_Pervasives_Native.None)
                                     quals
-                              | uu____27928 -> val_quals in
+                              | uu____27926 -> val_quals in
                             let quals2 =
-                              let uu____27932 =
+                              let uu____27930 =
                                 FStar_All.pipe_right lets1
                                   (FStar_Util.for_some
-                                     (fun uu____27965 ->
-                                        match uu____27965 with
-                                        | (uu____27979, (uu____27980, t)) ->
+                                     (fun uu____27963 ->
+                                        match uu____27963 with
+                                        | (uu____27977, (uu____27978, t)) ->
                                             t.FStar_Parser_AST.level =
                                               FStar_Parser_AST.Formula)) in
-                              if uu____27932
+                              if uu____27930
                               then FStar_Syntax_Syntax.Logic :: quals1
                               else quals1 in
                             let lbs1 =
-                              let uu____28000 =
+                              let uu____27998 =
                                 FStar_All.pipe_right quals2
                                   (FStar_List.contains
                                      FStar_Syntax_Syntax.Abstract) in
-                              if uu____28000
+                              if uu____27998
                               then
-                                let uu____28006 =
+                                let uu____28004 =
                                   FStar_All.pipe_right
                                     (FStar_Pervasives_Native.snd lbs)
                                     (FStar_List.map
@@ -7330,38 +7326,38 @@ and (desugar_decl_noattrs :
                                           let fv =
                                             FStar_Util.right
                                               lb.FStar_Syntax_Syntax.lbname in
-                                          let uu___3649_28021 = lb in
+                                          let uu___3649_28019 = lb in
                                           {
                                             FStar_Syntax_Syntax.lbname =
                                               (FStar_Util.Inr
-                                                 (let uu___3651_28023 = fv in
+                                                 (let uu___3651_28021 = fv in
                                                   {
                                                     FStar_Syntax_Syntax.fv_name
                                                       =
-                                                      (uu___3651_28023.FStar_Syntax_Syntax.fv_name);
+                                                      (uu___3651_28021.FStar_Syntax_Syntax.fv_name);
                                                     FStar_Syntax_Syntax.fv_delta
                                                       =
                                                       (FStar_Syntax_Syntax.Delta_abstract
                                                          (fv.FStar_Syntax_Syntax.fv_delta));
                                                     FStar_Syntax_Syntax.fv_qual
                                                       =
-                                                      (uu___3651_28023.FStar_Syntax_Syntax.fv_qual)
+                                                      (uu___3651_28021.FStar_Syntax_Syntax.fv_qual)
                                                   }));
                                             FStar_Syntax_Syntax.lbunivs =
-                                              (uu___3649_28021.FStar_Syntax_Syntax.lbunivs);
+                                              (uu___3649_28019.FStar_Syntax_Syntax.lbunivs);
                                             FStar_Syntax_Syntax.lbtyp =
-                                              (uu___3649_28021.FStar_Syntax_Syntax.lbtyp);
+                                              (uu___3649_28019.FStar_Syntax_Syntax.lbtyp);
                                             FStar_Syntax_Syntax.lbeff =
-                                              (uu___3649_28021.FStar_Syntax_Syntax.lbeff);
+                                              (uu___3649_28019.FStar_Syntax_Syntax.lbeff);
                                             FStar_Syntax_Syntax.lbdef =
-                                              (uu___3649_28021.FStar_Syntax_Syntax.lbdef);
+                                              (uu___3649_28019.FStar_Syntax_Syntax.lbdef);
                                             FStar_Syntax_Syntax.lbattrs =
-                                              (uu___3649_28021.FStar_Syntax_Syntax.lbattrs);
+                                              (uu___3649_28019.FStar_Syntax_Syntax.lbattrs);
                                             FStar_Syntax_Syntax.lbpos =
-                                              (uu___3649_28021.FStar_Syntax_Syntax.lbpos)
+                                              (uu___3649_28019.FStar_Syntax_Syntax.lbpos)
                                           })) in
                                 ((FStar_Pervasives_Native.fst lbs),
-                                  uu____28006)
+                                  uu____28004)
                               else lbs in
                             let names =
                               FStar_All.pipe_right fvs
@@ -7387,16 +7383,16 @@ and (desugar_decl_noattrs :
                               } in
                             let env1 = FStar_Syntax_DsEnv.push_sigelt env s in
                             (env1, [s]))
-                   | uu____28048 ->
+                   | uu____28046 ->
                        failwith "Desugaring a let did not produce a let")))
           else
-            (let uu____28056 =
+            (let uu____28054 =
                match lets with
                | (pat, body)::[] -> (pat, body)
-               | uu____28075 ->
+               | uu____28073 ->
                    failwith
                      "expand_toplevel_pattern should only allow single definition lets" in
-             match uu____28056 with
+             match uu____28054 with
              | (pat, body) ->
                  let fresh_toplevel_name =
                    FStar_Ident.gen FStar_Range.dummyRange in
@@ -7408,14 +7404,14 @@ and (desugar_decl_noattrs :
                        FStar_Range.dummyRange in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1, ty) ->
-                       let uu___3674_28112 = pat1 in
+                       let uu___3674_28110 = pat1 in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
-                           (uu___3674_28112.FStar_Parser_AST.prange)
+                           (uu___3674_28110.FStar_Parser_AST.prange)
                        }
-                   | uu____28119 -> var_pat in
+                   | uu____28117 -> var_pat in
                  let main_let =
                    let quals1 =
                      if
@@ -7425,42 +7421,42 @@ and (desugar_decl_noattrs :
                      else FStar_Parser_AST.Private ::
                        (d.FStar_Parser_AST.quals) in
                    desugar_decl env
-                     (let uu___3680_28130 = d in
+                     (let uu___3680_28128 = d in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
                              (isrec, [(fresh_pat, body)]));
                         FStar_Parser_AST.drange =
-                          (uu___3680_28130.FStar_Parser_AST.drange);
+                          (uu___3680_28128.FStar_Parser_AST.drange);
                         FStar_Parser_AST.quals = quals1;
                         FStar_Parser_AST.attrs =
-                          (uu___3680_28130.FStar_Parser_AST.attrs)
+                          (uu___3680_28128.FStar_Parser_AST.attrs)
                       }) in
                  let main =
-                   let uu____28146 =
-                     let uu____28147 =
+                   let uu____28144 =
+                     let uu____28145 =
                        FStar_Ident.lid_of_ids [fresh_toplevel_name] in
-                     FStar_Parser_AST.Var uu____28147 in
-                   FStar_Parser_AST.mk_term uu____28146
+                     FStar_Parser_AST.Var uu____28145 in
+                   FStar_Parser_AST.mk_term uu____28144
                      pat.FStar_Parser_AST.prange FStar_Parser_AST.Expr in
-                 let build_generic_projection uu____28171 id_opt =
-                   match uu____28171 with
+                 let build_generic_projection uu____28169 id_opt =
+                   match uu____28169 with
                    | (env1, ses) ->
-                       let uu____28193 =
+                       let uu____28191 =
                          match id_opt with
                          | FStar_Pervasives_Native.Some id ->
                              let lid = FStar_Ident.lid_of_ids [id] in
                              let branch =
-                               let uu____28205 = FStar_Ident.range_of_lid lid in
+                               let uu____28203 = FStar_Ident.range_of_lid lid in
                                FStar_Parser_AST.mk_term
-                                 (FStar_Parser_AST.Var lid) uu____28205
+                                 (FStar_Parser_AST.Var lid) uu____28203
                                  FStar_Parser_AST.Expr in
                              let bv_pat =
-                               let uu____28207 = FStar_Ident.range_of_id id in
+                               let uu____28205 = FStar_Ident.range_of_id id in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____28207 in
+                                 uu____28205 in
                              (bv_pat, branch)
                          | FStar_Pervasives_Native.None ->
                              let id = FStar_Ident.gen FStar_Range.dummyRange in
@@ -7470,28 +7466,28 @@ and (desugar_decl_noattrs :
                                     FStar_Const.Const_unit)
                                  FStar_Range.dummyRange FStar_Parser_AST.Expr in
                              let bv_pat =
-                               let uu____28213 = FStar_Ident.range_of_id id in
+                               let uu____28211 = FStar_Ident.range_of_id id in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____28213 in
+                                 uu____28211 in
                              let bv_pat1 =
-                               let uu____28217 =
-                                 let uu____28218 =
-                                   let uu____28229 =
-                                     let uu____28236 =
-                                       let uu____28237 =
+                               let uu____28215 =
+                                 let uu____28216 =
+                                   let uu____28227 =
+                                     let uu____28234 =
+                                       let uu____28235 =
                                          FStar_Ident.range_of_id id in
-                                       unit_ty uu____28237 in
-                                     (uu____28236,
+                                       unit_ty uu____28235 in
+                                     (uu____28234,
                                        FStar_Pervasives_Native.None) in
-                                   (bv_pat, uu____28229) in
-                                 FStar_Parser_AST.PatAscribed uu____28218 in
-                               let uu____28246 = FStar_Ident.range_of_id id in
-                               FStar_Parser_AST.mk_pattern uu____28217
-                                 uu____28246 in
+                                   (bv_pat, uu____28227) in
+                                 FStar_Parser_AST.PatAscribed uu____28216 in
+                               let uu____28244 = FStar_Ident.range_of_id id in
+                               FStar_Parser_AST.mk_pattern uu____28215
+                                 uu____28244 in
                              (bv_pat1, branch) in
-                       (match uu____28193 with
+                       (match uu____28191 with
                         | (bv_pat, branch) ->
                             let body1 =
                               FStar_Parser_AST.mk_term
@@ -7508,39 +7504,39 @@ and (desugar_decl_noattrs :
                                      [(bv_pat, body1)]))
                                 FStar_Range.dummyRange [] in
                             let id_decl1 =
-                              let uu___3704_28300 = id_decl in
+                              let uu___3704_28298 = id_decl in
                               {
                                 FStar_Parser_AST.d =
-                                  (uu___3704_28300.FStar_Parser_AST.d);
+                                  (uu___3704_28298.FStar_Parser_AST.d);
                                 FStar_Parser_AST.drange =
-                                  (uu___3704_28300.FStar_Parser_AST.drange);
+                                  (uu___3704_28298.FStar_Parser_AST.drange);
                                 FStar_Parser_AST.quals =
                                   (d.FStar_Parser_AST.quals);
                                 FStar_Parser_AST.attrs =
-                                  (uu___3704_28300.FStar_Parser_AST.attrs)
+                                  (uu___3704_28298.FStar_Parser_AST.attrs)
                               } in
-                            let uu____28301 = desugar_decl env1 id_decl1 in
-                            (match uu____28301 with
+                            let uu____28299 = desugar_decl env1 id_decl1 in
+                            (match uu____28299 with
                              | (env2, ses') ->
                                  (env2, (FStar_List.append ses ses')))) in
-                 let build_projection uu____28337 id =
-                   match uu____28337 with
+                 let build_projection uu____28335 id =
+                   match uu____28335 with
                    | (env1, ses) ->
                        build_generic_projection (env1, ses)
                          (FStar_Pervasives_Native.Some id) in
-                 let build_coverage_check uu____28376 =
-                   match uu____28376 with
+                 let build_coverage_check uu____28374 =
+                   match uu____28374 with
                    | (env1, ses) ->
                        build_generic_projection (env1, ses)
                          FStar_Pervasives_Native.None in
                  let bvs =
-                   let uu____28400 = gather_pattern_bound_vars pat in
-                   FStar_All.pipe_right uu____28400 FStar_Util.set_elements in
-                 let uu____28407 =
+                   let uu____28398 = gather_pattern_bound_vars pat in
+                   FStar_All.pipe_right uu____28398 FStar_Util.set_elements in
+                 let uu____28405 =
                    (FStar_List.isEmpty bvs) &&
-                     (let uu____28410 = is_var_pattern pat in
-                      Prims.op_Negation uu____28410) in
-                 if uu____28407
+                     (let uu____28408 = is_var_pattern pat in
+                      Prims.op_Negation uu____28408) in
+                 if uu____28405
                  then build_coverage_check main_let
                  else FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Assume (id, t) ->
@@ -7561,26 +7557,26 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Val (id, t) ->
           let quals = d.FStar_Parser_AST.quals in
           let t1 =
-            let uu____28433 = close_fun env t in desugar_term env uu____28433 in
+            let uu____28431 = close_fun env t in desugar_term env uu____28431 in
           let quals1 =
-            let uu____28437 =
+            let uu____28435 =
               (FStar_Syntax_DsEnv.iface env) &&
                 (FStar_Syntax_DsEnv.admitted_iface env) in
-            if uu____28437
+            if uu____28435
             then FStar_Parser_AST.Assumption :: quals
             else quals in
           let lid = FStar_Syntax_DsEnv.qualify env id in
           let attrs =
             FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs in
           let se =
-            let uu____28449 =
+            let uu____28447 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals1 in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-              FStar_Syntax_Syntax.sigquals = uu____28449;
+              FStar_Syntax_Syntax.sigquals = uu____28447;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = attrs;
@@ -7596,17 +7592,17 @@ and (desugar_decl_noattrs :
                   FStar_Parser_Const.exn_lid
             | FStar_Pervasives_Native.Some term ->
                 let t = desugar_term env term in
-                let uu____28462 =
-                  let uu____28471 = FStar_Syntax_Syntax.null_binder t in
-                  [uu____28471] in
-                let uu____28490 =
-                  let uu____28493 =
+                let uu____28460 =
+                  let uu____28469 = FStar_Syntax_Syntax.null_binder t in
+                  [uu____28469] in
+                let uu____28488 =
+                  let uu____28491 =
                     FStar_Syntax_DsEnv.fail_or env
                       (FStar_Syntax_DsEnv.try_lookup_lid env)
                       FStar_Parser_Const.exn_lid in
                   FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total
-                    uu____28493 in
-                FStar_Syntax_Util.arrow uu____28462 uu____28490 in
+                    uu____28491 in
+                FStar_Syntax_Util.arrow uu____28460 uu____28488 in
           let l = FStar_Syntax_DsEnv.qualify env id in
           let qual = [FStar_Syntax_Syntax.ExceptionConstructor] in
           let se =
@@ -7658,7 +7654,7 @@ and (desugar_decl_noattrs :
           desugar_effect env d quals true eff_name eff_binders eff_typ
             eff_decls attrs
       | FStar_Parser_AST.LayeredEffect (FStar_Parser_AST.RedefineEffect
-          uu____28556) ->
+          uu____28554) ->
           failwith
             "Impossible: LayeredEffect (RedefineEffect _) (should not be parseable)"
       | FStar_Parser_AST.SubEffect l ->
@@ -7668,42 +7664,42 @@ and (desugar_decl_noattrs :
           let dst_ed =
             lookup_effect_lid env l.FStar_Parser_AST.mdest
               d.FStar_Parser_AST.drange in
-          let uu____28573 =
-            let uu____28575 =
+          let uu____28571 =
+            let uu____28573 =
               (FStar_Syntax_Util.is_layered src_ed) ||
                 (FStar_Syntax_Util.is_layered dst_ed) in
-            Prims.op_Negation uu____28575 in
-          if uu____28573
+            Prims.op_Negation uu____28573 in
+          if uu____28571
           then
-            let uu____28582 =
+            let uu____28580 =
               match l.FStar_Parser_AST.lift_op with
               | FStar_Parser_AST.NonReifiableLift t ->
-                  let uu____28600 =
-                    let uu____28603 =
-                      let uu____28604 = desugar_term env t in
-                      ([], uu____28604) in
-                    FStar_Pervasives_Native.Some uu____28603 in
-                  (uu____28600, FStar_Pervasives_Native.None)
+                  let uu____28598 =
+                    let uu____28601 =
+                      let uu____28602 = desugar_term env t in
+                      ([], uu____28602) in
+                    FStar_Pervasives_Native.Some uu____28601 in
+                  (uu____28598, FStar_Pervasives_Native.None)
               | FStar_Parser_AST.ReifiableLift (wp, t) ->
-                  let uu____28617 =
-                    let uu____28620 =
-                      let uu____28621 = desugar_term env wp in
-                      ([], uu____28621) in
-                    FStar_Pervasives_Native.Some uu____28620 in
-                  let uu____28628 =
-                    let uu____28631 =
-                      let uu____28632 = desugar_term env t in
-                      ([], uu____28632) in
-                    FStar_Pervasives_Native.Some uu____28631 in
-                  (uu____28617, uu____28628)
+                  let uu____28615 =
+                    let uu____28618 =
+                      let uu____28619 = desugar_term env wp in
+                      ([], uu____28619) in
+                    FStar_Pervasives_Native.Some uu____28618 in
+                  let uu____28626 =
+                    let uu____28629 =
+                      let uu____28630 = desugar_term env t in
+                      ([], uu____28630) in
+                    FStar_Pervasives_Native.Some uu____28629 in
+                  (uu____28615, uu____28626)
               | FStar_Parser_AST.LiftForFree t ->
-                  let uu____28644 =
-                    let uu____28647 =
-                      let uu____28648 = desugar_term env t in
-                      ([], uu____28648) in
-                    FStar_Pervasives_Native.Some uu____28647 in
-                  (FStar_Pervasives_Native.None, uu____28644) in
-            (match uu____28582 with
+                  let uu____28642 =
+                    let uu____28645 =
+                      let uu____28646 = desugar_term env t in
+                      ([], uu____28646) in
+                    FStar_Pervasives_Native.Some uu____28645 in
+                  (FStar_Pervasives_Native.None, uu____28642) in
+            (match uu____28580 with
              | (lift_wp, lift) ->
                  let se =
                    {
@@ -7730,11 +7726,11 @@ and (desugar_decl_noattrs :
             (match l.FStar_Parser_AST.lift_op with
              | FStar_Parser_AST.NonReifiableLift t ->
                  let sub_eff =
-                   let uu____28682 =
-                     let uu____28685 =
-                       let uu____28686 = desugar_term env t in
-                       ([], uu____28686) in
-                     FStar_Pervasives_Native.Some uu____28685 in
+                   let uu____28680 =
+                     let uu____28683 =
+                       let uu____28684 = desugar_term env t in
+                       ([], uu____28684) in
+                     FStar_Pervasives_Native.Some uu____28683 in
                    {
                      FStar_Syntax_Syntax.source =
                        (src_ed.FStar_Syntax_Syntax.mname);
@@ -7742,7 +7738,7 @@ and (desugar_decl_noattrs :
                        (dst_ed.FStar_Syntax_Syntax.mname);
                      FStar_Syntax_Syntax.lift_wp =
                        FStar_Pervasives_Native.None;
-                     FStar_Syntax_Syntax.lift = uu____28682
+                     FStar_Syntax_Syntax.lift = uu____28680
                    } in
                  (env,
                    [{
@@ -7757,27 +7753,27 @@ and (desugar_decl_noattrs :
                       FStar_Syntax_Syntax.sigopts =
                         FStar_Pervasives_Native.None
                     }])
-             | uu____28693 ->
+             | uu____28691 ->
                  failwith
                    "Impossible! unexpected lift_op for lift to a layered effect")
       | FStar_Parser_AST.Polymonadic_bind (m_eff, n_eff, p_eff, bind) ->
           let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange in
           let n = lookup_effect_lid env n_eff d.FStar_Parser_AST.drange in
           let p = lookup_effect_lid env p_eff d.FStar_Parser_AST.drange in
-          let uu____28706 =
-            let uu____28707 =
-              let uu____28708 =
-                let uu____28709 =
-                  let uu____28720 =
-                    let uu____28721 = desugar_term env bind in
-                    ([], uu____28721) in
+          let uu____28704 =
+            let uu____28705 =
+              let uu____28706 =
+                let uu____28707 =
+                  let uu____28718 =
+                    let uu____28719 = desugar_term env bind in
+                    ([], uu____28719) in
                   ((m.FStar_Syntax_Syntax.mname),
                     (n.FStar_Syntax_Syntax.mname),
-                    (p.FStar_Syntax_Syntax.mname), uu____28720,
+                    (p.FStar_Syntax_Syntax.mname), uu____28718,
                     ([], FStar_Syntax_Syntax.tun)) in
-                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____28709 in
+                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____28707 in
               {
-                FStar_Syntax_Syntax.sigel = uu____28708;
+                FStar_Syntax_Syntax.sigel = uu____28706;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
@@ -7785,19 +7781,19 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = [];
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
-            [uu____28707] in
-          (env, uu____28706)
+            [uu____28705] in
+          (env, uu____28704)
       | FStar_Parser_AST.Splice (ids, t) ->
           let t1 = desugar_term env t in
           let se =
-            let uu____28740 =
-              let uu____28741 =
-                let uu____28748 =
+            let uu____28738 =
+              let uu____28739 =
+                let uu____28746 =
                   FStar_List.map (FStar_Syntax_DsEnv.qualify env) ids in
-                (uu____28748, t1) in
-              FStar_Syntax_Syntax.Sig_splice uu____28741 in
+                (uu____28746, t1) in
+              FStar_Syntax_Syntax.Sig_splice uu____28739 in
             {
-              FStar_Syntax_Syntax.sigel = uu____28740;
+              FStar_Syntax_Syntax.sigel = uu____28738;
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
@@ -7813,17 +7809,17 @@ let (desugar_decls :
   =
   fun env ->
     fun decls ->
-      let uu____28775 =
+      let uu____28773 =
         FStar_List.fold_left
-          (fun uu____28795 ->
+          (fun uu____28793 ->
              fun d ->
-               match uu____28795 with
+               match uu____28793 with
                | (env1, sigelts) ->
-                   let uu____28815 = desugar_decl env1 d in
-                   (match uu____28815 with
+                   let uu____28813 = desugar_decl env1 d in
+                   (match uu____28813 with
                     | (env2, se) -> (env2, (FStar_List.append sigelts se))))
           (env, []) decls in
-      match uu____28775 with | (env1, sigelts) -> (env1, sigelts)
+      match uu____28773 with | (env1, sigelts) -> (env1, sigelts)
 let (open_prims_all :
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
     Prims.list)
@@ -7844,36 +7840,36 @@ let (desugar_modul_common :
       fun m ->
         let env1 =
           match (curmod, m) with
-          | (FStar_Pervasives_Native.None, uu____28906) -> env
+          | (FStar_Pervasives_Native.None, uu____28904) -> env
           | (FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____28910;
-               FStar_Syntax_Syntax.exports = uu____28911;
-               FStar_Syntax_Syntax.is_interface = uu____28912;_},
-             FStar_Parser_AST.Module (current_lid, uu____28914)) when
+               FStar_Syntax_Syntax.declarations = uu____28908;
+               FStar_Syntax_Syntax.exports = uu____28909;
+               FStar_Syntax_Syntax.is_interface = uu____28910;_},
+             FStar_Parser_AST.Module (current_lid, uu____28912)) when
               (FStar_Ident.lid_equals prev_lid current_lid) &&
                 (FStar_Options.interactive ())
               -> env
-          | (FStar_Pervasives_Native.Some prev_mod, uu____28923) ->
-              let uu____28926 =
+          | (FStar_Pervasives_Native.Some prev_mod, uu____28921) ->
+              let uu____28924 =
                 FStar_Syntax_DsEnv.finish_module_or_interface env prev_mod in
-              FStar_Pervasives_Native.fst uu____28926 in
-        let uu____28931 =
+              FStar_Pervasives_Native.fst uu____28924 in
+        let uu____28929 =
           match m with
           | FStar_Parser_AST.Interface (mname, decls, admitted) ->
-              let uu____28973 =
+              let uu____28971 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface true admitted
                   env1 mname FStar_Syntax_DsEnv.default_mii in
-              (uu____28973, mname, decls, true)
+              (uu____28971, mname, decls, true)
           | FStar_Parser_AST.Module (mname, decls) ->
-              let uu____28995 =
+              let uu____28993 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface false false
                   env1 mname FStar_Syntax_DsEnv.default_mii in
-              (uu____28995, mname, decls, false) in
-        match uu____28931 with
+              (uu____28993, mname, decls, false) in
+        match uu____28929 with
         | ((env2, pop_when_done), mname, decls, intf) ->
-            let uu____29037 = desugar_decls env2 decls in
-            (match uu____29037 with
+            let uu____29035 = desugar_decls env2 decls in
+            (match uu____29035 with
              | (env3, sigelts) ->
                  let modul =
                    {
@@ -7897,22 +7893,22 @@ let (desugar_partial_modul :
     fun env ->
       fun m ->
         let m1 =
-          let uu____29105 =
+          let uu____29103 =
             (FStar_Options.interactive ()) &&
-              (let uu____29108 =
-                 let uu____29110 =
-                   let uu____29112 = FStar_Options.file_list () in
-                   FStar_List.hd uu____29112 in
-                 FStar_Util.get_file_extension uu____29110 in
-               FStar_List.mem uu____29108 ["fsti"; "fsi"]) in
-          if uu____29105 then as_interface m else m in
-        let uu____29126 = desugar_modul_common curmod env m1 in
-        match uu____29126 with
+              (let uu____29106 =
+                 let uu____29108 =
+                   let uu____29110 = FStar_Options.file_list () in
+                   FStar_List.hd uu____29110 in
+                 FStar_Util.get_file_extension uu____29108 in
+               FStar_List.mem uu____29106 ["fsti"; "fsi"]) in
+          if uu____29103 then as_interface m else m in
+        let uu____29124 = desugar_modul_common curmod env m1 in
+        match uu____29124 with
         | (env1, modul, pop_when_done) ->
             if pop_when_done
             then
-              let uu____29148 = FStar_Syntax_DsEnv.pop () in
-              (uu____29148, modul)
+              let uu____29146 = FStar_Syntax_DsEnv.pop () in
+              (uu____29146, modul)
             else (env1, modul)
 let (desugar_modul :
   FStar_Syntax_DsEnv.env ->
@@ -7920,33 +7916,33 @@ let (desugar_modul :
   =
   fun env ->
     fun m ->
-      let uu____29170 =
+      let uu____29168 =
         desugar_modul_common FStar_Pervasives_Native.None env m in
-      match uu____29170 with
+      match uu____29168 with
       | (env1, modul, pop_when_done) ->
-          let uu____29187 =
+          let uu____29185 =
             FStar_Syntax_DsEnv.finish_module_or_interface env1 modul in
-          (match uu____29187 with
+          (match uu____29185 with
            | (env2, modul1) ->
-               ((let uu____29199 =
-                   let uu____29201 =
+               ((let uu____29197 =
+                   let uu____29199 =
                      FStar_Ident.string_of_lid
                        modul1.FStar_Syntax_Syntax.name in
-                   FStar_Options.dump_module uu____29201 in
-                 if uu____29199
+                   FStar_Options.dump_module uu____29199 in
+                 if uu____29197
                  then
-                   let uu____29204 =
+                   let uu____29202 =
                      FStar_Syntax_Print.modul_to_string modul1 in
                    FStar_Util.print1 "Module after desugaring:\n%s\n"
-                     uu____29204
+                     uu____29202
                  else ());
-                (let uu____29209 =
+                (let uu____29207 =
                    if pop_when_done
                    then
                      FStar_Syntax_DsEnv.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
                    else env2 in
-                 (uu____29209, modul1))))
+                 (uu____29207, modul1))))
 let with_options : 'a . (unit -> 'a) -> 'a =
   fun f ->
     FStar_Options.push ();
@@ -7962,9 +7958,9 @@ let (ast_modul_to_modul :
   fun modul ->
     fun env ->
       with_options
-        (fun uu____29259 ->
-           let uu____29260 = desugar_modul env modul in
-           match uu____29260 with | (e, m) -> (m, e))
+        (fun uu____29257 ->
+           let uu____29258 = desugar_modul env modul in
+           match uu____29258 with | (e, m) -> (m, e))
 let (decls_to_sigelts :
   FStar_Parser_AST.decl Prims.list ->
     FStar_Syntax_Syntax.sigelts FStar_Syntax_DsEnv.withenv)
@@ -7972,9 +7968,9 @@ let (decls_to_sigelts :
   fun decls ->
     fun env ->
       with_options
-        (fun uu____29298 ->
-           let uu____29299 = desugar_decls env decls in
-           match uu____29299 with | (env1, sigelts) -> (sigelts, env1))
+        (fun uu____29296 ->
+           let uu____29297 = desugar_decls env decls in
+           match uu____29297 with | (env1, sigelts) -> (sigelts, env1))
 let (partial_ast_modul_to_modul :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_Parser_AST.modul ->
@@ -7984,9 +7980,9 @@ let (partial_ast_modul_to_modul :
     fun a_modul ->
       fun env ->
         with_options
-          (fun uu____29350 ->
-             let uu____29351 = desugar_partial_modul modul env a_modul in
-             match uu____29351 with | (env1, modul1) -> (modul1, env1))
+          (fun uu____29348 ->
+             let uu____29349 = desugar_partial_modul modul env a_modul in
+             match uu____29349 with | (env1, modul1) -> (modul1, env1))
 let (add_modul_to_env :
   FStar_Syntax_Syntax.modul ->
     FStar_Syntax_DsEnv.module_inclusion_info ->
@@ -8001,46 +7997,46 @@ let (add_modul_to_env :
             let erase_binders bs =
               match bs with
               | [] -> []
-              | uu____29446 ->
+              | uu____29444 ->
                   let t =
-                    let uu____29456 =
+                    let uu____29454 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
                         FStar_Range.dummyRange in
-                    erase_univs uu____29456 in
-                  let uu____29469 =
-                    let uu____29470 = FStar_Syntax_Subst.compress t in
-                    uu____29470.FStar_Syntax_Syntax.n in
-                  (match uu____29469 with
+                    erase_univs uu____29454 in
+                  let uu____29467 =
+                    let uu____29468 = FStar_Syntax_Subst.compress t in
+                    uu____29468.FStar_Syntax_Syntax.n in
+                  (match uu____29467 with
                    | FStar_Syntax_Syntax.Tm_abs
-                       (bs1, uu____29482, uu____29483) -> bs1
-                   | uu____29508 -> failwith "Impossible") in
-            let uu____29518 =
-              let uu____29525 = erase_binders ed.FStar_Syntax_Syntax.binders in
-              FStar_Syntax_Subst.open_term' uu____29525
+                       (bs1, uu____29480, uu____29481) -> bs1
+                   | uu____29506 -> failwith "Impossible") in
+            let uu____29516 =
+              let uu____29523 = erase_binders ed.FStar_Syntax_Syntax.binders in
+              FStar_Syntax_Subst.open_term' uu____29523
                 FStar_Syntax_Syntax.t_unit in
-            match uu____29518 with
-            | (binders, uu____29527, binders_opening) ->
+            match uu____29516 with
+            | (binders, uu____29525, binders_opening) ->
                 let erase_term t =
-                  let uu____29535 =
-                    let uu____29536 =
+                  let uu____29533 =
+                    let uu____29534 =
                       FStar_Syntax_Subst.subst binders_opening t in
-                    erase_univs uu____29536 in
-                  FStar_Syntax_Subst.close binders uu____29535 in
-                let erase_tscheme uu____29554 =
-                  match uu____29554 with
+                    erase_univs uu____29534 in
+                  FStar_Syntax_Subst.close binders uu____29533 in
+                let erase_tscheme uu____29552 =
+                  match uu____29552 with
                   | (us, t) ->
                       let t1 =
-                        let uu____29574 =
+                        let uu____29572 =
                           FStar_Syntax_Subst.shift_subst
                             (FStar_List.length us) binders_opening in
-                        FStar_Syntax_Subst.subst uu____29574 t in
-                      let uu____29577 =
-                        let uu____29578 = erase_univs t1 in
-                        FStar_Syntax_Subst.close binders uu____29578 in
-                      ([], uu____29577) in
+                        FStar_Syntax_Subst.subst uu____29572 t in
+                      let uu____29575 =
+                        let uu____29576 = erase_univs t1 in
+                        FStar_Syntax_Subst.close binders uu____29576 in
+                      ([], uu____29575) in
                 let erase_action action =
                   let opening =
                     FStar_Syntax_Subst.shift_subst
@@ -8050,111 +8046,111 @@ let (add_modul_to_env :
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
-                    | uu____29601 ->
+                    | uu____29599 ->
                         let bs =
-                          let uu____29611 =
+                          let uu____29609 =
                             FStar_Syntax_Subst.subst_binders opening
                               action.FStar_Syntax_Syntax.action_params in
-                          FStar_All.pipe_left erase_binders uu____29611 in
+                          FStar_All.pipe_left erase_binders uu____29609 in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
                                (bs, FStar_Syntax_Syntax.t_unit,
                                  FStar_Pervasives_Native.None))
                             FStar_Range.dummyRange in
-                        let uu____29651 =
-                          let uu____29652 =
-                            let uu____29655 =
+                        let uu____29649 =
+                          let uu____29650 =
+                            let uu____29653 =
                               FStar_Syntax_Subst.close binders t in
-                            FStar_Syntax_Subst.compress uu____29655 in
-                          uu____29652.FStar_Syntax_Syntax.n in
-                        (match uu____29651 with
+                            FStar_Syntax_Subst.compress uu____29653 in
+                          uu____29650.FStar_Syntax_Syntax.n in
+                        (match uu____29649 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (bs1, uu____29657, uu____29658) -> bs1
-                         | uu____29683 -> failwith "Impossible") in
+                             (bs1, uu____29655, uu____29656) -> bs1
+                         | uu____29681 -> failwith "Impossible") in
                   let erase_term1 t =
-                    let uu____29691 =
-                      let uu____29692 = FStar_Syntax_Subst.subst opening t in
-                      erase_univs uu____29692 in
-                    FStar_Syntax_Subst.close binders uu____29691 in
-                  let uu___3975_29693 = action in
-                  let uu____29694 =
+                    let uu____29689 =
+                      let uu____29690 = FStar_Syntax_Subst.subst opening t in
+                      erase_univs uu____29690 in
+                    FStar_Syntax_Subst.close binders uu____29689 in
+                  let uu___3975_29691 = action in
+                  let uu____29692 =
                     erase_term1 action.FStar_Syntax_Syntax.action_defn in
-                  let uu____29695 =
+                  let uu____29693 =
                     erase_term1 action.FStar_Syntax_Syntax.action_typ in
                   {
                     FStar_Syntax_Syntax.action_name =
-                      (uu___3975_29693.FStar_Syntax_Syntax.action_name);
+                      (uu___3975_29691.FStar_Syntax_Syntax.action_name);
                     FStar_Syntax_Syntax.action_unqualified_name =
-                      (uu___3975_29693.FStar_Syntax_Syntax.action_unqualified_name);
+                      (uu___3975_29691.FStar_Syntax_Syntax.action_unqualified_name);
                     FStar_Syntax_Syntax.action_univs = [];
                     FStar_Syntax_Syntax.action_params = erased_action_params;
-                    FStar_Syntax_Syntax.action_defn = uu____29694;
-                    FStar_Syntax_Syntax.action_typ = uu____29695
+                    FStar_Syntax_Syntax.action_defn = uu____29692;
+                    FStar_Syntax_Syntax.action_typ = uu____29693
                   } in
-                let uu___3977_29696 = ed in
-                let uu____29697 = FStar_Syntax_Subst.close_binders binders in
-                let uu____29698 =
+                let uu___3977_29694 = ed in
+                let uu____29695 = FStar_Syntax_Subst.close_binders binders in
+                let uu____29696 =
                   erase_tscheme ed.FStar_Syntax_Syntax.signature in
-                let uu____29699 =
+                let uu____29697 =
                   FStar_Syntax_Util.apply_eff_combinators erase_tscheme
                     ed.FStar_Syntax_Syntax.combinators in
-                let uu____29700 =
+                let uu____29698 =
                   FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions in
                 {
                   FStar_Syntax_Syntax.mname =
-                    (uu___3977_29696.FStar_Syntax_Syntax.mname);
+                    (uu___3977_29694.FStar_Syntax_Syntax.mname);
                   FStar_Syntax_Syntax.cattributes =
-                    (uu___3977_29696.FStar_Syntax_Syntax.cattributes);
+                    (uu___3977_29694.FStar_Syntax_Syntax.cattributes);
                   FStar_Syntax_Syntax.univs = [];
-                  FStar_Syntax_Syntax.binders = uu____29697;
-                  FStar_Syntax_Syntax.signature = uu____29698;
-                  FStar_Syntax_Syntax.combinators = uu____29699;
-                  FStar_Syntax_Syntax.actions = uu____29700;
+                  FStar_Syntax_Syntax.binders = uu____29695;
+                  FStar_Syntax_Syntax.signature = uu____29696;
+                  FStar_Syntax_Syntax.combinators = uu____29697;
+                  FStar_Syntax_Syntax.actions = uu____29698;
                   FStar_Syntax_Syntax.eff_attrs =
-                    (uu___3977_29696.FStar_Syntax_Syntax.eff_attrs)
+                    (uu___3977_29694.FStar_Syntax_Syntax.eff_attrs)
                 } in
           let push_sigelt env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___3984_29716 = se in
-                  let uu____29717 =
-                    let uu____29718 = erase_univs_ed ed in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____29718 in
+                  let uu___3984_29714 = se in
+                  let uu____29715 =
+                    let uu____29716 = erase_univs_ed ed in
+                    FStar_Syntax_Syntax.Sig_new_effect uu____29716 in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____29717;
+                    FStar_Syntax_Syntax.sigel = uu____29715;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3984_29716.FStar_Syntax_Syntax.sigrng);
+                      (uu___3984_29714.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3984_29716.FStar_Syntax_Syntax.sigquals);
+                      (uu___3984_29714.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3984_29716.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3984_29714.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3984_29716.FStar_Syntax_Syntax.sigattrs);
+                      (uu___3984_29714.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___3984_29716.FStar_Syntax_Syntax.sigopts)
+                      (uu___3984_29714.FStar_Syntax_Syntax.sigopts)
                   } in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se' in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____29720 -> FStar_Syntax_DsEnv.push_sigelt env se in
-          let uu____29721 =
+            | uu____29718 -> FStar_Syntax_DsEnv.push_sigelt env se in
+          let uu____29719 =
             FStar_Syntax_DsEnv.prepare_module_or_interface false false en
               m.FStar_Syntax_Syntax.name mii in
-          match uu____29721 with
+          match uu____29719 with
           | (en1, pop_when_done) ->
               let en2 =
-                let uu____29738 =
+                let uu____29736 =
                   FStar_Syntax_DsEnv.set_current_module en1
                     m.FStar_Syntax_Syntax.name in
-                FStar_List.fold_left push_sigelt uu____29738
+                FStar_List.fold_left push_sigelt uu____29736
                   m.FStar_Syntax_Syntax.exports in
               let env = FStar_Syntax_DsEnv.finish en2 m in
-              let uu____29740 =
+              let uu____29738 =
                 if pop_when_done
                 then
                   FStar_Syntax_DsEnv.export_interface
                     m.FStar_Syntax_Syntax.name env
                 else env in
-              ((), uu____29740)
+              ((), uu____29738)

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -379,1832 +379,1647 @@ let (tc_layered_eff_decl :
                              FStar_Syntax_Subst.close_univ_vars us uu____709 in
                            (sig_us, uu____706, sig_ty))))) in
          log_combinator "signature" signature;
-         (let uu____718 =
+         (let repr =
             let repr_ts =
-              let uu____740 =
+              let uu____736 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr in
-              FStar_All.pipe_right uu____740 FStar_Util.must in
+              FStar_All.pipe_right uu____736 FStar_Util.must in
             let r =
               (FStar_Pervasives_Native.snd repr_ts).FStar_Syntax_Syntax.pos in
-            let uu____768 = check_and_gen1 "repr" Prims.int_one repr_ts in
-            match uu____768 with
+            let uu____764 = check_and_gen1 "repr" Prims.int_one repr_ts in
+            match uu____764 with
             | (repr_us, repr_t, repr_ty) ->
-                let underlying_effect_lid =
-                  let repr_t1 =
-                    FStar_TypeChecker_Normalize.normalize
-                      [FStar_TypeChecker_Env.UnfoldUntil
-                         (FStar_Syntax_Syntax.Delta_constant_at_level
-                            Prims.int_zero);
-                      FStar_TypeChecker_Env.AllowUnboundUniverses] env0
-                      repr_t in
-                  let uu____799 =
-                    let uu____800 = FStar_Syntax_Subst.compress repr_t1 in
-                    uu____800.FStar_Syntax_Syntax.n in
-                  match uu____799 with
-                  | FStar_Syntax_Syntax.Tm_abs (uu____803, t, uu____805) ->
-                      let uu____830 =
-                        let uu____831 = FStar_Syntax_Subst.compress t in
-                        uu____831.FStar_Syntax_Syntax.n in
-                      (match uu____830 with
-                       | FStar_Syntax_Syntax.Tm_arrow (uu____834, c) ->
-                           let uu____856 =
-                             FStar_All.pipe_right c
-                               FStar_Syntax_Util.comp_effect_name in
-                           FStar_All.pipe_right uu____856
-                             (FStar_TypeChecker_Env.norm_eff_name env0)
-                       | uu____859 ->
-                           let uu____860 =
-                             let uu____866 =
-                               let uu____868 =
-                                 FStar_All.pipe_right
-                                   ed.FStar_Syntax_Syntax.mname
-                                   FStar_Ident.string_of_lid in
-                               let uu____871 =
-                                 FStar_Syntax_Print.term_to_string t in
-                               FStar_Util.format2
-                                 "repr body for %s is not an arrow (%s)"
-                                 uu____868 uu____871 in
-                             (FStar_Errors.Fatal_UnexpectedEffect, uu____866) in
-                           FStar_Errors.raise_error uu____860 r)
-                  | uu____875 ->
-                      let uu____876 =
-                        let uu____882 =
-                          let uu____884 =
-                            FStar_All.pipe_right ed.FStar_Syntax_Syntax.mname
-                              FStar_Ident.string_of_lid in
-                          let uu____887 =
-                            FStar_Syntax_Print.term_to_string repr_t1 in
-                          FStar_Util.format2
-                            "repr for %s is not an abstraction (%s)"
-                            uu____884 uu____887 in
-                        (FStar_Errors.Fatal_UnexpectedEffect, uu____882) in
-                      FStar_Errors.raise_error uu____876 r in
-                ((let uu____892 =
-                    (FStar_All.pipe_right quals
-                       (FStar_List.contains FStar_Syntax_Syntax.TotalEffect))
-                      &&
-                      (let uu____898 =
-                         FStar_TypeChecker_Env.is_total_effect env0
-                           underlying_effect_lid in
-                       Prims.op_Negation uu____898) in
-                  if uu____892
-                  then
-                    let uu____901 =
-                      let uu____907 =
-                        let uu____909 =
-                          FStar_All.pipe_right ed.FStar_Syntax_Syntax.mname
-                            FStar_Ident.string_of_lid in
-                        let uu____912 =
-                          FStar_All.pipe_right underlying_effect_lid
-                            FStar_Ident.string_of_lid in
-                        FStar_Util.format2
-                          "Effect %s is marked total but its underlying effect %s is not total"
-                          uu____909 uu____912 in
-                      (FStar_Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                        uu____907) in
-                    FStar_Errors.raise_error uu____901 r
-                  else ());
-                 (let uu____919 =
-                    FStar_Syntax_Subst.open_univ_vars repr_us repr_ty in
-                  match uu____919 with
+                let uu____788 =
+                  FStar_Syntax_Subst.open_univ_vars repr_us repr_ty in
+                (match uu____788 with
+                 | (us, ty) ->
+                     let env = FStar_TypeChecker_Env.push_univ_vars env0 us in
+                     let uu____808 = fresh_a_and_u_a "a" in
+                     (match uu____808 with
+                      | (a, u) ->
+                          let rest_bs =
+                            let signature_ts =
+                              let uu____830 = signature in
+                              match uu____830 with
+                              | (us1, t, uu____845) -> (us1, t) in
+                            let uu____862 =
+                              let uu____863 =
+                                FStar_All.pipe_right a
+                                  FStar_Pervasives_Native.fst in
+                              FStar_All.pipe_right uu____863
+                                FStar_Syntax_Syntax.bv_to_name in
+                            FStar_TypeChecker_Util.layered_effect_indices_as_binders
+                              env r ed.FStar_Syntax_Syntax.mname signature_ts
+                              u uu____862 in
+                          let bs = a :: rest_bs in
+                          let k =
+                            let uu____890 =
+                              let uu____893 = FStar_Syntax_Util.type_u () in
+                              FStar_All.pipe_right uu____893
+                                (fun uu____906 ->
+                                   match uu____906 with
+                                   | (t, u1) ->
+                                       let uu____913 =
+                                         let uu____916 =
+                                           FStar_TypeChecker_Env.new_u_univ
+                                             () in
+                                         FStar_Pervasives_Native.Some
+                                           uu____916 in
+                                       FStar_Syntax_Syntax.mk_Total' t
+                                         uu____913) in
+                            FStar_Syntax_Util.arrow bs uu____890 in
+                          let g = FStar_TypeChecker_Rel.teq env ty k in
+                          (FStar_TypeChecker_Rel.force_trivial_guard env g;
+                           (let uu____919 =
+                              let uu____922 =
+                                FStar_All.pipe_right k
+                                  (FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                     env) in
+                              FStar_Syntax_Subst.close_univ_vars us uu____922 in
+                            (repr_us, repr_t, uu____919))))) in
+          log_combinator "repr" repr;
+          (let fresh_repr r env u a_tm =
+             let signature_ts =
+               let uu____957 = signature in
+               match uu____957 with | (us, t, uu____972) -> (us, t) in
+             let repr_ts =
+               let uu____990 = repr in
+               match uu____990 with | (us, t, uu____1005) -> (us, t) in
+             FStar_TypeChecker_Util.fresh_effect_repr env r
+               ed.FStar_Syntax_Syntax.mname signature_ts
+               (FStar_Pervasives_Native.Some repr_ts) u a_tm in
+           let not_an_arrow_error comb n t r =
+             let uu____1055 =
+               let uu____1061 =
+                 let uu____1063 =
+                   FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
+                 let uu____1065 = FStar_Util.string_of_int n in
+                 let uu____1067 = FStar_Syntax_Print.tag_of_term t in
+                 let uu____1069 = FStar_Syntax_Print.term_to_string t in
+                 FStar_Util.format5
+                   "Type of %s:%s is not an arrow with >= %s binders (%s::%s)"
+                   uu____1063 comb uu____1065 uu____1067 uu____1069 in
+               (FStar_Errors.Fatal_UnexpectedEffect, uu____1061) in
+             FStar_Errors.raise_error uu____1055 r in
+           let return_repr =
+             let return_repr_ts =
+               let uu____1099 =
+                 FStar_All.pipe_right ed FStar_Syntax_Util.get_return_repr in
+               FStar_All.pipe_right uu____1099 FStar_Util.must in
+             let r =
+               (FStar_Pervasives_Native.snd return_repr_ts).FStar_Syntax_Syntax.pos in
+             let uu____1127 =
+               check_and_gen1 "return_repr" Prims.int_one return_repr_ts in
+             match uu____1127 with
+             | (ret_us, ret_t, ret_ty) ->
+                 let uu____1151 =
+                   FStar_Syntax_Subst.open_univ_vars ret_us ret_ty in
+                 (match uu____1151 with
                   | (us, ty) ->
                       let env = FStar_TypeChecker_Env.push_univ_vars env0 us in
-                      let uu____943 = fresh_a_and_u_a "a" in
-                      (match uu____943 with
-                       | (a, u) ->
-                           let rest_bs =
-                             let signature_ts =
-                               let uu____969 = signature in
-                               match uu____969 with
-                               | (us1, t, uu____984) -> (us1, t) in
-                             let uu____1001 =
-                               let uu____1002 =
-                                 FStar_All.pipe_right a
-                                   FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____1002
-                                 FStar_Syntax_Syntax.bv_to_name in
-                             FStar_TypeChecker_Util.layered_effect_indices_as_binders
-                               env r ed.FStar_Syntax_Syntax.mname
-                               signature_ts u uu____1001 in
-                           let bs = a :: rest_bs in
-                           let k =
-                             let uu____1029 =
-                               let uu____1032 = FStar_Syntax_Util.type_u () in
-                               FStar_All.pipe_right uu____1032
-                                 (fun uu____1045 ->
-                                    match uu____1045 with
-                                    | (t, u1) ->
-                                        let uu____1052 =
-                                          let uu____1055 =
-                                            FStar_TypeChecker_Env.new_u_univ
-                                              () in
-                                          FStar_Pervasives_Native.Some
-                                            uu____1055 in
-                                        FStar_Syntax_Syntax.mk_Total' t
-                                          uu____1052) in
-                             FStar_Syntax_Util.arrow bs uu____1029 in
-                           let g = FStar_TypeChecker_Rel.teq env ty k in
-                           (FStar_TypeChecker_Rel.force_trivial_guard env g;
-                            (let uu____1058 =
-                               let uu____1071 =
-                                 let uu____1074 =
-                                   FStar_All.pipe_right k
-                                     (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                        env) in
-                                 FStar_Syntax_Subst.close_univ_vars us
-                                   uu____1074 in
-                               (repr_us, repr_t, uu____1071) in
-                             (uu____1058, underlying_effect_lid)))))) in
-          match uu____718 with
-          | (repr, underlying_effect_lid) ->
-              (log_combinator "repr" repr;
-               (let fresh_repr r env u a_tm =
-                  let signature_ts =
-                    let uu____1147 = signature in
-                    match uu____1147 with | (us, t, uu____1162) -> (us, t) in
-                  let repr_ts =
-                    let uu____1180 = repr in
-                    match uu____1180 with | (us, t, uu____1195) -> (us, t) in
-                  FStar_TypeChecker_Util.fresh_effect_repr env r
-                    ed.FStar_Syntax_Syntax.mname signature_ts
-                    (FStar_Pervasives_Native.Some repr_ts) u a_tm in
-                let not_an_arrow_error comb n t r =
-                  let uu____1245 =
-                    let uu____1251 =
-                      let uu____1253 =
-                        FStar_Ident.string_of_lid
-                          ed.FStar_Syntax_Syntax.mname in
-                      let uu____1255 = FStar_Util.string_of_int n in
-                      let uu____1257 = FStar_Syntax_Print.tag_of_term t in
-                      let uu____1259 = FStar_Syntax_Print.term_to_string t in
-                      FStar_Util.format5
-                        "Type of %s:%s is not an arrow with >= %s binders (%s::%s)"
-                        uu____1253 comb uu____1255 uu____1257 uu____1259 in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu____1251) in
-                  FStar_Errors.raise_error uu____1245 r in
-                let return_repr =
-                  let return_repr_ts =
-                    let uu____1289 =
-                      FStar_All.pipe_right ed
-                        FStar_Syntax_Util.get_return_repr in
-                    FStar_All.pipe_right uu____1289 FStar_Util.must in
-                  let r =
-                    (FStar_Pervasives_Native.snd return_repr_ts).FStar_Syntax_Syntax.pos in
-                  let uu____1317 =
-                    check_and_gen1 "return_repr" Prims.int_one return_repr_ts in
-                  match uu____1317 with
-                  | (ret_us, ret_t, ret_ty) ->
-                      let uu____1341 =
-                        FStar_Syntax_Subst.open_univ_vars ret_us ret_ty in
-                      (match uu____1341 with
-                       | (us, ty) ->
-                           let env =
-                             FStar_TypeChecker_Env.push_univ_vars env0 us in
-                           (check_no_subtyping_for_layered_combinator env ty
-                              FStar_Pervasives_Native.None;
-                            (let uu____1362 = fresh_a_and_u_a "a" in
-                             match uu____1362 with
-                             | (a, u_a) ->
-                                 let x_a = fresh_x_a "x" a in
-                                 let rest_bs =
-                                   let uu____1393 =
-                                     let uu____1394 =
-                                       FStar_Syntax_Subst.compress ty in
-                                     uu____1394.FStar_Syntax_Syntax.n in
-                                   match uu____1393 with
-                                   | FStar_Syntax_Syntax.Tm_arrow
-                                       (bs, uu____1406) when
-                                       (FStar_List.length bs) >=
-                                         (Prims.of_int (2))
+                      (check_no_subtyping_for_layered_combinator env ty
+                         FStar_Pervasives_Native.None;
+                       (let uu____1172 = fresh_a_and_u_a "a" in
+                        match uu____1172 with
+                        | (a, u_a) ->
+                            let x_a = fresh_x_a "x" a in
+                            let rest_bs =
+                              let uu____1203 =
+                                let uu____1204 =
+                                  FStar_Syntax_Subst.compress ty in
+                                uu____1204.FStar_Syntax_Syntax.n in
+                              match uu____1203 with
+                              | FStar_Syntax_Syntax.Tm_arrow (bs, uu____1216)
+                                  when
+                                  (FStar_List.length bs) >=
+                                    (Prims.of_int (2))
+                                  ->
+                                  let uu____1244 =
+                                    FStar_Syntax_Subst.open_binders bs in
+                                  (match uu____1244 with
+                                   | (a', uu____1254)::(x', uu____1256)::bs1
                                        ->
-                                       let uu____1434 =
-                                         FStar_Syntax_Subst.open_binders bs in
-                                       (match uu____1434 with
-                                        | (a', uu____1444)::(x', uu____1446)::bs1
-                                            ->
-                                            let uu____1476 =
-                                              let uu____1477 =
-                                                let uu____1482 =
-                                                  let uu____1485 =
-                                                    let uu____1486 =
-                                                      let uu____1493 =
-                                                        FStar_Syntax_Syntax.bv_to_name
-                                                          (FStar_Pervasives_Native.fst
-                                                             a) in
-                                                      (a', uu____1493) in
-                                                    FStar_Syntax_Syntax.NT
-                                                      uu____1486 in
-                                                  [uu____1485] in
-                                                FStar_Syntax_Subst.subst_binders
-                                                  uu____1482 in
-                                              FStar_All.pipe_right bs1
-                                                uu____1477 in
-                                            let uu____1500 =
-                                              let uu____1513 =
-                                                let uu____1516 =
-                                                  let uu____1517 =
-                                                    let uu____1524 =
-                                                      FStar_Syntax_Syntax.bv_to_name
-                                                        (FStar_Pervasives_Native.fst
-                                                           x_a) in
-                                                    (x', uu____1524) in
-                                                  FStar_Syntax_Syntax.NT
-                                                    uu____1517 in
-                                                [uu____1516] in
-                                              FStar_Syntax_Subst.subst_binders
-                                                uu____1513 in
-                                            FStar_All.pipe_right uu____1476
-                                              uu____1500)
-                                   | uu____1539 ->
-                                       not_an_arrow_error "return"
-                                         (Prims.of_int (2)) ty r in
-                                 let bs = a :: x_a :: rest_bs in
-                                 let uu____1563 =
-                                   let uu____1568 =
-                                     FStar_TypeChecker_Env.push_binders env
-                                       bs in
-                                   let uu____1569 =
-                                     FStar_All.pipe_right
-                                       (FStar_Pervasives_Native.fst a)
-                                       FStar_Syntax_Syntax.bv_to_name in
-                                   fresh_repr r uu____1568 u_a uu____1569 in
-                                 (match uu____1563 with
-                                  | (repr1, g) ->
-                                      let k =
-                                        let uu____1589 =
-                                          FStar_Syntax_Syntax.mk_Total' repr1
-                                            (FStar_Pervasives_Native.Some u_a) in
-                                        FStar_Syntax_Util.arrow bs uu____1589 in
-                                      let g_eq =
-                                        FStar_TypeChecker_Rel.teq env ty k in
-                                      ((let uu____1594 =
-                                          FStar_TypeChecker_Env.conj_guard g
-                                            g_eq in
-                                        FStar_TypeChecker_Rel.force_trivial_guard
-                                          env uu____1594);
-                                       (let uu____1595 =
-                                          let uu____1598 =
-                                            FStar_All.pipe_right k
-                                              (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                 env) in
-                                          FStar_All.pipe_right uu____1598
-                                            (FStar_Syntax_Subst.close_univ_vars
-                                               us) in
-                                        (ret_us, ret_t, uu____1595))))))) in
-                log_combinator "return_repr" return_repr;
-                (let bind_repr =
-                   let bind_repr_ts =
-                     let uu____1627 =
-                       FStar_All.pipe_right ed
-                         FStar_Syntax_Util.get_bind_repr in
-                     FStar_All.pipe_right uu____1627 FStar_Util.must in
-                   let r =
-                     (FStar_Pervasives_Native.snd bind_repr_ts).FStar_Syntax_Syntax.pos in
-                   let uu____1655 =
-                     check_and_gen1 "bind_repr" (Prims.of_int (2))
-                       bind_repr_ts in
-                   match uu____1655 with
-                   | (bind_us, bind_t, bind_ty) ->
-                       let uu____1679 =
-                         FStar_Syntax_Subst.open_univ_vars bind_us bind_ty in
-                       (match uu____1679 with
-                        | (us, ty) ->
-                            let env =
-                              FStar_TypeChecker_Env.push_univ_vars env0 us in
-                            (check_no_subtyping_for_layered_combinator env ty
-                               FStar_Pervasives_Native.None;
-                             (let uu____1700 = fresh_a_and_u_a "a" in
-                              match uu____1700 with
-                              | (a, u_a) ->
-                                  let uu____1720 = fresh_a_and_u_a "b" in
-                                  (match uu____1720 with
-                                   | (b, u_b) ->
-                                       let rest_bs =
-                                         let uu____1749 =
-                                           let uu____1750 =
-                                             FStar_Syntax_Subst.compress ty in
-                                           uu____1750.FStar_Syntax_Syntax.n in
-                                         match uu____1749 with
-                                         | FStar_Syntax_Syntax.Tm_arrow
-                                             (bs, uu____1762) when
-                                             (FStar_List.length bs) >=
-                                               (Prims.of_int (4))
+                                       let uu____1286 =
+                                         let uu____1287 =
+                                           let uu____1292 =
+                                             let uu____1295 =
+                                               let uu____1296 =
+                                                 let uu____1303 =
+                                                   FStar_Syntax_Syntax.bv_to_name
+                                                     (FStar_Pervasives_Native.fst
+                                                        a) in
+                                                 (a', uu____1303) in
+                                               FStar_Syntax_Syntax.NT
+                                                 uu____1296 in
+                                             [uu____1295] in
+                                           FStar_Syntax_Subst.subst_binders
+                                             uu____1292 in
+                                         FStar_All.pipe_right bs1 uu____1287 in
+                                       let uu____1310 =
+                                         let uu____1323 =
+                                           let uu____1326 =
+                                             let uu____1327 =
+                                               let uu____1334 =
+                                                 FStar_Syntax_Syntax.bv_to_name
+                                                   (FStar_Pervasives_Native.fst
+                                                      x_a) in
+                                               (x', uu____1334) in
+                                             FStar_Syntax_Syntax.NT
+                                               uu____1327 in
+                                           [uu____1326] in
+                                         FStar_Syntax_Subst.subst_binders
+                                           uu____1323 in
+                                       FStar_All.pipe_right uu____1286
+                                         uu____1310)
+                              | uu____1349 ->
+                                  not_an_arrow_error "return"
+                                    (Prims.of_int (2)) ty r in
+                            let bs = a :: x_a :: rest_bs in
+                            let uu____1373 =
+                              let uu____1378 =
+                                FStar_TypeChecker_Env.push_binders env bs in
+                              let uu____1379 =
+                                FStar_All.pipe_right
+                                  (FStar_Pervasives_Native.fst a)
+                                  FStar_Syntax_Syntax.bv_to_name in
+                              fresh_repr r uu____1378 u_a uu____1379 in
+                            (match uu____1373 with
+                             | (repr1, g) ->
+                                 let k =
+                                   let uu____1399 =
+                                     FStar_Syntax_Syntax.mk_Total' repr1
+                                       (FStar_Pervasives_Native.Some u_a) in
+                                   FStar_Syntax_Util.arrow bs uu____1399 in
+                                 let g_eq =
+                                   FStar_TypeChecker_Rel.teq env ty k in
+                                 ((let uu____1404 =
+                                     FStar_TypeChecker_Env.conj_guard g g_eq in
+                                   FStar_TypeChecker_Rel.force_trivial_guard
+                                     env uu____1404);
+                                  (let uu____1405 =
+                                     let uu____1408 =
+                                       FStar_All.pipe_right k
+                                         (FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                            env) in
+                                     FStar_All.pipe_right uu____1408
+                                       (FStar_Syntax_Subst.close_univ_vars us) in
+                                   (ret_us, ret_t, uu____1405))))))) in
+           log_combinator "return_repr" return_repr;
+           (let bind_repr =
+              let bind_repr_ts =
+                let uu____1437 =
+                  FStar_All.pipe_right ed FStar_Syntax_Util.get_bind_repr in
+                FStar_All.pipe_right uu____1437 FStar_Util.must in
+              let r =
+                (FStar_Pervasives_Native.snd bind_repr_ts).FStar_Syntax_Syntax.pos in
+              let uu____1465 =
+                check_and_gen1 "bind_repr" (Prims.of_int (2)) bind_repr_ts in
+              match uu____1465 with
+              | (bind_us, bind_t, bind_ty) ->
+                  let uu____1489 =
+                    FStar_Syntax_Subst.open_univ_vars bind_us bind_ty in
+                  (match uu____1489 with
+                   | (us, ty) ->
+                       let env = FStar_TypeChecker_Env.push_univ_vars env0 us in
+                       (check_no_subtyping_for_layered_combinator env ty
+                          FStar_Pervasives_Native.None;
+                        (let uu____1510 = fresh_a_and_u_a "a" in
+                         match uu____1510 with
+                         | (a, u_a) ->
+                             let uu____1530 = fresh_a_and_u_a "b" in
+                             (match uu____1530 with
+                              | (b, u_b) ->
+                                  let rest_bs =
+                                    let uu____1559 =
+                                      let uu____1560 =
+                                        FStar_Syntax_Subst.compress ty in
+                                      uu____1560.FStar_Syntax_Syntax.n in
+                                    match uu____1559 with
+                                    | FStar_Syntax_Syntax.Tm_arrow
+                                        (bs, uu____1572) when
+                                        (FStar_List.length bs) >=
+                                          (Prims.of_int (4))
+                                        ->
+                                        let uu____1600 =
+                                          FStar_Syntax_Subst.open_binders bs in
+                                        (match uu____1600 with
+                                         | (a', uu____1610)::(b', uu____1612)::bs1
                                              ->
-                                             let uu____1790 =
-                                               FStar_Syntax_Subst.open_binders
-                                                 bs in
-                                             (match uu____1790 with
-                                              | (a', uu____1800)::(b',
-                                                                   uu____1802)::bs1
-                                                  ->
-                                                  let uu____1832 =
-                                                    let uu____1833 =
-                                                      FStar_All.pipe_right
-                                                        bs1
-                                                        (FStar_List.splitAt
-                                                           ((FStar_List.length
-                                                               bs1)
-                                                              -
-                                                              (Prims.of_int (2)))) in
-                                                    FStar_All.pipe_right
-                                                      uu____1833
-                                                      FStar_Pervasives_Native.fst in
-                                                  let uu____1899 =
-                                                    let uu____1912 =
-                                                      let uu____1915 =
-                                                        let uu____1916 =
-                                                          let uu____1923 =
-                                                            FStar_Syntax_Syntax.bv_to_name
-                                                              (FStar_Pervasives_Native.fst
-                                                                 a) in
-                                                          (a', uu____1923) in
-                                                        FStar_Syntax_Syntax.NT
-                                                          uu____1916 in
-                                                      let uu____1930 =
-                                                        let uu____1933 =
-                                                          let uu____1934 =
-                                                            let uu____1941 =
-                                                              FStar_Syntax_Syntax.bv_to_name
-                                                                (FStar_Pervasives_Native.fst
-                                                                   b) in
-                                                            (b', uu____1941) in
-                                                          FStar_Syntax_Syntax.NT
-                                                            uu____1934 in
-                                                        [uu____1933] in
-                                                      uu____1915 ::
-                                                        uu____1930 in
-                                                    FStar_Syntax_Subst.subst_binders
-                                                      uu____1912 in
-                                                  FStar_All.pipe_right
-                                                    uu____1832 uu____1899)
-                                         | uu____1956 ->
-                                             not_an_arrow_error "bind"
-                                               (Prims.of_int (4)) ty r in
-                                       let bs = a :: b :: rest_bs in
-                                       let uu____1980 =
-                                         let uu____1991 =
-                                           let uu____1996 =
-                                             FStar_TypeChecker_Env.push_binders
-                                               env bs in
-                                           let uu____1997 =
-                                             FStar_All.pipe_right
-                                               (FStar_Pervasives_Native.fst a)
-                                               FStar_Syntax_Syntax.bv_to_name in
-                                           fresh_repr r uu____1996 u_a
-                                             uu____1997 in
-                                         match uu____1991 with
-                                         | (repr1, g) ->
-                                             let uu____2012 =
-                                               let uu____2019 =
-                                                 FStar_Syntax_Syntax.gen_bv
-                                                   "f"
-                                                   FStar_Pervasives_Native.None
-                                                   repr1 in
+                                             let uu____1642 =
+                                               let uu____1643 =
+                                                 FStar_All.pipe_right bs1
+                                                   (FStar_List.splitAt
+                                                      ((FStar_List.length bs1)
+                                                         - (Prims.of_int (2)))) in
                                                FStar_All.pipe_right
-                                                 uu____2019
-                                                 FStar_Syntax_Syntax.mk_binder in
-                                             (uu____2012, g) in
-                                       (match uu____1980 with
-                                        | (f, guard_f) ->
-                                            let uu____2059 =
-                                              let x_a = fresh_x_a "x" a in
-                                              let uu____2072 =
-                                                let uu____2077 =
-                                                  FStar_TypeChecker_Env.push_binders
-                                                    env
-                                                    (FStar_List.append bs
-                                                       [x_a]) in
-                                                let uu____2096 =
-                                                  FStar_All.pipe_right
-                                                    (FStar_Pervasives_Native.fst
-                                                       b)
-                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                fresh_repr r uu____2077 u_b
-                                                  uu____2096 in
-                                              match uu____2072 with
-                                              | (repr1, g) ->
-                                                  let uu____2111 =
-                                                    let uu____2118 =
-                                                      let uu____2119 =
-                                                        let uu____2120 =
-                                                          let uu____2123 =
-                                                            let uu____2126 =
-                                                              FStar_TypeChecker_Env.new_u_univ
-                                                                () in
-                                                            FStar_Pervasives_Native.Some
-                                                              uu____2126 in
-                                                          FStar_Syntax_Syntax.mk_Total'
-                                                            repr1 uu____2123 in
-                                                        FStar_Syntax_Util.arrow
-                                                          [x_a] uu____2120 in
-                                                      FStar_Syntax_Syntax.gen_bv
-                                                        "g"
-                                                        FStar_Pervasives_Native.None
-                                                        uu____2119 in
-                                                    FStar_All.pipe_right
-                                                      uu____2118
-                                                      FStar_Syntax_Syntax.mk_binder in
-                                                  (uu____2111, g) in
-                                            (match uu____2059 with
-                                             | (g, guard_g) ->
-                                                 let uu____2178 =
-                                                   let uu____2183 =
-                                                     FStar_TypeChecker_Env.push_binders
-                                                       env bs in
-                                                   let uu____2184 =
-                                                     FStar_All.pipe_right
-                                                       (FStar_Pervasives_Native.fst
-                                                          b)
-                                                       FStar_Syntax_Syntax.bv_to_name in
-                                                   fresh_repr r uu____2183
-                                                     u_b uu____2184 in
-                                                 (match uu____2178 with
-                                                  | (repr1, guard_repr) ->
-                                                      let uu____2201 =
-                                                        let uu____2206 =
-                                                          FStar_TypeChecker_Env.push_binders
-                                                            env bs in
-                                                        let uu____2207 =
-                                                          let uu____2209 =
-                                                            FStar_Ident.string_of_lid
-                                                              ed.FStar_Syntax_Syntax.mname in
-                                                          FStar_Util.format1
-                                                            "implicit for pure_wp in checking bind for %s"
-                                                            uu____2209 in
-                                                        pure_wp_uvar
-                                                          uu____2206 repr1
-                                                          uu____2207 r in
-                                                      (match uu____2201 with
-                                                       | (pure_wp_uvar1,
-                                                          g_pure_wp_uvar) ->
-                                                           let k =
-                                                             let uu____2229 =
-                                                               let uu____2232
-                                                                 =
-                                                                 let uu____2233
-                                                                   =
-                                                                   let uu____2234
-                                                                    =
-                                                                    FStar_TypeChecker_Env.new_u_univ
-                                                                    () in
-                                                                   [uu____2234] in
-                                                                 let uu____2235
-                                                                   =
-                                                                   let uu____2246
-                                                                    =
-                                                                    FStar_All.pipe_right
-                                                                    pure_wp_uvar1
-                                                                    FStar_Syntax_Syntax.as_arg in
-                                                                   [uu____2246] in
-                                                                 {
-                                                                   FStar_Syntax_Syntax.comp_univs
-                                                                    =
-                                                                    uu____2233;
-                                                                   FStar_Syntax_Syntax.effect_name
-                                                                    =
-                                                                    FStar_Parser_Const.effect_PURE_lid;
-                                                                   FStar_Syntax_Syntax.result_typ
-                                                                    = repr1;
-                                                                   FStar_Syntax_Syntax.effect_args
-                                                                    =
-                                                                    uu____2235;
-                                                                   FStar_Syntax_Syntax.flags
-                                                                    = []
-                                                                 } in
-                                                               FStar_Syntax_Syntax.mk_Comp
-                                                                 uu____2232 in
-                                                             FStar_Syntax_Util.arrow
-                                                               (FStar_List.append
-                                                                  bs 
-                                                                  [f; g])
-                                                               uu____2229 in
-                                                           let guard_eq =
-                                                             FStar_TypeChecker_Rel.teq
-                                                               env ty k in
-                                                           (FStar_List.iter
-                                                              (FStar_TypeChecker_Rel.force_trivial_guard
-                                                                 env)
-                                                              [guard_f;
-                                                              guard_g;
-                                                              guard_repr;
-                                                              g_pure_wp_uvar;
-                                                              guard_eq];
-                                                            (let uu____2305 =
-                                                               let uu____2308
-                                                                 =
-                                                                 FStar_All.pipe_right
-                                                                   k
-                                                                   (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                                    env) in
-                                                               FStar_All.pipe_right
-                                                                 uu____2308
-                                                                 (FStar_Syntax_Subst.close_univ_vars
-                                                                    bind_us) in
-                                                             (bind_us,
-                                                               bind_t,
-                                                               uu____2305))))))))))) in
-                 log_combinator "bind_repr" bind_repr;
-                 (let stronger_repr =
-                    let stronger_repr =
-                      let uu____2337 =
-                        FStar_All.pipe_right ed
-                          FStar_Syntax_Util.get_stronger_repr in
-                      FStar_All.pipe_right uu____2337 FStar_Util.must in
-                    let r =
-                      (FStar_Pervasives_Native.snd stronger_repr).FStar_Syntax_Syntax.pos in
-                    let uu____2365 =
-                      check_and_gen1 "stronger_repr" Prims.int_one
-                        stronger_repr in
-                    match uu____2365 with
-                    | (stronger_us, stronger_t, stronger_ty) ->
-                        ((let uu____2390 =
-                            FStar_All.pipe_left
-                              (FStar_TypeChecker_Env.debug env0)
-                              (FStar_Options.Other "LayeredEffects") in
-                          if uu____2390
-                          then
-                            let uu____2395 =
-                              FStar_Syntax_Print.tscheme_to_string
-                                (stronger_us, stronger_t) in
-                            let uu____2401 =
-                              FStar_Syntax_Print.tscheme_to_string
-                                (stronger_us, stronger_ty) in
-                            FStar_Util.print2
-                              "stronger combinator typechecked with term: %s and type: %s\n"
-                              uu____2395 uu____2401
-                          else ());
-                         (let uu____2410 =
-                            FStar_Syntax_Subst.open_univ_vars stronger_us
-                              stronger_ty in
-                          match uu____2410 with
-                          | (us, ty) ->
-                              let env =
-                                FStar_TypeChecker_Env.push_univ_vars env0 us in
-                              (check_no_subtyping_for_layered_combinator env
-                                 ty FStar_Pervasives_Native.None;
-                               (let uu____2431 = fresh_a_and_u_a "a" in
-                                match uu____2431 with
-                                | (a, u) ->
-                                    let rest_bs =
-                                      let uu____2460 =
-                                        let uu____2461 =
-                                          FStar_Syntax_Subst.compress ty in
-                                        uu____2461.FStar_Syntax_Syntax.n in
-                                      match uu____2460 with
-                                      | FStar_Syntax_Syntax.Tm_arrow
-                                          (bs, uu____2473) when
-                                          (FStar_List.length bs) >=
-                                            (Prims.of_int (2))
-                                          ->
-                                          let uu____2501 =
-                                            FStar_Syntax_Subst.open_binders
-                                              bs in
-                                          (match uu____2501 with
-                                           | (a', uu____2511)::bs1 ->
-                                               let uu____2531 =
-                                                 let uu____2532 =
-                                                   FStar_All.pipe_right bs1
-                                                     (FStar_List.splitAt
-                                                        ((FStar_List.length
-                                                            bs1)
-                                                           - Prims.int_one)) in
-                                                 FStar_All.pipe_right
-                                                   uu____2532
-                                                   FStar_Pervasives_Native.fst in
-                                               let uu____2630 =
-                                                 let uu____2643 =
-                                                   let uu____2646 =
-                                                     let uu____2647 =
-                                                       let uu____2654 =
+                                                 uu____1643
+                                                 FStar_Pervasives_Native.fst in
+                                             let uu____1709 =
+                                               let uu____1722 =
+                                                 let uu____1725 =
+                                                   let uu____1726 =
+                                                     let uu____1733 =
+                                                       FStar_Syntax_Syntax.bv_to_name
+                                                         (FStar_Pervasives_Native.fst
+                                                            a) in
+                                                     (a', uu____1733) in
+                                                   FStar_Syntax_Syntax.NT
+                                                     uu____1726 in
+                                                 let uu____1740 =
+                                                   let uu____1743 =
+                                                     let uu____1744 =
+                                                       let uu____1751 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            (FStar_Pervasives_Native.fst
-                                                              a) in
-                                                       (a', uu____2654) in
+                                                              b) in
+                                                       (b', uu____1751) in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____2647 in
-                                                   [uu____2646] in
-                                                 FStar_Syntax_Subst.subst_binders
-                                                   uu____2643 in
-                                               FStar_All.pipe_right
-                                                 uu____2531 uu____2630)
-                                      | uu____2669 ->
-                                          not_an_arrow_error "stronger"
-                                            (Prims.of_int (2)) ty r in
-                                    let bs = a :: rest_bs in
-                                    let uu____2687 =
-                                      let uu____2698 =
-                                        let uu____2703 =
-                                          FStar_TypeChecker_Env.push_binders
-                                            env bs in
-                                        let uu____2704 =
-                                          FStar_All.pipe_right
-                                            (FStar_Pervasives_Native.fst a)
-                                            FStar_Syntax_Syntax.bv_to_name in
-                                        fresh_repr r uu____2703 u uu____2704 in
-                                      match uu____2698 with
-                                      | (repr1, g) ->
-                                          let uu____2719 =
-                                            let uu____2726 =
-                                              FStar_Syntax_Syntax.gen_bv "f"
-                                                FStar_Pervasives_Native.None
-                                                repr1 in
-                                            FStar_All.pipe_right uu____2726
-                                              FStar_Syntax_Syntax.mk_binder in
-                                          (uu____2719, g) in
-                                    (match uu____2687 with
-                                     | (f, guard_f) ->
-                                         let uu____2766 =
-                                           let uu____2771 =
+                                                       uu____1744 in
+                                                   [uu____1743] in
+                                                 uu____1725 :: uu____1740 in
+                                               FStar_Syntax_Subst.subst_binders
+                                                 uu____1722 in
+                                             FStar_All.pipe_right uu____1642
+                                               uu____1709)
+                                    | uu____1766 ->
+                                        not_an_arrow_error "bind"
+                                          (Prims.of_int (4)) ty r in
+                                  let bs = a :: b :: rest_bs in
+                                  let uu____1790 =
+                                    let uu____1801 =
+                                      let uu____1806 =
+                                        FStar_TypeChecker_Env.push_binders
+                                          env bs in
+                                      let uu____1807 =
+                                        FStar_All.pipe_right
+                                          (FStar_Pervasives_Native.fst a)
+                                          FStar_Syntax_Syntax.bv_to_name in
+                                      fresh_repr r uu____1806 u_a uu____1807 in
+                                    match uu____1801 with
+                                    | (repr1, g) ->
+                                        let uu____1822 =
+                                          let uu____1829 =
+                                            FStar_Syntax_Syntax.gen_bv "f"
+                                              FStar_Pervasives_Native.None
+                                              repr1 in
+                                          FStar_All.pipe_right uu____1829
+                                            FStar_Syntax_Syntax.mk_binder in
+                                        (uu____1822, g) in
+                                  (match uu____1790 with
+                                   | (f, guard_f) ->
+                                       let uu____1869 =
+                                         let x_a = fresh_x_a "x" a in
+                                         let uu____1882 =
+                                           let uu____1887 =
                                              FStar_TypeChecker_Env.push_binders
-                                               env bs in
-                                           let uu____2772 =
+                                               env
+                                               (FStar_List.append bs [x_a]) in
+                                           let uu____1906 =
                                              FStar_All.pipe_right
-                                               (FStar_Pervasives_Native.fst a)
+                                               (FStar_Pervasives_Native.fst b)
                                                FStar_Syntax_Syntax.bv_to_name in
-                                           fresh_repr r uu____2771 u
-                                             uu____2772 in
-                                         (match uu____2766 with
-                                          | (ret_t, guard_ret_t) ->
-                                              let uu____2789 =
-                                                let uu____2794 =
-                                                  FStar_TypeChecker_Env.push_binders
-                                                    env bs in
-                                                let uu____2795 =
-                                                  let uu____2797 =
-                                                    FStar_Ident.string_of_lid
-                                                      ed.FStar_Syntax_Syntax.mname in
-                                                  FStar_Util.format1
-                                                    "implicit for pure_wp in checking stronger for %s"
-                                                    uu____2797 in
-                                                pure_wp_uvar uu____2794 ret_t
-                                                  uu____2795 r in
-                                              (match uu____2789 with
-                                               | (pure_wp_uvar1, guard_wp) ->
-                                                   let c =
-                                                     let uu____2815 =
-                                                       let uu____2816 =
-                                                         let uu____2817 =
-                                                           FStar_TypeChecker_Env.new_u_univ
-                                                             () in
-                                                         [uu____2817] in
-                                                       let uu____2818 =
-                                                         let uu____2829 =
-                                                           FStar_All.pipe_right
-                                                             pure_wp_uvar1
-                                                             FStar_Syntax_Syntax.as_arg in
-                                                         [uu____2829] in
-                                                       {
-                                                         FStar_Syntax_Syntax.comp_univs
-                                                           = uu____2816;
-                                                         FStar_Syntax_Syntax.effect_name
-                                                           =
-                                                           FStar_Parser_Const.effect_PURE_lid;
-                                                         FStar_Syntax_Syntax.result_typ
-                                                           = ret_t;
-                                                         FStar_Syntax_Syntax.effect_args
-                                                           = uu____2818;
-                                                         FStar_Syntax_Syntax.flags
-                                                           = []
-                                                       } in
-                                                     FStar_Syntax_Syntax.mk_Comp
-                                                       uu____2815 in
-                                                   let k =
-                                                     FStar_Syntax_Util.arrow
-                                                       (FStar_List.append bs
-                                                          [f]) c in
-                                                   ((let uu____2884 =
-                                                       FStar_All.pipe_left
-                                                         (FStar_TypeChecker_Env.debug
+                                           fresh_repr r uu____1887 u_b
+                                             uu____1906 in
+                                         match uu____1882 with
+                                         | (repr1, g) ->
+                                             let uu____1921 =
+                                               let uu____1928 =
+                                                 let uu____1929 =
+                                                   let uu____1930 =
+                                                     let uu____1933 =
+                                                       let uu____1936 =
+                                                         FStar_TypeChecker_Env.new_u_univ
+                                                           () in
+                                                       FStar_Pervasives_Native.Some
+                                                         uu____1936 in
+                                                     FStar_Syntax_Syntax.mk_Total'
+                                                       repr1 uu____1933 in
+                                                   FStar_Syntax_Util.arrow
+                                                     [x_a] uu____1930 in
+                                                 FStar_Syntax_Syntax.gen_bv
+                                                   "g"
+                                                   FStar_Pervasives_Native.None
+                                                   uu____1929 in
+                                               FStar_All.pipe_right
+                                                 uu____1928
+                                                 FStar_Syntax_Syntax.mk_binder in
+                                             (uu____1921, g) in
+                                       (match uu____1869 with
+                                        | (g, guard_g) ->
+                                            let uu____1988 =
+                                              let uu____1993 =
+                                                FStar_TypeChecker_Env.push_binders
+                                                  env bs in
+                                              let uu____1994 =
+                                                FStar_All.pipe_right
+                                                  (FStar_Pervasives_Native.fst
+                                                     b)
+                                                  FStar_Syntax_Syntax.bv_to_name in
+                                              fresh_repr r uu____1993 u_b
+                                                uu____1994 in
+                                            (match uu____1988 with
+                                             | (repr1, guard_repr) ->
+                                                 let uu____2011 =
+                                                   let uu____2016 =
+                                                     FStar_TypeChecker_Env.push_binders
+                                                       env bs in
+                                                   let uu____2017 =
+                                                     let uu____2019 =
+                                                       FStar_Ident.string_of_lid
+                                                         ed.FStar_Syntax_Syntax.mname in
+                                                     FStar_Util.format1
+                                                       "implicit for pure_wp in checking bind for %s"
+                                                       uu____2019 in
+                                                   pure_wp_uvar uu____2016
+                                                     repr1 uu____2017 r in
+                                                 (match uu____2011 with
+                                                  | (pure_wp_uvar1,
+                                                     g_pure_wp_uvar) ->
+                                                      let k =
+                                                        let uu____2039 =
+                                                          let uu____2042 =
+                                                            let uu____2043 =
+                                                              let uu____2044
+                                                                =
+                                                                FStar_TypeChecker_Env.new_u_univ
+                                                                  () in
+                                                              [uu____2044] in
+                                                            let uu____2045 =
+                                                              let uu____2056
+                                                                =
+                                                                FStar_All.pipe_right
+                                                                  pure_wp_uvar1
+                                                                  FStar_Syntax_Syntax.as_arg in
+                                                              [uu____2056] in
+                                                            {
+                                                              FStar_Syntax_Syntax.comp_univs
+                                                                = uu____2043;
+                                                              FStar_Syntax_Syntax.effect_name
+                                                                =
+                                                                FStar_Parser_Const.effect_PURE_lid;
+                                                              FStar_Syntax_Syntax.result_typ
+                                                                = repr1;
+                                                              FStar_Syntax_Syntax.effect_args
+                                                                = uu____2045;
+                                                              FStar_Syntax_Syntax.flags
+                                                                = []
+                                                            } in
+                                                          FStar_Syntax_Syntax.mk_Comp
+                                                            uu____2042 in
+                                                        FStar_Syntax_Util.arrow
+                                                          (FStar_List.append
+                                                             bs [f; g])
+                                                          uu____2039 in
+                                                      let guard_eq =
+                                                        FStar_TypeChecker_Rel.teq
+                                                          env ty k in
+                                                      (FStar_List.iter
+                                                         (FStar_TypeChecker_Rel.force_trivial_guard
                                                             env)
-                                                         (FStar_Options.Other
-                                                            "LayeredEffects") in
-                                                     if uu____2884
-                                                     then
-                                                       let uu____2889 =
-                                                         FStar_Syntax_Print.term_to_string
-                                                           k in
-                                                       FStar_Util.print1
-                                                         "Expected type before unification: %s\n"
-                                                         uu____2889
-                                                     else ());
-                                                    (let guard_eq =
-                                                       FStar_TypeChecker_Rel.teq
-                                                         env ty k in
-                                                     FStar_List.iter
-                                                       (FStar_TypeChecker_Rel.force_trivial_guard
-                                                          env)
-                                                       [guard_f;
-                                                       guard_ret_t;
-                                                       guard_wp;
-                                                       guard_eq];
-                                                     (let uu____2896 =
-                                                        let uu____2899 =
-                                                          let uu____2900 =
+                                                         [guard_f;
+                                                         guard_g;
+                                                         guard_repr;
+                                                         g_pure_wp_uvar;
+                                                         guard_eq];
+                                                       (let uu____2115 =
+                                                          let uu____2118 =
                                                             FStar_All.pipe_right
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env) in
                                                           FStar_All.pipe_right
-                                                            uu____2900
-                                                            (FStar_TypeChecker_Normalize.normalize
-                                                               [FStar_TypeChecker_Env.Beta;
-                                                               FStar_TypeChecker_Env.Eager_unfolding]
-                                                               env) in
-                                                        FStar_All.pipe_right
-                                                          uu____2899
-                                                          (FStar_Syntax_Subst.close_univ_vars
-                                                             stronger_us) in
-                                                      (stronger_us,
-                                                        stronger_t,
-                                                        uu____2896))))))))))) in
-                  log_combinator "stronger_repr" stronger_repr;
-                  (let if_then_else =
-                     let if_then_else_ts =
-                       let uu____2931 =
-                         FStar_All.pipe_right ed
-                           FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                       FStar_All.pipe_right uu____2931 FStar_Util.must in
-                     let r =
-                       (FStar_Pervasives_Native.snd if_then_else_ts).FStar_Syntax_Syntax.pos in
-                     let uu____2971 =
-                       check_and_gen1 "if_then_else" Prims.int_one
-                         if_then_else_ts in
-                     match uu____2971 with
-                     | (if_then_else_us, if_then_else_t, if_then_else_ty) ->
-                         let uu____2995 =
-                           FStar_Syntax_Subst.open_univ_vars if_then_else_us
-                             if_then_else_t in
-                         (match uu____2995 with
-                          | (us, t) ->
-                              let uu____3014 =
-                                FStar_Syntax_Subst.open_univ_vars
-                                  if_then_else_us if_then_else_ty in
-                              (match uu____3014 with
-                               | (uu____3031, ty) ->
-                                   let env =
-                                     FStar_TypeChecker_Env.push_univ_vars
-                                       env0 us in
-                                   (check_no_subtyping_for_layered_combinator
-                                      env t (FStar_Pervasives_Native.Some ty);
-                                    (let uu____3035 = fresh_a_and_u_a "a" in
-                                     match uu____3035 with
-                                     | (a, u_a) ->
-                                         let rest_bs =
-                                           let uu____3064 =
-                                             let uu____3065 =
-                                               FStar_Syntax_Subst.compress ty in
-                                             uu____3065.FStar_Syntax_Syntax.n in
-                                           match uu____3064 with
-                                           | FStar_Syntax_Syntax.Tm_arrow
-                                               (bs, uu____3077) when
-                                               (FStar_List.length bs) >=
-                                                 (Prims.of_int (4))
-                                               ->
-                                               let uu____3105 =
-                                                 FStar_Syntax_Subst.open_binders
-                                                   bs in
-                                               (match uu____3105 with
-                                                | (a', uu____3115)::bs1 ->
-                                                    let uu____3135 =
-                                                      let uu____3136 =
-                                                        FStar_All.pipe_right
-                                                          bs1
-                                                          (FStar_List.splitAt
-                                                             ((FStar_List.length
-                                                                 bs1)
-                                                                -
-                                                                (Prims.of_int (3)))) in
+                                                            uu____2118
+                                                            (FStar_Syntax_Subst.close_univ_vars
+                                                               bind_us) in
+                                                        (bind_us, bind_t,
+                                                          uu____2115))))))))))) in
+            log_combinator "bind_repr" bind_repr;
+            (let stronger_repr =
+               let stronger_repr =
+                 let uu____2147 =
+                   FStar_All.pipe_right ed
+                     FStar_Syntax_Util.get_stronger_repr in
+                 FStar_All.pipe_right uu____2147 FStar_Util.must in
+               let r =
+                 (FStar_Pervasives_Native.snd stronger_repr).FStar_Syntax_Syntax.pos in
+               let uu____2159 =
+                 check_and_gen1 "stronger_repr" Prims.int_one stronger_repr in
+               match uu____2159 with
+               | (stronger_us, stronger_t, stronger_ty) ->
+                   ((let uu____2184 =
+                       FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
+                         (FStar_Options.Other "LayeredEffects") in
+                     if uu____2184
+                     then
+                       let uu____2189 =
+                         FStar_Syntax_Print.tscheme_to_string
+                           (stronger_us, stronger_t) in
+                       let uu____2195 =
+                         FStar_Syntax_Print.tscheme_to_string
+                           (stronger_us, stronger_ty) in
+                       FStar_Util.print2
+                         "stronger combinator typechecked with term: %s and type: %s\n"
+                         uu____2189 uu____2195
+                     else ());
+                    (let uu____2204 =
+                       FStar_Syntax_Subst.open_univ_vars stronger_us
+                         stronger_ty in
+                     match uu____2204 with
+                     | (us, ty) ->
+                         let env =
+                           FStar_TypeChecker_Env.push_univ_vars env0 us in
+                         (check_no_subtyping_for_layered_combinator env ty
+                            FStar_Pervasives_Native.None;
+                          (let uu____2225 = fresh_a_and_u_a "a" in
+                           match uu____2225 with
+                           | (a, u) ->
+                               let rest_bs =
+                                 let uu____2254 =
+                                   let uu____2255 =
+                                     FStar_Syntax_Subst.compress ty in
+                                   uu____2255.FStar_Syntax_Syntax.n in
+                                 match uu____2254 with
+                                 | FStar_Syntax_Syntax.Tm_arrow
+                                     (bs, uu____2267) when
+                                     (FStar_List.length bs) >=
+                                       (Prims.of_int (2))
+                                     ->
+                                     let uu____2295 =
+                                       FStar_Syntax_Subst.open_binders bs in
+                                     (match uu____2295 with
+                                      | (a', uu____2305)::bs1 ->
+                                          let uu____2325 =
+                                            let uu____2326 =
+                                              FStar_All.pipe_right bs1
+                                                (FStar_List.splitAt
+                                                   ((FStar_List.length bs1) -
+                                                      Prims.int_one)) in
+                                            FStar_All.pipe_right uu____2326
+                                              FStar_Pervasives_Native.fst in
+                                          let uu____2424 =
+                                            let uu____2437 =
+                                              let uu____2440 =
+                                                let uu____2441 =
+                                                  let uu____2448 =
+                                                    FStar_Syntax_Syntax.bv_to_name
+                                                      (FStar_Pervasives_Native.fst
+                                                         a) in
+                                                  (a', uu____2448) in
+                                                FStar_Syntax_Syntax.NT
+                                                  uu____2441 in
+                                              [uu____2440] in
+                                            FStar_Syntax_Subst.subst_binders
+                                              uu____2437 in
+                                          FStar_All.pipe_right uu____2325
+                                            uu____2424)
+                                 | uu____2463 ->
+                                     not_an_arrow_error "stronger"
+                                       (Prims.of_int (2)) ty r in
+                               let bs = a :: rest_bs in
+                               let uu____2481 =
+                                 let uu____2492 =
+                                   let uu____2497 =
+                                     FStar_TypeChecker_Env.push_binders env
+                                       bs in
+                                   let uu____2498 =
+                                     FStar_All.pipe_right
+                                       (FStar_Pervasives_Native.fst a)
+                                       FStar_Syntax_Syntax.bv_to_name in
+                                   fresh_repr r uu____2497 u uu____2498 in
+                                 match uu____2492 with
+                                 | (repr1, g) ->
+                                     let uu____2513 =
+                                       let uu____2520 =
+                                         FStar_Syntax_Syntax.gen_bv "f"
+                                           FStar_Pervasives_Native.None repr1 in
+                                       FStar_All.pipe_right uu____2520
+                                         FStar_Syntax_Syntax.mk_binder in
+                                     (uu____2513, g) in
+                               (match uu____2481 with
+                                | (f, guard_f) ->
+                                    let uu____2560 =
+                                      let uu____2565 =
+                                        FStar_TypeChecker_Env.push_binders
+                                          env bs in
+                                      let uu____2566 =
+                                        FStar_All.pipe_right
+                                          (FStar_Pervasives_Native.fst a)
+                                          FStar_Syntax_Syntax.bv_to_name in
+                                      fresh_repr r uu____2565 u uu____2566 in
+                                    (match uu____2560 with
+                                     | (ret_t, guard_ret_t) ->
+                                         let uu____2583 =
+                                           let uu____2588 =
+                                             FStar_TypeChecker_Env.push_binders
+                                               env bs in
+                                           let uu____2589 =
+                                             let uu____2591 =
+                                               FStar_Ident.string_of_lid
+                                                 ed.FStar_Syntax_Syntax.mname in
+                                             FStar_Util.format1
+                                               "implicit for pure_wp in checking stronger for %s"
+                                               uu____2591 in
+                                           pure_wp_uvar uu____2588 ret_t
+                                             uu____2589 r in
+                                         (match uu____2583 with
+                                          | (pure_wp_uvar1, guard_wp) ->
+                                              let c =
+                                                let uu____2609 =
+                                                  let uu____2610 =
+                                                    let uu____2611 =
+                                                      FStar_TypeChecker_Env.new_u_univ
+                                                        () in
+                                                    [uu____2611] in
+                                                  let uu____2612 =
+                                                    let uu____2623 =
                                                       FStar_All.pipe_right
-                                                        uu____3136
-                                                        FStar_Pervasives_Native.fst in
-                                                    let uu____3234 =
-                                                      let uu____3247 =
-                                                        let uu____3250 =
-                                                          let uu____3251 =
-                                                            let uu____3258 =
-                                                              let uu____3261
-                                                                =
-                                                                FStar_All.pipe_right
-                                                                  a
-                                                                  FStar_Pervasives_Native.fst in
-                                                              FStar_All.pipe_right
-                                                                uu____3261
-                                                                FStar_Syntax_Syntax.bv_to_name in
-                                                            (a', uu____3258) in
-                                                          FStar_Syntax_Syntax.NT
-                                                            uu____3251 in
-                                                        [uu____3250] in
-                                                      FStar_Syntax_Subst.subst_binders
-                                                        uu____3247 in
-                                                    FStar_All.pipe_right
-                                                      uu____3135 uu____3234)
-                                           | uu____3282 ->
-                                               not_an_arrow_error
-                                                 "if_then_else"
-                                                 (Prims.of_int (4)) ty r in
-                                         let bs = a :: rest_bs in
-                                         let uu____3300 =
-                                           let uu____3311 =
-                                             let uu____3316 =
+                                                        pure_wp_uvar1
+                                                        FStar_Syntax_Syntax.as_arg in
+                                                    [uu____2623] in
+                                                  {
+                                                    FStar_Syntax_Syntax.comp_univs
+                                                      = uu____2610;
+                                                    FStar_Syntax_Syntax.effect_name
+                                                      =
+                                                      FStar_Parser_Const.effect_PURE_lid;
+                                                    FStar_Syntax_Syntax.result_typ
+                                                      = ret_t;
+                                                    FStar_Syntax_Syntax.effect_args
+                                                      = uu____2612;
+                                                    FStar_Syntax_Syntax.flags
+                                                      = []
+                                                  } in
+                                                FStar_Syntax_Syntax.mk_Comp
+                                                  uu____2609 in
+                                              let k =
+                                                FStar_Syntax_Util.arrow
+                                                  (FStar_List.append bs [f])
+                                                  c in
+                                              ((let uu____2678 =
+                                                  FStar_All.pipe_left
+                                                    (FStar_TypeChecker_Env.debug
+                                                       env)
+                                                    (FStar_Options.Other
+                                                       "LayeredEffects") in
+                                                if uu____2678
+                                                then
+                                                  let uu____2683 =
+                                                    FStar_Syntax_Print.term_to_string
+                                                      k in
+                                                  FStar_Util.print1
+                                                    "Expected type before unification: %s\n"
+                                                    uu____2683
+                                                else ());
+                                               (let guard_eq =
+                                                  FStar_TypeChecker_Rel.teq
+                                                    env ty k in
+                                                FStar_List.iter
+                                                  (FStar_TypeChecker_Rel.force_trivial_guard
+                                                     env)
+                                                  [guard_f;
+                                                  guard_ret_t;
+                                                  guard_wp;
+                                                  guard_eq];
+                                                (let uu____2690 =
+                                                   let uu____2693 =
+                                                     let uu____2694 =
+                                                       FStar_All.pipe_right k
+                                                         (FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                                            env) in
+                                                     FStar_All.pipe_right
+                                                       uu____2694
+                                                       (FStar_TypeChecker_Normalize.normalize
+                                                          [FStar_TypeChecker_Env.Beta;
+                                                          FStar_TypeChecker_Env.Eager_unfolding]
+                                                          env) in
+                                                   FStar_All.pipe_right
+                                                     uu____2693
+                                                     (FStar_Syntax_Subst.close_univ_vars
+                                                        stronger_us) in
+                                                 (stronger_us, stronger_t,
+                                                   uu____2690))))))))))) in
+             log_combinator "stronger_repr" stronger_repr;
+             (let if_then_else =
+                let if_then_else_ts =
+                  let uu____2723 =
+                    FStar_All.pipe_right ed
+                      FStar_Syntax_Util.get_layered_if_then_else_combinator in
+                  FStar_All.pipe_right uu____2723 FStar_Util.must in
+                let r =
+                  (FStar_Pervasives_Native.snd if_then_else_ts).FStar_Syntax_Syntax.pos in
+                let uu____2735 =
+                  check_and_gen1 "if_then_else" Prims.int_one if_then_else_ts in
+                match uu____2735 with
+                | (if_then_else_us, if_then_else_t, if_then_else_ty) ->
+                    let uu____2759 =
+                      FStar_Syntax_Subst.open_univ_vars if_then_else_us
+                        if_then_else_t in
+                    (match uu____2759 with
+                     | (us, t) ->
+                         let uu____2778 =
+                           FStar_Syntax_Subst.open_univ_vars if_then_else_us
+                             if_then_else_ty in
+                         (match uu____2778 with
+                          | (uu____2795, ty) ->
+                              let env =
+                                FStar_TypeChecker_Env.push_univ_vars env0 us in
+                              (check_no_subtyping_for_layered_combinator env
+                                 t (FStar_Pervasives_Native.Some ty);
+                               (let uu____2799 = fresh_a_and_u_a "a" in
+                                match uu____2799 with
+                                | (a, u_a) ->
+                                    let rest_bs =
+                                      let uu____2828 =
+                                        let uu____2829 =
+                                          FStar_Syntax_Subst.compress ty in
+                                        uu____2829.FStar_Syntax_Syntax.n in
+                                      match uu____2828 with
+                                      | FStar_Syntax_Syntax.Tm_arrow
+                                          (bs, uu____2841) when
+                                          (FStar_List.length bs) >=
+                                            (Prims.of_int (4))
+                                          ->
+                                          let uu____2869 =
+                                            FStar_Syntax_Subst.open_binders
+                                              bs in
+                                          (match uu____2869 with
+                                           | (a', uu____2879)::bs1 ->
+                                               let uu____2899 =
+                                                 let uu____2900 =
+                                                   FStar_All.pipe_right bs1
+                                                     (FStar_List.splitAt
+                                                        ((FStar_List.length
+                                                            bs1)
+                                                           -
+                                                           (Prims.of_int (3)))) in
+                                                 FStar_All.pipe_right
+                                                   uu____2900
+                                                   FStar_Pervasives_Native.fst in
+                                               let uu____2966 =
+                                                 let uu____2979 =
+                                                   let uu____2982 =
+                                                     let uu____2983 =
+                                                       let uu____2990 =
+                                                         let uu____2993 =
+                                                           FStar_All.pipe_right
+                                                             a
+                                                             FStar_Pervasives_Native.fst in
+                                                         FStar_All.pipe_right
+                                                           uu____2993
+                                                           FStar_Syntax_Syntax.bv_to_name in
+                                                       (a', uu____2990) in
+                                                     FStar_Syntax_Syntax.NT
+                                                       uu____2983 in
+                                                   [uu____2982] in
+                                                 FStar_Syntax_Subst.subst_binders
+                                                   uu____2979 in
+                                               FStar_All.pipe_right
+                                                 uu____2899 uu____2966)
+                                      | uu____3014 ->
+                                          not_an_arrow_error "if_then_else"
+                                            (Prims.of_int (4)) ty r in
+                                    let bs = a :: rest_bs in
+                                    let uu____3032 =
+                                      let uu____3043 =
+                                        let uu____3048 =
+                                          FStar_TypeChecker_Env.push_binders
+                                            env bs in
+                                        let uu____3049 =
+                                          let uu____3050 =
+                                            FStar_All.pipe_right a
+                                              FStar_Pervasives_Native.fst in
+                                          FStar_All.pipe_right uu____3050
+                                            FStar_Syntax_Syntax.bv_to_name in
+                                        fresh_repr r uu____3048 u_a
+                                          uu____3049 in
+                                      match uu____3043 with
+                                      | (repr1, g) ->
+                                          let uu____3071 =
+                                            let uu____3078 =
+                                              FStar_Syntax_Syntax.gen_bv "f"
+                                                FStar_Pervasives_Native.None
+                                                repr1 in
+                                            FStar_All.pipe_right uu____3078
+                                              FStar_Syntax_Syntax.mk_binder in
+                                          (uu____3071, g) in
+                                    (match uu____3032 with
+                                     | (f_bs, guard_f) ->
+                                         let uu____3118 =
+                                           let uu____3129 =
+                                             let uu____3134 =
                                                FStar_TypeChecker_Env.push_binders
                                                  env bs in
-                                             let uu____3317 =
-                                               let uu____3318 =
+                                             let uu____3135 =
+                                               let uu____3136 =
                                                  FStar_All.pipe_right a
                                                    FStar_Pervasives_Native.fst in
                                                FStar_All.pipe_right
-                                                 uu____3318
+                                                 uu____3136
                                                  FStar_Syntax_Syntax.bv_to_name in
-                                             fresh_repr r uu____3316 u_a
-                                               uu____3317 in
-                                           match uu____3311 with
+                                             fresh_repr r uu____3134 u_a
+                                               uu____3135 in
+                                           match uu____3129 with
                                            | (repr1, g) ->
-                                               let uu____3339 =
-                                                 let uu____3346 =
+                                               let uu____3157 =
+                                                 let uu____3164 =
                                                    FStar_Syntax_Syntax.gen_bv
-                                                     "f"
+                                                     "g"
                                                      FStar_Pervasives_Native.None
                                                      repr1 in
                                                  FStar_All.pipe_right
-                                                   uu____3346
+                                                   uu____3164
                                                    FStar_Syntax_Syntax.mk_binder in
-                                               (uu____3339, g) in
-                                         (match uu____3300 with
-                                          | (f_bs, guard_f) ->
-                                              let uu____3386 =
-                                                let uu____3397 =
-                                                  let uu____3402 =
-                                                    FStar_TypeChecker_Env.push_binders
-                                                      env bs in
-                                                  let uu____3403 =
-                                                    let uu____3404 =
-                                                      FStar_All.pipe_right a
-                                                        FStar_Pervasives_Native.fst in
-                                                    FStar_All.pipe_right
-                                                      uu____3404
-                                                      FStar_Syntax_Syntax.bv_to_name in
-                                                  fresh_repr r uu____3402 u_a
-                                                    uu____3403 in
-                                                match uu____3397 with
-                                                | (repr1, g) ->
-                                                    let uu____3425 =
-                                                      let uu____3432 =
-                                                        FStar_Syntax_Syntax.gen_bv
-                                                          "g"
-                                                          FStar_Pervasives_Native.None
-                                                          repr1 in
-                                                      FStar_All.pipe_right
-                                                        uu____3432
-                                                        FStar_Syntax_Syntax.mk_binder in
-                                                    (uu____3425, g) in
-                                              (match uu____3386 with
-                                               | (g_bs, guard_g) ->
-                                                   let p_b =
-                                                     let uu____3479 =
-                                                       FStar_Syntax_Syntax.gen_bv
-                                                         "p"
-                                                         FStar_Pervasives_Native.None
-                                                         FStar_Syntax_Util.ktype0 in
-                                                     FStar_All.pipe_right
-                                                       uu____3479
-                                                       FStar_Syntax_Syntax.mk_binder in
-                                                   let uu____3487 =
-                                                     let uu____3492 =
-                                                       FStar_TypeChecker_Env.push_binders
-                                                         env
-                                                         (FStar_List.append
-                                                            bs [p_b]) in
-                                                     let uu____3511 =
-                                                       let uu____3512 =
+                                               (uu____3157, g) in
+                                         (match uu____3118 with
+                                          | (g_bs, guard_g) ->
+                                              let p_b =
+                                                let uu____3211 =
+                                                  FStar_Syntax_Syntax.gen_bv
+                                                    "p"
+                                                    FStar_Pervasives_Native.None
+                                                    FStar_Syntax_Util.ktype0 in
+                                                FStar_All.pipe_right
+                                                  uu____3211
+                                                  FStar_Syntax_Syntax.mk_binder in
+                                              let uu____3219 =
+                                                let uu____3224 =
+                                                  FStar_TypeChecker_Env.push_binders
+                                                    env
+                                                    (FStar_List.append bs
+                                                       [p_b]) in
+                                                let uu____3243 =
+                                                  let uu____3244 =
+                                                    FStar_All.pipe_right a
+                                                      FStar_Pervasives_Native.fst in
+                                                  FStar_All.pipe_right
+                                                    uu____3244
+                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                fresh_repr r uu____3224 u_a
+                                                  uu____3243 in
+                                              (match uu____3219 with
+                                               | (t_body, guard_body) ->
+                                                   let k =
+                                                     FStar_Syntax_Util.abs
+                                                       (FStar_List.append bs
+                                                          [f_bs; g_bs; p_b])
+                                                       t_body
+                                                       FStar_Pervasives_Native.None in
+                                                   let guard_eq =
+                                                     FStar_TypeChecker_Rel.teq
+                                                       env t k in
+                                                   (FStar_All.pipe_right
+                                                      [guard_f;
+                                                      guard_g;
+                                                      guard_body;
+                                                      guard_eq]
+                                                      (FStar_List.iter
+                                                         (FStar_TypeChecker_Rel.force_trivial_guard
+                                                            env));
+                                                    (let uu____3304 =
+                                                       let uu____3307 =
                                                          FStar_All.pipe_right
-                                                           a
-                                                           FStar_Pervasives_Native.fst in
+                                                           k
+                                                           (FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                                              env) in
                                                        FStar_All.pipe_right
-                                                         uu____3512
-                                                         FStar_Syntax_Syntax.bv_to_name in
-                                                     fresh_repr r uu____3492
-                                                       u_a uu____3511 in
-                                                   (match uu____3487 with
-                                                    | (t_body, guard_body) ->
-                                                        let k =
-                                                          FStar_Syntax_Util.abs
-                                                            (FStar_List.append
-                                                               bs
-                                                               [f_bs;
-                                                               g_bs;
-                                                               p_b]) t_body
-                                                            FStar_Pervasives_Native.None in
-                                                        let guard_eq =
-                                                          FStar_TypeChecker_Rel.teq
-                                                            env t k in
-                                                        (FStar_All.pipe_right
-                                                           [guard_f;
-                                                           guard_g;
-                                                           guard_body;
-                                                           guard_eq]
-                                                           (FStar_List.iter
-                                                              (FStar_TypeChecker_Rel.force_trivial_guard
-                                                                 env));
-                                                         (let uu____3572 =
-                                                            let uu____3575 =
-                                                              FStar_All.pipe_right
-                                                                k
-                                                                (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                                   env) in
-                                                            FStar_All.pipe_right
-                                                              uu____3575
-                                                              (FStar_Syntax_Subst.close_univ_vars
-                                                                 if_then_else_us) in
-                                                          (if_then_else_us,
-                                                            uu____3572,
-                                                            if_then_else_ty)))))))))) in
-                   log_combinator "if_then_else" if_then_else;
-                   (let r =
-                      let uu____3588 =
-                        let uu____3591 =
-                          let uu____3600 =
-                            FStar_All.pipe_right ed
-                              FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                          FStar_All.pipe_right uu____3600 FStar_Util.must in
-                        FStar_All.pipe_right uu____3591
-                          FStar_Pervasives_Native.snd in
-                      uu____3588.FStar_Syntax_Syntax.pos in
-                    let uu____3661 = if_then_else in
-                    match uu____3661 with
-                    | (ite_us, ite_t, uu____3676) ->
-                        let uu____3689 =
-                          FStar_Syntax_Subst.open_univ_vars ite_us ite_t in
-                        (match uu____3689 with
-                         | (us, ite_t1) ->
-                             let uu____3696 =
-                               let uu____3711 =
-                                 let uu____3712 =
-                                   FStar_Syntax_Subst.compress ite_t1 in
-                                 uu____3712.FStar_Syntax_Syntax.n in
-                               match uu____3711 with
-                               | FStar_Syntax_Syntax.Tm_abs
-                                   (bs, uu____3730, uu____3731) ->
-                                   let bs1 =
-                                     FStar_Syntax_Subst.open_binders bs in
-                                   let uu____3757 =
-                                     let uu____3770 =
-                                       let uu____3775 =
-                                         let uu____3778 =
-                                           let uu____3787 =
-                                             FStar_All.pipe_right bs1
-                                               (FStar_List.splitAt
-                                                  ((FStar_List.length bs1) -
-                                                     (Prims.of_int (3)))) in
-                                           FStar_All.pipe_right uu____3787
-                                             FStar_Pervasives_Native.snd in
-                                         FStar_All.pipe_right uu____3778
+                                                         uu____3307
+                                                         (FStar_Syntax_Subst.close_univ_vars
+                                                            if_then_else_us) in
+                                                     (if_then_else_us,
+                                                       uu____3304,
+                                                       if_then_else_ty)))))))))) in
+              log_combinator "if_then_else" if_then_else;
+              (let r =
+                 let uu____3320 =
+                   let uu____3323 =
+                     let uu____3332 =
+                       FStar_All.pipe_right ed
+                         FStar_Syntax_Util.get_layered_if_then_else_combinator in
+                     FStar_All.pipe_right uu____3332 FStar_Util.must in
+                   FStar_All.pipe_right uu____3323
+                     FStar_Pervasives_Native.snd in
+                 uu____3320.FStar_Syntax_Syntax.pos in
+               let uu____3361 = if_then_else in
+               match uu____3361 with
+               | (ite_us, ite_t, uu____3376) ->
+                   let uu____3389 =
+                     FStar_Syntax_Subst.open_univ_vars ite_us ite_t in
+                   (match uu____3389 with
+                    | (us, ite_t1) ->
+                        let uu____3396 =
+                          let uu____3411 =
+                            let uu____3412 =
+                              FStar_Syntax_Subst.compress ite_t1 in
+                            uu____3412.FStar_Syntax_Syntax.n in
+                          match uu____3411 with
+                          | FStar_Syntax_Syntax.Tm_abs
+                              (bs, uu____3430, uu____3431) ->
+                              let bs1 = FStar_Syntax_Subst.open_binders bs in
+                              let uu____3457 =
+                                let uu____3470 =
+                                  let uu____3475 =
+                                    let uu____3478 =
+                                      let uu____3487 =
+                                        FStar_All.pipe_right bs1
+                                          (FStar_List.splitAt
+                                             ((FStar_List.length bs1) -
+                                                (Prims.of_int (3)))) in
+                                      FStar_All.pipe_right uu____3487
+                                        FStar_Pervasives_Native.snd in
+                                    FStar_All.pipe_right uu____3478
+                                      (FStar_List.map
+                                         FStar_Pervasives_Native.fst) in
+                                  FStar_All.pipe_right uu____3475
+                                    (FStar_List.map
+                                       FStar_Syntax_Syntax.bv_to_name) in
+                                FStar_All.pipe_right uu____3470
+                                  (fun l ->
+                                     let uu____3643 = l in
+                                     match uu____3643 with
+                                     | f::g::p::[] -> (f, g, p)) in
+                              (match uu____3457 with
+                               | (f, g, p) ->
+                                   let uu____3712 =
+                                     let uu____3713 =
+                                       FStar_TypeChecker_Env.push_univ_vars
+                                         env0 us in
+                                     FStar_TypeChecker_Env.push_binders
+                                       uu____3713 bs1 in
+                                   let uu____3714 =
+                                     let uu____3715 =
+                                       let uu____3716 =
+                                         let uu____3719 =
+                                           FStar_All.pipe_right bs1
+                                             (FStar_List.map
+                                                FStar_Pervasives_Native.fst) in
+                                         FStar_All.pipe_right uu____3719
                                            (FStar_List.map
-                                              FStar_Pervasives_Native.fst) in
-                                       FStar_All.pipe_right uu____3775
+                                              FStar_Syntax_Syntax.bv_to_name) in
+                                       FStar_All.pipe_right uu____3716
                                          (FStar_List.map
-                                            FStar_Syntax_Syntax.bv_to_name) in
-                                     FStar_All.pipe_right uu____3770
-                                       (fun l ->
-                                          let uu____3943 = l in
-                                          match uu____3943 with
-                                          | f::g::p::[] -> (f, g, p)) in
-                                   (match uu____3757 with
-                                    | (f, g, p) ->
-                                        let uu____4012 =
-                                          let uu____4013 =
-                                            FStar_TypeChecker_Env.push_univ_vars
-                                              env0 us in
-                                          FStar_TypeChecker_Env.push_binders
-                                            uu____4013 bs1 in
-                                        let uu____4014 =
-                                          let uu____4015 =
-                                            let uu____4016 =
-                                              let uu____4019 =
-                                                FStar_All.pipe_right bs1
-                                                  (FStar_List.map
-                                                     FStar_Pervasives_Native.fst) in
-                                              FStar_All.pipe_right uu____4019
-                                                (FStar_List.map
-                                                   FStar_Syntax_Syntax.bv_to_name) in
-                                            FStar_All.pipe_right uu____4016
-                                              (FStar_List.map
-                                                 FStar_Syntax_Syntax.as_arg) in
-                                          FStar_Syntax_Syntax.mk_Tm_app
-                                            ite_t1 uu____4015 r in
-                                        (uu____4012, uu____4014, f, g, p))
-                               | uu____4050 ->
-                                   failwith
-                                     "Impossible! ite_t must have been an abstraction with at least 3 binders" in
-                             (match uu____3696 with
-                              | (env, ite_t_applied, f_t, g_t, p_t) ->
-                                  let uu____4079 =
-                                    let uu____4088 = stronger_repr in
-                                    match uu____4088 with
-                                    | (uu____4109, subcomp_t, subcomp_ty) ->
-                                        let uu____4124 =
-                                          FStar_Syntax_Subst.open_univ_vars
-                                            us subcomp_t in
-                                        (match uu____4124 with
-                                         | (uu____4137, subcomp_t1) ->
-                                             let uu____4139 =
-                                               let uu____4150 =
-                                                 FStar_Syntax_Subst.open_univ_vars
-                                                   us subcomp_ty in
-                                               match uu____4150 with
-                                               | (uu____4165, subcomp_ty1) ->
-                                                   let uu____4167 =
-                                                     let uu____4168 =
-                                                       FStar_Syntax_Subst.compress
-                                                         subcomp_ty1 in
-                                                     uu____4168.FStar_Syntax_Syntax.n in
-                                                   (match uu____4167 with
-                                                    | FStar_Syntax_Syntax.Tm_arrow
-                                                        (bs, uu____4182) ->
-                                                        let uu____4203 =
+                                            FStar_Syntax_Syntax.as_arg) in
+                                     FStar_Syntax_Syntax.mk_Tm_app ite_t1
+                                       uu____3715 r in
+                                   (uu____3712, uu____3714, f, g, p))
+                          | uu____3750 ->
+                              failwith
+                                "Impossible! ite_t must have been an abstraction with at least 3 binders" in
+                        (match uu____3396 with
+                         | (env, ite_t_applied, f_t, g_t, p_t) ->
+                             let uu____3779 =
+                               let uu____3788 = stronger_repr in
+                               match uu____3788 with
+                               | (uu____3809, subcomp_t, subcomp_ty) ->
+                                   let uu____3824 =
+                                     FStar_Syntax_Subst.open_univ_vars us
+                                       subcomp_t in
+                                   (match uu____3824 with
+                                    | (uu____3837, subcomp_t1) ->
+                                        let uu____3839 =
+                                          let uu____3850 =
+                                            FStar_Syntax_Subst.open_univ_vars
+                                              us subcomp_ty in
+                                          match uu____3850 with
+                                          | (uu____3865, subcomp_ty1) ->
+                                              let uu____3867 =
+                                                let uu____3868 =
+                                                  FStar_Syntax_Subst.compress
+                                                    subcomp_ty1 in
+                                                uu____3868.FStar_Syntax_Syntax.n in
+                                              (match uu____3867 with
+                                               | FStar_Syntax_Syntax.Tm_arrow
+                                                   (bs, uu____3882) ->
+                                                   let uu____3903 =
+                                                     FStar_All.pipe_right bs
+                                                       (FStar_List.splitAt
+                                                          ((FStar_List.length
+                                                              bs)
+                                                             - Prims.int_one)) in
+                                                   (match uu____3903 with
+                                                    | (bs_except_last,
+                                                       last_b) ->
+                                                        let uu____4009 =
                                                           FStar_All.pipe_right
-                                                            bs
-                                                            (FStar_List.splitAt
-                                                               ((FStar_List.length
-                                                                   bs)
-                                                                  -
-                                                                  Prims.int_one)) in
-                                                        (match uu____4203
-                                                         with
-                                                         | (bs_except_last,
-                                                            last_b) ->
-                                                             let uu____4309 =
-                                                               FStar_All.pipe_right
-                                                                 bs_except_last
-                                                                 (FStar_List.map
-                                                                    FStar_Pervasives_Native.snd) in
-                                                             let uu____4336 =
-                                                               let uu____4339
-                                                                 =
-                                                                 FStar_All.pipe_right
-                                                                   last_b
-                                                                   FStar_List.hd in
-                                                               FStar_All.pipe_right
-                                                                 uu____4339
-                                                                 FStar_Pervasives_Native.snd in
-                                                             (uu____4309,
-                                                               uu____4336))
-                                                    | uu____4382 ->
-                                                        failwith
-                                                          "Impossible! subcomp_ty must have been an arrow with at lease 1 binder") in
-                                             (match uu____4139 with
-                                              | (aqs_except_last, last_aq) ->
-                                                  let aux t =
-                                                    let tun_args =
-                                                      FStar_All.pipe_right
-                                                        aqs_except_last
-                                                        (FStar_List.map
-                                                           (fun aq ->
-                                                              (FStar_Syntax_Syntax.tun,
-                                                                aq))) in
-                                                    FStar_Syntax_Syntax.mk_Tm_app
-                                                      subcomp_t1
-                                                      (FStar_List.append
-                                                         tun_args
-                                                         [(t, last_aq)]) r in
-                                                  let uu____4493 = aux f_t in
-                                                  let uu____4496 = aux g_t in
-                                                  (uu____4493, uu____4496))) in
-                                  (match uu____4079 with
-                                   | (subcomp_f, subcomp_g) ->
-                                       let uu____4513 =
-                                         let aux t =
-                                           let uu____4530 =
-                                             let uu____4531 =
-                                               let uu____4558 =
-                                                 let uu____4575 =
-                                                   let uu____4584 =
-                                                     FStar_Syntax_Syntax.mk_Total
-                                                       ite_t_applied in
-                                                   FStar_Util.Inr uu____4584 in
-                                                 (uu____4575,
-                                                   FStar_Pervasives_Native.None) in
-                                               (t, uu____4558,
-                                                 FStar_Pervasives_Native.None) in
-                                             FStar_Syntax_Syntax.Tm_ascribed
-                                               uu____4531 in
-                                           FStar_Syntax_Syntax.mk uu____4530
-                                             r in
-                                         let uu____4625 = aux subcomp_f in
-                                         let uu____4626 = aux subcomp_g in
-                                         (uu____4625, uu____4626) in
-                                       (match uu____4513 with
-                                        | (tm_subcomp_ascribed_f,
-                                           tm_subcomp_ascribed_g) ->
-                                            ((let uu____4630 =
-                                                FStar_All.pipe_left
-                                                  (FStar_TypeChecker_Env.debug
-                                                     env)
-                                                  (FStar_Options.Other
-                                                     "LayeredEffects") in
-                                              if uu____4630
-                                              then
-                                                let uu____4635 =
-                                                  FStar_Syntax_Print.term_to_string
-                                                    tm_subcomp_ascribed_f in
-                                                let uu____4637 =
-                                                  FStar_Syntax_Print.term_to_string
-                                                    tm_subcomp_ascribed_g in
-                                                FStar_Util.print2
-                                                  "Checking the soundness of the if_then_else combinators, f: %s, g: %s\n"
-                                                  uu____4635 uu____4637
-                                              else ());
-                                             (let uu____4642 =
-                                                FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                  env tm_subcomp_ascribed_f in
-                                              match uu____4642 with
-                                              | (uu____4649, uu____4650, g_f)
-                                                  ->
-                                                  let g_f1 =
-                                                    let uu____4653 =
-                                                      FStar_TypeChecker_Env.guard_of_guard_formula
-                                                        (FStar_TypeChecker_Common.NonTrivial
-                                                           p_t) in
-                                                    FStar_TypeChecker_Env.imp_guard
-                                                      uu____4653 g_f in
-                                                  (FStar_TypeChecker_Rel.force_trivial_guard
-                                                     env g_f1;
-                                                   (let uu____4655 =
-                                                      FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                        env
-                                                        tm_subcomp_ascribed_g in
-                                                    match uu____4655 with
-                                                    | (uu____4662,
-                                                       uu____4663, g_g) ->
-                                                        let g_g1 =
-                                                          let not_p =
-                                                            let uu____4667 =
-                                                              let uu____4668
-                                                                =
-                                                                FStar_Syntax_Syntax.lid_as_fv
-                                                                  FStar_Parser_Const.not_lid
-                                                                  FStar_Syntax_Syntax.delta_constant
-                                                                  FStar_Pervasives_Native.None in
-                                                              FStar_All.pipe_right
-                                                                uu____4668
-                                                                FStar_Syntax_Syntax.fv_to_tm in
-                                                            let uu____4669 =
-                                                              let uu____4670
-                                                                =
-                                                                FStar_All.pipe_right
-                                                                  p_t
-                                                                  FStar_Syntax_Syntax.as_arg in
-                                                              [uu____4670] in
-                                                            FStar_Syntax_Syntax.mk_Tm_app
-                                                              uu____4667
-                                                              uu____4669 r in
-                                                          let uu____4703 =
-                                                            FStar_TypeChecker_Env.guard_of_guard_formula
-                                                              (FStar_TypeChecker_Common.NonTrivial
-                                                                 not_p) in
-                                                          FStar_TypeChecker_Env.imp_guard
-                                                            uu____4703 g_g in
-                                                        FStar_TypeChecker_Rel.force_trivial_guard
-                                                          env g_g1)))))))));
-                   (let tc_action env act =
-                      let env01 = env in
-                      let r =
-                        (act.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-                      if
-                        (FStar_List.length
-                           act.FStar_Syntax_Syntax.action_params)
-                          <> Prims.int_zero
-                      then
-                        (let uu____4727 =
-                           let uu____4733 =
-                             let uu____4735 =
-                               FStar_Ident.string_of_lid
-                                 ed.FStar_Syntax_Syntax.mname in
-                             let uu____4737 =
-                               FStar_Ident.string_of_lid
-                                 act.FStar_Syntax_Syntax.action_name in
-                             let uu____4739 =
-                               FStar_Syntax_Print.binders_to_string "; "
-                                 act.FStar_Syntax_Syntax.action_params in
-                             FStar_Util.format3
-                               "Action %s:%s has non-empty action params (%s)"
-                               uu____4735 uu____4737 uu____4739 in
-                           (FStar_Errors.Fatal_MalformedActionDeclaration,
-                             uu____4733) in
-                         FStar_Errors.raise_error uu____4727 r)
-                      else ();
-                      (let uu____4746 =
-                         let uu____4751 =
-                           FStar_Syntax_Subst.univ_var_opening
-                             act.FStar_Syntax_Syntax.action_univs in
-                         match uu____4751 with
-                         | (usubst, us) ->
-                             let uu____4774 =
-                               FStar_TypeChecker_Env.push_univ_vars env us in
-                             let uu____4775 =
-                               let uu___452_4776 = act in
-                               let uu____4777 =
-                                 FStar_Syntax_Subst.subst usubst
-                                   act.FStar_Syntax_Syntax.action_defn in
-                               let uu____4778 =
-                                 FStar_Syntax_Subst.subst usubst
-                                   act.FStar_Syntax_Syntax.action_typ in
+                                                            bs_except_last
+                                                            (FStar_List.map
+                                                               FStar_Pervasives_Native.snd) in
+                                                        let uu____4036 =
+                                                          let uu____4039 =
+                                                            FStar_All.pipe_right
+                                                              last_b
+                                                              FStar_List.hd in
+                                                          FStar_All.pipe_right
+                                                            uu____4039
+                                                            FStar_Pervasives_Native.snd in
+                                                        (uu____4009,
+                                                          uu____4036))
+                                               | uu____4082 ->
+                                                   failwith
+                                                     "Impossible! subcomp_ty must have been an arrow with at lease 1 binder") in
+                                        (match uu____3839 with
+                                         | (aqs_except_last, last_aq) ->
+                                             let aux t =
+                                               let tun_args =
+                                                 FStar_All.pipe_right
+                                                   aqs_except_last
+                                                   (FStar_List.map
+                                                      (fun aq ->
+                                                         (FStar_Syntax_Syntax.tun,
+                                                           aq))) in
+                                               FStar_Syntax_Syntax.mk_Tm_app
+                                                 subcomp_t1
+                                                 (FStar_List.append tun_args
+                                                    [(t, last_aq)]) r in
+                                             let uu____4193 = aux f_t in
+                                             let uu____4196 = aux g_t in
+                                             (uu____4193, uu____4196))) in
+                             (match uu____3779 with
+                              | (subcomp_f, subcomp_g) ->
+                                  let uu____4213 =
+                                    let aux t =
+                                      let uu____4230 =
+                                        let uu____4231 =
+                                          let uu____4258 =
+                                            let uu____4275 =
+                                              let uu____4284 =
+                                                FStar_Syntax_Syntax.mk_Total
+                                                  ite_t_applied in
+                                              FStar_Util.Inr uu____4284 in
+                                            (uu____4275,
+                                              FStar_Pervasives_Native.None) in
+                                          (t, uu____4258,
+                                            FStar_Pervasives_Native.None) in
+                                        FStar_Syntax_Syntax.Tm_ascribed
+                                          uu____4231 in
+                                      FStar_Syntax_Syntax.mk uu____4230 r in
+                                    let uu____4325 = aux subcomp_f in
+                                    let uu____4326 = aux subcomp_g in
+                                    (uu____4325, uu____4326) in
+                                  (match uu____4213 with
+                                   | (tm_subcomp_ascribed_f,
+                                      tm_subcomp_ascribed_g) ->
+                                       ((let uu____4330 =
+                                           FStar_All.pipe_left
+                                             (FStar_TypeChecker_Env.debug env)
+                                             (FStar_Options.Other
+                                                "LayeredEffects") in
+                                         if uu____4330
+                                         then
+                                           let uu____4335 =
+                                             FStar_Syntax_Print.term_to_string
+                                               tm_subcomp_ascribed_f in
+                                           let uu____4337 =
+                                             FStar_Syntax_Print.term_to_string
+                                               tm_subcomp_ascribed_g in
+                                           FStar_Util.print2
+                                             "Checking the soundness of the if_then_else combinators, f: %s, g: %s\n"
+                                             uu____4335 uu____4337
+                                         else ());
+                                        (let uu____4342 =
+                                           FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
+                                             env tm_subcomp_ascribed_f in
+                                         match uu____4342 with
+                                         | (uu____4349, uu____4350, g_f) ->
+                                             let g_f1 =
+                                               let uu____4353 =
+                                                 FStar_TypeChecker_Env.guard_of_guard_formula
+                                                   (FStar_TypeChecker_Common.NonTrivial
+                                                      p_t) in
+                                               FStar_TypeChecker_Env.imp_guard
+                                                 uu____4353 g_f in
+                                             (FStar_TypeChecker_Rel.force_trivial_guard
+                                                env g_f1;
+                                              (let uu____4355 =
+                                                 FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
+                                                   env tm_subcomp_ascribed_g in
+                                               match uu____4355 with
+                                               | (uu____4362, uu____4363,
+                                                  g_g) ->
+                                                   let g_g1 =
+                                                     let not_p =
+                                                       let uu____4367 =
+                                                         let uu____4368 =
+                                                           FStar_Syntax_Syntax.lid_as_fv
+                                                             FStar_Parser_Const.not_lid
+                                                             FStar_Syntax_Syntax.delta_constant
+                                                             FStar_Pervasives_Native.None in
+                                                         FStar_All.pipe_right
+                                                           uu____4368
+                                                           FStar_Syntax_Syntax.fv_to_tm in
+                                                       let uu____4369 =
+                                                         let uu____4370 =
+                                                           FStar_All.pipe_right
+                                                             p_t
+                                                             FStar_Syntax_Syntax.as_arg in
+                                                         [uu____4370] in
+                                                       FStar_Syntax_Syntax.mk_Tm_app
+                                                         uu____4367
+                                                         uu____4369 r in
+                                                     let uu____4403 =
+                                                       FStar_TypeChecker_Env.guard_of_guard_formula
+                                                         (FStar_TypeChecker_Common.NonTrivial
+                                                            not_p) in
+                                                     FStar_TypeChecker_Env.imp_guard
+                                                       uu____4403 g_g in
+                                                   FStar_TypeChecker_Rel.force_trivial_guard
+                                                     env g_g1)))))))));
+              (let tc_action env act =
+                 let env01 = env in
+                 let r =
+                   (act.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
+                 if
+                   (FStar_List.length act.FStar_Syntax_Syntax.action_params)
+                     <> Prims.int_zero
+                 then
+                   (let uu____4427 =
+                      let uu____4433 =
+                        let uu____4435 =
+                          FStar_Ident.string_of_lid
+                            ed.FStar_Syntax_Syntax.mname in
+                        let uu____4437 =
+                          FStar_Ident.string_of_lid
+                            act.FStar_Syntax_Syntax.action_name in
+                        let uu____4439 =
+                          FStar_Syntax_Print.binders_to_string "; "
+                            act.FStar_Syntax_Syntax.action_params in
+                        FStar_Util.format3
+                          "Action %s:%s has non-empty action params (%s)"
+                          uu____4435 uu____4437 uu____4439 in
+                      (FStar_Errors.Fatal_MalformedActionDeclaration,
+                        uu____4433) in
+                    FStar_Errors.raise_error uu____4427 r)
+                 else ();
+                 (let uu____4446 =
+                    let uu____4451 =
+                      FStar_Syntax_Subst.univ_var_opening
+                        act.FStar_Syntax_Syntax.action_univs in
+                    match uu____4451 with
+                    | (usubst, us) ->
+                        let uu____4474 =
+                          FStar_TypeChecker_Env.push_univ_vars env us in
+                        let uu____4475 =
+                          let uu___435_4476 = act in
+                          let uu____4477 =
+                            FStar_Syntax_Subst.subst usubst
+                              act.FStar_Syntax_Syntax.action_defn in
+                          let uu____4478 =
+                            FStar_Syntax_Subst.subst usubst
+                              act.FStar_Syntax_Syntax.action_typ in
+                          {
+                            FStar_Syntax_Syntax.action_name =
+                              (uu___435_4476.FStar_Syntax_Syntax.action_name);
+                            FStar_Syntax_Syntax.action_unqualified_name =
+                              (uu___435_4476.FStar_Syntax_Syntax.action_unqualified_name);
+                            FStar_Syntax_Syntax.action_univs = us;
+                            FStar_Syntax_Syntax.action_params =
+                              (uu___435_4476.FStar_Syntax_Syntax.action_params);
+                            FStar_Syntax_Syntax.action_defn = uu____4477;
+                            FStar_Syntax_Syntax.action_typ = uu____4478
+                          } in
+                        (uu____4474, uu____4475) in
+                  match uu____4446 with
+                  | (env1, act1) ->
+                      let act_typ =
+                        let uu____4482 =
+                          let uu____4483 =
+                            FStar_Syntax_Subst.compress
+                              act1.FStar_Syntax_Syntax.action_typ in
+                          uu____4483.FStar_Syntax_Syntax.n in
+                        match uu____4482 with
+                        | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
+                            let ct = FStar_Syntax_Util.comp_to_comp_typ c in
+                            let uu____4509 =
+                              FStar_Ident.lid_equals
+                                ct.FStar_Syntax_Syntax.effect_name
+                                ed.FStar_Syntax_Syntax.mname in
+                            if uu____4509
+                            then
+                              let repr_ts =
+                                let uu____4513 = repr in
+                                match uu____4513 with
+                                | (us, t, uu____4528) -> (us, t) in
+                              let repr1 =
+                                let uu____4546 =
+                                  FStar_TypeChecker_Env.inst_tscheme_with
+                                    repr_ts ct.FStar_Syntax_Syntax.comp_univs in
+                                FStar_All.pipe_right uu____4546
+                                  FStar_Pervasives_Native.snd in
+                              let repr2 =
+                                let uu____4556 =
+                                  let uu____4557 =
+                                    FStar_Syntax_Syntax.as_arg
+                                      ct.FStar_Syntax_Syntax.result_typ in
+                                  uu____4557 ::
+                                    (ct.FStar_Syntax_Syntax.effect_args) in
+                                FStar_Syntax_Syntax.mk_Tm_app repr1
+                                  uu____4556 r in
+                              let c1 =
+                                let uu____4575 =
+                                  let uu____4578 =
+                                    FStar_TypeChecker_Env.new_u_univ () in
+                                  FStar_Pervasives_Native.Some uu____4578 in
+                                FStar_Syntax_Syntax.mk_Total' repr2
+                                  uu____4575 in
+                              FStar_Syntax_Util.arrow bs c1
+                            else act1.FStar_Syntax_Syntax.action_typ
+                        | uu____4581 -> act1.FStar_Syntax_Syntax.action_typ in
+                      let uu____4582 =
+                        FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env1
+                          act_typ in
+                      (match uu____4582 with
+                       | (act_typ1, uu____4590, g_t) ->
+                           let uu____4592 =
+                             let uu____4599 =
+                               let uu___460_4600 =
+                                 FStar_TypeChecker_Env.set_expected_typ env1
+                                   act_typ1 in
                                {
-                                 FStar_Syntax_Syntax.action_name =
-                                   (uu___452_4776.FStar_Syntax_Syntax.action_name);
-                                 FStar_Syntax_Syntax.action_unqualified_name
+                                 FStar_TypeChecker_Env.solver =
+                                   (uu___460_4600.FStar_TypeChecker_Env.solver);
+                                 FStar_TypeChecker_Env.range =
+                                   (uu___460_4600.FStar_TypeChecker_Env.range);
+                                 FStar_TypeChecker_Env.curmodule =
+                                   (uu___460_4600.FStar_TypeChecker_Env.curmodule);
+                                 FStar_TypeChecker_Env.gamma =
+                                   (uu___460_4600.FStar_TypeChecker_Env.gamma);
+                                 FStar_TypeChecker_Env.gamma_sig =
+                                   (uu___460_4600.FStar_TypeChecker_Env.gamma_sig);
+                                 FStar_TypeChecker_Env.gamma_cache =
+                                   (uu___460_4600.FStar_TypeChecker_Env.gamma_cache);
+                                 FStar_TypeChecker_Env.modules =
+                                   (uu___460_4600.FStar_TypeChecker_Env.modules);
+                                 FStar_TypeChecker_Env.expected_typ =
+                                   (uu___460_4600.FStar_TypeChecker_Env.expected_typ);
+                                 FStar_TypeChecker_Env.sigtab =
+                                   (uu___460_4600.FStar_TypeChecker_Env.sigtab);
+                                 FStar_TypeChecker_Env.attrtab =
+                                   (uu___460_4600.FStar_TypeChecker_Env.attrtab);
+                                 FStar_TypeChecker_Env.instantiate_imp =
+                                   false;
+                                 FStar_TypeChecker_Env.effects =
+                                   (uu___460_4600.FStar_TypeChecker_Env.effects);
+                                 FStar_TypeChecker_Env.generalize =
+                                   (uu___460_4600.FStar_TypeChecker_Env.generalize);
+                                 FStar_TypeChecker_Env.letrecs =
+                                   (uu___460_4600.FStar_TypeChecker_Env.letrecs);
+                                 FStar_TypeChecker_Env.top_level =
+                                   (uu___460_4600.FStar_TypeChecker_Env.top_level);
+                                 FStar_TypeChecker_Env.check_uvars =
+                                   (uu___460_4600.FStar_TypeChecker_Env.check_uvars);
+                                 FStar_TypeChecker_Env.use_eq =
+                                   (uu___460_4600.FStar_TypeChecker_Env.use_eq);
+                                 FStar_TypeChecker_Env.use_eq_strict =
+                                   (uu___460_4600.FStar_TypeChecker_Env.use_eq_strict);
+                                 FStar_TypeChecker_Env.is_iface =
+                                   (uu___460_4600.FStar_TypeChecker_Env.is_iface);
+                                 FStar_TypeChecker_Env.admit =
+                                   (uu___460_4600.FStar_TypeChecker_Env.admit);
+                                 FStar_TypeChecker_Env.lax =
+                                   (uu___460_4600.FStar_TypeChecker_Env.lax);
+                                 FStar_TypeChecker_Env.lax_universes =
+                                   (uu___460_4600.FStar_TypeChecker_Env.lax_universes);
+                                 FStar_TypeChecker_Env.phase1 =
+                                   (uu___460_4600.FStar_TypeChecker_Env.phase1);
+                                 FStar_TypeChecker_Env.failhard =
+                                   (uu___460_4600.FStar_TypeChecker_Env.failhard);
+                                 FStar_TypeChecker_Env.nosynth =
+                                   (uu___460_4600.FStar_TypeChecker_Env.nosynth);
+                                 FStar_TypeChecker_Env.uvar_subtyping =
+                                   (uu___460_4600.FStar_TypeChecker_Env.uvar_subtyping);
+                                 FStar_TypeChecker_Env.tc_term =
+                                   (uu___460_4600.FStar_TypeChecker_Env.tc_term);
+                                 FStar_TypeChecker_Env.type_of =
+                                   (uu___460_4600.FStar_TypeChecker_Env.type_of);
+                                 FStar_TypeChecker_Env.universe_of =
+                                   (uu___460_4600.FStar_TypeChecker_Env.universe_of);
+                                 FStar_TypeChecker_Env.check_type_of =
+                                   (uu___460_4600.FStar_TypeChecker_Env.check_type_of);
+                                 FStar_TypeChecker_Env.use_bv_sorts =
+                                   (uu___460_4600.FStar_TypeChecker_Env.use_bv_sorts);
+                                 FStar_TypeChecker_Env.qtbl_name_and_index =
+                                   (uu___460_4600.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                 FStar_TypeChecker_Env.normalized_eff_names =
+                                   (uu___460_4600.FStar_TypeChecker_Env.normalized_eff_names);
+                                 FStar_TypeChecker_Env.fv_delta_depths =
+                                   (uu___460_4600.FStar_TypeChecker_Env.fv_delta_depths);
+                                 FStar_TypeChecker_Env.proof_ns =
+                                   (uu___460_4600.FStar_TypeChecker_Env.proof_ns);
+                                 FStar_TypeChecker_Env.synth_hook =
+                                   (uu___460_4600.FStar_TypeChecker_Env.synth_hook);
+                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                    =
-                                   (uu___452_4776.FStar_Syntax_Syntax.action_unqualified_name);
-                                 FStar_Syntax_Syntax.action_univs = us;
-                                 FStar_Syntax_Syntax.action_params =
-                                   (uu___452_4776.FStar_Syntax_Syntax.action_params);
-                                 FStar_Syntax_Syntax.action_defn = uu____4777;
-                                 FStar_Syntax_Syntax.action_typ = uu____4778
+                                   (uu___460_4600.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                 FStar_TypeChecker_Env.splice =
+                                   (uu___460_4600.FStar_TypeChecker_Env.splice);
+                                 FStar_TypeChecker_Env.mpreprocess =
+                                   (uu___460_4600.FStar_TypeChecker_Env.mpreprocess);
+                                 FStar_TypeChecker_Env.postprocess =
+                                   (uu___460_4600.FStar_TypeChecker_Env.postprocess);
+                                 FStar_TypeChecker_Env.identifier_info =
+                                   (uu___460_4600.FStar_TypeChecker_Env.identifier_info);
+                                 FStar_TypeChecker_Env.tc_hooks =
+                                   (uu___460_4600.FStar_TypeChecker_Env.tc_hooks);
+                                 FStar_TypeChecker_Env.dsenv =
+                                   (uu___460_4600.FStar_TypeChecker_Env.dsenv);
+                                 FStar_TypeChecker_Env.nbe =
+                                   (uu___460_4600.FStar_TypeChecker_Env.nbe);
+                                 FStar_TypeChecker_Env.strict_args_tab =
+                                   (uu___460_4600.FStar_TypeChecker_Env.strict_args_tab);
+                                 FStar_TypeChecker_Env.erasable_types_tab =
+                                   (uu___460_4600.FStar_TypeChecker_Env.erasable_types_tab);
+                                 FStar_TypeChecker_Env.enable_defer_to_tac =
+                                   (uu___460_4600.FStar_TypeChecker_Env.enable_defer_to_tac)
                                } in
-                             (uu____4774, uu____4775) in
-                       match uu____4746 with
-                       | (env1, act1) ->
-                           let act_typ =
-                             let uu____4782 =
-                               let uu____4783 =
-                                 FStar_Syntax_Subst.compress
-                                   act1.FStar_Syntax_Syntax.action_typ in
-                               uu____4783.FStar_Syntax_Syntax.n in
-                             match uu____4782 with
-                             | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                                 let ct =
-                                   FStar_Syntax_Util.comp_to_comp_typ c in
-                                 let uu____4809 =
-                                   FStar_Ident.lid_equals
-                                     ct.FStar_Syntax_Syntax.effect_name
-                                     ed.FStar_Syntax_Syntax.mname in
-                                 if uu____4809
-                                 then
-                                   let repr_ts =
-                                     let uu____4813 = repr in
-                                     match uu____4813 with
-                                     | (us, t, uu____4828) -> (us, t) in
-                                   let repr1 =
-                                     let uu____4846 =
-                                       FStar_TypeChecker_Env.inst_tscheme_with
-                                         repr_ts
-                                         ct.FStar_Syntax_Syntax.comp_univs in
-                                     FStar_All.pipe_right uu____4846
-                                       FStar_Pervasives_Native.snd in
-                                   let repr2 =
-                                     let uu____4856 =
-                                       let uu____4857 =
-                                         FStar_Syntax_Syntax.as_arg
-                                           ct.FStar_Syntax_Syntax.result_typ in
-                                       uu____4857 ::
-                                         (ct.FStar_Syntax_Syntax.effect_args) in
-                                     FStar_Syntax_Syntax.mk_Tm_app repr1
-                                       uu____4856 r in
-                                   let c1 =
-                                     let uu____4875 =
-                                       let uu____4878 =
-                                         FStar_TypeChecker_Env.new_u_univ () in
-                                       FStar_Pervasives_Native.Some
-                                         uu____4878 in
-                                     FStar_Syntax_Syntax.mk_Total' repr2
-                                       uu____4875 in
-                                   FStar_Syntax_Util.arrow bs c1
-                                 else act1.FStar_Syntax_Syntax.action_typ
-                             | uu____4881 ->
-                                 act1.FStar_Syntax_Syntax.action_typ in
-                           let uu____4882 =
                              FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                               env1 act_typ in
-                           (match uu____4882 with
-                            | (act_typ1, uu____4890, g_t) ->
-                                let uu____4892 =
-                                  let uu____4899 =
-                                    let uu___477_4900 =
-                                      FStar_TypeChecker_Env.set_expected_typ
-                                        env1 act_typ1 in
-                                    {
-                                      FStar_TypeChecker_Env.solver =
-                                        (uu___477_4900.FStar_TypeChecker_Env.solver);
-                                      FStar_TypeChecker_Env.range =
-                                        (uu___477_4900.FStar_TypeChecker_Env.range);
-                                      FStar_TypeChecker_Env.curmodule =
-                                        (uu___477_4900.FStar_TypeChecker_Env.curmodule);
-                                      FStar_TypeChecker_Env.gamma =
-                                        (uu___477_4900.FStar_TypeChecker_Env.gamma);
-                                      FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___477_4900.FStar_TypeChecker_Env.gamma_sig);
-                                      FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___477_4900.FStar_TypeChecker_Env.gamma_cache);
-                                      FStar_TypeChecker_Env.modules =
-                                        (uu___477_4900.FStar_TypeChecker_Env.modules);
-                                      FStar_TypeChecker_Env.expected_typ =
-                                        (uu___477_4900.FStar_TypeChecker_Env.expected_typ);
-                                      FStar_TypeChecker_Env.sigtab =
-                                        (uu___477_4900.FStar_TypeChecker_Env.sigtab);
-                                      FStar_TypeChecker_Env.attrtab =
-                                        (uu___477_4900.FStar_TypeChecker_Env.attrtab);
-                                      FStar_TypeChecker_Env.instantiate_imp =
-                                        false;
-                                      FStar_TypeChecker_Env.effects =
-                                        (uu___477_4900.FStar_TypeChecker_Env.effects);
-                                      FStar_TypeChecker_Env.generalize =
-                                        (uu___477_4900.FStar_TypeChecker_Env.generalize);
-                                      FStar_TypeChecker_Env.letrecs =
-                                        (uu___477_4900.FStar_TypeChecker_Env.letrecs);
-                                      FStar_TypeChecker_Env.top_level =
-                                        (uu___477_4900.FStar_TypeChecker_Env.top_level);
-                                      FStar_TypeChecker_Env.check_uvars =
-                                        (uu___477_4900.FStar_TypeChecker_Env.check_uvars);
-                                      FStar_TypeChecker_Env.use_eq =
-                                        (uu___477_4900.FStar_TypeChecker_Env.use_eq);
-                                      FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___477_4900.FStar_TypeChecker_Env.use_eq_strict);
-                                      FStar_TypeChecker_Env.is_iface =
-                                        (uu___477_4900.FStar_TypeChecker_Env.is_iface);
-                                      FStar_TypeChecker_Env.admit =
-                                        (uu___477_4900.FStar_TypeChecker_Env.admit);
-                                      FStar_TypeChecker_Env.lax =
-                                        (uu___477_4900.FStar_TypeChecker_Env.lax);
-                                      FStar_TypeChecker_Env.lax_universes =
-                                        (uu___477_4900.FStar_TypeChecker_Env.lax_universes);
-                                      FStar_TypeChecker_Env.phase1 =
-                                        (uu___477_4900.FStar_TypeChecker_Env.phase1);
-                                      FStar_TypeChecker_Env.failhard =
-                                        (uu___477_4900.FStar_TypeChecker_Env.failhard);
-                                      FStar_TypeChecker_Env.nosynth =
-                                        (uu___477_4900.FStar_TypeChecker_Env.nosynth);
-                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___477_4900.FStar_TypeChecker_Env.uvar_subtyping);
-                                      FStar_TypeChecker_Env.tc_term =
-                                        (uu___477_4900.FStar_TypeChecker_Env.tc_term);
-                                      FStar_TypeChecker_Env.type_of =
-                                        (uu___477_4900.FStar_TypeChecker_Env.type_of);
-                                      FStar_TypeChecker_Env.universe_of =
-                                        (uu___477_4900.FStar_TypeChecker_Env.universe_of);
-                                      FStar_TypeChecker_Env.check_type_of =
-                                        (uu___477_4900.FStar_TypeChecker_Env.check_type_of);
-                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___477_4900.FStar_TypeChecker_Env.use_bv_sorts);
-                                      FStar_TypeChecker_Env.qtbl_name_and_index
-                                        =
-                                        (uu___477_4900.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                      FStar_TypeChecker_Env.normalized_eff_names
-                                        =
-                                        (uu___477_4900.FStar_TypeChecker_Env.normalized_eff_names);
-                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___477_4900.FStar_TypeChecker_Env.fv_delta_depths);
-                                      FStar_TypeChecker_Env.proof_ns =
-                                        (uu___477_4900.FStar_TypeChecker_Env.proof_ns);
-                                      FStar_TypeChecker_Env.synth_hook =
-                                        (uu___477_4900.FStar_TypeChecker_Env.synth_hook);
-                                      FStar_TypeChecker_Env.try_solve_implicits_hook
-                                        =
-                                        (uu___477_4900.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                                      FStar_TypeChecker_Env.splice =
-                                        (uu___477_4900.FStar_TypeChecker_Env.splice);
-                                      FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___477_4900.FStar_TypeChecker_Env.mpreprocess);
-                                      FStar_TypeChecker_Env.postprocess =
-                                        (uu___477_4900.FStar_TypeChecker_Env.postprocess);
-                                      FStar_TypeChecker_Env.identifier_info =
-                                        (uu___477_4900.FStar_TypeChecker_Env.identifier_info);
-                                      FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___477_4900.FStar_TypeChecker_Env.tc_hooks);
-                                      FStar_TypeChecker_Env.dsenv =
-                                        (uu___477_4900.FStar_TypeChecker_Env.dsenv);
-                                      FStar_TypeChecker_Env.nbe =
-                                        (uu___477_4900.FStar_TypeChecker_Env.nbe);
-                                      FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___477_4900.FStar_TypeChecker_Env.strict_args_tab);
-                                      FStar_TypeChecker_Env.erasable_types_tab
-                                        =
-                                        (uu___477_4900.FStar_TypeChecker_Env.erasable_types_tab);
-                                      FStar_TypeChecker_Env.enable_defer_to_tac
-                                        =
-                                        (uu___477_4900.FStar_TypeChecker_Env.enable_defer_to_tac)
-                                    } in
-                                  FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                    uu____4899
-                                    act1.FStar_Syntax_Syntax.action_defn in
-                                (match uu____4892 with
-                                 | (act_defn, uu____4903, g_d) ->
-                                     ((let uu____4906 =
-                                         FStar_All.pipe_left
-                                           (FStar_TypeChecker_Env.debug env1)
-                                           (FStar_Options.Other
-                                              "LayeredEffects") in
-                                       if uu____4906
-                                       then
-                                         let uu____4911 =
-                                           FStar_Syntax_Print.term_to_string
-                                             act_defn in
-                                         let uu____4913 =
-                                           FStar_Syntax_Print.term_to_string
-                                             act_typ1 in
-                                         FStar_Util.print2
-                                           "Typechecked action definition: %s and action type: %s\n"
-                                           uu____4911 uu____4913
-                                       else ());
-                                      (let uu____4918 =
-                                         let act_typ2 =
-                                           FStar_TypeChecker_Normalize.normalize
-                                             [FStar_TypeChecker_Env.Beta]
-                                             env1 act_typ1 in
-                                         let uu____4926 =
-                                           let uu____4927 =
-                                             FStar_Syntax_Subst.compress
-                                               act_typ2 in
-                                           uu____4927.FStar_Syntax_Syntax.n in
-                                         match uu____4926 with
-                                         | FStar_Syntax_Syntax.Tm_arrow
-                                             (bs, uu____4937) ->
-                                             let bs1 =
-                                               FStar_Syntax_Subst.open_binders
-                                                 bs in
-                                             let env2 =
-                                               FStar_TypeChecker_Env.push_binders
-                                                 env1 bs1 in
-                                             let uu____4960 =
-                                               FStar_Syntax_Util.type_u () in
-                                             (match uu____4960 with
-                                              | (t, u) ->
-                                                  let reason =
-                                                    let uu____4975 =
-                                                      FStar_Ident.string_of_lid
-                                                        ed.FStar_Syntax_Syntax.mname in
-                                                    let uu____4977 =
-                                                      FStar_Ident.string_of_lid
-                                                        act1.FStar_Syntax_Syntax.action_name in
-                                                    FStar_Util.format2
-                                                      "implicit for return type of action %s:%s"
-                                                      uu____4975 uu____4977 in
-                                                  let uu____4980 =
-                                                    FStar_TypeChecker_Util.new_implicit_var
-                                                      reason r env2 t in
-                                                  (match uu____4980 with
-                                                   | (a_tm, uu____5000, g_tm)
-                                                       ->
-                                                       let uu____5014 =
-                                                         fresh_repr r env2 u
-                                                           a_tm in
-                                                       (match uu____5014 with
-                                                        | (repr1, g) ->
-                                                            let uu____5027 =
-                                                              let uu____5030
-                                                                =
-                                                                let uu____5033
-                                                                  =
-                                                                  let uu____5036
-                                                                    =
-                                                                    FStar_TypeChecker_Env.new_u_univ
-                                                                    () in
-                                                                  FStar_All.pipe_right
-                                                                    uu____5036
-                                                                    (
-                                                                    fun
-                                                                    uu____5039
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu____5039) in
-                                                                FStar_Syntax_Syntax.mk_Total'
-                                                                  repr1
-                                                                  uu____5033 in
-                                                              FStar_Syntax_Util.arrow
-                                                                bs1
-                                                                uu____5030 in
-                                                            let uu____5040 =
-                                                              FStar_TypeChecker_Env.conj_guard
-                                                                g g_tm in
-                                                            (uu____5027,
-                                                              uu____5040))))
-                                         | uu____5043 ->
-                                             let uu____5044 =
-                                               let uu____5050 =
-                                                 let uu____5052 =
-                                                   FStar_Ident.string_of_lid
-                                                     ed.FStar_Syntax_Syntax.mname in
-                                                 let uu____5054 =
-                                                   FStar_Ident.string_of_lid
-                                                     act1.FStar_Syntax_Syntax.action_name in
-                                                 let uu____5056 =
-                                                   FStar_Syntax_Print.term_to_string
-                                                     act_typ2 in
-                                                 FStar_Util.format3
-                                                   "Unexpected non-function type for action %s:%s (%s)"
-                                                   uu____5052 uu____5054
-                                                   uu____5056 in
-                                               (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                 uu____5050) in
-                                             FStar_Errors.raise_error
-                                               uu____5044 r in
-                                       match uu____4918 with
-                                       | (k, g_k) ->
-                                           ((let uu____5073 =
-                                               FStar_All.pipe_left
-                                                 (FStar_TypeChecker_Env.debug
-                                                    env1)
-                                                 (FStar_Options.Other
-                                                    "LayeredEffects") in
-                                             if uu____5073
-                                             then
-                                               let uu____5078 =
-                                                 FStar_Syntax_Print.term_to_string
-                                                   k in
-                                               FStar_Util.print1
-                                                 "Expected action type: %s\n"
-                                                 uu____5078
-                                             else ());
-                                            (let g =
-                                               FStar_TypeChecker_Rel.teq env1
-                                                 act_typ1 k in
-                                             FStar_List.iter
-                                               (FStar_TypeChecker_Rel.force_trivial_guard
-                                                  env1) [g_t; g_d; g_k; g];
-                                             (let uu____5086 =
-                                                FStar_All.pipe_left
-                                                  (FStar_TypeChecker_Env.debug
-                                                     env1)
-                                                  (FStar_Options.Other
-                                                     "LayeredEffects") in
-                                              if uu____5086
-                                              then
-                                                let uu____5091 =
-                                                  FStar_Syntax_Print.term_to_string
-                                                    k in
-                                                FStar_Util.print1
-                                                  "Expected action type after unification: %s\n"
-                                                  uu____5091
-                                              else ());
-                                             (let act_typ2 =
-                                                let err_msg t =
-                                                  let uu____5104 =
-                                                    FStar_Ident.string_of_lid
-                                                      ed.FStar_Syntax_Syntax.mname in
-                                                  let uu____5106 =
-                                                    FStar_Ident.string_of_lid
-                                                      act1.FStar_Syntax_Syntax.action_name in
-                                                  let uu____5108 =
-                                                    FStar_Syntax_Print.term_to_string
-                                                      t in
-                                                  FStar_Util.format3
-                                                    "Unexpected (k-)type of action %s:%s, expected bs -> repr<u> i_1 ... i_n, found: %s"
-                                                    uu____5104 uu____5106
-                                                    uu____5108 in
-                                                let repr_args t =
-                                                  let uu____5129 =
-                                                    let uu____5130 =
-                                                      FStar_Syntax_Subst.compress
-                                                        t in
-                                                    uu____5130.FStar_Syntax_Syntax.n in
-                                                  match uu____5129 with
-                                                  | FStar_Syntax_Syntax.Tm_app
-                                                      (head, a::is) ->
-                                                      let uu____5182 =
-                                                        let uu____5183 =
-                                                          FStar_Syntax_Subst.compress
-                                                            head in
-                                                        uu____5183.FStar_Syntax_Syntax.n in
-                                                      (match uu____5182 with
-                                                       | FStar_Syntax_Syntax.Tm_uinst
-                                                           (uu____5192, us)
-                                                           ->
-                                                           (us,
-                                                             (FStar_Pervasives_Native.fst
-                                                                a), is)
-                                                       | uu____5202 ->
-                                                           let uu____5203 =
-                                                             let uu____5209 =
-                                                               err_msg t in
-                                                             (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                               uu____5209) in
-                                                           FStar_Errors.raise_error
-                                                             uu____5203 r)
-                                                  | uu____5218 ->
-                                                      let uu____5219 =
-                                                        let uu____5225 =
+                               uu____4599
+                               act1.FStar_Syntax_Syntax.action_defn in
+                           (match uu____4592 with
+                            | (act_defn, uu____4603, g_d) ->
+                                ((let uu____4606 =
+                                    FStar_All.pipe_left
+                                      (FStar_TypeChecker_Env.debug env1)
+                                      (FStar_Options.Other "LayeredEffects") in
+                                  if uu____4606
+                                  then
+                                    let uu____4611 =
+                                      FStar_Syntax_Print.term_to_string
+                                        act_defn in
+                                    let uu____4613 =
+                                      FStar_Syntax_Print.term_to_string
+                                        act_typ1 in
+                                    FStar_Util.print2
+                                      "Typechecked action definition: %s and action type: %s\n"
+                                      uu____4611 uu____4613
+                                  else ());
+                                 (let uu____4618 =
+                                    let act_typ2 =
+                                      FStar_TypeChecker_Normalize.normalize
+                                        [FStar_TypeChecker_Env.Beta] env1
+                                        act_typ1 in
+                                    let uu____4626 =
+                                      let uu____4627 =
+                                        FStar_Syntax_Subst.compress act_typ2 in
+                                      uu____4627.FStar_Syntax_Syntax.n in
+                                    match uu____4626 with
+                                    | FStar_Syntax_Syntax.Tm_arrow
+                                        (bs, uu____4637) ->
+                                        let bs1 =
+                                          FStar_Syntax_Subst.open_binders bs in
+                                        let env2 =
+                                          FStar_TypeChecker_Env.push_binders
+                                            env1 bs1 in
+                                        let uu____4660 =
+                                          FStar_Syntax_Util.type_u () in
+                                        (match uu____4660 with
+                                         | (t, u) ->
+                                             let reason =
+                                               let uu____4675 =
+                                                 FStar_Ident.string_of_lid
+                                                   ed.FStar_Syntax_Syntax.mname in
+                                               let uu____4677 =
+                                                 FStar_Ident.string_of_lid
+                                                   act1.FStar_Syntax_Syntax.action_name in
+                                               FStar_Util.format2
+                                                 "implicit for return type of action %s:%s"
+                                                 uu____4675 uu____4677 in
+                                             let uu____4680 =
+                                               FStar_TypeChecker_Util.new_implicit_var
+                                                 reason r env2 t in
+                                             (match uu____4680 with
+                                              | (a_tm, uu____4700, g_tm) ->
+                                                  let uu____4714 =
+                                                    fresh_repr r env2 u a_tm in
+                                                  (match uu____4714 with
+                                                   | (repr1, g) ->
+                                                       let uu____4727 =
+                                                         let uu____4730 =
+                                                           let uu____4733 =
+                                                             let uu____4736 =
+                                                               FStar_TypeChecker_Env.new_u_univ
+                                                                 () in
+                                                             FStar_All.pipe_right
+                                                               uu____4736
+                                                               (fun
+                                                                  uu____4739
+                                                                  ->
+                                                                  FStar_Pervasives_Native.Some
+                                                                    uu____4739) in
+                                                           FStar_Syntax_Syntax.mk_Total'
+                                                             repr1 uu____4733 in
+                                                         FStar_Syntax_Util.arrow
+                                                           bs1 uu____4730 in
+                                                       let uu____4740 =
+                                                         FStar_TypeChecker_Env.conj_guard
+                                                           g g_tm in
+                                                       (uu____4727,
+                                                         uu____4740))))
+                                    | uu____4743 ->
+                                        let uu____4744 =
+                                          let uu____4750 =
+                                            let uu____4752 =
+                                              FStar_Ident.string_of_lid
+                                                ed.FStar_Syntax_Syntax.mname in
+                                            let uu____4754 =
+                                              FStar_Ident.string_of_lid
+                                                act1.FStar_Syntax_Syntax.action_name in
+                                            let uu____4756 =
+                                              FStar_Syntax_Print.term_to_string
+                                                act_typ2 in
+                                            FStar_Util.format3
+                                              "Unexpected non-function type for action %s:%s (%s)"
+                                              uu____4752 uu____4754
+                                              uu____4756 in
+                                          (FStar_Errors.Fatal_ActionMustHaveFunctionType,
+                                            uu____4750) in
+                                        FStar_Errors.raise_error uu____4744 r in
+                                  match uu____4618 with
+                                  | (k, g_k) ->
+                                      ((let uu____4773 =
+                                          FStar_All.pipe_left
+                                            (FStar_TypeChecker_Env.debug env1)
+                                            (FStar_Options.Other
+                                               "LayeredEffects") in
+                                        if uu____4773
+                                        then
+                                          let uu____4778 =
+                                            FStar_Syntax_Print.term_to_string
+                                              k in
+                                          FStar_Util.print1
+                                            "Expected action type: %s\n"
+                                            uu____4778
+                                        else ());
+                                       (let g =
+                                          FStar_TypeChecker_Rel.teq env1
+                                            act_typ1 k in
+                                        FStar_List.iter
+                                          (FStar_TypeChecker_Rel.force_trivial_guard
+                                             env1) [g_t; g_d; g_k; g];
+                                        (let uu____4786 =
+                                           FStar_All.pipe_left
+                                             (FStar_TypeChecker_Env.debug
+                                                env1)
+                                             (FStar_Options.Other
+                                                "LayeredEffects") in
+                                         if uu____4786
+                                         then
+                                           let uu____4791 =
+                                             FStar_Syntax_Print.term_to_string
+                                               k in
+                                           FStar_Util.print1
+                                             "Expected action type after unification: %s\n"
+                                             uu____4791
+                                         else ());
+                                        (let act_typ2 =
+                                           let err_msg t =
+                                             let uu____4804 =
+                                               FStar_Ident.string_of_lid
+                                                 ed.FStar_Syntax_Syntax.mname in
+                                             let uu____4806 =
+                                               FStar_Ident.string_of_lid
+                                                 act1.FStar_Syntax_Syntax.action_name in
+                                             let uu____4808 =
+                                               FStar_Syntax_Print.term_to_string
+                                                 t in
+                                             FStar_Util.format3
+                                               "Unexpected (k-)type of action %s:%s, expected bs -> repr<u> i_1 ... i_n, found: %s"
+                                               uu____4804 uu____4806
+                                               uu____4808 in
+                                           let repr_args t =
+                                             let uu____4829 =
+                                               let uu____4830 =
+                                                 FStar_Syntax_Subst.compress
+                                                   t in
+                                               uu____4830.FStar_Syntax_Syntax.n in
+                                             match uu____4829 with
+                                             | FStar_Syntax_Syntax.Tm_app
+                                                 (head, a::is) ->
+                                                 let uu____4882 =
+                                                   let uu____4883 =
+                                                     FStar_Syntax_Subst.compress
+                                                       head in
+                                                   uu____4883.FStar_Syntax_Syntax.n in
+                                                 (match uu____4882 with
+                                                  | FStar_Syntax_Syntax.Tm_uinst
+                                                      (uu____4892, us) ->
+                                                      (us,
+                                                        (FStar_Pervasives_Native.fst
+                                                           a), is)
+                                                  | uu____4902 ->
+                                                      let uu____4903 =
+                                                        let uu____4909 =
                                                           err_msg t in
                                                         (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                          uu____5225) in
+                                                          uu____4909) in
                                                       FStar_Errors.raise_error
-                                                        uu____5219 r in
-                                                let k1 =
-                                                  FStar_TypeChecker_Normalize.normalize
-                                                    [FStar_TypeChecker_Env.Beta]
-                                                    env1 k in
-                                                let uu____5235 =
-                                                  let uu____5236 =
-                                                    FStar_Syntax_Subst.compress
-                                                      k1 in
-                                                  uu____5236.FStar_Syntax_Syntax.n in
-                                                match uu____5235 with
-                                                | FStar_Syntax_Syntax.Tm_arrow
-                                                    (bs, c) ->
-                                                    let uu____5261 =
-                                                      FStar_Syntax_Subst.open_comp
-                                                        bs c in
-                                                    (match uu____5261 with
-                                                     | (bs1, c1) ->
-                                                         let uu____5268 =
-                                                           repr_args
-                                                             (FStar_Syntax_Util.comp_result
-                                                                c1) in
-                                                         (match uu____5268
-                                                          with
-                                                          | (us, a, is) ->
-                                                              let ct =
-                                                                {
-                                                                  FStar_Syntax_Syntax.comp_univs
-                                                                    = us;
-                                                                  FStar_Syntax_Syntax.effect_name
-                                                                    =
-                                                                    (
-                                                                    ed.FStar_Syntax_Syntax.mname);
-                                                                  FStar_Syntax_Syntax.result_typ
-                                                                    = a;
-                                                                  FStar_Syntax_Syntax.effect_args
-                                                                    = is;
-                                                                  FStar_Syntax_Syntax.flags
-                                                                    = []
-                                                                } in
-                                                              let uu____5279
-                                                                =
-                                                                FStar_Syntax_Syntax.mk_Comp
-                                                                  ct in
-                                                              FStar_Syntax_Util.arrow
-                                                                bs1
-                                                                uu____5279))
-                                                | uu____5282 ->
-                                                    let uu____5283 =
-                                                      let uu____5289 =
-                                                        err_msg k1 in
-                                                      (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                        uu____5289) in
-                                                    FStar_Errors.raise_error
-                                                      uu____5283 r in
-                                              (let uu____5293 =
-                                                 FStar_All.pipe_left
-                                                   (FStar_TypeChecker_Env.debug
-                                                      env1)
-                                                   (FStar_Options.Other
-                                                      "LayeredEffects") in
-                                               if uu____5293
-                                               then
-                                                 let uu____5298 =
-                                                   FStar_Syntax_Print.term_to_string
-                                                     act_typ2 in
-                                                 FStar_Util.print1
-                                                   "Action type after injecting it into the monad: %s\n"
-                                                   uu____5298
-                                               else ());
-                                              (let act2 =
-                                                 let uu____5304 =
-                                                   FStar_TypeChecker_Util.generalize_universes
-                                                     env1 act_defn in
-                                                 match uu____5304 with
-                                                 | (us, act_defn1) ->
-                                                     if
-                                                       act1.FStar_Syntax_Syntax.action_univs
-                                                         = []
-                                                     then
-                                                       let uu___550_5318 =
-                                                         act1 in
-                                                       let uu____5319 =
-                                                         FStar_Syntax_Subst.close_univ_vars
-                                                           us act_typ2 in
-                                                       {
-                                                         FStar_Syntax_Syntax.action_name
-                                                           =
-                                                           (uu___550_5318.FStar_Syntax_Syntax.action_name);
-                                                         FStar_Syntax_Syntax.action_unqualified_name
-                                                           =
-                                                           (uu___550_5318.FStar_Syntax_Syntax.action_unqualified_name);
-                                                         FStar_Syntax_Syntax.action_univs
-                                                           = us;
-                                                         FStar_Syntax_Syntax.action_params
-                                                           =
-                                                           (uu___550_5318.FStar_Syntax_Syntax.action_params);
-                                                         FStar_Syntax_Syntax.action_defn
-                                                           = act_defn1;
-                                                         FStar_Syntax_Syntax.action_typ
-                                                           = uu____5319
-                                                       }
-                                                     else
-                                                       (let uu____5322 =
-                                                          ((FStar_List.length
-                                                              us)
-                                                             =
-                                                             (FStar_List.length
-                                                                act1.FStar_Syntax_Syntax.action_univs))
-                                                            &&
-                                                            (FStar_List.forall2
-                                                               (fun u1 ->
-                                                                  fun u2 ->
-                                                                    let uu____5329
-                                                                    =
-                                                                    FStar_Syntax_Syntax.order_univ_name
-                                                                    u1 u2 in
-                                                                    uu____5329
-                                                                    =
-                                                                    Prims.int_zero)
-                                                               us
-                                                               act1.FStar_Syntax_Syntax.action_univs) in
-                                                        if uu____5322
-                                                        then
-                                                          let uu___555_5334 =
-                                                            act1 in
-                                                          let uu____5335 =
-                                                            FStar_Syntax_Subst.close_univ_vars
-                                                              act1.FStar_Syntax_Syntax.action_univs
-                                                              act_typ2 in
-                                                          {
-                                                            FStar_Syntax_Syntax.action_name
-                                                              =
-                                                              (uu___555_5334.FStar_Syntax_Syntax.action_name);
-                                                            FStar_Syntax_Syntax.action_unqualified_name
-                                                              =
-                                                              (uu___555_5334.FStar_Syntax_Syntax.action_unqualified_name);
-                                                            FStar_Syntax_Syntax.action_univs
-                                                              =
-                                                              (uu___555_5334.FStar_Syntax_Syntax.action_univs);
-                                                            FStar_Syntax_Syntax.action_params
-                                                              =
-                                                              (uu___555_5334.FStar_Syntax_Syntax.action_params);
-                                                            FStar_Syntax_Syntax.action_defn
-                                                              = act_defn1;
-                                                            FStar_Syntax_Syntax.action_typ
-                                                              = uu____5335
-                                                          }
-                                                        else
-                                                          (let uu____5338 =
-                                                             let uu____5344 =
-                                                               let uu____5346
+                                                        uu____4903 r)
+                                             | uu____4918 ->
+                                                 let uu____4919 =
+                                                   let uu____4925 = err_msg t in
+                                                   (FStar_Errors.Fatal_ActionMustHaveFunctionType,
+                                                     uu____4925) in
+                                                 FStar_Errors.raise_error
+                                                   uu____4919 r in
+                                           let k1 =
+                                             FStar_TypeChecker_Normalize.normalize
+                                               [FStar_TypeChecker_Env.Beta]
+                                               env1 k in
+                                           let uu____4935 =
+                                             let uu____4936 =
+                                               FStar_Syntax_Subst.compress k1 in
+                                             uu____4936.FStar_Syntax_Syntax.n in
+                                           match uu____4935 with
+                                           | FStar_Syntax_Syntax.Tm_arrow
+                                               (bs, c) ->
+                                               let uu____4961 =
+                                                 FStar_Syntax_Subst.open_comp
+                                                   bs c in
+                                               (match uu____4961 with
+                                                | (bs1, c1) ->
+                                                    let uu____4968 =
+                                                      repr_args
+                                                        (FStar_Syntax_Util.comp_result
+                                                           c1) in
+                                                    (match uu____4968 with
+                                                     | (us, a, is) ->
+                                                         let ct =
+                                                           {
+                                                             FStar_Syntax_Syntax.comp_univs
+                                                               = us;
+                                                             FStar_Syntax_Syntax.effect_name
+                                                               =
+                                                               (ed.FStar_Syntax_Syntax.mname);
+                                                             FStar_Syntax_Syntax.result_typ
+                                                               = a;
+                                                             FStar_Syntax_Syntax.effect_args
+                                                               = is;
+                                                             FStar_Syntax_Syntax.flags
+                                                               = []
+                                                           } in
+                                                         let uu____4979 =
+                                                           FStar_Syntax_Syntax.mk_Comp
+                                                             ct in
+                                                         FStar_Syntax_Util.arrow
+                                                           bs1 uu____4979))
+                                           | uu____4982 ->
+                                               let uu____4983 =
+                                                 let uu____4989 = err_msg k1 in
+                                                 (FStar_Errors.Fatal_ActionMustHaveFunctionType,
+                                                   uu____4989) in
+                                               FStar_Errors.raise_error
+                                                 uu____4983 r in
+                                         (let uu____4993 =
+                                            FStar_All.pipe_left
+                                              (FStar_TypeChecker_Env.debug
+                                                 env1)
+                                              (FStar_Options.Other
+                                                 "LayeredEffects") in
+                                          if uu____4993
+                                          then
+                                            let uu____4998 =
+                                              FStar_Syntax_Print.term_to_string
+                                                act_typ2 in
+                                            FStar_Util.print1
+                                              "Action type after injecting it into the monad: %s\n"
+                                              uu____4998
+                                          else ());
+                                         (let act2 =
+                                            let uu____5004 =
+                                              FStar_TypeChecker_Util.generalize_universes
+                                                env1 act_defn in
+                                            match uu____5004 with
+                                            | (us, act_defn1) ->
+                                                if
+                                                  act1.FStar_Syntax_Syntax.action_univs
+                                                    = []
+                                                then
+                                                  let uu___533_5018 = act1 in
+                                                  let uu____5019 =
+                                                    FStar_Syntax_Subst.close_univ_vars
+                                                      us act_typ2 in
+                                                  {
+                                                    FStar_Syntax_Syntax.action_name
+                                                      =
+                                                      (uu___533_5018.FStar_Syntax_Syntax.action_name);
+                                                    FStar_Syntax_Syntax.action_unqualified_name
+                                                      =
+                                                      (uu___533_5018.FStar_Syntax_Syntax.action_unqualified_name);
+                                                    FStar_Syntax_Syntax.action_univs
+                                                      = us;
+                                                    FStar_Syntax_Syntax.action_params
+                                                      =
+                                                      (uu___533_5018.FStar_Syntax_Syntax.action_params);
+                                                    FStar_Syntax_Syntax.action_defn
+                                                      = act_defn1;
+                                                    FStar_Syntax_Syntax.action_typ
+                                                      = uu____5019
+                                                  }
+                                                else
+                                                  (let uu____5022 =
+                                                     ((FStar_List.length us)
+                                                        =
+                                                        (FStar_List.length
+                                                           act1.FStar_Syntax_Syntax.action_univs))
+                                                       &&
+                                                       (FStar_List.forall2
+                                                          (fun u1 ->
+                                                             fun u2 ->
+                                                               let uu____5029
                                                                  =
-                                                                 FStar_Ident.string_of_lid
-                                                                   ed.FStar_Syntax_Syntax.mname in
-                                                               let uu____5348
-                                                                 =
-                                                                 FStar_Ident.string_of_lid
-                                                                   act1.FStar_Syntax_Syntax.action_name in
-                                                               let uu____5350
-                                                                 =
-                                                                 FStar_Syntax_Print.univ_names_to_string
-                                                                   us in
-                                                               let uu____5352
-                                                                 =
-                                                                 FStar_Syntax_Print.univ_names_to_string
-                                                                   act1.FStar_Syntax_Syntax.action_univs in
-                                                               FStar_Util.format4
-                                                                 "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
-                                                                 uu____5346
-                                                                 uu____5348
-                                                                 uu____5350
-                                                                 uu____5352 in
-                                                             (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                               uu____5344) in
-                                                           FStar_Errors.raise_error
-                                                             uu____5338 r)) in
-                                               act2))))))))) in
-                    let tschemes_of uu____5377 =
-                      match uu____5377 with
-                      | (us, t, ty) -> ((us, t), (us, ty)) in
-                    let combinators =
-                      let uu____5422 =
-                        let uu____5423 = tschemes_of repr in
-                        let uu____5428 = tschemes_of return_repr in
-                        let uu____5433 = tschemes_of bind_repr in
-                        let uu____5438 = tschemes_of stronger_repr in
-                        let uu____5443 = tschemes_of if_then_else in
-                        {
-                          FStar_Syntax_Syntax.l_base_effect =
-                            underlying_effect_lid;
-                          FStar_Syntax_Syntax.l_repr = uu____5423;
-                          FStar_Syntax_Syntax.l_return = uu____5428;
-                          FStar_Syntax_Syntax.l_bind = uu____5433;
-                          FStar_Syntax_Syntax.l_subcomp = uu____5438;
-                          FStar_Syntax_Syntax.l_if_then_else = uu____5443
-                        } in
-                      FStar_Syntax_Syntax.Layered_eff uu____5422 in
-                    let uu___564_5448 = ed in
-                    let uu____5449 =
-                      FStar_List.map (tc_action env0)
-                        ed.FStar_Syntax_Syntax.actions in
-                    {
-                      FStar_Syntax_Syntax.mname =
-                        (uu___564_5448.FStar_Syntax_Syntax.mname);
-                      FStar_Syntax_Syntax.cattributes =
-                        (uu___564_5448.FStar_Syntax_Syntax.cattributes);
-                      FStar_Syntax_Syntax.univs =
-                        (uu___564_5448.FStar_Syntax_Syntax.univs);
-                      FStar_Syntax_Syntax.binders =
-                        (uu___564_5448.FStar_Syntax_Syntax.binders);
-                      FStar_Syntax_Syntax.signature =
-                        (let uu____5456 = signature in
-                         match uu____5456 with
-                         | (us, t, uu____5471) -> (us, t));
-                      FStar_Syntax_Syntax.combinators = combinators;
-                      FStar_Syntax_Syntax.actions = uu____5449;
-                      FStar_Syntax_Syntax.eff_attrs =
-                        (uu___564_5448.FStar_Syntax_Syntax.eff_attrs)
-                    }))))))))
+                                                                 FStar_Syntax_Syntax.order_univ_name
+                                                                   u1 u2 in
+                                                               uu____5029 =
+                                                                 Prims.int_zero)
+                                                          us
+                                                          act1.FStar_Syntax_Syntax.action_univs) in
+                                                   if uu____5022
+                                                   then
+                                                     let uu___538_5034 = act1 in
+                                                     let uu____5035 =
+                                                       FStar_Syntax_Subst.close_univ_vars
+                                                         act1.FStar_Syntax_Syntax.action_univs
+                                                         act_typ2 in
+                                                     {
+                                                       FStar_Syntax_Syntax.action_name
+                                                         =
+                                                         (uu___538_5034.FStar_Syntax_Syntax.action_name);
+                                                       FStar_Syntax_Syntax.action_unqualified_name
+                                                         =
+                                                         (uu___538_5034.FStar_Syntax_Syntax.action_unqualified_name);
+                                                       FStar_Syntax_Syntax.action_univs
+                                                         =
+                                                         (uu___538_5034.FStar_Syntax_Syntax.action_univs);
+                                                       FStar_Syntax_Syntax.action_params
+                                                         =
+                                                         (uu___538_5034.FStar_Syntax_Syntax.action_params);
+                                                       FStar_Syntax_Syntax.action_defn
+                                                         = act_defn1;
+                                                       FStar_Syntax_Syntax.action_typ
+                                                         = uu____5035
+                                                     }
+                                                   else
+                                                     (let uu____5038 =
+                                                        let uu____5044 =
+                                                          let uu____5046 =
+                                                            FStar_Ident.string_of_lid
+                                                              ed.FStar_Syntax_Syntax.mname in
+                                                          let uu____5048 =
+                                                            FStar_Ident.string_of_lid
+                                                              act1.FStar_Syntax_Syntax.action_name in
+                                                          let uu____5050 =
+                                                            FStar_Syntax_Print.univ_names_to_string
+                                                              us in
+                                                          let uu____5052 =
+                                                            FStar_Syntax_Print.univ_names_to_string
+                                                              act1.FStar_Syntax_Syntax.action_univs in
+                                                          FStar_Util.format4
+                                                            "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
+                                                            uu____5046
+                                                            uu____5048
+                                                            uu____5050
+                                                            uu____5052 in
+                                                        (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
+                                                          uu____5044) in
+                                                      FStar_Errors.raise_error
+                                                        uu____5038 r)) in
+                                          act2))))))))) in
+               let tschemes_of uu____5077 =
+                 match uu____5077 with | (us, t, ty) -> ((us, t), (us, ty)) in
+               let combinators =
+                 let uu____5122 =
+                   let uu____5123 = tschemes_of repr in
+                   let uu____5128 = tschemes_of return_repr in
+                   let uu____5133 = tschemes_of bind_repr in
+                   let uu____5138 = tschemes_of stronger_repr in
+                   let uu____5143 = tschemes_of if_then_else in
+                   {
+                     FStar_Syntax_Syntax.l_repr = uu____5123;
+                     FStar_Syntax_Syntax.l_return = uu____5128;
+                     FStar_Syntax_Syntax.l_bind = uu____5133;
+                     FStar_Syntax_Syntax.l_subcomp = uu____5138;
+                     FStar_Syntax_Syntax.l_if_then_else = uu____5143
+                   } in
+                 FStar_Syntax_Syntax.Layered_eff uu____5122 in
+               let uu___547_5148 = ed in
+               let uu____5149 =
+                 FStar_List.map (tc_action env0)
+                   ed.FStar_Syntax_Syntax.actions in
+               {
+                 FStar_Syntax_Syntax.mname =
+                   (uu___547_5148.FStar_Syntax_Syntax.mname);
+                 FStar_Syntax_Syntax.cattributes =
+                   (uu___547_5148.FStar_Syntax_Syntax.cattributes);
+                 FStar_Syntax_Syntax.univs =
+                   (uu___547_5148.FStar_Syntax_Syntax.univs);
+                 FStar_Syntax_Syntax.binders =
+                   (uu___547_5148.FStar_Syntax_Syntax.binders);
+                 FStar_Syntax_Syntax.signature =
+                   (let uu____5156 = signature in
+                    match uu____5156 with | (us, t, uu____5171) -> (us, t));
+                 FStar_Syntax_Syntax.combinators = combinators;
+                 FStar_Syntax_Syntax.actions = uu____5149;
+                 FStar_Syntax_Syntax.eff_attrs =
+                   (uu___547_5148.FStar_Syntax_Syntax.eff_attrs)
+               })))))))
 let (tc_non_layered_eff_decl :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.eff_decl ->
@@ -2214,213 +2029,213 @@ let (tc_non_layered_eff_decl :
   fun env0 ->
     fun ed ->
       fun _quals ->
-        (let uu____5509 =
+        (let uu____5209 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
              (FStar_Options.Other "ED") in
-         if uu____5509
+         if uu____5209
          then
-           let uu____5514 = FStar_Syntax_Print.eff_decl_to_string false ed in
-           FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____5514
+           let uu____5214 = FStar_Syntax_Print.eff_decl_to_string false ed in
+           FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____5214
          else ());
-        (let uu____5520 =
-           let uu____5525 =
+        (let uu____5220 =
+           let uu____5225 =
              FStar_Syntax_Subst.univ_var_opening ed.FStar_Syntax_Syntax.univs in
-           match uu____5525 with
+           match uu____5225 with
            | (ed_univs_subst, ed_univs) ->
                let bs =
-                 let uu____5549 =
+                 let uu____5249 =
                    FStar_Syntax_Subst.subst_binders ed_univs_subst
                      ed.FStar_Syntax_Syntax.binders in
-                 FStar_Syntax_Subst.open_binders uu____5549 in
-               let uu____5550 =
-                 let uu____5557 =
+                 FStar_Syntax_Subst.open_binders uu____5249 in
+               let uu____5250 =
+                 let uu____5257 =
                    FStar_TypeChecker_Env.push_univ_vars env0 ed_univs in
-                 FStar_TypeChecker_TcTerm.tc_tparams uu____5557 bs in
-               (match uu____5550 with
-                | (bs1, uu____5563, uu____5564) ->
-                    let uu____5565 =
+                 FStar_TypeChecker_TcTerm.tc_tparams uu____5257 bs in
+               (match uu____5250 with
+                | (bs1, uu____5263, uu____5264) ->
+                    let uu____5265 =
                       let tmp_t =
-                        let uu____5575 =
-                          let uu____5578 =
+                        let uu____5275 =
+                          let uu____5278 =
                             FStar_All.pipe_right FStar_Syntax_Syntax.U_zero
-                              (fun uu____5583 ->
-                                 FStar_Pervasives_Native.Some uu____5583) in
+                              (fun uu____5283 ->
+                                 FStar_Pervasives_Native.Some uu____5283) in
                           FStar_Syntax_Syntax.mk_Total'
-                            FStar_Syntax_Syntax.t_unit uu____5578 in
-                        FStar_Syntax_Util.arrow bs1 uu____5575 in
-                      let uu____5584 =
+                            FStar_Syntax_Syntax.t_unit uu____5278 in
+                        FStar_Syntax_Util.arrow bs1 uu____5275 in
+                      let uu____5284 =
                         FStar_TypeChecker_Util.generalize_universes env0
                           tmp_t in
-                      match uu____5584 with
+                      match uu____5284 with
                       | (us, tmp_t1) ->
-                          let uu____5601 =
-                            let uu____5602 =
-                              let uu____5603 =
+                          let uu____5301 =
+                            let uu____5302 =
+                              let uu____5303 =
                                 FStar_All.pipe_right tmp_t1
                                   FStar_Syntax_Util.arrow_formals in
-                              FStar_All.pipe_right uu____5603
+                              FStar_All.pipe_right uu____5303
                                 FStar_Pervasives_Native.fst in
-                            FStar_All.pipe_right uu____5602
+                            FStar_All.pipe_right uu____5302
                               FStar_Syntax_Subst.close_binders in
-                          (us, uu____5601) in
-                    (match uu____5565 with
+                          (us, uu____5301) in
+                    (match uu____5265 with
                      | (us, bs2) ->
                          (match ed_univs with
                           | [] -> (us, bs2)
-                          | uu____5640 ->
-                              let uu____5643 =
+                          | uu____5340 ->
+                              let uu____5343 =
                                 ((FStar_List.length ed_univs) =
                                    (FStar_List.length us))
                                   &&
                                   (FStar_List.forall2
                                      (fun u1 ->
                                         fun u2 ->
-                                          let uu____5650 =
+                                          let uu____5350 =
                                             FStar_Syntax_Syntax.order_univ_name
                                               u1 u2 in
-                                          uu____5650 = Prims.int_zero)
+                                          uu____5350 = Prims.int_zero)
                                      ed_univs us) in
-                              if uu____5643
+                              if uu____5343
                               then (us, bs2)
                               else
-                                (let uu____5661 =
-                                   let uu____5667 =
-                                     let uu____5669 =
+                                (let uu____5361 =
+                                   let uu____5367 =
+                                     let uu____5369 =
                                        FStar_Ident.string_of_lid
                                          ed.FStar_Syntax_Syntax.mname in
-                                     let uu____5671 =
+                                     let uu____5371 =
                                        FStar_Util.string_of_int
                                          (FStar_List.length ed_univs) in
-                                     let uu____5673 =
+                                     let uu____5373 =
                                        FStar_Util.string_of_int
                                          (FStar_List.length us) in
                                      FStar_Util.format3
                                        "Expected and generalized universes in effect declaration for %s are different, expected: %s, but found %s"
-                                       uu____5669 uu____5671 uu____5673 in
+                                       uu____5369 uu____5371 uu____5373 in
                                    (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                     uu____5667) in
-                                 let uu____5677 =
+                                     uu____5367) in
+                                 let uu____5377 =
                                    FStar_Ident.range_of_lid
                                      ed.FStar_Syntax_Syntax.mname in
-                                 FStar_Errors.raise_error uu____5661
-                                   uu____5677)))) in
-         match uu____5520 with
+                                 FStar_Errors.raise_error uu____5361
+                                   uu____5377)))) in
+         match uu____5220 with
          | (us, bs) ->
              let ed1 =
-               let uu___598_5685 = ed in
+               let uu___581_5385 = ed in
                {
                  FStar_Syntax_Syntax.mname =
-                   (uu___598_5685.FStar_Syntax_Syntax.mname);
+                   (uu___581_5385.FStar_Syntax_Syntax.mname);
                  FStar_Syntax_Syntax.cattributes =
-                   (uu___598_5685.FStar_Syntax_Syntax.cattributes);
+                   (uu___581_5385.FStar_Syntax_Syntax.cattributes);
                  FStar_Syntax_Syntax.univs = us;
                  FStar_Syntax_Syntax.binders = bs;
                  FStar_Syntax_Syntax.signature =
-                   (uu___598_5685.FStar_Syntax_Syntax.signature);
+                   (uu___581_5385.FStar_Syntax_Syntax.signature);
                  FStar_Syntax_Syntax.combinators =
-                   (uu___598_5685.FStar_Syntax_Syntax.combinators);
+                   (uu___581_5385.FStar_Syntax_Syntax.combinators);
                  FStar_Syntax_Syntax.actions =
-                   (uu___598_5685.FStar_Syntax_Syntax.actions);
+                   (uu___581_5385.FStar_Syntax_Syntax.actions);
                  FStar_Syntax_Syntax.eff_attrs =
-                   (uu___598_5685.FStar_Syntax_Syntax.eff_attrs)
+                   (uu___581_5385.FStar_Syntax_Syntax.eff_attrs)
                } in
-             let uu____5686 = FStar_Syntax_Subst.univ_var_opening us in
-             (match uu____5686 with
+             let uu____5386 = FStar_Syntax_Subst.univ_var_opening us in
+             (match uu____5386 with
               | (ed_univs_subst, ed_univs) ->
-                  let uu____5705 =
-                    let uu____5710 =
+                  let uu____5405 =
+                    let uu____5410 =
                       FStar_Syntax_Subst.subst_binders ed_univs_subst bs in
-                    FStar_Syntax_Subst.open_binders' uu____5710 in
-                  (match uu____5705 with
+                    FStar_Syntax_Subst.open_binders' uu____5410 in
+                  (match uu____5405 with
                    | (ed_bs, ed_bs_subst) ->
                        let ed2 =
-                         let op uu____5731 =
-                           match uu____5731 with
+                         let op uu____5431 =
+                           match uu____5431 with
                            | (us1, t) ->
                                let t1 =
-                                 let uu____5751 =
+                                 let uu____5451 =
                                    FStar_Syntax_Subst.shift_subst
                                      ((FStar_List.length ed_bs) +
                                         (FStar_List.length us1))
                                      ed_univs_subst in
-                                 FStar_Syntax_Subst.subst uu____5751 t in
-                               let uu____5760 =
-                                 let uu____5761 =
+                                 FStar_Syntax_Subst.subst uu____5451 t in
+                               let uu____5460 =
+                                 let uu____5461 =
                                    FStar_Syntax_Subst.shift_subst
                                      (FStar_List.length us1) ed_bs_subst in
-                                 FStar_Syntax_Subst.subst uu____5761 t1 in
-                               (us1, uu____5760) in
-                         let uu___612_5766 = ed1 in
-                         let uu____5767 =
+                                 FStar_Syntax_Subst.subst uu____5461 t1 in
+                               (us1, uu____5460) in
+                         let uu___595_5466 = ed1 in
+                         let uu____5467 =
                            op ed1.FStar_Syntax_Syntax.signature in
-                         let uu____5768 =
+                         let uu____5468 =
                            FStar_Syntax_Util.apply_eff_combinators op
                              ed1.FStar_Syntax_Syntax.combinators in
-                         let uu____5769 =
+                         let uu____5469 =
                            FStar_List.map
                              (fun a ->
-                                let uu___615_5777 = a in
-                                let uu____5778 =
-                                  let uu____5779 =
+                                let uu___598_5477 = a in
+                                let uu____5478 =
+                                  let uu____5479 =
                                     op
                                       ((a.FStar_Syntax_Syntax.action_univs),
                                         (a.FStar_Syntax_Syntax.action_defn)) in
-                                  FStar_Pervasives_Native.snd uu____5779 in
-                                let uu____5790 =
-                                  let uu____5791 =
+                                  FStar_Pervasives_Native.snd uu____5479 in
+                                let uu____5490 =
+                                  let uu____5491 =
                                     op
                                       ((a.FStar_Syntax_Syntax.action_univs),
                                         (a.FStar_Syntax_Syntax.action_typ)) in
-                                  FStar_Pervasives_Native.snd uu____5791 in
+                                  FStar_Pervasives_Native.snd uu____5491 in
                                 {
                                   FStar_Syntax_Syntax.action_name =
-                                    (uu___615_5777.FStar_Syntax_Syntax.action_name);
+                                    (uu___598_5477.FStar_Syntax_Syntax.action_name);
                                   FStar_Syntax_Syntax.action_unqualified_name
                                     =
-                                    (uu___615_5777.FStar_Syntax_Syntax.action_unqualified_name);
+                                    (uu___598_5477.FStar_Syntax_Syntax.action_unqualified_name);
                                   FStar_Syntax_Syntax.action_univs =
-                                    (uu___615_5777.FStar_Syntax_Syntax.action_univs);
+                                    (uu___598_5477.FStar_Syntax_Syntax.action_univs);
                                   FStar_Syntax_Syntax.action_params =
-                                    (uu___615_5777.FStar_Syntax_Syntax.action_params);
+                                    (uu___598_5477.FStar_Syntax_Syntax.action_params);
                                   FStar_Syntax_Syntax.action_defn =
-                                    uu____5778;
-                                  FStar_Syntax_Syntax.action_typ = uu____5790
+                                    uu____5478;
+                                  FStar_Syntax_Syntax.action_typ = uu____5490
                                 }) ed1.FStar_Syntax_Syntax.actions in
                          {
                            FStar_Syntax_Syntax.mname =
-                             (uu___612_5766.FStar_Syntax_Syntax.mname);
+                             (uu___595_5466.FStar_Syntax_Syntax.mname);
                            FStar_Syntax_Syntax.cattributes =
-                             (uu___612_5766.FStar_Syntax_Syntax.cattributes);
+                             (uu___595_5466.FStar_Syntax_Syntax.cattributes);
                            FStar_Syntax_Syntax.univs =
-                             (uu___612_5766.FStar_Syntax_Syntax.univs);
+                             (uu___595_5466.FStar_Syntax_Syntax.univs);
                            FStar_Syntax_Syntax.binders =
-                             (uu___612_5766.FStar_Syntax_Syntax.binders);
-                           FStar_Syntax_Syntax.signature = uu____5767;
-                           FStar_Syntax_Syntax.combinators = uu____5768;
-                           FStar_Syntax_Syntax.actions = uu____5769;
+                             (uu___595_5466.FStar_Syntax_Syntax.binders);
+                           FStar_Syntax_Syntax.signature = uu____5467;
+                           FStar_Syntax_Syntax.combinators = uu____5468;
+                           FStar_Syntax_Syntax.actions = uu____5469;
                            FStar_Syntax_Syntax.eff_attrs =
-                             (uu___612_5766.FStar_Syntax_Syntax.eff_attrs)
+                             (uu___595_5466.FStar_Syntax_Syntax.eff_attrs)
                          } in
-                       ((let uu____5803 =
+                       ((let uu____5503 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env0)
                              (FStar_Options.Other "ED") in
-                         if uu____5803
+                         if uu____5503
                          then
-                           let uu____5808 =
+                           let uu____5508 =
                              FStar_Syntax_Print.eff_decl_to_string false ed2 in
                            FStar_Util.print1
                              "After typechecking binders eff_decl: \n\t%s\n"
-                             uu____5808
+                             uu____5508
                          else ());
                         (let env =
-                           let uu____5815 =
+                           let uu____5515 =
                              FStar_TypeChecker_Env.push_univ_vars env0
                                ed_univs in
-                           FStar_TypeChecker_Env.push_binders uu____5815
+                           FStar_TypeChecker_Env.push_binders uu____5515
                              ed_bs in
-                         let check_and_gen' comb n env_opt uu____5850 k =
-                           match uu____5850 with
+                         let check_and_gen' comb n env_opt uu____5550 k =
+                           match uu____5550 with
                            | (us1, t) ->
                                let env1 =
                                  if FStar_Util.is_some env_opt
@@ -2428,54 +2243,54 @@ let (tc_non_layered_eff_decl :
                                    FStar_All.pipe_right env_opt
                                      FStar_Util.must
                                  else env in
-                               let uu____5870 =
+                               let uu____5570 =
                                  FStar_Syntax_Subst.open_univ_vars us1 t in
-                               (match uu____5870 with
+                               (match uu____5570 with
                                 | (us2, t1) ->
                                     let t2 =
                                       match k with
                                       | FStar_Pervasives_Native.Some k1 ->
-                                          let uu____5879 =
+                                          let uu____5579 =
                                             FStar_TypeChecker_Env.push_univ_vars
                                               env1 us2 in
                                           FStar_TypeChecker_TcTerm.tc_check_trivial_guard
-                                            uu____5879 t1 k1
+                                            uu____5579 t1 k1
                                       | FStar_Pervasives_Native.None ->
-                                          let uu____5880 =
-                                            let uu____5887 =
+                                          let uu____5580 =
+                                            let uu____5587 =
                                               FStar_TypeChecker_Env.push_univ_vars
                                                 env1 us2 in
                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                              uu____5887 t1 in
-                                          (match uu____5880 with
-                                           | (t2, uu____5889, g) ->
+                                              uu____5587 t1 in
+                                          (match uu____5580 with
+                                           | (t2, uu____5589, g) ->
                                                (FStar_TypeChecker_Rel.force_trivial_guard
                                                   env1 g;
                                                 t2)) in
-                                    let uu____5892 =
+                                    let uu____5592 =
                                       FStar_TypeChecker_Util.generalize_universes
                                         env1 t2 in
-                                    (match uu____5892 with
+                                    (match uu____5592 with
                                      | (g_us, t3) ->
                                          (if (FStar_List.length g_us) <> n
                                           then
                                             (let error =
-                                               let uu____5908 =
+                                               let uu____5608 =
                                                  FStar_Ident.string_of_lid
                                                    ed2.FStar_Syntax_Syntax.mname in
-                                               let uu____5910 =
+                                               let uu____5610 =
                                                  FStar_Util.string_of_int n in
-                                               let uu____5912 =
-                                                 let uu____5914 =
+                                               let uu____5612 =
+                                                 let uu____5614 =
                                                    FStar_All.pipe_right g_us
                                                      FStar_List.length in
                                                  FStar_All.pipe_right
-                                                   uu____5914
+                                                   uu____5614
                                                    FStar_Util.string_of_int in
                                                FStar_Util.format4
                                                  "Expected %s:%s to be universe-polymorphic in %s universes, found %s"
-                                                 uu____5908 comb uu____5910
-                                                 uu____5912 in
+                                                 uu____5608 comb uu____5610
+                                                 uu____5612 in
                                              FStar_Errors.raise_error
                                                (FStar_Errors.Fatal_MismatchUniversePolymorphic,
                                                  error)
@@ -2483,583 +2298,583 @@ let (tc_non_layered_eff_decl :
                                           else ();
                                           (match us2 with
                                            | [] -> (g_us, t3)
-                                           | uu____5929 ->
-                                               let uu____5930 =
+                                           | uu____5629 ->
+                                               let uu____5630 =
                                                  ((FStar_List.length us2) =
                                                     (FStar_List.length g_us))
                                                    &&
                                                    (FStar_List.forall2
                                                       (fun u1 ->
                                                          fun u2 ->
-                                                           let uu____5937 =
+                                                           let uu____5637 =
                                                              FStar_Syntax_Syntax.order_univ_name
                                                                u1 u2 in
-                                                           uu____5937 =
+                                                           uu____5637 =
                                                              Prims.int_zero)
                                                       us2 g_us) in
-                                               if uu____5930
+                                               if uu____5630
                                                then (g_us, t3)
                                                else
-                                                 (let uu____5948 =
-                                                    let uu____5954 =
-                                                      let uu____5956 =
+                                                 (let uu____5648 =
+                                                    let uu____5654 =
+                                                      let uu____5656 =
                                                         FStar_Ident.string_of_lid
                                                           ed2.FStar_Syntax_Syntax.mname in
-                                                      let uu____5958 =
+                                                      let uu____5658 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
                                                              us2) in
-                                                      let uu____5960 =
+                                                      let uu____5660 =
                                                         FStar_Util.string_of_int
                                                           (FStar_List.length
                                                              g_us) in
                                                       FStar_Util.format4
                                                         "Expected and generalized universes in the declaration for %s:%s are different, expected: %s, but found %s"
-                                                        uu____5956 comb
-                                                        uu____5958 uu____5960 in
+                                                        uu____5656 comb
+                                                        uu____5658 uu____5660 in
                                                     (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                      uu____5954) in
+                                                      uu____5654) in
                                                   FStar_Errors.raise_error
-                                                    uu____5948
+                                                    uu____5648
                                                     t3.FStar_Syntax_Syntax.pos))))) in
                          let signature =
                            check_and_gen' "signature" Prims.int_one
                              FStar_Pervasives_Native.None
                              ed2.FStar_Syntax_Syntax.signature
                              FStar_Pervasives_Native.None in
-                         (let uu____5968 =
+                         (let uu____5668 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "ED") in
-                          if uu____5968
+                          if uu____5668
                           then
-                            let uu____5973 =
+                            let uu____5673 =
                               FStar_Syntax_Print.tscheme_to_string signature in
                             FStar_Util.print1 "Typechecked signature: %s\n"
-                              uu____5973
+                              uu____5673
                           else ());
-                         (let fresh_a_and_wp uu____5989 =
+                         (let fresh_a_and_wp uu____5689 =
                             let fail t =
-                              let uu____6002 =
+                              let uu____5702 =
                                 FStar_TypeChecker_Err.unexpected_signature_for_monad
                                   env ed2.FStar_Syntax_Syntax.mname t in
-                              FStar_Errors.raise_error uu____6002
+                              FStar_Errors.raise_error uu____5702
                                 (FStar_Pervasives_Native.snd
                                    ed2.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos in
-                            let uu____6018 =
+                            let uu____5718 =
                               FStar_TypeChecker_Env.inst_tscheme signature in
-                            match uu____6018 with
-                            | (uu____6029, signature1) ->
-                                let uu____6031 =
-                                  let uu____6032 =
+                            match uu____5718 with
+                            | (uu____5729, signature1) ->
+                                let uu____5731 =
+                                  let uu____5732 =
                                     FStar_Syntax_Subst.compress signature1 in
-                                  uu____6032.FStar_Syntax_Syntax.n in
-                                (match uu____6031 with
+                                  uu____5732.FStar_Syntax_Syntax.n in
+                                (match uu____5731 with
                                  | FStar_Syntax_Syntax.Tm_arrow
-                                     (bs1, uu____6042) ->
+                                     (bs1, uu____5742) ->
                                      let bs2 =
                                        FStar_Syntax_Subst.open_binders bs1 in
                                      (match bs2 with
-                                      | (a, uu____6071)::(wp, uu____6073)::[]
+                                      | (a, uu____5771)::(wp, uu____5773)::[]
                                           ->
                                           (a, (wp.FStar_Syntax_Syntax.sort))
-                                      | uu____6102 -> fail signature1)
-                                 | uu____6103 -> fail signature1) in
+                                      | uu____5802 -> fail signature1)
+                                 | uu____5803 -> fail signature1) in
                           let log_combinator s ts =
-                            let uu____6117 =
+                            let uu____5817 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "ED") in
-                            if uu____6117
+                            if uu____5817
                             then
-                              let uu____6122 =
+                              let uu____5822 =
                                 FStar_Ident.string_of_lid
                                   ed2.FStar_Syntax_Syntax.mname in
-                              let uu____6124 =
+                              let uu____5824 =
                                 FStar_Syntax_Print.tscheme_to_string ts in
                               FStar_Util.print3 "Typechecked %s:%s = %s\n"
-                                uu____6122 s uu____6124
+                                uu____5822 s uu____5824
                             else () in
                           let ret_wp =
-                            let uu____6130 = fresh_a_and_wp () in
-                            match uu____6130 with
+                            let uu____5830 = fresh_a_and_wp () in
+                            match uu____5830 with
                             | (a, wp_sort) ->
                                 let k =
-                                  let uu____6146 =
-                                    let uu____6155 =
+                                  let uu____5846 =
+                                    let uu____5855 =
                                       FStar_Syntax_Syntax.mk_binder a in
-                                    let uu____6162 =
-                                      let uu____6171 =
-                                        let uu____6178 =
+                                    let uu____5862 =
+                                      let uu____5871 =
+                                        let uu____5878 =
                                           FStar_Syntax_Syntax.bv_to_name a in
                                         FStar_Syntax_Syntax.null_binder
-                                          uu____6178 in
-                                      [uu____6171] in
-                                    uu____6155 :: uu____6162 in
-                                  let uu____6197 =
+                                          uu____5878 in
+                                      [uu____5871] in
+                                    uu____5855 :: uu____5862 in
+                                  let uu____5897 =
                                     FStar_Syntax_Syntax.mk_GTotal wp_sort in
-                                  FStar_Syntax_Util.arrow uu____6146
-                                    uu____6197 in
-                                let uu____6200 =
+                                  FStar_Syntax_Util.arrow uu____5846
+                                    uu____5897 in
+                                let uu____5900 =
                                   FStar_All.pipe_right ed2
                                     FStar_Syntax_Util.get_return_vc_combinator in
                                 check_and_gen' "ret_wp" Prims.int_one
-                                  FStar_Pervasives_Native.None uu____6200
+                                  FStar_Pervasives_Native.None uu____5900
                                   (FStar_Pervasives_Native.Some k) in
                           log_combinator "ret_wp" ret_wp;
                           (let bind_wp =
-                             let uu____6214 = fresh_a_and_wp () in
-                             match uu____6214 with
+                             let uu____5914 = fresh_a_and_wp () in
+                             match uu____5914 with
                              | (a, wp_sort_a) ->
-                                 let uu____6227 = fresh_a_and_wp () in
-                                 (match uu____6227 with
+                                 let uu____5927 = fresh_a_and_wp () in
+                                 (match uu____5927 with
                                   | (b, wp_sort_b) ->
                                       let wp_sort_a_b =
-                                        let uu____6243 =
-                                          let uu____6252 =
-                                            let uu____6259 =
+                                        let uu____5943 =
+                                          let uu____5952 =
+                                            let uu____5959 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a in
                                             FStar_Syntax_Syntax.null_binder
-                                              uu____6259 in
-                                          [uu____6252] in
-                                        let uu____6272 =
+                                              uu____5959 in
+                                          [uu____5952] in
+                                        let uu____5972 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_b in
-                                        FStar_Syntax_Util.arrow uu____6243
-                                          uu____6272 in
+                                        FStar_Syntax_Util.arrow uu____5943
+                                          uu____5972 in
                                       let k =
-                                        let uu____6278 =
-                                          let uu____6287 =
+                                        let uu____5978 =
+                                          let uu____5987 =
                                             FStar_Syntax_Syntax.null_binder
                                               FStar_Syntax_Syntax.t_range in
-                                          let uu____6294 =
-                                            let uu____6303 =
+                                          let uu____5994 =
+                                            let uu____6003 =
                                               FStar_Syntax_Syntax.mk_binder a in
-                                            let uu____6310 =
-                                              let uu____6319 =
+                                            let uu____6010 =
+                                              let uu____6019 =
                                                 FStar_Syntax_Syntax.mk_binder
                                                   b in
-                                              let uu____6326 =
-                                                let uu____6335 =
+                                              let uu____6026 =
+                                                let uu____6035 =
                                                   FStar_Syntax_Syntax.null_binder
                                                     wp_sort_a in
-                                                let uu____6342 =
-                                                  let uu____6351 =
+                                                let uu____6042 =
+                                                  let uu____6051 =
                                                     FStar_Syntax_Syntax.null_binder
                                                       wp_sort_a_b in
-                                                  [uu____6351] in
-                                                uu____6335 :: uu____6342 in
-                                              uu____6319 :: uu____6326 in
-                                            uu____6303 :: uu____6310 in
-                                          uu____6287 :: uu____6294 in
-                                        let uu____6394 =
+                                                  [uu____6051] in
+                                                uu____6035 :: uu____6042 in
+                                              uu____6019 :: uu____6026 in
+                                            uu____6003 :: uu____6010 in
+                                          uu____5987 :: uu____5994 in
+                                        let uu____6094 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_b in
-                                        FStar_Syntax_Util.arrow uu____6278
-                                          uu____6394 in
-                                      let uu____6397 =
+                                        FStar_Syntax_Util.arrow uu____5978
+                                          uu____6094 in
+                                      let uu____6097 =
                                         FStar_All.pipe_right ed2
                                           FStar_Syntax_Util.get_bind_vc_combinator in
                                       check_and_gen' "bind_wp"
                                         (Prims.of_int (2))
                                         FStar_Pervasives_Native.None
-                                        uu____6397
+                                        uu____6097
                                         (FStar_Pervasives_Native.Some k)) in
                            log_combinator "bind_wp" bind_wp;
                            (let stronger =
-                              let uu____6411 = fresh_a_and_wp () in
-                              match uu____6411 with
+                              let uu____6111 = fresh_a_and_wp () in
+                              match uu____6111 with
                               | (a, wp_sort_a) ->
-                                  let uu____6424 =
+                                  let uu____6124 =
                                     FStar_Syntax_Util.type_u () in
-                                  (match uu____6424 with
-                                   | (t, uu____6430) ->
+                                  (match uu____6124 with
+                                   | (t, uu____6130) ->
                                        let k =
-                                         let uu____6434 =
-                                           let uu____6443 =
+                                         let uu____6134 =
+                                           let uu____6143 =
                                              FStar_Syntax_Syntax.mk_binder a in
-                                           let uu____6450 =
-                                             let uu____6459 =
+                                           let uu____6150 =
+                                             let uu____6159 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a in
-                                             let uu____6466 =
-                                               let uu____6475 =
+                                             let uu____6166 =
+                                               let uu____6175 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_a in
-                                               [uu____6475] in
-                                             uu____6459 :: uu____6466 in
-                                           uu____6443 :: uu____6450 in
-                                         let uu____6506 =
+                                               [uu____6175] in
+                                             uu____6159 :: uu____6166 in
+                                           uu____6143 :: uu____6150 in
+                                         let uu____6206 =
                                            FStar_Syntax_Syntax.mk_Total t in
-                                         FStar_Syntax_Util.arrow uu____6434
-                                           uu____6506 in
-                                       let uu____6509 =
+                                         FStar_Syntax_Util.arrow uu____6134
+                                           uu____6206 in
+                                       let uu____6209 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_stronger_vc_combinator in
                                        check_and_gen' "stronger"
                                          Prims.int_one
                                          FStar_Pervasives_Native.None
-                                         uu____6509
+                                         uu____6209
                                          (FStar_Pervasives_Native.Some k)) in
                             log_combinator "stronger" stronger;
                             (let if_then_else =
-                               let uu____6523 = fresh_a_and_wp () in
-                               match uu____6523 with
+                               let uu____6223 = fresh_a_and_wp () in
+                               match uu____6223 with
                                | (a, wp_sort_a) ->
                                    let p =
-                                     let uu____6537 =
-                                       let uu____6540 =
+                                     let uu____6237 =
+                                       let uu____6240 =
                                          FStar_Ident.range_of_lid
                                            ed2.FStar_Syntax_Syntax.mname in
                                        FStar_Pervasives_Native.Some
-                                         uu____6540 in
-                                     let uu____6541 =
-                                       let uu____6542 =
+                                         uu____6240 in
+                                     let uu____6241 =
+                                       let uu____6242 =
                                          FStar_Syntax_Util.type_u () in
-                                       FStar_All.pipe_right uu____6542
+                                       FStar_All.pipe_right uu____6242
                                          FStar_Pervasives_Native.fst in
-                                     FStar_Syntax_Syntax.new_bv uu____6537
-                                       uu____6541 in
+                                     FStar_Syntax_Syntax.new_bv uu____6237
+                                       uu____6241 in
                                    let k =
-                                     let uu____6554 =
-                                       let uu____6563 =
+                                     let uu____6254 =
+                                       let uu____6263 =
                                          FStar_Syntax_Syntax.mk_binder a in
-                                       let uu____6570 =
-                                         let uu____6579 =
+                                       let uu____6270 =
+                                         let uu____6279 =
                                            FStar_Syntax_Syntax.mk_binder p in
-                                         let uu____6586 =
-                                           let uu____6595 =
+                                         let uu____6286 =
+                                           let uu____6295 =
                                              FStar_Syntax_Syntax.null_binder
                                                wp_sort_a in
-                                           let uu____6602 =
-                                             let uu____6611 =
+                                           let uu____6302 =
+                                             let uu____6311 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a in
-                                             [uu____6611] in
-                                           uu____6595 :: uu____6602 in
-                                         uu____6579 :: uu____6586 in
-                                       uu____6563 :: uu____6570 in
-                                     let uu____6648 =
+                                             [uu____6311] in
+                                           uu____6295 :: uu____6302 in
+                                         uu____6279 :: uu____6286 in
+                                       uu____6263 :: uu____6270 in
+                                     let uu____6348 =
                                        FStar_Syntax_Syntax.mk_Total wp_sort_a in
-                                     FStar_Syntax_Util.arrow uu____6554
-                                       uu____6648 in
-                                   let uu____6651 =
-                                     let uu____6656 =
+                                     FStar_Syntax_Util.arrow uu____6254
+                                       uu____6348 in
+                                   let uu____6351 =
+                                     let uu____6356 =
                                        FStar_All.pipe_right ed2
                                          FStar_Syntax_Util.get_wp_if_then_else_combinator in
-                                     FStar_All.pipe_right uu____6656
+                                     FStar_All.pipe_right uu____6356
                                        FStar_Util.must in
                                    check_and_gen' "if_then_else"
                                      Prims.int_one
-                                     FStar_Pervasives_Native.None uu____6651
+                                     FStar_Pervasives_Native.None uu____6351
                                      (FStar_Pervasives_Native.Some k) in
                              log_combinator "if_then_else" if_then_else;
                              (let ite_wp =
-                                let uu____6688 = fresh_a_and_wp () in
-                                match uu____6688 with
+                                let uu____6388 = fresh_a_and_wp () in
+                                match uu____6388 with
                                 | (a, wp_sort_a) ->
                                     let k =
-                                      let uu____6704 =
-                                        let uu____6713 =
+                                      let uu____6404 =
+                                        let uu____6413 =
                                           FStar_Syntax_Syntax.mk_binder a in
-                                        let uu____6720 =
-                                          let uu____6729 =
+                                        let uu____6420 =
+                                          let uu____6429 =
                                             FStar_Syntax_Syntax.null_binder
                                               wp_sort_a in
-                                          [uu____6729] in
-                                        uu____6713 :: uu____6720 in
-                                      let uu____6754 =
+                                          [uu____6429] in
+                                        uu____6413 :: uu____6420 in
+                                      let uu____6454 =
                                         FStar_Syntax_Syntax.mk_Total
                                           wp_sort_a in
-                                      FStar_Syntax_Util.arrow uu____6704
-                                        uu____6754 in
-                                    let uu____6757 =
-                                      let uu____6762 =
+                                      FStar_Syntax_Util.arrow uu____6404
+                                        uu____6454 in
+                                    let uu____6457 =
+                                      let uu____6462 =
                                         FStar_All.pipe_right ed2
                                           FStar_Syntax_Util.get_wp_ite_combinator in
-                                      FStar_All.pipe_right uu____6762
+                                      FStar_All.pipe_right uu____6462
                                         FStar_Util.must in
                                     check_and_gen' "ite_wp" Prims.int_one
-                                      FStar_Pervasives_Native.None uu____6757
+                                      FStar_Pervasives_Native.None uu____6457
                                       (FStar_Pervasives_Native.Some k) in
                               log_combinator "ite_wp" ite_wp;
                               (let close_wp =
-                                 let uu____6778 = fresh_a_and_wp () in
-                                 match uu____6778 with
+                                 let uu____6478 = fresh_a_and_wp () in
+                                 match uu____6478 with
                                  | (a, wp_sort_a) ->
                                      let b =
-                                       let uu____6792 =
-                                         let uu____6795 =
+                                       let uu____6492 =
+                                         let uu____6495 =
                                            FStar_Ident.range_of_lid
                                              ed2.FStar_Syntax_Syntax.mname in
                                          FStar_Pervasives_Native.Some
-                                           uu____6795 in
-                                       let uu____6796 =
-                                         let uu____6797 =
+                                           uu____6495 in
+                                       let uu____6496 =
+                                         let uu____6497 =
                                            FStar_Syntax_Util.type_u () in
-                                         FStar_All.pipe_right uu____6797
+                                         FStar_All.pipe_right uu____6497
                                            FStar_Pervasives_Native.fst in
-                                       FStar_Syntax_Syntax.new_bv uu____6792
-                                         uu____6796 in
+                                       FStar_Syntax_Syntax.new_bv uu____6492
+                                         uu____6496 in
                                      let wp_sort_b_a =
-                                       let uu____6809 =
-                                         let uu____6818 =
-                                           let uu____6825 =
+                                       let uu____6509 =
+                                         let uu____6518 =
+                                           let uu____6525 =
                                              FStar_Syntax_Syntax.bv_to_name b in
                                            FStar_Syntax_Syntax.null_binder
-                                             uu____6825 in
-                                         [uu____6818] in
-                                       let uu____6838 =
+                                             uu____6525 in
+                                         [uu____6518] in
+                                       let uu____6538 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a in
-                                       FStar_Syntax_Util.arrow uu____6809
-                                         uu____6838 in
+                                       FStar_Syntax_Util.arrow uu____6509
+                                         uu____6538 in
                                      let k =
-                                       let uu____6844 =
-                                         let uu____6853 =
+                                       let uu____6544 =
+                                         let uu____6553 =
                                            FStar_Syntax_Syntax.mk_binder a in
-                                         let uu____6860 =
-                                           let uu____6869 =
+                                         let uu____6560 =
+                                           let uu____6569 =
                                              FStar_Syntax_Syntax.mk_binder b in
-                                           let uu____6876 =
-                                             let uu____6885 =
+                                           let uu____6576 =
+                                             let uu____6585 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_b_a in
-                                             [uu____6885] in
-                                           uu____6869 :: uu____6876 in
-                                         uu____6853 :: uu____6860 in
-                                       let uu____6916 =
+                                             [uu____6585] in
+                                           uu____6569 :: uu____6576 in
+                                         uu____6553 :: uu____6560 in
+                                       let uu____6616 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a in
-                                       FStar_Syntax_Util.arrow uu____6844
-                                         uu____6916 in
-                                     let uu____6919 =
-                                       let uu____6924 =
+                                       FStar_Syntax_Util.arrow uu____6544
+                                         uu____6616 in
+                                     let uu____6619 =
+                                       let uu____6624 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_wp_close_combinator in
-                                       FStar_All.pipe_right uu____6924
+                                       FStar_All.pipe_right uu____6624
                                          FStar_Util.must in
                                      check_and_gen' "close_wp"
                                        (Prims.of_int (2))
                                        FStar_Pervasives_Native.None
-                                       uu____6919
+                                       uu____6619
                                        (FStar_Pervasives_Native.Some k) in
                                log_combinator "close_wp" close_wp;
                                (let trivial =
-                                  let uu____6940 = fresh_a_and_wp () in
-                                  match uu____6940 with
+                                  let uu____6640 = fresh_a_and_wp () in
+                                  match uu____6640 with
                                   | (a, wp_sort_a) ->
-                                      let uu____6953 =
+                                      let uu____6653 =
                                         FStar_Syntax_Util.type_u () in
-                                      (match uu____6953 with
-                                       | (t, uu____6959) ->
+                                      (match uu____6653 with
+                                       | (t, uu____6659) ->
                                            let k =
-                                             let uu____6963 =
-                                               let uu____6972 =
+                                             let uu____6663 =
+                                               let uu____6672 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    a in
-                                               let uu____6979 =
-                                                 let uu____6988 =
+                                               let uu____6679 =
+                                                 let uu____6688 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      wp_sort_a in
-                                                 [uu____6988] in
-                                               uu____6972 :: uu____6979 in
-                                             let uu____7013 =
+                                                 [uu____6688] in
+                                               uu____6672 :: uu____6679 in
+                                             let uu____6713 =
                                                FStar_Syntax_Syntax.mk_GTotal
                                                  t in
                                              FStar_Syntax_Util.arrow
-                                               uu____6963 uu____7013 in
+                                               uu____6663 uu____6713 in
                                            let trivial =
-                                             let uu____7017 =
-                                               let uu____7022 =
+                                             let uu____6717 =
+                                               let uu____6722 =
                                                  FStar_All.pipe_right ed2
                                                    FStar_Syntax_Util.get_wp_trivial_combinator in
                                                FStar_All.pipe_right
-                                                 uu____7022 FStar_Util.must in
+                                                 uu____6722 FStar_Util.must in
                                              check_and_gen' "trivial"
                                                Prims.int_one
                                                FStar_Pervasives_Native.None
-                                               uu____7017
+                                               uu____6717
                                                (FStar_Pervasives_Native.Some
                                                   k) in
                                            (log_combinator "trivial" trivial;
                                             trivial)) in
-                                let uu____7037 =
-                                  let uu____7054 =
+                                let uu____6737 =
+                                  let uu____6754 =
                                     FStar_All.pipe_right ed2
                                       FStar_Syntax_Util.get_eff_repr in
-                                  match uu____7054 with
+                                  match uu____6754 with
                                   | FStar_Pervasives_Native.None ->
                                       (FStar_Pervasives_Native.None,
                                         FStar_Pervasives_Native.None,
                                         FStar_Pervasives_Native.None,
                                         (ed2.FStar_Syntax_Syntax.actions))
-                                  | uu____7083 ->
+                                  | uu____6783 ->
                                       let repr =
-                                        let uu____7087 = fresh_a_and_wp () in
-                                        match uu____7087 with
+                                        let uu____6787 = fresh_a_and_wp () in
+                                        match uu____6787 with
                                         | (a, wp_sort_a) ->
-                                            let uu____7100 =
+                                            let uu____6800 =
                                               FStar_Syntax_Util.type_u () in
-                                            (match uu____7100 with
-                                             | (t, uu____7106) ->
+                                            (match uu____6800 with
+                                             | (t, uu____6806) ->
                                                  let k =
-                                                   let uu____7110 =
-                                                     let uu____7119 =
+                                                   let uu____6810 =
+                                                     let uu____6819 =
                                                        FStar_Syntax_Syntax.mk_binder
                                                          a in
-                                                     let uu____7126 =
-                                                       let uu____7135 =
+                                                     let uu____6826 =
+                                                       let uu____6835 =
                                                          FStar_Syntax_Syntax.null_binder
                                                            wp_sort_a in
-                                                       [uu____7135] in
-                                                     uu____7119 :: uu____7126 in
-                                                   let uu____7160 =
+                                                       [uu____6835] in
+                                                     uu____6819 :: uu____6826 in
+                                                   let uu____6860 =
                                                      FStar_Syntax_Syntax.mk_GTotal
                                                        t in
                                                    FStar_Syntax_Util.arrow
-                                                     uu____7110 uu____7160 in
-                                                 let uu____7163 =
-                                                   let uu____7168 =
+                                                     uu____6810 uu____6860 in
+                                                 let uu____6863 =
+                                                   let uu____6868 =
                                                      FStar_All.pipe_right ed2
                                                        FStar_Syntax_Util.get_eff_repr in
                                                    FStar_All.pipe_right
-                                                     uu____7168
+                                                     uu____6868
                                                      FStar_Util.must in
                                                  check_and_gen' "repr"
                                                    Prims.int_one
                                                    FStar_Pervasives_Native.None
-                                                   uu____7163
+                                                   uu____6863
                                                    (FStar_Pervasives_Native.Some
                                                       k)) in
                                       (log_combinator "repr" repr;
                                        (let mk_repr' t wp =
-                                          let uu____7212 =
+                                          let uu____6912 =
                                             FStar_TypeChecker_Env.inst_tscheme
                                               repr in
-                                          match uu____7212 with
-                                          | (uu____7219, repr1) ->
+                                          match uu____6912 with
+                                          | (uu____6919, repr1) ->
                                               let repr2 =
                                                 FStar_TypeChecker_Normalize.normalize
                                                   [FStar_TypeChecker_Env.EraseUniverses;
                                                   FStar_TypeChecker_Env.AllowUnboundUniverses]
                                                   env repr1 in
-                                              let uu____7222 =
-                                                let uu____7223 =
-                                                  let uu____7240 =
-                                                    let uu____7251 =
+                                              let uu____6922 =
+                                                let uu____6923 =
+                                                  let uu____6940 =
+                                                    let uu____6951 =
                                                       FStar_All.pipe_right t
                                                         FStar_Syntax_Syntax.as_arg in
-                                                    let uu____7268 =
-                                                      let uu____7279 =
+                                                    let uu____6968 =
+                                                      let uu____6979 =
                                                         FStar_All.pipe_right
                                                           wp
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      [uu____7279] in
-                                                    uu____7251 :: uu____7268 in
-                                                  (repr2, uu____7240) in
+                                                      [uu____6979] in
+                                                    uu____6951 :: uu____6968 in
+                                                  (repr2, uu____6940) in
                                                 FStar_Syntax_Syntax.Tm_app
-                                                  uu____7223 in
+                                                  uu____6923 in
                                               FStar_Syntax_Syntax.mk
-                                                uu____7222
+                                                uu____6922
                                                 FStar_Range.dummyRange in
                                         let mk_repr a wp =
-                                          let uu____7345 =
+                                          let uu____7045 =
                                             FStar_Syntax_Syntax.bv_to_name a in
-                                          mk_repr' uu____7345 wp in
+                                          mk_repr' uu____7045 wp in
                                         let destruct_repr t =
-                                          let uu____7360 =
-                                            let uu____7361 =
+                                          let uu____7060 =
+                                            let uu____7061 =
                                               FStar_Syntax_Subst.compress t in
-                                            uu____7361.FStar_Syntax_Syntax.n in
-                                          match uu____7360 with
+                                            uu____7061.FStar_Syntax_Syntax.n in
+                                          match uu____7060 with
                                           | FStar_Syntax_Syntax.Tm_app
-                                              (uu____7372,
-                                               (t1, uu____7374)::(wp,
-                                                                  uu____7376)::[])
+                                              (uu____7072,
+                                               (t1, uu____7074)::(wp,
+                                                                  uu____7076)::[])
                                               -> (t1, wp)
-                                          | uu____7435 ->
+                                          | uu____7135 ->
                                               failwith "Unexpected repr type" in
                                         let return_repr =
                                           let return_repr_ts =
-                                            let uu____7451 =
+                                            let uu____7151 =
                                               FStar_All.pipe_right ed2
                                                 FStar_Syntax_Util.get_return_repr in
-                                            FStar_All.pipe_right uu____7451
+                                            FStar_All.pipe_right uu____7151
                                               FStar_Util.must in
-                                          let uu____7478 = fresh_a_and_wp () in
-                                          match uu____7478 with
-                                          | (a, uu____7486) ->
+                                          let uu____7178 = fresh_a_and_wp () in
+                                          match uu____7178 with
+                                          | (a, uu____7186) ->
                                               let x_a =
-                                                let uu____7492 =
+                                                let uu____7192 =
                                                   FStar_Syntax_Syntax.bv_to_name
                                                     a in
                                                 FStar_Syntax_Syntax.gen_bv
                                                   "x_a"
                                                   FStar_Pervasives_Native.None
-                                                  uu____7492 in
+                                                  uu____7192 in
                                               let res =
                                                 let wp =
-                                                  let uu____7498 =
-                                                    let uu____7499 =
+                                                  let uu____7198 =
+                                                    let uu____7199 =
                                                       FStar_TypeChecker_Env.inst_tscheme
                                                         ret_wp in
                                                     FStar_All.pipe_right
-                                                      uu____7499
+                                                      uu____7199
                                                       FStar_Pervasives_Native.snd in
-                                                  let uu____7508 =
-                                                    let uu____7509 =
-                                                      let uu____7518 =
+                                                  let uu____7208 =
+                                                    let uu____7209 =
+                                                      let uu____7218 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           a in
                                                       FStar_All.pipe_right
-                                                        uu____7518
+                                                        uu____7218
                                                         FStar_Syntax_Syntax.as_arg in
-                                                    let uu____7527 =
-                                                      let uu____7538 =
-                                                        let uu____7547 =
+                                                    let uu____7227 =
+                                                      let uu____7238 =
+                                                        let uu____7247 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             x_a in
                                                         FStar_All.pipe_right
-                                                          uu____7547
+                                                          uu____7247
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      [uu____7538] in
-                                                    uu____7509 :: uu____7527 in
+                                                      [uu____7238] in
+                                                    uu____7209 :: uu____7227 in
                                                   FStar_Syntax_Syntax.mk_Tm_app
-                                                    uu____7498 uu____7508
+                                                    uu____7198 uu____7208
                                                     FStar_Range.dummyRange in
                                                 mk_repr a wp in
                                               let k =
-                                                let uu____7583 =
-                                                  let uu____7592 =
+                                                let uu____7283 =
+                                                  let uu____7292 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       a in
-                                                  let uu____7599 =
-                                                    let uu____7608 =
+                                                  let uu____7299 =
+                                                    let uu____7308 =
                                                       FStar_Syntax_Syntax.mk_binder
                                                         x_a in
-                                                    [uu____7608] in
-                                                  uu____7592 :: uu____7599 in
-                                                let uu____7633 =
+                                                    [uu____7308] in
+                                                  uu____7292 :: uu____7299 in
+                                                let uu____7333 =
                                                   FStar_Syntax_Syntax.mk_Total
                                                     res in
                                                 FStar_Syntax_Util.arrow
-                                                  uu____7583 uu____7633 in
-                                              let uu____7636 =
+                                                  uu____7283 uu____7333 in
+                                              let uu____7336 =
                                                 FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                   env k in
-                                              (match uu____7636 with
-                                               | (k1, uu____7644, uu____7645)
+                                              (match uu____7336 with
+                                               | (k1, uu____7344, uu____7345)
                                                    ->
                                                    let env1 =
-                                                     let uu____7649 =
+                                                     let uu____7349 =
                                                        FStar_TypeChecker_Env.set_range
                                                          env
                                                          (FStar_Pervasives_Native.snd
                                                             return_repr_ts).FStar_Syntax_Syntax.pos in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____7649 in
+                                                       uu____7349 in
                                                    check_and_gen'
                                                      "return_repr"
                                                      Prims.int_one env1
@@ -3070,40 +2885,40 @@ let (tc_non_layered_eff_decl :
                                           return_repr;
                                         (let bind_repr =
                                            let bind_repr_ts =
-                                             let uu____7662 =
+                                             let uu____7362 =
                                                FStar_All.pipe_right ed2
                                                  FStar_Syntax_Util.get_bind_repr in
-                                             FStar_All.pipe_right uu____7662
+                                             FStar_All.pipe_right uu____7362
                                                FStar_Util.must in
                                            let r =
-                                             let uu____7700 =
+                                             let uu____7400 =
                                                FStar_Syntax_Syntax.lid_as_fv
                                                  FStar_Parser_Const.range_0
                                                  FStar_Syntax_Syntax.delta_constant
                                                  FStar_Pervasives_Native.None in
-                                             FStar_All.pipe_right uu____7700
+                                             FStar_All.pipe_right uu____7400
                                                FStar_Syntax_Syntax.fv_to_tm in
-                                           let uu____7701 = fresh_a_and_wp () in
-                                           match uu____7701 with
+                                           let uu____7401 = fresh_a_and_wp () in
+                                           match uu____7401 with
                                            | (a, wp_sort_a) ->
-                                               let uu____7714 =
+                                               let uu____7414 =
                                                  fresh_a_and_wp () in
-                                               (match uu____7714 with
+                                               (match uu____7414 with
                                                 | (b, wp_sort_b) ->
                                                     let wp_sort_a_b =
-                                                      let uu____7730 =
-                                                        let uu____7739 =
-                                                          let uu____7746 =
+                                                      let uu____7430 =
+                                                        let uu____7439 =
+                                                          let uu____7446 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               a in
                                                           FStar_Syntax_Syntax.null_binder
-                                                            uu____7746 in
-                                                        [uu____7739] in
-                                                      let uu____7759 =
+                                                            uu____7446 in
+                                                        [uu____7439] in
+                                                      let uu____7459 =
                                                         FStar_Syntax_Syntax.mk_Total
                                                           wp_sort_b in
                                                       FStar_Syntax_Util.arrow
-                                                        uu____7730 uu____7759 in
+                                                        uu____7430 uu____7459 in
                                                     let wp_f =
                                                       FStar_Syntax_Syntax.gen_bv
                                                         "wp_f"
@@ -3115,187 +2930,187 @@ let (tc_non_layered_eff_decl :
                                                         FStar_Pervasives_Native.None
                                                         wp_sort_a_b in
                                                     let x_a =
-                                                      let uu____7767 =
+                                                      let uu____7467 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           a in
                                                       FStar_Syntax_Syntax.gen_bv
                                                         "x_a"
                                                         FStar_Pervasives_Native.None
-                                                        uu____7767 in
+                                                        uu____7467 in
                                                     let wp_g_x =
-                                                      let uu____7770 =
+                                                      let uu____7470 =
                                                         FStar_Syntax_Syntax.bv_to_name
                                                           wp_g in
-                                                      let uu____7771 =
-                                                        let uu____7772 =
-                                                          let uu____7781 =
+                                                      let uu____7471 =
+                                                        let uu____7472 =
+                                                          let uu____7481 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x_a in
                                                           FStar_All.pipe_right
-                                                            uu____7781
+                                                            uu____7481
                                                             FStar_Syntax_Syntax.as_arg in
-                                                        [uu____7772] in
+                                                        [uu____7472] in
                                                       FStar_Syntax_Syntax.mk_Tm_app
-                                                        uu____7770 uu____7771
+                                                        uu____7470 uu____7471
                                                         FStar_Range.dummyRange in
                                                     let res =
                                                       let wp =
-                                                        let uu____7810 =
-                                                          let uu____7811 =
+                                                        let uu____7510 =
+                                                          let uu____7511 =
                                                             FStar_TypeChecker_Env.inst_tscheme
                                                               bind_wp in
                                                           FStar_All.pipe_right
-                                                            uu____7811
+                                                            uu____7511
                                                             FStar_Pervasives_Native.snd in
-                                                        let uu____7820 =
-                                                          let uu____7821 =
-                                                            let uu____7824 =
-                                                              let uu____7827
+                                                        let uu____7520 =
+                                                          let uu____7521 =
+                                                            let uu____7524 =
+                                                              let uu____7527
                                                                 =
                                                                 FStar_Syntax_Syntax.bv_to_name
                                                                   a in
-                                                              let uu____7828
+                                                              let uu____7528
                                                                 =
-                                                                let uu____7831
+                                                                let uu____7531
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     b in
-                                                                let uu____7832
+                                                                let uu____7532
                                                                   =
-                                                                  let uu____7835
+                                                                  let uu____7535
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f in
-                                                                  let uu____7836
+                                                                  let uu____7536
                                                                     =
-                                                                    let uu____7839
+                                                                    let uu____7539
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_g in
-                                                                    [uu____7839] in
-                                                                  uu____7835
+                                                                    [uu____7539] in
+                                                                  uu____7535
                                                                     ::
-                                                                    uu____7836 in
-                                                                uu____7831 ::
-                                                                  uu____7832 in
-                                                              uu____7827 ::
-                                                                uu____7828 in
-                                                            r :: uu____7824 in
+                                                                    uu____7536 in
+                                                                uu____7531 ::
+                                                                  uu____7532 in
+                                                              uu____7527 ::
+                                                                uu____7528 in
+                                                            r :: uu____7524 in
                                                           FStar_List.map
                                                             FStar_Syntax_Syntax.as_arg
-                                                            uu____7821 in
+                                                            uu____7521 in
                                                         FStar_Syntax_Syntax.mk_Tm_app
-                                                          uu____7810
-                                                          uu____7820
+                                                          uu____7510
+                                                          uu____7520
                                                           FStar_Range.dummyRange in
                                                       mk_repr b wp in
                                                     let maybe_range_arg =
-                                                      let uu____7857 =
+                                                      let uu____7557 =
                                                         FStar_Util.for_some
                                                           (FStar_Syntax_Util.attr_eq
                                                              FStar_Syntax_Util.dm4f_bind_range_attr)
                                                           ed2.FStar_Syntax_Syntax.eff_attrs in
-                                                      if uu____7857
+                                                      if uu____7557
                                                       then
-                                                        let uu____7868 =
+                                                        let uu____7568 =
                                                           FStar_Syntax_Syntax.null_binder
                                                             FStar_Syntax_Syntax.t_range in
-                                                        let uu____7875 =
-                                                          let uu____7884 =
+                                                        let uu____7575 =
+                                                          let uu____7584 =
                                                             FStar_Syntax_Syntax.null_binder
                                                               FStar_Syntax_Syntax.t_range in
-                                                          [uu____7884] in
-                                                        uu____7868 ::
-                                                          uu____7875
+                                                          [uu____7584] in
+                                                        uu____7568 ::
+                                                          uu____7575
                                                       else [] in
                                                     let k =
-                                                      let uu____7920 =
-                                                        let uu____7929 =
-                                                          let uu____7938 =
+                                                      let uu____7620 =
+                                                        let uu____7629 =
+                                                          let uu____7638 =
                                                             FStar_Syntax_Syntax.mk_binder
                                                               a in
-                                                          let uu____7945 =
-                                                            let uu____7954 =
+                                                          let uu____7645 =
+                                                            let uu____7654 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 b in
-                                                            [uu____7954] in
-                                                          uu____7938 ::
-                                                            uu____7945 in
-                                                        let uu____7979 =
-                                                          let uu____7988 =
-                                                            let uu____7997 =
+                                                            [uu____7654] in
+                                                          uu____7638 ::
+                                                            uu____7645 in
+                                                        let uu____7679 =
+                                                          let uu____7688 =
+                                                            let uu____7697 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 wp_f in
-                                                            let uu____8004 =
-                                                              let uu____8013
+                                                            let uu____7704 =
+                                                              let uu____7713
                                                                 =
-                                                                let uu____8020
+                                                                let uu____7720
                                                                   =
-                                                                  let uu____8021
+                                                                  let uu____7721
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f in
                                                                   mk_repr a
-                                                                    uu____8021 in
+                                                                    uu____7721 in
                                                                 FStar_Syntax_Syntax.null_binder
-                                                                  uu____8020 in
-                                                              let uu____8022
+                                                                  uu____7720 in
+                                                              let uu____7722
                                                                 =
-                                                                let uu____8031
+                                                                let uu____7731
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     wp_g in
-                                                                let uu____8038
+                                                                let uu____7738
                                                                   =
-                                                                  let uu____8047
+                                                                  let uu____7747
                                                                     =
-                                                                    let uu____8054
+                                                                    let uu____7754
                                                                     =
-                                                                    let uu____8055
+                                                                    let uu____7755
                                                                     =
-                                                                    let uu____8064
+                                                                    let uu____7764
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x_a in
-                                                                    [uu____8064] in
-                                                                    let uu____8083
+                                                                    [uu____7764] in
+                                                                    let uu____7783
                                                                     =
-                                                                    let uu____8086
+                                                                    let uu____7786
                                                                     =
                                                                     mk_repr b
                                                                     wp_g_x in
                                                                     FStar_All.pipe_left
                                                                     FStar_Syntax_Syntax.mk_Total
-                                                                    uu____8086 in
+                                                                    uu____7786 in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____8055
-                                                                    uu____8083 in
+                                                                    uu____7755
+                                                                    uu____7783 in
                                                                     FStar_Syntax_Syntax.null_binder
-                                                                    uu____8054 in
-                                                                  [uu____8047] in
-                                                                uu____8031 ::
-                                                                  uu____8038 in
-                                                              uu____8013 ::
-                                                                uu____8022 in
-                                                            uu____7997 ::
-                                                              uu____8004 in
+                                                                    uu____7754 in
+                                                                  [uu____7747] in
+                                                                uu____7731 ::
+                                                                  uu____7738 in
+                                                              uu____7713 ::
+                                                                uu____7722 in
+                                                            uu____7697 ::
+                                                              uu____7704 in
                                                           FStar_List.append
                                                             maybe_range_arg
-                                                            uu____7988 in
+                                                            uu____7688 in
                                                         FStar_List.append
-                                                          uu____7929
-                                                          uu____7979 in
-                                                      let uu____8131 =
+                                                          uu____7629
+                                                          uu____7679 in
+                                                      let uu____7831 =
                                                         FStar_Syntax_Syntax.mk_Total
                                                           res in
                                                       FStar_Syntax_Util.arrow
-                                                        uu____7920 uu____8131 in
-                                                    let uu____8134 =
+                                                        uu____7620 uu____7831 in
+                                                    let uu____7834 =
                                                       FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                         env k in
-                                                    (match uu____8134 with
-                                                     | (k1, uu____8142,
-                                                        uu____8143) ->
+                                                    (match uu____7834 with
+                                                     | (k1, uu____7842,
+                                                        uu____7843) ->
                                                          let env1 =
                                                            FStar_TypeChecker_Env.set_range
                                                              env
@@ -3303,154 +3118,154 @@ let (tc_non_layered_eff_decl :
                                                                 bind_repr_ts).FStar_Syntax_Syntax.pos in
                                                          let env2 =
                                                            FStar_All.pipe_right
-                                                             (let uu___810_8153
+                                                             (let uu___793_7853
                                                                 = env1 in
                                                               {
                                                                 FStar_TypeChecker_Env.solver
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.solver);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.solver);
                                                                 FStar_TypeChecker_Env.range
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.range);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.range);
                                                                 FStar_TypeChecker_Env.curmodule
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.curmodule);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.curmodule);
                                                                 FStar_TypeChecker_Env.gamma
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.gamma);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.gamma);
                                                                 FStar_TypeChecker_Env.gamma_sig
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.gamma_sig);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.gamma_sig);
                                                                 FStar_TypeChecker_Env.gamma_cache
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.gamma_cache);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.gamma_cache);
                                                                 FStar_TypeChecker_Env.modules
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.modules);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.modules);
                                                                 FStar_TypeChecker_Env.expected_typ
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.expected_typ);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.expected_typ);
                                                                 FStar_TypeChecker_Env.sigtab
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.sigtab);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.sigtab);
                                                                 FStar_TypeChecker_Env.attrtab
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.attrtab);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.attrtab);
                                                                 FStar_TypeChecker_Env.instantiate_imp
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.instantiate_imp);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.instantiate_imp);
                                                                 FStar_TypeChecker_Env.effects
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.effects);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.effects);
                                                                 FStar_TypeChecker_Env.generalize
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.generalize);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.generalize);
                                                                 FStar_TypeChecker_Env.letrecs
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.letrecs);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.letrecs);
                                                                 FStar_TypeChecker_Env.top_level
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.top_level);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.top_level);
                                                                 FStar_TypeChecker_Env.check_uvars
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.check_uvars);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.check_uvars);
                                                                 FStar_TypeChecker_Env.use_eq
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.use_eq);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.use_eq);
                                                                 FStar_TypeChecker_Env.use_eq_strict
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.use_eq_strict);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.use_eq_strict);
                                                                 FStar_TypeChecker_Env.is_iface
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.is_iface);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.is_iface);
                                                                 FStar_TypeChecker_Env.admit
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.admit);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.admit);
                                                                 FStar_TypeChecker_Env.lax
                                                                   = true;
                                                                 FStar_TypeChecker_Env.lax_universes
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.lax_universes);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.lax_universes);
                                                                 FStar_TypeChecker_Env.phase1
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.phase1);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.phase1);
                                                                 FStar_TypeChecker_Env.failhard
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.failhard);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.failhard);
                                                                 FStar_TypeChecker_Env.nosynth
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.nosynth);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.nosynth);
                                                                 FStar_TypeChecker_Env.uvar_subtyping
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.uvar_subtyping);
                                                                 FStar_TypeChecker_Env.tc_term
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.tc_term);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.tc_term);
                                                                 FStar_TypeChecker_Env.type_of
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.type_of);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.type_of);
                                                                 FStar_TypeChecker_Env.universe_of
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.universe_of);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.universe_of);
                                                                 FStar_TypeChecker_Env.check_type_of
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.check_type_of);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.check_type_of);
                                                                 FStar_TypeChecker_Env.use_bv_sorts
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.use_bv_sorts);
                                                                 FStar_TypeChecker_Env.qtbl_name_and_index
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                 FStar_TypeChecker_Env.normalized_eff_names
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.normalized_eff_names);
                                                                 FStar_TypeChecker_Env.fv_delta_depths
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.fv_delta_depths);
                                                                 FStar_TypeChecker_Env.proof_ns
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.proof_ns);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.proof_ns);
                                                                 FStar_TypeChecker_Env.synth_hook
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.synth_hook);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.synth_hook);
                                                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                 FStar_TypeChecker_Env.splice
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.splice);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.splice);
                                                                 FStar_TypeChecker_Env.mpreprocess
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.mpreprocess);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.mpreprocess);
                                                                 FStar_TypeChecker_Env.postprocess
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.postprocess);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.postprocess);
                                                                 FStar_TypeChecker_Env.identifier_info
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.identifier_info);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.identifier_info);
                                                                 FStar_TypeChecker_Env.tc_hooks
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.tc_hooks);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.tc_hooks);
                                                                 FStar_TypeChecker_Env.dsenv
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.dsenv);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.dsenv);
                                                                 FStar_TypeChecker_Env.nbe
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.nbe);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.nbe);
                                                                 FStar_TypeChecker_Env.strict_args_tab
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.strict_args_tab);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.strict_args_tab);
                                                                 FStar_TypeChecker_Env.erasable_types_tab
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.erasable_types_tab);
                                                                 FStar_TypeChecker_Env.enable_defer_to_tac
                                                                   =
-                                                                  (uu___810_8153.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                  (uu___793_7853.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                               })
-                                                             (fun uu____8155
+                                                             (fun uu____7855
                                                                 ->
                                                                 FStar_Pervasives_Native.Some
-                                                                  uu____8155) in
+                                                                  uu____7855) in
                                                          check_and_gen'
                                                            "bind_repr"
                                                            (Prims.of_int (2))
@@ -3468,273 +3283,273 @@ let (tc_non_layered_eff_decl :
                                                 failwith
                                                   "tc_eff_decl: expected action_params to be empty"
                                               else ();
-                                              (let uu____8182 =
+                                              (let uu____7882 =
                                                  if
                                                    act.FStar_Syntax_Syntax.action_univs
                                                      = []
                                                  then (env, act)
                                                  else
-                                                   (let uu____8196 =
+                                                   (let uu____7896 =
                                                       FStar_Syntax_Subst.univ_var_opening
                                                         act.FStar_Syntax_Syntax.action_univs in
-                                                    match uu____8196 with
+                                                    match uu____7896 with
                                                     | (usubst, uvs) ->
-                                                        let uu____8219 =
+                                                        let uu____7919 =
                                                           FStar_TypeChecker_Env.push_univ_vars
                                                             env uvs in
-                                                        let uu____8220 =
-                                                          let uu___823_8221 =
+                                                        let uu____7920 =
+                                                          let uu___806_7921 =
                                                             act in
-                                                          let uu____8222 =
+                                                          let uu____7922 =
                                                             FStar_Syntax_Subst.subst
                                                               usubst
                                                               act.FStar_Syntax_Syntax.action_defn in
-                                                          let uu____8223 =
+                                                          let uu____7923 =
                                                             FStar_Syntax_Subst.subst
                                                               usubst
                                                               act.FStar_Syntax_Syntax.action_typ in
                                                           {
                                                             FStar_Syntax_Syntax.action_name
                                                               =
-                                                              (uu___823_8221.FStar_Syntax_Syntax.action_name);
+                                                              (uu___806_7921.FStar_Syntax_Syntax.action_name);
                                                             FStar_Syntax_Syntax.action_unqualified_name
                                                               =
-                                                              (uu___823_8221.FStar_Syntax_Syntax.action_unqualified_name);
+                                                              (uu___806_7921.FStar_Syntax_Syntax.action_unqualified_name);
                                                             FStar_Syntax_Syntax.action_univs
                                                               = uvs;
                                                             FStar_Syntax_Syntax.action_params
                                                               =
-                                                              (uu___823_8221.FStar_Syntax_Syntax.action_params);
+                                                              (uu___806_7921.FStar_Syntax_Syntax.action_params);
                                                             FStar_Syntax_Syntax.action_defn
-                                                              = uu____8222;
+                                                              = uu____7922;
                                                             FStar_Syntax_Syntax.action_typ
-                                                              = uu____8223
+                                                              = uu____7923
                                                           } in
-                                                        (uu____8219,
-                                                          uu____8220)) in
-                                               match uu____8182 with
+                                                        (uu____7919,
+                                                          uu____7920)) in
+                                               match uu____7882 with
                                                | (env1, act1) ->
                                                    let act_typ =
-                                                     let uu____8227 =
-                                                       let uu____8228 =
+                                                     let uu____7927 =
+                                                       let uu____7928 =
                                                          FStar_Syntax_Subst.compress
                                                            act1.FStar_Syntax_Syntax.action_typ in
-                                                       uu____8228.FStar_Syntax_Syntax.n in
-                                                     match uu____8227 with
+                                                       uu____7928.FStar_Syntax_Syntax.n in
+                                                     match uu____7927 with
                                                      | FStar_Syntax_Syntax.Tm_arrow
                                                          (bs1, c) ->
                                                          let c1 =
                                                            FStar_Syntax_Util.comp_to_comp_typ
                                                              c in
-                                                         let uu____8254 =
+                                                         let uu____7954 =
                                                            FStar_Ident.lid_equals
                                                              c1.FStar_Syntax_Syntax.effect_name
                                                              ed2.FStar_Syntax_Syntax.mname in
-                                                         if uu____8254
+                                                         if uu____7954
                                                          then
-                                                           let uu____8257 =
-                                                             let uu____8260 =
-                                                               let uu____8261
+                                                           let uu____7957 =
+                                                             let uu____7960 =
+                                                               let uu____7961
                                                                  =
-                                                                 let uu____8262
+                                                                 let uu____7962
                                                                    =
                                                                    FStar_List.hd
                                                                     c1.FStar_Syntax_Syntax.effect_args in
                                                                  FStar_Pervasives_Native.fst
-                                                                   uu____8262 in
+                                                                   uu____7962 in
                                                                mk_repr'
                                                                  c1.FStar_Syntax_Syntax.result_typ
-                                                                 uu____8261 in
+                                                                 uu____7961 in
                                                              FStar_Syntax_Syntax.mk_Total
-                                                               uu____8260 in
+                                                               uu____7960 in
                                                            FStar_Syntax_Util.arrow
-                                                             bs1 uu____8257
+                                                             bs1 uu____7957
                                                          else
                                                            act1.FStar_Syntax_Syntax.action_typ
-                                                     | uu____8285 ->
+                                                     | uu____7985 ->
                                                          act1.FStar_Syntax_Syntax.action_typ in
-                                                   let uu____8286 =
+                                                   let uu____7986 =
                                                      FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                        env1 act_typ in
-                                                   (match uu____8286 with
-                                                    | (act_typ1, uu____8294,
+                                                   (match uu____7986 with
+                                                    | (act_typ1, uu____7994,
                                                        g_t) ->
                                                         let env' =
-                                                          let uu___840_8297 =
+                                                          let uu___823_7997 =
                                                             FStar_TypeChecker_Env.set_expected_typ
                                                               env1 act_typ1 in
                                                           {
                                                             FStar_TypeChecker_Env.solver
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.solver);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.solver);
                                                             FStar_TypeChecker_Env.range
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.range);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.range);
                                                             FStar_TypeChecker_Env.curmodule
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.curmodule);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.curmodule);
                                                             FStar_TypeChecker_Env.gamma
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.gamma);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.gamma);
                                                             FStar_TypeChecker_Env.gamma_sig
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.gamma_sig);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.gamma_sig);
                                                             FStar_TypeChecker_Env.gamma_cache
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.gamma_cache);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.gamma_cache);
                                                             FStar_TypeChecker_Env.modules
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.modules);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.modules);
                                                             FStar_TypeChecker_Env.expected_typ
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.expected_typ);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.expected_typ);
                                                             FStar_TypeChecker_Env.sigtab
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.sigtab);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.sigtab);
                                                             FStar_TypeChecker_Env.attrtab
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.attrtab);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.attrtab);
                                                             FStar_TypeChecker_Env.instantiate_imp
                                                               = false;
                                                             FStar_TypeChecker_Env.effects
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.effects);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.effects);
                                                             FStar_TypeChecker_Env.generalize
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.generalize);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.generalize);
                                                             FStar_TypeChecker_Env.letrecs
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.letrecs);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.letrecs);
                                                             FStar_TypeChecker_Env.top_level
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.top_level);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.top_level);
                                                             FStar_TypeChecker_Env.check_uvars
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.check_uvars);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.check_uvars);
                                                             FStar_TypeChecker_Env.use_eq
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.use_eq);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.use_eq);
                                                             FStar_TypeChecker_Env.use_eq_strict
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.use_eq_strict);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.use_eq_strict);
                                                             FStar_TypeChecker_Env.is_iface
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.is_iface);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.is_iface);
                                                             FStar_TypeChecker_Env.admit
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.admit);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.admit);
                                                             FStar_TypeChecker_Env.lax
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.lax);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.lax);
                                                             FStar_TypeChecker_Env.lax_universes
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.lax_universes);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.lax_universes);
                                                             FStar_TypeChecker_Env.phase1
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.phase1);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.phase1);
                                                             FStar_TypeChecker_Env.failhard
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.failhard);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.failhard);
                                                             FStar_TypeChecker_Env.nosynth
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.nosynth);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.nosynth);
                                                             FStar_TypeChecker_Env.uvar_subtyping
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.uvar_subtyping);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.uvar_subtyping);
                                                             FStar_TypeChecker_Env.tc_term
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.tc_term);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.tc_term);
                                                             FStar_TypeChecker_Env.type_of
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.type_of);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.type_of);
                                                             FStar_TypeChecker_Env.universe_of
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.universe_of);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.universe_of);
                                                             FStar_TypeChecker_Env.check_type_of
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.check_type_of);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.check_type_of);
                                                             FStar_TypeChecker_Env.use_bv_sorts
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.use_bv_sorts);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.use_bv_sorts);
                                                             FStar_TypeChecker_Env.qtbl_name_and_index
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                             FStar_TypeChecker_Env.normalized_eff_names
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.normalized_eff_names);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.normalized_eff_names);
                                                             FStar_TypeChecker_Env.fv_delta_depths
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.fv_delta_depths);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.fv_delta_depths);
                                                             FStar_TypeChecker_Env.proof_ns
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.proof_ns);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.proof_ns);
                                                             FStar_TypeChecker_Env.synth_hook
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.synth_hook);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.synth_hook);
                                                             FStar_TypeChecker_Env.try_solve_implicits_hook
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                             FStar_TypeChecker_Env.splice
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.splice);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.splice);
                                                             FStar_TypeChecker_Env.mpreprocess
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.mpreprocess);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.mpreprocess);
                                                             FStar_TypeChecker_Env.postprocess
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.postprocess);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.postprocess);
                                                             FStar_TypeChecker_Env.identifier_info
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.identifier_info);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.identifier_info);
                                                             FStar_TypeChecker_Env.tc_hooks
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.tc_hooks);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.tc_hooks);
                                                             FStar_TypeChecker_Env.dsenv
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.dsenv);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.dsenv);
                                                             FStar_TypeChecker_Env.nbe
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.nbe);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.nbe);
                                                             FStar_TypeChecker_Env.strict_args_tab
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.strict_args_tab);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.strict_args_tab);
                                                             FStar_TypeChecker_Env.erasable_types_tab
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.erasable_types_tab);
+                                                              (uu___823_7997.FStar_TypeChecker_Env.erasable_types_tab);
                                                             FStar_TypeChecker_Env.enable_defer_to_tac
                                                               =
-                                                              (uu___840_8297.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                              (uu___823_7997.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                           } in
-                                                        ((let uu____8300 =
+                                                        ((let uu____8000 =
                                                             FStar_TypeChecker_Env.debug
                                                               env1
                                                               (FStar_Options.Other
                                                                  "ED") in
-                                                          if uu____8300
+                                                          if uu____8000
                                                           then
-                                                            let uu____8304 =
+                                                            let uu____8004 =
                                                               FStar_Ident.string_of_lid
                                                                 act1.FStar_Syntax_Syntax.action_name in
-                                                            let uu____8306 =
+                                                            let uu____8006 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 act1.FStar_Syntax_Syntax.action_defn in
-                                                            let uu____8308 =
+                                                            let uu____8008 =
                                                               FStar_Syntax_Print.term_to_string
                                                                 act_typ1 in
                                                             FStar_Util.print3
                                                               "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
-                                                              uu____8304
-                                                              uu____8306
-                                                              uu____8308
+                                                              uu____8004
+                                                              uu____8006
+                                                              uu____8008
                                                           else ());
-                                                         (let uu____8313 =
+                                                         (let uu____8013 =
                                                             FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                               env'
                                                               act1.FStar_Syntax_Syntax.action_defn in
-                                                          match uu____8313
+                                                          match uu____8013
                                                           with
                                                           | (act_defn,
-                                                             uu____8321, g_a)
+                                                             uu____8021, g_a)
                                                               ->
                                                               let act_defn1 =
                                                                 FStar_TypeChecker_Normalize.normalize
@@ -3750,7 +3565,7 @@ let (tc_non_layered_eff_decl :
                                                                   FStar_TypeChecker_Env.Beta]
                                                                   env1
                                                                   act_typ1 in
-                                                              let uu____8325
+                                                              let uu____8025
                                                                 =
                                                                 let act_typ3
                                                                   =
@@ -3762,63 +3577,63 @@ let (tc_non_layered_eff_decl :
                                                                 | FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1, c)
                                                                     ->
-                                                                    let uu____8361
+                                                                    let uu____8061
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c in
-                                                                    (match uu____8361
+                                                                    (match uu____8061
                                                                     with
                                                                     | 
                                                                     (bs2,
-                                                                    uu____8373)
+                                                                    uu____8073)
                                                                     ->
                                                                     let res =
                                                                     mk_repr'
                                                                     FStar_Syntax_Syntax.tun
                                                                     FStar_Syntax_Syntax.tun in
                                                                     let k =
-                                                                    let uu____8380
+                                                                    let uu____8080
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     res in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____8380 in
-                                                                    let uu____8383
+                                                                    uu____8080 in
+                                                                    let uu____8083
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                                     env1 k in
-                                                                    (match uu____8383
+                                                                    (match uu____8083
                                                                     with
                                                                     | 
                                                                     (k1,
-                                                                    uu____8397,
+                                                                    uu____8097,
                                                                     g) ->
                                                                     (k1, g)))
-                                                                | uu____8401
+                                                                | uu____8101
                                                                     ->
-                                                                    let uu____8402
+                                                                    let uu____8102
                                                                     =
-                                                                    let uu____8408
+                                                                    let uu____8108
                                                                     =
-                                                                    let uu____8410
+                                                                    let uu____8110
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     act_typ3 in
-                                                                    let uu____8412
+                                                                    let uu____8112
                                                                     =
                                                                     FStar_Syntax_Print.tag_of_term
                                                                     act_typ3 in
                                                                     FStar_Util.format2
                                                                     "Actions must have function types (not: %s, a.k.a. %s)"
-                                                                    uu____8410
-                                                                    uu____8412 in
+                                                                    uu____8110
+                                                                    uu____8112 in
                                                                     (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                                    uu____8408) in
+                                                                    uu____8108) in
                                                                     FStar_Errors.raise_error
-                                                                    uu____8402
+                                                                    uu____8102
                                                                     act_defn1.FStar_Syntax_Syntax.pos in
-                                                              (match uu____8325
+                                                              (match uu____8025
                                                                with
                                                                | (expected_k,
                                                                   g_k) ->
@@ -3828,77 +3643,77 @@ let (tc_non_layered_eff_decl :
                                                                     act_typ2
                                                                     expected_k in
                                                                    ((
-                                                                    let uu____8430
+                                                                    let uu____8130
                                                                     =
-                                                                    let uu____8431
+                                                                    let uu____8131
                                                                     =
-                                                                    let uu____8432
+                                                                    let uu____8132
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_t g in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_k
-                                                                    uu____8432 in
+                                                                    uu____8132 in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_a
-                                                                    uu____8431 in
+                                                                    uu____8131 in
                                                                     FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env1
-                                                                    uu____8430);
+                                                                    uu____8130);
                                                                     (
                                                                     let act_typ3
                                                                     =
-                                                                    let uu____8434
+                                                                    let uu____8134
                                                                     =
-                                                                    let uu____8435
+                                                                    let uu____8135
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     expected_k in
-                                                                    uu____8435.FStar_Syntax_Syntax.n in
-                                                                    match uu____8434
+                                                                    uu____8135.FStar_Syntax_Syntax.n in
+                                                                    match uu____8134
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1, c)
                                                                     ->
-                                                                    let uu____8460
+                                                                    let uu____8160
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c in
-                                                                    (match uu____8460
+                                                                    (match uu____8160
                                                                     with
                                                                     | 
                                                                     (bs2, c1)
                                                                     ->
-                                                                    let uu____8467
+                                                                    let uu____8167
                                                                     =
                                                                     destruct_repr
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c1) in
-                                                                    (match uu____8467
+                                                                    (match uu____8167
                                                                     with
                                                                     | 
                                                                     (a, wp)
                                                                     ->
                                                                     let c2 =
-                                                                    let uu____8487
+                                                                    let uu____8187
                                                                     =
-                                                                    let uu____8488
+                                                                    let uu____8188
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 a in
-                                                                    [uu____8488] in
-                                                                    let uu____8489
+                                                                    [uu____8188] in
+                                                                    let uu____8189
                                                                     =
-                                                                    let uu____8500
+                                                                    let uu____8200
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     wp in
-                                                                    [uu____8500] in
+                                                                    [uu____8200] in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____8487;
+                                                                    uu____8187;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     =
                                                                     (ed2.FStar_Syntax_Syntax.mname);
@@ -3906,23 +3721,23 @@ let (tc_non_layered_eff_decl :
                                                                     = a;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____8489;
+                                                                    uu____8189;
                                                                     FStar_Syntax_Syntax.flags
                                                                     = []
                                                                     } in
-                                                                    let uu____8525
+                                                                    let uu____8225
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Comp
                                                                     c2 in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____8525))
+                                                                    uu____8225))
                                                                     | 
-                                                                    uu____8528
+                                                                    uu____8228
                                                                     ->
                                                                     failwith
                                                                     "Impossible (expected_k is an arrow)" in
-                                                                    let uu____8530
+                                                                    let uu____8230
                                                                     =
                                                                     if
                                                                     act1.FStar_Syntax_Syntax.action_univs
@@ -3932,14 +3747,14 @@ let (tc_non_layered_eff_decl :
                                                                     env1
                                                                     act_defn1
                                                                     else
-                                                                    (let uu____8552
+                                                                    (let uu____8252
                                                                     =
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     act1.FStar_Syntax_Syntax.action_univs
                                                                     act_defn1 in
                                                                     ((act1.FStar_Syntax_Syntax.action_univs),
-                                                                    uu____8552)) in
-                                                                    match uu____8530
+                                                                    uu____8252)) in
+                                                                    match uu____8230
                                                                     with
                                                                     | 
                                                                     (univs,
@@ -3956,20 +3771,20 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     univs
                                                                     act_typ4 in
-                                                                    let uu___890_8571
+                                                                    let uu___873_8271
                                                                     = act1 in
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___890_8571.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___873_8271.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___890_8571.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___873_8271.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     = univs;
                                                                     FStar_Syntax_Syntax.action_params
                                                                     =
-                                                                    (uu___890_8571.FStar_Syntax_Syntax.action_params);
+                                                                    (uu___873_8271.FStar_Syntax_Syntax.action_params);
                                                                     FStar_Syntax_Syntax.action_defn
                                                                     =
                                                                     act_defn2;
@@ -3985,7 +3800,7 @@ let (tc_non_layered_eff_decl :
                                                return_repr),
                                             (FStar_Pervasives_Native.Some
                                                bind_repr), actions))))) in
-                                match uu____7037 with
+                                match uu____6737 with
                                 | (repr, return_repr, bind_repr, actions) ->
                                     let cl ts =
                                       let ts1 =
@@ -3994,12 +3809,12 @@ let (tc_non_layered_eff_decl :
                                       let ed_univs_closing =
                                         FStar_Syntax_Subst.univ_var_closing
                                           ed_univs in
-                                      let uu____8614 =
+                                      let uu____8314 =
                                         FStar_Syntax_Subst.shift_subst
                                           (FStar_List.length ed_bs)
                                           ed_univs_closing in
                                       FStar_Syntax_Subst.subst_tscheme
-                                        uu____8614 ts1 in
+                                        uu____8314 ts1 in
                                     let combinators =
                                       {
                                         FStar_Syntax_Syntax.ret_wp = ret_wp;
@@ -4025,87 +3840,87 @@ let (tc_non_layered_eff_decl :
                                       match ed2.FStar_Syntax_Syntax.combinators
                                       with
                                       | FStar_Syntax_Syntax.Primitive_eff
-                                          uu____8626 ->
+                                          uu____8326 ->
                                           FStar_Syntax_Syntax.Primitive_eff
                                             combinators1
                                       | FStar_Syntax_Syntax.DM4F_eff
-                                          uu____8627 ->
+                                          uu____8327 ->
                                           FStar_Syntax_Syntax.DM4F_eff
                                             combinators1
-                                      | uu____8628 ->
+                                      | uu____8328 ->
                                           failwith
                                             "Impossible! tc_eff_decl on a layered effect is not expected" in
                                     let ed3 =
-                                      let uu___910_8631 = ed2 in
-                                      let uu____8632 = cl signature in
-                                      let uu____8633 =
+                                      let uu___893_8331 = ed2 in
+                                      let uu____8332 = cl signature in
+                                      let uu____8333 =
                                         FStar_List.map
                                           (fun a ->
-                                             let uu___913_8641 = a in
-                                             let uu____8642 =
-                                               let uu____8643 =
+                                             let uu___896_8341 = a in
+                                             let uu____8342 =
+                                               let uu____8343 =
                                                  cl
                                                    ((a.FStar_Syntax_Syntax.action_univs),
                                                      (a.FStar_Syntax_Syntax.action_defn)) in
                                                FStar_All.pipe_right
-                                                 uu____8643
+                                                 uu____8343
                                                  FStar_Pervasives_Native.snd in
-                                             let uu____8668 =
-                                               let uu____8669 =
+                                             let uu____8368 =
+                                               let uu____8369 =
                                                  cl
                                                    ((a.FStar_Syntax_Syntax.action_univs),
                                                      (a.FStar_Syntax_Syntax.action_typ)) in
                                                FStar_All.pipe_right
-                                                 uu____8669
+                                                 uu____8369
                                                  FStar_Pervasives_Native.snd in
                                              {
                                                FStar_Syntax_Syntax.action_name
                                                  =
-                                                 (uu___913_8641.FStar_Syntax_Syntax.action_name);
+                                                 (uu___896_8341.FStar_Syntax_Syntax.action_name);
                                                FStar_Syntax_Syntax.action_unqualified_name
                                                  =
-                                                 (uu___913_8641.FStar_Syntax_Syntax.action_unqualified_name);
+                                                 (uu___896_8341.FStar_Syntax_Syntax.action_unqualified_name);
                                                FStar_Syntax_Syntax.action_univs
                                                  =
-                                                 (uu___913_8641.FStar_Syntax_Syntax.action_univs);
+                                                 (uu___896_8341.FStar_Syntax_Syntax.action_univs);
                                                FStar_Syntax_Syntax.action_params
                                                  =
-                                                 (uu___913_8641.FStar_Syntax_Syntax.action_params);
+                                                 (uu___896_8341.FStar_Syntax_Syntax.action_params);
                                                FStar_Syntax_Syntax.action_defn
-                                                 = uu____8642;
+                                                 = uu____8342;
                                                FStar_Syntax_Syntax.action_typ
-                                                 = uu____8668
+                                                 = uu____8368
                                              }) actions in
                                       {
                                         FStar_Syntax_Syntax.mname =
-                                          (uu___910_8631.FStar_Syntax_Syntax.mname);
+                                          (uu___893_8331.FStar_Syntax_Syntax.mname);
                                         FStar_Syntax_Syntax.cattributes =
-                                          (uu___910_8631.FStar_Syntax_Syntax.cattributes);
+                                          (uu___893_8331.FStar_Syntax_Syntax.cattributes);
                                         FStar_Syntax_Syntax.univs =
-                                          (uu___910_8631.FStar_Syntax_Syntax.univs);
+                                          (uu___893_8331.FStar_Syntax_Syntax.univs);
                                         FStar_Syntax_Syntax.binders =
-                                          (uu___910_8631.FStar_Syntax_Syntax.binders);
+                                          (uu___893_8331.FStar_Syntax_Syntax.binders);
                                         FStar_Syntax_Syntax.signature =
-                                          uu____8632;
+                                          uu____8332;
                                         FStar_Syntax_Syntax.combinators =
                                           combinators2;
                                         FStar_Syntax_Syntax.actions =
-                                          uu____8633;
+                                          uu____8333;
                                         FStar_Syntax_Syntax.eff_attrs =
-                                          (uu___910_8631.FStar_Syntax_Syntax.eff_attrs)
+                                          (uu___893_8331.FStar_Syntax_Syntax.eff_attrs)
                                       } in
-                                    ((let uu____8695 =
+                                    ((let uu____8395 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env)
                                           (FStar_Options.Other "ED") in
-                                      if uu____8695
+                                      if uu____8395
                                       then
-                                        let uu____8700 =
+                                        let uu____8400 =
                                           FStar_Syntax_Print.eff_decl_to_string
                                             false ed3 in
                                         FStar_Util.print1
                                           "Typechecked effect declaration:\n\t%s\n"
-                                          uu____8700
+                                          uu____8400
                                       else ());
                                      ed3)))))))))))))
 let (tc_eff_decl :
@@ -4117,11 +3932,11 @@ let (tc_eff_decl :
   fun env ->
     fun ed ->
       fun quals ->
-        let uu____8726 =
-          let uu____8741 =
+        let uu____8426 =
+          let uu____8441 =
             FStar_All.pipe_right ed FStar_Syntax_Util.is_layered in
-          if uu____8741 then tc_layered_eff_decl else tc_non_layered_eff_decl in
-        uu____8726 env ed quals
+          if uu____8441 then tc_layered_eff_decl else tc_non_layered_eff_decl in
+        uu____8426 env ed quals
 let (monad_signature :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -4132,337 +3947,290 @@ let (monad_signature :
   fun env ->
     fun m ->
       fun s ->
-        let fail uu____8791 =
-          let uu____8792 =
+        let fail uu____8491 =
+          let uu____8492 =
             FStar_TypeChecker_Err.unexpected_signature_for_monad env m s in
-          let uu____8798 = FStar_Ident.range_of_lid m in
-          FStar_Errors.raise_error uu____8792 uu____8798 in
+          let uu____8498 = FStar_Ident.range_of_lid m in
+          FStar_Errors.raise_error uu____8492 uu____8498 in
         let s1 = FStar_Syntax_Subst.compress s in
         match s1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
             let bs1 = FStar_Syntax_Subst.open_binders bs in
             (match bs1 with
-             | (a, uu____8842)::(wp, uu____8844)::[] ->
+             | (a, uu____8542)::(wp, uu____8544)::[] ->
                  (a, (wp.FStar_Syntax_Syntax.sort))
-             | uu____8873 -> fail ())
-        | uu____8874 -> fail ()
+             | uu____8573 -> fail ())
+        | uu____8574 -> fail ()
 let (tc_layered_lift :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sub_eff -> FStar_Syntax_Syntax.sub_eff)
   =
   fun env0 ->
     fun sub ->
-      (let uu____8887 =
+      (let uu____8587 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
            (FStar_Options.Other "LayeredEffects") in
-       if uu____8887
+       if uu____8587
        then
-         let uu____8892 = FStar_Syntax_Print.sub_eff_to_string sub in
-         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____8892
+         let uu____8592 = FStar_Syntax_Print.sub_eff_to_string sub in
+         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____8592
        else ());
       (let lift_ts =
          FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift FStar_Util.must in
        let r =
-         let uu____8909 =
+         let uu____8617 =
            FStar_All.pipe_right lift_ts FStar_Pervasives_Native.snd in
-         uu____8909.FStar_Syntax_Syntax.pos in
-       (let src_ed =
-          FStar_TypeChecker_Env.get_effect_decl env0
-            sub.FStar_Syntax_Syntax.source in
-        let tgt_ed =
-          FStar_TypeChecker_Env.get_effect_decl env0
-            sub.FStar_Syntax_Syntax.target in
-        let uu____8921 =
-          ((FStar_All.pipe_right src_ed FStar_Syntax_Util.is_layered) &&
-             (let uu____8925 =
-                let uu____8926 =
-                  FStar_All.pipe_right src_ed
-                    FStar_Syntax_Util.get_layered_effect_base in
-                FStar_All.pipe_right uu____8926 FStar_Util.must in
-              FStar_Ident.lid_equals uu____8925
-                tgt_ed.FStar_Syntax_Syntax.mname))
-            ||
-            (((FStar_All.pipe_right tgt_ed FStar_Syntax_Util.is_layered) &&
-                (let uu____8935 =
-                   let uu____8936 =
-                     FStar_All.pipe_right tgt_ed
-                       FStar_Syntax_Util.get_layered_effect_base in
-                   FStar_All.pipe_right uu____8936 FStar_Util.must in
-                 FStar_Ident.lid_equals uu____8935
-                   src_ed.FStar_Syntax_Syntax.mname))
-               &&
-               (let uu____8944 =
-                  FStar_Ident.lid_equals src_ed.FStar_Syntax_Syntax.mname
-                    FStar_Parser_Const.effect_PURE_lid in
-                Prims.op_Negation uu____8944)) in
-        if uu____8921
-        then
-          let uu____8947 =
-            let uu____8953 =
-              let uu____8955 =
-                FStar_All.pipe_right src_ed.FStar_Syntax_Syntax.mname
-                  FStar_Ident.string_of_lid in
-              let uu____8958 =
-                FStar_All.pipe_right tgt_ed.FStar_Syntax_Syntax.mname
-                  FStar_Ident.string_of_lid in
-              FStar_Util.format2
-                "Lifts cannot be defined from a layered effect to its repr or vice versa (%s and %s here)"
-                uu____8955 uu____8958 in
-            (FStar_Errors.Fatal_EffectsCannotBeComposed, uu____8953) in
-          FStar_Errors.raise_error uu____8947 r
-        else ());
-       (let uu____8965 = check_and_gen env0 "" "lift" Prims.int_one lift_ts in
-        match uu____8965 with
-        | (us, lift, lift_ty) ->
-            ((let uu____8979 =
-                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
-                  (FStar_Options.Other "LayeredEffects") in
-              if uu____8979
-              then
-                let uu____8984 =
-                  FStar_Syntax_Print.tscheme_to_string (us, lift) in
-                let uu____8990 =
-                  FStar_Syntax_Print.tscheme_to_string (us, lift_ty) in
-                FStar_Util.print2 "Typechecked lift: %s and lift_ty: %s\n"
-                  uu____8984 uu____8990
-              else ());
-             (let uu____8999 = FStar_Syntax_Subst.open_univ_vars us lift_ty in
-              match uu____8999 with
-              | (us1, lift_ty1) ->
-                  let env = FStar_TypeChecker_Env.push_univ_vars env0 us1 in
-                  (check_no_subtyping_for_layered_combinator env lift_ty1
-                     FStar_Pervasives_Native.None;
-                   (let lift_t_shape_error s =
-                      let uu____9017 =
-                        FStar_Ident.string_of_lid
-                          sub.FStar_Syntax_Syntax.source in
-                      let uu____9019 =
-                        FStar_Ident.string_of_lid
-                          sub.FStar_Syntax_Syntax.target in
-                      let uu____9021 =
-                        FStar_Syntax_Print.term_to_string lift_ty1 in
-                      FStar_Util.format4
-                        "Unexpected shape of lift %s~>%s, reason:%s (t:%s)"
-                        uu____9017 uu____9019 s uu____9021 in
-                    let uu____9024 =
-                      let uu____9031 =
-                        let uu____9036 = FStar_Syntax_Util.type_u () in
-                        FStar_All.pipe_right uu____9036
-                          (fun uu____9053 ->
-                             match uu____9053 with
-                             | (t, u) ->
-                                 let uu____9064 =
-                                   let uu____9065 =
-                                     FStar_Syntax_Syntax.gen_bv "a"
-                                       FStar_Pervasives_Native.None t in
-                                   FStar_All.pipe_right uu____9065
-                                     FStar_Syntax_Syntax.mk_binder in
-                                 (uu____9064, u)) in
-                      match uu____9031 with
-                      | (a, u_a) ->
-                          let rest_bs =
-                            let uu____9084 =
-                              let uu____9085 =
-                                FStar_Syntax_Subst.compress lift_ty1 in
-                              uu____9085.FStar_Syntax_Syntax.n in
-                            match uu____9084 with
-                            | FStar_Syntax_Syntax.Tm_arrow (bs, uu____9097)
-                                when
-                                (FStar_List.length bs) >= (Prims.of_int (2))
-                                ->
-                                let uu____9125 =
-                                  FStar_Syntax_Subst.open_binders bs in
-                                (match uu____9125 with
-                                 | (a', uu____9135)::bs1 ->
-                                     let uu____9155 =
-                                       let uu____9156 =
-                                         FStar_All.pipe_right bs1
-                                           (FStar_List.splitAt
-                                              ((FStar_List.length bs1) -
-                                                 Prims.int_one)) in
-                                       FStar_All.pipe_right uu____9156
-                                         FStar_Pervasives_Native.fst in
-                                     let uu____9222 =
-                                       let uu____9235 =
-                                         let uu____9238 =
-                                           let uu____9239 =
-                                             let uu____9246 =
-                                               FStar_Syntax_Syntax.bv_to_name
-                                                 (FStar_Pervasives_Native.fst
-                                                    a) in
-                                             (a', uu____9246) in
-                                           FStar_Syntax_Syntax.NT uu____9239 in
-                                         [uu____9238] in
-                                       FStar_Syntax_Subst.subst_binders
-                                         uu____9235 in
-                                     FStar_All.pipe_right uu____9155
-                                       uu____9222)
-                            | uu____9261 ->
-                                let uu____9262 =
-                                  let uu____9268 =
-                                    lift_t_shape_error
-                                      "either not an arrow, or not enough binders" in
-                                  (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                    uu____9268) in
-                                FStar_Errors.raise_error uu____9262 r in
-                          let uu____9280 =
-                            let uu____9291 =
-                              let uu____9296 =
-                                FStar_TypeChecker_Env.push_binders env (a ::
-                                  rest_bs) in
-                              let uu____9303 =
-                                let uu____9304 =
-                                  FStar_All.pipe_right a
-                                    FStar_Pervasives_Native.fst in
-                                FStar_All.pipe_right uu____9304
-                                  FStar_Syntax_Syntax.bv_to_name in
-                              FStar_TypeChecker_Util.fresh_effect_repr_en
-                                uu____9296 r sub.FStar_Syntax_Syntax.source
-                                u_a uu____9303 in
-                            match uu____9291 with
-                            | (f_sort, g) ->
-                                let uu____9325 =
-                                  let uu____9332 =
-                                    FStar_Syntax_Syntax.gen_bv "f"
-                                      FStar_Pervasives_Native.None f_sort in
-                                  FStar_All.pipe_right uu____9332
+         uu____8617.FStar_Syntax_Syntax.pos in
+       let uu____8630 = check_and_gen env0 "" "lift" Prims.int_one lift_ts in
+       match uu____8630 with
+       | (us, lift, lift_ty) ->
+           ((let uu____8644 =
+               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
+                 (FStar_Options.Other "LayeredEffects") in
+             if uu____8644
+             then
+               let uu____8649 =
+                 FStar_Syntax_Print.tscheme_to_string (us, lift) in
+               let uu____8655 =
+                 FStar_Syntax_Print.tscheme_to_string (us, lift_ty) in
+               FStar_Util.print2 "Typechecked lift: %s and lift_ty: %s\n"
+                 uu____8649 uu____8655
+             else ());
+            (let uu____8664 = FStar_Syntax_Subst.open_univ_vars us lift_ty in
+             match uu____8664 with
+             | (us1, lift_ty1) ->
+                 let env = FStar_TypeChecker_Env.push_univ_vars env0 us1 in
+                 (check_no_subtyping_for_layered_combinator env lift_ty1
+                    FStar_Pervasives_Native.None;
+                  (let lift_t_shape_error s =
+                     let uu____8682 =
+                       FStar_Ident.string_of_lid
+                         sub.FStar_Syntax_Syntax.source in
+                     let uu____8684 =
+                       FStar_Ident.string_of_lid
+                         sub.FStar_Syntax_Syntax.target in
+                     let uu____8686 =
+                       FStar_Syntax_Print.term_to_string lift_ty1 in
+                     FStar_Util.format4
+                       "Unexpected shape of lift %s~>%s, reason:%s (t:%s)"
+                       uu____8682 uu____8684 s uu____8686 in
+                   let uu____8689 =
+                     let uu____8696 =
+                       let uu____8701 = FStar_Syntax_Util.type_u () in
+                       FStar_All.pipe_right uu____8701
+                         (fun uu____8718 ->
+                            match uu____8718 with
+                            | (t, u) ->
+                                let uu____8729 =
+                                  let uu____8730 =
+                                    FStar_Syntax_Syntax.gen_bv "a"
+                                      FStar_Pervasives_Native.None t in
+                                  FStar_All.pipe_right uu____8730
                                     FStar_Syntax_Syntax.mk_binder in
-                                (uu____9325, g) in
-                          (match uu____9280 with
-                           | (f_b, g_f_b) ->
-                               let bs = a ::
-                                 (FStar_List.append rest_bs [f_b]) in
-                               let uu____9399 =
-                                 let uu____9404 =
-                                   FStar_TypeChecker_Env.push_binders env bs in
-                                 let uu____9405 =
-                                   let uu____9406 =
-                                     FStar_All.pipe_right a
-                                       FStar_Pervasives_Native.fst in
-                                   FStar_All.pipe_right uu____9406
-                                     FStar_Syntax_Syntax.bv_to_name in
-                                 FStar_TypeChecker_Util.fresh_effect_repr_en
-                                   uu____9404 r
-                                   sub.FStar_Syntax_Syntax.target u_a
-                                   uu____9405 in
-                               (match uu____9399 with
-                                | (repr, g_repr) ->
-                                    let uu____9423 =
-                                      let uu____9428 =
-                                        FStar_TypeChecker_Env.push_binders
-                                          env bs in
-                                      let uu____9429 =
-                                        let uu____9431 =
-                                          FStar_Ident.string_of_lid
-                                            sub.FStar_Syntax_Syntax.source in
-                                        let uu____9433 =
-                                          FStar_Ident.string_of_lid
-                                            sub.FStar_Syntax_Syntax.target in
-                                        FStar_Util.format2
-                                          "implicit for pure_wp in typechecking lift %s~>%s"
-                                          uu____9431 uu____9433 in
-                                      pure_wp_uvar uu____9428 repr uu____9429
-                                        r in
-                                    (match uu____9423 with
-                                     | (pure_wp_uvar1, guard_wp) ->
-                                         let c =
-                                           let uu____9445 =
-                                             let uu____9446 =
-                                               let uu____9447 =
-                                                 FStar_TypeChecker_Env.new_u_univ
-                                                   () in
-                                               [uu____9447] in
-                                             let uu____9448 =
-                                               let uu____9459 =
-                                                 FStar_All.pipe_right
-                                                   pure_wp_uvar1
-                                                   FStar_Syntax_Syntax.as_arg in
-                                               [uu____9459] in
-                                             {
-                                               FStar_Syntax_Syntax.comp_univs
-                                                 = uu____9446;
-                                               FStar_Syntax_Syntax.effect_name
-                                                 =
-                                                 FStar_Parser_Const.effect_PURE_lid;
-                                               FStar_Syntax_Syntax.result_typ
-                                                 = repr;
-                                               FStar_Syntax_Syntax.effect_args
-                                                 = uu____9448;
-                                               FStar_Syntax_Syntax.flags = []
-                                             } in
-                                           FStar_Syntax_Syntax.mk_Comp
-                                             uu____9445 in
-                                         let uu____9492 =
-                                           FStar_Syntax_Util.arrow bs c in
-                                         let uu____9495 =
-                                           let uu____9496 =
-                                             FStar_TypeChecker_Env.conj_guard
-                                               g_f_b g_repr in
-                                           FStar_TypeChecker_Env.conj_guard
-                                             uu____9496 guard_wp in
-                                         (uu____9492, uu____9495)))) in
-                    match uu____9024 with
-                    | (k, g_k) ->
-                        ((let uu____9506 =
+                                (uu____8729, u)) in
+                     match uu____8696 with
+                     | (a, u_a) ->
+                         let rest_bs =
+                           let uu____8749 =
+                             let uu____8750 =
+                               FStar_Syntax_Subst.compress lift_ty1 in
+                             uu____8750.FStar_Syntax_Syntax.n in
+                           match uu____8749 with
+                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu____8762)
+                               when
+                               (FStar_List.length bs) >= (Prims.of_int (2))
+                               ->
+                               let uu____8790 =
+                                 FStar_Syntax_Subst.open_binders bs in
+                               (match uu____8790 with
+                                | (a', uu____8800)::bs1 ->
+                                    let uu____8820 =
+                                      let uu____8821 =
+                                        FStar_All.pipe_right bs1
+                                          (FStar_List.splitAt
+                                             ((FStar_List.length bs1) -
+                                                Prims.int_one)) in
+                                      FStar_All.pipe_right uu____8821
+                                        FStar_Pervasives_Native.fst in
+                                    let uu____8887 =
+                                      let uu____8900 =
+                                        let uu____8903 =
+                                          let uu____8904 =
+                                            let uu____8911 =
+                                              FStar_Syntax_Syntax.bv_to_name
+                                                (FStar_Pervasives_Native.fst
+                                                   a) in
+                                            (a', uu____8911) in
+                                          FStar_Syntax_Syntax.NT uu____8904 in
+                                        [uu____8903] in
+                                      FStar_Syntax_Subst.subst_binders
+                                        uu____8900 in
+                                    FStar_All.pipe_right uu____8820
+                                      uu____8887)
+                           | uu____8926 ->
+                               let uu____8927 =
+                                 let uu____8933 =
+                                   lift_t_shape_error
+                                     "either not an arrow, or not enough binders" in
+                                 (FStar_Errors.Fatal_UnexpectedExpressionType,
+                                   uu____8933) in
+                               FStar_Errors.raise_error uu____8927 r in
+                         let uu____8945 =
+                           let uu____8956 =
+                             let uu____8961 =
+                               FStar_TypeChecker_Env.push_binders env (a ::
+                                 rest_bs) in
+                             let uu____8968 =
+                               let uu____8969 =
+                                 FStar_All.pipe_right a
+                                   FStar_Pervasives_Native.fst in
+                               FStar_All.pipe_right uu____8969
+                                 FStar_Syntax_Syntax.bv_to_name in
+                             FStar_TypeChecker_Util.fresh_effect_repr_en
+                               uu____8961 r sub.FStar_Syntax_Syntax.source
+                               u_a uu____8968 in
+                           match uu____8956 with
+                           | (f_sort, g) ->
+                               let uu____8990 =
+                                 let uu____8997 =
+                                   FStar_Syntax_Syntax.gen_bv "f"
+                                     FStar_Pervasives_Native.None f_sort in
+                                 FStar_All.pipe_right uu____8997
+                                   FStar_Syntax_Syntax.mk_binder in
+                               (uu____8990, g) in
+                         (match uu____8945 with
+                          | (f_b, g_f_b) ->
+                              let bs = a :: (FStar_List.append rest_bs [f_b]) in
+                              let uu____9064 =
+                                let uu____9069 =
+                                  FStar_TypeChecker_Env.push_binders env bs in
+                                let uu____9070 =
+                                  let uu____9071 =
+                                    FStar_All.pipe_right a
+                                      FStar_Pervasives_Native.fst in
+                                  FStar_All.pipe_right uu____9071
+                                    FStar_Syntax_Syntax.bv_to_name in
+                                FStar_TypeChecker_Util.fresh_effect_repr_en
+                                  uu____9069 r sub.FStar_Syntax_Syntax.target
+                                  u_a uu____9070 in
+                              (match uu____9064 with
+                               | (repr, g_repr) ->
+                                   let uu____9088 =
+                                     let uu____9093 =
+                                       FStar_TypeChecker_Env.push_binders env
+                                         bs in
+                                     let uu____9094 =
+                                       let uu____9096 =
+                                         FStar_Ident.string_of_lid
+                                           sub.FStar_Syntax_Syntax.source in
+                                       let uu____9098 =
+                                         FStar_Ident.string_of_lid
+                                           sub.FStar_Syntax_Syntax.target in
+                                       FStar_Util.format2
+                                         "implicit for pure_wp in typechecking lift %s~>%s"
+                                         uu____9096 uu____9098 in
+                                     pure_wp_uvar uu____9093 repr uu____9094
+                                       r in
+                                   (match uu____9088 with
+                                    | (pure_wp_uvar1, guard_wp) ->
+                                        let c =
+                                          let uu____9110 =
+                                            let uu____9111 =
+                                              let uu____9112 =
+                                                FStar_TypeChecker_Env.new_u_univ
+                                                  () in
+                                              [uu____9112] in
+                                            let uu____9113 =
+                                              let uu____9124 =
+                                                FStar_All.pipe_right
+                                                  pure_wp_uvar1
+                                                  FStar_Syntax_Syntax.as_arg in
+                                              [uu____9124] in
+                                            {
+                                              FStar_Syntax_Syntax.comp_univs
+                                                = uu____9111;
+                                              FStar_Syntax_Syntax.effect_name
+                                                =
+                                                FStar_Parser_Const.effect_PURE_lid;
+                                              FStar_Syntax_Syntax.result_typ
+                                                = repr;
+                                              FStar_Syntax_Syntax.effect_args
+                                                = uu____9113;
+                                              FStar_Syntax_Syntax.flags = []
+                                            } in
+                                          FStar_Syntax_Syntax.mk_Comp
+                                            uu____9110 in
+                                        let uu____9157 =
+                                          FStar_Syntax_Util.arrow bs c in
+                                        let uu____9160 =
+                                          let uu____9161 =
+                                            FStar_TypeChecker_Env.conj_guard
+                                              g_f_b g_repr in
+                                          FStar_TypeChecker_Env.conj_guard
+                                            uu____9161 guard_wp in
+                                        (uu____9157, uu____9160)))) in
+                   match uu____8689 with
+                   | (k, g_k) ->
+                       ((let uu____9171 =
+                           FStar_All.pipe_left
+                             (FStar_TypeChecker_Env.debug env)
+                             (FStar_Options.Other "LayeredEffects") in
+                         if uu____9171
+                         then
+                           let uu____9176 =
+                             FStar_Syntax_Print.term_to_string k in
+                           FStar_Util.print1
+                             "tc_layered_lift: before unification k: %s\n"
+                             uu____9176
+                         else ());
+                        (let g = FStar_TypeChecker_Rel.teq env lift_ty1 k in
+                         FStar_TypeChecker_Rel.force_trivial_guard env g_k;
+                         FStar_TypeChecker_Rel.force_trivial_guard env g;
+                         (let uu____9185 =
                             FStar_All.pipe_left
-                              (FStar_TypeChecker_Env.debug env)
+                              (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "LayeredEffects") in
-                          if uu____9506
+                          if uu____9185
                           then
-                            let uu____9511 =
+                            let uu____9190 =
                               FStar_Syntax_Print.term_to_string k in
-                            FStar_Util.print1
-                              "tc_layered_lift: before unification k: %s\n"
-                              uu____9511
+                            FStar_Util.print1 "After unification k: %s\n"
+                              uu____9190
                           else ());
-                         (let g = FStar_TypeChecker_Rel.teq env lift_ty1 k in
-                          FStar_TypeChecker_Rel.force_trivial_guard env g_k;
-                          FStar_TypeChecker_Rel.force_trivial_guard env g;
-                          (let uu____9520 =
+                         (let sub1 =
+                            let uu___985_9196 = sub in
+                            let uu____9197 =
+                              let uu____9200 =
+                                let uu____9201 =
+                                  let uu____9204 =
+                                    FStar_All.pipe_right k
+                                      (FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                         env) in
+                                  FStar_All.pipe_right uu____9204
+                                    (FStar_Syntax_Subst.close_univ_vars us1) in
+                                (us1, uu____9201) in
+                              FStar_Pervasives_Native.Some uu____9200 in
+                            {
+                              FStar_Syntax_Syntax.source =
+                                (uu___985_9196.FStar_Syntax_Syntax.source);
+                              FStar_Syntax_Syntax.target =
+                                (uu___985_9196.FStar_Syntax_Syntax.target);
+                              FStar_Syntax_Syntax.lift_wp = uu____9197;
+                              FStar_Syntax_Syntax.lift =
+                                (FStar_Pervasives_Native.Some (us1, lift))
+                            } in
+                          (let uu____9216 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env0)
                                (FStar_Options.Other "LayeredEffects") in
-                           if uu____9520
+                           if uu____9216
                            then
-                             let uu____9525 =
-                               FStar_Syntax_Print.term_to_string k in
-                             FStar_Util.print1 "After unification k: %s\n"
-                               uu____9525
+                             let uu____9221 =
+                               FStar_Syntax_Print.sub_eff_to_string sub1 in
+                             FStar_Util.print1 "Final sub_effect: %s\n"
+                               uu____9221
                            else ());
-                          (let sub1 =
-                             let uu___1006_9531 = sub in
-                             let uu____9532 =
-                               let uu____9535 =
-                                 let uu____9536 =
-                                   let uu____9539 =
-                                     FStar_All.pipe_right k
-                                       (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                          env) in
-                                   FStar_All.pipe_right uu____9539
-                                     (FStar_Syntax_Subst.close_univ_vars us1) in
-                                 (us1, uu____9536) in
-                               FStar_Pervasives_Native.Some uu____9535 in
-                             {
-                               FStar_Syntax_Syntax.source =
-                                 (uu___1006_9531.FStar_Syntax_Syntax.source);
-                               FStar_Syntax_Syntax.target =
-                                 (uu___1006_9531.FStar_Syntax_Syntax.target);
-                               FStar_Syntax_Syntax.lift_wp = uu____9532;
-                               FStar_Syntax_Syntax.lift =
-                                 (FStar_Pervasives_Native.Some (us1, lift))
-                             } in
-                           (let uu____9551 =
-                              FStar_All.pipe_left
-                                (FStar_TypeChecker_Env.debug env0)
-                                (FStar_Options.Other "LayeredEffects") in
-                            if uu____9551
-                            then
-                              let uu____9556 =
-                                FStar_Syntax_Print.sub_eff_to_string sub1 in
-                              FStar_Util.print1 "Final sub_effect: %s\n"
-                                uu____9556
-                            else ());
-                           sub1)))))))))
+                          sub1))))))))
 let (tc_lift :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sub_eff ->
@@ -4472,107 +4240,107 @@ let (tc_lift :
     fun sub ->
       fun r ->
         let check_and_gen1 env1 t k =
-          let uu____9593 =
+          let uu____9258 =
             FStar_TypeChecker_TcTerm.tc_check_trivial_guard env1 t k in
-          FStar_TypeChecker_Util.generalize_universes env1 uu____9593 in
+          FStar_TypeChecker_Util.generalize_universes env1 uu____9258 in
         let ed_src =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.source in
         let ed_tgt =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.target in
-        let uu____9596 =
+        let uu____9261 =
           (FStar_All.pipe_right ed_src FStar_Syntax_Util.is_layered) ||
             (FStar_All.pipe_right ed_tgt FStar_Syntax_Util.is_layered) in
-        if uu____9596
+        if uu____9261
         then tc_layered_lift env sub
         else
-          (let uu____9603 =
-             let uu____9610 =
+          (let uu____9268 =
+             let uu____9275 =
                FStar_TypeChecker_Env.lookup_effect_lid env
                  sub.FStar_Syntax_Syntax.source in
-             monad_signature env sub.FStar_Syntax_Syntax.source uu____9610 in
-           match uu____9603 with
+             monad_signature env sub.FStar_Syntax_Syntax.source uu____9275 in
+           match uu____9268 with
            | (a, wp_a_src) ->
-               let uu____9617 =
-                 let uu____9624 =
+               let uu____9282 =
+                 let uu____9289 =
                    FStar_TypeChecker_Env.lookup_effect_lid env
                      sub.FStar_Syntax_Syntax.target in
                  monad_signature env sub.FStar_Syntax_Syntax.target
-                   uu____9624 in
-               (match uu____9617 with
+                   uu____9289 in
+               (match uu____9282 with
                 | (b, wp_b_tgt) ->
                     let wp_a_tgt =
-                      let uu____9632 =
-                        let uu____9635 =
-                          let uu____9636 =
-                            let uu____9643 = FStar_Syntax_Syntax.bv_to_name a in
-                            (b, uu____9643) in
-                          FStar_Syntax_Syntax.NT uu____9636 in
-                        [uu____9635] in
-                      FStar_Syntax_Subst.subst uu____9632 wp_b_tgt in
+                      let uu____9297 =
+                        let uu____9300 =
+                          let uu____9301 =
+                            let uu____9308 = FStar_Syntax_Syntax.bv_to_name a in
+                            (b, uu____9308) in
+                          FStar_Syntax_Syntax.NT uu____9301 in
+                        [uu____9300] in
+                      FStar_Syntax_Subst.subst uu____9297 wp_b_tgt in
                     let expected_k =
-                      let uu____9651 =
-                        let uu____9660 = FStar_Syntax_Syntax.mk_binder a in
-                        let uu____9667 =
-                          let uu____9676 =
+                      let uu____9316 =
+                        let uu____9325 = FStar_Syntax_Syntax.mk_binder a in
+                        let uu____9332 =
+                          let uu____9341 =
                             FStar_Syntax_Syntax.null_binder wp_a_src in
-                          [uu____9676] in
-                        uu____9660 :: uu____9667 in
-                      let uu____9701 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
-                      FStar_Syntax_Util.arrow uu____9651 uu____9701 in
+                          [uu____9341] in
+                        uu____9325 :: uu____9332 in
+                      let uu____9366 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
+                      FStar_Syntax_Util.arrow uu____9316 uu____9366 in
                     let repr_type eff_name a1 wp =
-                      (let uu____9723 =
-                         let uu____9725 =
+                      (let uu____9388 =
+                         let uu____9390 =
                            FStar_TypeChecker_Env.is_reifiable_effect env
                              eff_name in
-                         Prims.op_Negation uu____9725 in
-                       if uu____9723
+                         Prims.op_Negation uu____9390 in
+                       if uu____9388
                        then
-                         let uu____9728 =
-                           let uu____9734 =
-                             let uu____9736 =
+                         let uu____9393 =
+                           let uu____9399 =
+                             let uu____9401 =
                                FStar_Ident.string_of_lid eff_name in
                              FStar_Util.format1 "Effect %s cannot be reified"
-                               uu____9736 in
+                               uu____9401 in
                            (FStar_Errors.Fatal_EffectCannotBeReified,
-                             uu____9734) in
-                         let uu____9740 = FStar_TypeChecker_Env.get_range env in
-                         FStar_Errors.raise_error uu____9728 uu____9740
+                             uu____9399) in
+                         let uu____9405 = FStar_TypeChecker_Env.get_range env in
+                         FStar_Errors.raise_error uu____9393 uu____9405
                        else ());
-                      (let uu____9743 =
+                      (let uu____9408 =
                          FStar_TypeChecker_Env.effect_decl_opt env eff_name in
-                       match uu____9743 with
+                       match uu____9408 with
                        | FStar_Pervasives_Native.None ->
                            failwith
                              "internal error: reifiable effect has no decl?"
                        | FStar_Pervasives_Native.Some (ed, qualifiers) ->
                            let repr =
-                             let uu____9776 =
-                               let uu____9777 =
+                             let uu____9441 =
+                               let uu____9442 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr in
-                               FStar_All.pipe_right uu____9777
+                               FStar_All.pipe_right uu____9442
                                  FStar_Util.must in
                              FStar_TypeChecker_Env.inst_effect_fun_with
                                [FStar_Syntax_Syntax.U_unknown] env ed
-                               uu____9776 in
-                           let uu____9784 =
-                             let uu____9785 =
-                               let uu____9802 =
-                                 let uu____9813 =
+                               uu____9441 in
+                           let uu____9449 =
+                             let uu____9450 =
+                               let uu____9467 =
+                                 let uu____9478 =
                                    FStar_Syntax_Syntax.as_arg a1 in
-                                 let uu____9822 =
-                                   let uu____9833 =
+                                 let uu____9487 =
+                                   let uu____9498 =
                                      FStar_Syntax_Syntax.as_arg wp in
-                                   [uu____9833] in
-                                 uu____9813 :: uu____9822 in
-                               (repr, uu____9802) in
-                             FStar_Syntax_Syntax.Tm_app uu____9785 in
-                           let uu____9878 =
+                                   [uu____9498] in
+                                 uu____9478 :: uu____9487 in
+                               (repr, uu____9467) in
+                             FStar_Syntax_Syntax.Tm_app uu____9450 in
+                           let uu____9543 =
                              FStar_TypeChecker_Env.get_range env in
-                           FStar_Syntax_Syntax.mk uu____9784 uu____9878) in
-                    let uu____9879 =
+                           FStar_Syntax_Syntax.mk uu____9449 uu____9543) in
+                    let uu____9544 =
                       match ((sub.FStar_Syntax_Syntax.lift),
                               (sub.FStar_Syntax_Syntax.lift_wp))
                       with
@@ -4581,21 +4349,21 @@ let (tc_lift :
                           failwith "Impossible (parser)"
                       | (lift, FStar_Pervasives_Native.Some (uvs, lift_wp))
                           ->
-                          let uu____10052 =
+                          let uu____9717 =
                             if (FStar_List.length uvs) > Prims.int_zero
                             then
-                              let uu____10063 =
+                              let uu____9728 =
                                 FStar_Syntax_Subst.univ_var_opening uvs in
-                              match uu____10063 with
+                              match uu____9728 with
                               | (usubst, uvs1) ->
-                                  let uu____10086 =
+                                  let uu____9751 =
                                     FStar_TypeChecker_Env.push_univ_vars env
                                       uvs1 in
-                                  let uu____10087 =
+                                  let uu____9752 =
                                     FStar_Syntax_Subst.subst usubst lift_wp in
-                                  (uu____10086, uu____10087)
+                                  (uu____9751, uu____9752)
                             else (env, lift_wp) in
-                          (match uu____10052 with
+                          (match uu____9717 with
                            | (env1, lift_wp1) ->
                                let lift_wp2 =
                                  if (FStar_List.length uvs) = Prims.int_zero
@@ -4604,53 +4372,53 @@ let (tc_lift :
                                    (let lift_wp2 =
                                       FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                         env1 lift_wp1 expected_k in
-                                    let uu____10137 =
+                                    let uu____9802 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
                                         lift_wp2 in
-                                    (uvs, uu____10137)) in
+                                    (uvs, uu____9802)) in
                                (lift, lift_wp2))
                       | (FStar_Pervasives_Native.Some (what, lift),
                          FStar_Pervasives_Native.None) ->
-                          let uu____10208 =
+                          let uu____9873 =
                             if (FStar_List.length what) > Prims.int_zero
                             then
-                              let uu____10223 =
+                              let uu____9888 =
                                 FStar_Syntax_Subst.univ_var_opening what in
-                              match uu____10223 with
+                              match uu____9888 with
                               | (usubst, uvs) ->
-                                  let uu____10248 =
+                                  let uu____9913 =
                                     FStar_Syntax_Subst.subst usubst lift in
-                                  (uvs, uu____10248)
+                                  (uvs, uu____9913)
                             else ([], lift) in
-                          (match uu____10208 with
+                          (match uu____9873 with
                            | (uvs, lift1) ->
-                               ((let uu____10284 =
+                               ((let uu____9949 =
                                    FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other "ED") in
-                                 if uu____10284
+                                 if uu____9949
                                  then
-                                   let uu____10288 =
+                                   let uu____9953 =
                                      FStar_Syntax_Print.term_to_string lift1 in
                                    FStar_Util.print1 "Lift for free : %s\n"
-                                     uu____10288
+                                     uu____9953
                                  else ());
                                 (let dmff_env =
                                    FStar_TypeChecker_DMFF.empty env
                                      (FStar_TypeChecker_TcTerm.tc_constant
                                         env FStar_Range.dummyRange) in
-                                 let uu____10294 =
-                                   let uu____10301 =
+                                 let uu____9959 =
+                                   let uu____9966 =
                                      FStar_TypeChecker_Env.push_univ_vars env
                                        uvs in
                                    FStar_TypeChecker_TcTerm.tc_term
-                                     uu____10301 lift1 in
-                                 match uu____10294 with
-                                 | (lift2, comp, uu____10326) ->
-                                     let uu____10327 =
+                                     uu____9966 lift1 in
+                                 match uu____9959 with
+                                 | (lift2, comp, uu____9991) ->
+                                     let uu____9992 =
                                        FStar_TypeChecker_DMFF.star_expr
                                          dmff_env lift2 in
-                                     (match uu____10327 with
-                                      | (uu____10356, lift_wp, lift_elab) ->
+                                     (match uu____9992 with
+                                      | (uu____10021, lift_wp, lift_elab) ->
                                           let lift_wp1 =
                                             FStar_TypeChecker_DMFF.recheck_debug
                                               "lift-wp" env lift_wp in
@@ -4661,156 +4429,156 @@ let (tc_lift :
                                             (FStar_List.length uvs) =
                                               Prims.int_zero
                                           then
-                                            let uu____10388 =
-                                              let uu____10399 =
+                                            let uu____10053 =
+                                              let uu____10064 =
                                                 FStar_TypeChecker_Util.generalize_universes
                                                   env lift_elab1 in
                                               FStar_Pervasives_Native.Some
-                                                uu____10399 in
-                                            let uu____10416 =
+                                                uu____10064 in
+                                            let uu____10081 =
                                               FStar_TypeChecker_Util.generalize_universes
                                                 env lift_wp1 in
-                                            (uu____10388, uu____10416)
+                                            (uu____10053, uu____10081)
                                           else
-                                            (let uu____10445 =
-                                               let uu____10456 =
-                                                 let uu____10465 =
+                                            (let uu____10110 =
+                                               let uu____10121 =
+                                                 let uu____10130 =
                                                    FStar_Syntax_Subst.close_univ_vars
                                                      uvs lift_elab1 in
-                                                 (uvs, uu____10465) in
+                                                 (uvs, uu____10130) in
                                                FStar_Pervasives_Native.Some
-                                                 uu____10456 in
-                                             let uu____10480 =
-                                               let uu____10489 =
+                                                 uu____10121 in
+                                             let uu____10145 =
+                                               let uu____10154 =
                                                  FStar_Syntax_Subst.close_univ_vars
                                                    uvs lift_wp1 in
-                                               (uvs, uu____10489) in
-                                             (uu____10445, uu____10480)))))) in
-                    (match uu____9879 with
+                                               (uvs, uu____10154) in
+                                             (uu____10110, uu____10145)))))) in
+                    (match uu____9544 with
                      | (lift, lift_wp) ->
                          let env1 =
-                           let uu___1090_10553 = env in
+                           let uu___1069_10218 = env in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___1090_10553.FStar_TypeChecker_Env.solver);
+                               (uu___1069_10218.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___1090_10553.FStar_TypeChecker_Env.range);
+                               (uu___1069_10218.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___1090_10553.FStar_TypeChecker_Env.curmodule);
+                               (uu___1069_10218.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___1090_10553.FStar_TypeChecker_Env.gamma);
+                               (uu___1069_10218.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___1090_10553.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___1069_10218.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___1090_10553.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___1069_10218.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___1090_10553.FStar_TypeChecker_Env.modules);
+                               (uu___1069_10218.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___1090_10553.FStar_TypeChecker_Env.expected_typ);
+                               (uu___1069_10218.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___1090_10553.FStar_TypeChecker_Env.sigtab);
+                               (uu___1069_10218.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___1090_10553.FStar_TypeChecker_Env.attrtab);
+                               (uu___1069_10218.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___1090_10553.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___1069_10218.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___1090_10553.FStar_TypeChecker_Env.effects);
+                               (uu___1069_10218.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___1090_10553.FStar_TypeChecker_Env.generalize);
+                               (uu___1069_10218.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___1090_10553.FStar_TypeChecker_Env.letrecs);
+                               (uu___1069_10218.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level =
-                               (uu___1090_10553.FStar_TypeChecker_Env.top_level);
+                               (uu___1069_10218.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___1090_10553.FStar_TypeChecker_Env.check_uvars);
+                               (uu___1069_10218.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___1090_10553.FStar_TypeChecker_Env.use_eq);
+                               (uu___1069_10218.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___1090_10553.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___1069_10218.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___1090_10553.FStar_TypeChecker_Env.is_iface);
+                               (uu___1069_10218.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___1090_10553.FStar_TypeChecker_Env.admit);
+                               (uu___1069_10218.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax = true;
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___1090_10553.FStar_TypeChecker_Env.lax_universes);
+                               (uu___1069_10218.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___1090_10553.FStar_TypeChecker_Env.phase1);
+                               (uu___1069_10218.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___1090_10553.FStar_TypeChecker_Env.failhard);
+                               (uu___1069_10218.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___1090_10553.FStar_TypeChecker_Env.nosynth);
+                               (uu___1069_10218.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___1090_10553.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___1069_10218.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___1090_10553.FStar_TypeChecker_Env.tc_term);
+                               (uu___1069_10218.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___1090_10553.FStar_TypeChecker_Env.type_of);
+                               (uu___1069_10218.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___1090_10553.FStar_TypeChecker_Env.universe_of);
+                               (uu___1069_10218.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___1090_10553.FStar_TypeChecker_Env.check_type_of);
+                               (uu___1069_10218.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___1090_10553.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___1069_10218.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___1090_10553.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___1069_10218.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___1090_10553.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___1069_10218.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___1090_10553.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___1069_10218.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___1090_10553.FStar_TypeChecker_Env.proof_ns);
+                               (uu___1069_10218.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___1090_10553.FStar_TypeChecker_Env.synth_hook);
+                               (uu___1069_10218.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___1090_10553.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___1069_10218.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___1090_10553.FStar_TypeChecker_Env.splice);
+                               (uu___1069_10218.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___1090_10553.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___1069_10218.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___1090_10553.FStar_TypeChecker_Env.postprocess);
+                               (uu___1069_10218.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___1090_10553.FStar_TypeChecker_Env.identifier_info);
+                               (uu___1069_10218.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___1090_10553.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___1069_10218.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___1090_10553.FStar_TypeChecker_Env.dsenv);
+                               (uu___1069_10218.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___1090_10553.FStar_TypeChecker_Env.nbe);
+                               (uu___1069_10218.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___1090_10553.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___1069_10218.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___1090_10553.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___1069_10218.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___1090_10553.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___1069_10218.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
                          let lift1 =
                            match lift with
                            | FStar_Pervasives_Native.None ->
                                FStar_Pervasives_Native.None
                            | FStar_Pervasives_Native.Some (uvs, lift1) ->
-                               let uu____10586 =
-                                 let uu____10591 =
+                               let uu____10251 =
+                                 let uu____10256 =
                                    FStar_Syntax_Subst.univ_var_opening uvs in
-                                 match uu____10591 with
+                                 match uu____10256 with
                                  | (usubst, uvs1) ->
-                                     let uu____10614 =
+                                     let uu____10279 =
                                        FStar_TypeChecker_Env.push_univ_vars
                                          env1 uvs1 in
-                                     let uu____10615 =
+                                     let uu____10280 =
                                        FStar_Syntax_Subst.subst usubst lift1 in
-                                     (uu____10614, uu____10615) in
-                               (match uu____10586 with
+                                     (uu____10279, uu____10280) in
+                               (match uu____10251 with
                                 | (env2, lift2) ->
-                                    let uu____10620 =
-                                      let uu____10627 =
+                                    let uu____10285 =
+                                      let uu____10292 =
                                         FStar_TypeChecker_Env.lookup_effect_lid
                                           env2 sub.FStar_Syntax_Syntax.source in
                                       monad_signature env2
                                         sub.FStar_Syntax_Syntax.source
-                                        uu____10627 in
-                                    (match uu____10620 with
+                                        uu____10292 in
+                                    (match uu____10285 with
                                      | (a1, wp_a_src1) ->
                                          let wp_a =
                                            FStar_Syntax_Syntax.new_bv
@@ -4834,56 +4602,56 @@ let (tc_lift :
                                                (FStar_Pervasives_Native.snd
                                                   lift_wp) in
                                            let lift_wp_a =
-                                             let uu____10653 =
-                                               let uu____10654 =
-                                                 let uu____10671 =
-                                                   let uu____10682 =
+                                             let uu____10318 =
+                                               let uu____10319 =
+                                                 let uu____10336 =
+                                                   let uu____10347 =
                                                      FStar_Syntax_Syntax.as_arg
                                                        a_typ in
-                                                   let uu____10691 =
-                                                     let uu____10702 =
+                                                   let uu____10356 =
+                                                     let uu____10367 =
                                                        FStar_Syntax_Syntax.as_arg
                                                          wp_a_typ in
-                                                     [uu____10702] in
-                                                   uu____10682 :: uu____10691 in
-                                                 (lift_wp1, uu____10671) in
+                                                     [uu____10367] in
+                                                   uu____10347 :: uu____10356 in
+                                                 (lift_wp1, uu____10336) in
                                                FStar_Syntax_Syntax.Tm_app
-                                                 uu____10654 in
-                                             let uu____10747 =
+                                                 uu____10319 in
+                                             let uu____10412 =
                                                FStar_TypeChecker_Env.get_range
                                                  env2 in
                                              FStar_Syntax_Syntax.mk
-                                               uu____10653 uu____10747 in
+                                               uu____10318 uu____10412 in
                                            repr_type
                                              sub.FStar_Syntax_Syntax.target
                                              a_typ lift_wp_a in
                                          let expected_k1 =
-                                           let uu____10751 =
-                                             let uu____10760 =
+                                           let uu____10416 =
+                                             let uu____10425 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  a1 in
-                                             let uu____10767 =
-                                               let uu____10776 =
+                                             let uu____10432 =
+                                               let uu____10441 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    wp_a in
-                                               let uu____10783 =
-                                                 let uu____10792 =
+                                               let uu____10448 =
+                                                 let uu____10457 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      repr_f in
-                                                 [uu____10792] in
-                                               uu____10776 :: uu____10783 in
-                                             uu____10760 :: uu____10767 in
-                                           let uu____10823 =
+                                                 [uu____10457] in
+                                               uu____10441 :: uu____10448 in
+                                             uu____10425 :: uu____10432 in
+                                           let uu____10488 =
                                              FStar_Syntax_Syntax.mk_Total
                                                repr_result in
                                            FStar_Syntax_Util.arrow
-                                             uu____10751 uu____10823 in
-                                         let uu____10826 =
+                                             uu____10416 uu____10488 in
+                                         let uu____10491 =
                                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                              env2 expected_k1 in
-                                         (match uu____10826 with
-                                          | (expected_k2, uu____10836,
-                                             uu____10837) ->
+                                         (match uu____10491 with
+                                          | (expected_k2, uu____10501,
+                                             uu____10502) ->
                                               let lift3 =
                                                 if
                                                   (FStar_List.length uvs) =
@@ -4895,93 +4663,93 @@ let (tc_lift :
                                                   (let lift3 =
                                                      FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                                        env2 lift2 expected_k2 in
-                                                   let uu____10845 =
+                                                   let uu____10510 =
                                                      FStar_Syntax_Subst.close_univ_vars
                                                        uvs lift3 in
-                                                   (uvs, uu____10845)) in
+                                                   (uvs, uu____10510)) in
                                               FStar_Pervasives_Native.Some
                                                 lift3))) in
-                         ((let uu____10853 =
-                             let uu____10855 =
-                               let uu____10857 =
+                         ((let uu____10518 =
+                             let uu____10520 =
+                               let uu____10522 =
                                  FStar_All.pipe_right lift_wp
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____10857
+                               FStar_All.pipe_right uu____10522
                                  FStar_List.length in
-                             uu____10855 <> Prims.int_one in
-                           if uu____10853
+                             uu____10520 <> Prims.int_one in
+                           if uu____10518
                            then
-                             let uu____10880 =
-                               let uu____10886 =
-                                 let uu____10888 =
+                             let uu____10545 =
+                               let uu____10551 =
+                                 let uu____10553 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source in
-                                 let uu____10890 =
+                                 let uu____10555 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target in
-                                 let uu____10892 =
-                                   let uu____10894 =
-                                     let uu____10896 =
+                                 let uu____10557 =
+                                   let uu____10559 =
+                                     let uu____10561 =
                                        FStar_All.pipe_right lift_wp
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____10896
+                                     FStar_All.pipe_right uu____10561
                                        FStar_List.length in
-                                   FStar_All.pipe_right uu____10894
+                                   FStar_All.pipe_right uu____10559
                                      FStar_Util.string_of_int in
                                  FStar_Util.format3
                                    "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____10888 uu____10890 uu____10892 in
+                                   uu____10553 uu____10555 uu____10557 in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____10886) in
-                             FStar_Errors.raise_error uu____10880 r
+                                 uu____10551) in
+                             FStar_Errors.raise_error uu____10545 r
                            else ());
-                          (let uu____10923 =
+                          (let uu____10588 =
                              (FStar_Util.is_some lift1) &&
-                               (let uu____10926 =
-                                  let uu____10928 =
-                                    let uu____10931 =
+                               (let uu____10591 =
+                                  let uu____10593 =
+                                    let uu____10596 =
                                       FStar_All.pipe_right lift1
                                         FStar_Util.must in
-                                    FStar_All.pipe_right uu____10931
+                                    FStar_All.pipe_right uu____10596
                                       FStar_Pervasives_Native.fst in
-                                  FStar_All.pipe_right uu____10928
+                                  FStar_All.pipe_right uu____10593
                                     FStar_List.length in
-                                uu____10926 <> Prims.int_one) in
-                           if uu____10923
+                                uu____10591 <> Prims.int_one) in
+                           if uu____10588
                            then
-                             let uu____10970 =
-                               let uu____10976 =
-                                 let uu____10978 =
+                             let uu____10635 =
+                               let uu____10641 =
+                                 let uu____10643 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source in
-                                 let uu____10980 =
+                                 let uu____10645 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target in
-                                 let uu____10982 =
-                                   let uu____10984 =
-                                     let uu____10986 =
-                                       let uu____10989 =
+                                 let uu____10647 =
+                                   let uu____10649 =
+                                     let uu____10651 =
+                                       let uu____10654 =
                                          FStar_All.pipe_right lift1
                                            FStar_Util.must in
-                                       FStar_All.pipe_right uu____10989
+                                       FStar_All.pipe_right uu____10654
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____10986
+                                     FStar_All.pipe_right uu____10651
                                        FStar_List.length in
-                                   FStar_All.pipe_right uu____10984
+                                   FStar_All.pipe_right uu____10649
                                      FStar_Util.string_of_int in
                                  FStar_Util.format3
                                    "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____10978 uu____10980 uu____10982 in
+                                   uu____10643 uu____10645 uu____10647 in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____10976) in
-                             FStar_Errors.raise_error uu____10970 r
+                                 uu____10641) in
+                             FStar_Errors.raise_error uu____10635 r
                            else ());
-                          (let uu___1127_11031 = sub in
+                          (let uu___1106_10696 = sub in
                            {
                              FStar_Syntax_Syntax.source =
-                               (uu___1127_11031.FStar_Syntax_Syntax.source);
+                               (uu___1106_10696.FStar_Syntax_Syntax.source);
                              FStar_Syntax_Syntax.target =
-                               (uu___1127_11031.FStar_Syntax_Syntax.target);
+                               (uu___1106_10696.FStar_Syntax_Syntax.target);
                              FStar_Syntax_Syntax.lift_wp =
                                (FStar_Pervasives_Native.Some lift_wp);
                              FStar_Syntax_Syntax.lift = lift1
@@ -4995,139 +4763,139 @@ let (tc_effect_abbrev :
           FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun env ->
-    fun uu____11062 ->
+    fun uu____10727 ->
       fun r ->
-        match uu____11062 with
+        match uu____10727 with
         | (lid, uvs, tps, c) ->
             let env0 = env in
-            let uu____11085 =
+            let uu____10750 =
               if (FStar_List.length uvs) = Prims.int_zero
               then (env, uvs, tps, c)
               else
-                (let uu____11113 = FStar_Syntax_Subst.univ_var_opening uvs in
-                 match uu____11113 with
+                (let uu____10778 = FStar_Syntax_Subst.univ_var_opening uvs in
+                 match uu____10778 with
                  | (usubst, uvs1) ->
                      let tps1 = FStar_Syntax_Subst.subst_binders usubst tps in
                      let c1 =
-                       let uu____11144 =
+                       let uu____10809 =
                          FStar_Syntax_Subst.shift_subst
                            (FStar_List.length tps1) usubst in
-                       FStar_Syntax_Subst.subst_comp uu____11144 c in
-                     let uu____11153 =
+                       FStar_Syntax_Subst.subst_comp uu____10809 c in
+                     let uu____10818 =
                        FStar_TypeChecker_Env.push_univ_vars env uvs1 in
-                     (uu____11153, uvs1, tps1, c1)) in
-            (match uu____11085 with
+                     (uu____10818, uvs1, tps1, c1)) in
+            (match uu____10750 with
              | (env1, uvs1, tps1, c1) ->
                  let env2 = FStar_TypeChecker_Env.set_range env1 r in
-                 let uu____11173 = FStar_Syntax_Subst.open_comp tps1 c1 in
-                 (match uu____11173 with
+                 let uu____10838 = FStar_Syntax_Subst.open_comp tps1 c1 in
+                 (match uu____10838 with
                   | (tps2, c2) ->
-                      let uu____11188 =
+                      let uu____10853 =
                         FStar_TypeChecker_TcTerm.tc_tparams env2 tps2 in
-                      (match uu____11188 with
+                      (match uu____10853 with
                        | (tps3, env3, us) ->
-                           let uu____11206 =
+                           let uu____10871 =
                              FStar_TypeChecker_TcTerm.tc_comp env3 c2 in
-                           (match uu____11206 with
+                           (match uu____10871 with
                             | (c3, u, g) ->
                                 (FStar_TypeChecker_Rel.force_trivial_guard
                                    env3 g;
                                  (let expected_result_typ =
                                     match tps3 with
-                                    | (x, uu____11232)::uu____11233 ->
+                                    | (x, uu____10897)::uu____10898 ->
                                         FStar_Syntax_Syntax.bv_to_name x
-                                    | uu____11252 ->
+                                    | uu____10917 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
                                             "Effect abbreviations must bind at least the result type")
                                           r in
                                   let def_result_typ =
                                     FStar_Syntax_Util.comp_result c3 in
-                                  let uu____11260 =
-                                    let uu____11262 =
+                                  let uu____10925 =
+                                    let uu____10927 =
                                       FStar_TypeChecker_Rel.teq_nosmt_force
                                         env3 expected_result_typ
                                         def_result_typ in
-                                    Prims.op_Negation uu____11262 in
-                                  if uu____11260
+                                    Prims.op_Negation uu____10927 in
+                                  if uu____10925
                                   then
-                                    let uu____11265 =
-                                      let uu____11271 =
-                                        let uu____11273 =
+                                    let uu____10930 =
+                                      let uu____10936 =
+                                        let uu____10938 =
                                           FStar_Syntax_Print.term_to_string
                                             expected_result_typ in
-                                        let uu____11275 =
+                                        let uu____10940 =
                                           FStar_Syntax_Print.term_to_string
                                             def_result_typ in
                                         FStar_Util.format2
                                           "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
-                                          uu____11273 uu____11275 in
+                                          uu____10938 uu____10940 in
                                       (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
-                                        uu____11271) in
-                                    FStar_Errors.raise_error uu____11265 r
+                                        uu____10936) in
+                                    FStar_Errors.raise_error uu____10930 r
                                   else ());
                                  (let tps4 =
                                     FStar_Syntax_Subst.close_binders tps3 in
                                   let c4 =
                                     FStar_Syntax_Subst.close_comp tps4 c3 in
-                                  let uu____11283 =
-                                    let uu____11284 =
+                                  let uu____10948 =
+                                    let uu____10949 =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_arrow
                                            (tps4, c4)) r in
                                     FStar_TypeChecker_Util.generalize_universes
-                                      env0 uu____11284 in
-                                  match uu____11283 with
+                                      env0 uu____10949 in
+                                  match uu____10948 with
                                   | (uvs2, t) ->
-                                      let uu____11313 =
-                                        let uu____11318 =
-                                          let uu____11331 =
-                                            let uu____11332 =
+                                      let uu____10978 =
+                                        let uu____10983 =
+                                          let uu____10996 =
+                                            let uu____10997 =
                                               FStar_Syntax_Subst.compress t in
-                                            uu____11332.FStar_Syntax_Syntax.n in
-                                          (tps4, uu____11331) in
-                                        match uu____11318 with
+                                            uu____10997.FStar_Syntax_Syntax.n in
+                                          (tps4, uu____10996) in
+                                        match uu____10983 with
                                         | ([], FStar_Syntax_Syntax.Tm_arrow
-                                           (uu____11347, c5)) -> ([], c5)
-                                        | (uu____11389,
+                                           (uu____11012, c5)) -> ([], c5)
+                                        | (uu____11054,
                                            FStar_Syntax_Syntax.Tm_arrow
                                            (tps5, c5)) -> (tps5, c5)
-                                        | uu____11428 ->
+                                        | uu____11093 ->
                                             failwith
                                               "Impossible (t is an arrow)" in
-                                      (match uu____11313 with
+                                      (match uu____10978 with
                                        | (tps5, c5) ->
                                            (if
                                               (FStar_List.length uvs2) <>
                                                 Prims.int_one
                                             then
-                                              (let uu____11460 =
+                                              (let uu____11125 =
                                                  FStar_Syntax_Subst.open_univ_vars
                                                    uvs2 t in
-                                               match uu____11460 with
-                                               | (uu____11465, t1) ->
-                                                   let uu____11467 =
-                                                     let uu____11473 =
-                                                       let uu____11475 =
+                                               match uu____11125 with
+                                               | (uu____11130, t1) ->
+                                                   let uu____11132 =
+                                                     let uu____11138 =
+                                                       let uu____11140 =
                                                          FStar_Syntax_Print.lid_to_string
                                                            lid in
-                                                       let uu____11477 =
+                                                       let uu____11142 =
                                                          FStar_All.pipe_right
                                                            (FStar_List.length
                                                               uvs2)
                                                            FStar_Util.string_of_int in
-                                                       let uu____11481 =
+                                                       let uu____11146 =
                                                          FStar_Syntax_Print.term_to_string
                                                            t1 in
                                                        FStar_Util.format3
                                                          "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                         uu____11475
-                                                         uu____11477
-                                                         uu____11481 in
+                                                         uu____11140
+                                                         uu____11142
+                                                         uu____11146 in
                                                      (FStar_Errors.Fatal_TooManyUniverse,
-                                                       uu____11473) in
+                                                       uu____11138) in
                                                    FStar_Errors.raise_error
-                                                     uu____11467 r)
+                                                     uu____11132 r)
                                             else ();
                                             (lid, uvs2, tps5, c5)))))))))
 let (tc_polymonadic_bind :
@@ -5144,263 +4912,263 @@ let (tc_polymonadic_bind :
         fun p ->
           fun ts ->
             let eff_name =
-              let uu____11523 = FStar_Ident.string_of_lid m in
-              let uu____11525 = FStar_Ident.string_of_lid n in
-              let uu____11527 = FStar_Ident.string_of_lid p in
-              FStar_Util.format3 "(%s, %s) |> %s)" uu____11523 uu____11525
-                uu____11527 in
+              let uu____11188 = FStar_Ident.string_of_lid m in
+              let uu____11190 = FStar_Ident.string_of_lid n in
+              let uu____11192 = FStar_Ident.string_of_lid p in
+              FStar_Util.format3 "(%s, %s) |> %s)" uu____11188 uu____11190
+                uu____11192 in
             let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos in
-            let uu____11535 =
+            let uu____11200 =
               check_and_gen env eff_name "polymonadic_bind"
                 (Prims.of_int (2)) ts in
-            match uu____11535 with
+            match uu____11200 with
             | (us, t, ty) ->
-                let uu____11551 = FStar_Syntax_Subst.open_univ_vars us ty in
-                (match uu____11551 with
+                let uu____11216 = FStar_Syntax_Subst.open_univ_vars us ty in
+                (match uu____11216 with
                  | (us1, ty1) ->
                      let env1 = FStar_TypeChecker_Env.push_univ_vars env us1 in
                      (check_no_subtyping_for_layered_combinator env1 ty1
                         FStar_Pervasives_Native.None;
-                      (let uu____11564 =
-                         let uu____11569 = FStar_Syntax_Util.type_u () in
-                         FStar_All.pipe_right uu____11569
-                           (fun uu____11586 ->
-                              match uu____11586 with
+                      (let uu____11229 =
+                         let uu____11234 = FStar_Syntax_Util.type_u () in
+                         FStar_All.pipe_right uu____11234
+                           (fun uu____11251 ->
+                              match uu____11251 with
                               | (t1, u) ->
-                                  let uu____11597 =
-                                    let uu____11598 =
+                                  let uu____11262 =
+                                    let uu____11263 =
                                       FStar_Syntax_Syntax.gen_bv "a"
                                         FStar_Pervasives_Native.None t1 in
-                                    FStar_All.pipe_right uu____11598
+                                    FStar_All.pipe_right uu____11263
                                       FStar_Syntax_Syntax.mk_binder in
-                                  (uu____11597, u)) in
-                       match uu____11564 with
+                                  (uu____11262, u)) in
+                       match uu____11229 with
                        | (a, u_a) ->
-                           let uu____11606 =
-                             let uu____11611 = FStar_Syntax_Util.type_u () in
-                             FStar_All.pipe_right uu____11611
-                               (fun uu____11628 ->
-                                  match uu____11628 with
+                           let uu____11271 =
+                             let uu____11276 = FStar_Syntax_Util.type_u () in
+                             FStar_All.pipe_right uu____11276
+                               (fun uu____11293 ->
+                                  match uu____11293 with
                                   | (t1, u) ->
-                                      let uu____11639 =
-                                        let uu____11640 =
+                                      let uu____11304 =
+                                        let uu____11305 =
                                           FStar_Syntax_Syntax.gen_bv "b"
                                             FStar_Pervasives_Native.None t1 in
-                                        FStar_All.pipe_right uu____11640
+                                        FStar_All.pipe_right uu____11305
                                           FStar_Syntax_Syntax.mk_binder in
-                                      (uu____11639, u)) in
-                           (match uu____11606 with
+                                      (uu____11304, u)) in
+                           (match uu____11271 with
                             | (b, u_b) ->
                                 let rest_bs =
-                                  let uu____11657 =
-                                    let uu____11658 =
+                                  let uu____11322 =
+                                    let uu____11323 =
                                       FStar_Syntax_Subst.compress ty1 in
-                                    uu____11658.FStar_Syntax_Syntax.n in
-                                  match uu____11657 with
+                                    uu____11323.FStar_Syntax_Syntax.n in
+                                  match uu____11322 with
                                   | FStar_Syntax_Syntax.Tm_arrow
-                                      (bs, uu____11670) when
+                                      (bs, uu____11335) when
                                       (FStar_List.length bs) >=
                                         (Prims.of_int (4))
                                       ->
-                                      let uu____11698 =
+                                      let uu____11363 =
                                         FStar_Syntax_Subst.open_binders bs in
-                                      (match uu____11698 with
-                                       | (a', uu____11708)::(b', uu____11710)::bs1
+                                      (match uu____11363 with
+                                       | (a', uu____11373)::(b', uu____11375)::bs1
                                            ->
-                                           let uu____11740 =
-                                             let uu____11741 =
+                                           let uu____11405 =
+                                             let uu____11406 =
                                                FStar_All.pipe_right bs1
                                                  (FStar_List.splitAt
                                                     ((FStar_List.length bs1)
                                                        - (Prims.of_int (2)))) in
-                                             FStar_All.pipe_right uu____11741
+                                             FStar_All.pipe_right uu____11406
                                                FStar_Pervasives_Native.fst in
-                                           let uu____11807 =
-                                             let uu____11820 =
-                                               let uu____11823 =
-                                                 let uu____11824 =
-                                                   let uu____11831 =
-                                                     let uu____11834 =
+                                           let uu____11472 =
+                                             let uu____11485 =
+                                               let uu____11488 =
+                                                 let uu____11489 =
+                                                   let uu____11496 =
+                                                     let uu____11499 =
                                                        FStar_All.pipe_right a
                                                          FStar_Pervasives_Native.fst in
                                                      FStar_All.pipe_right
-                                                       uu____11834
+                                                       uu____11499
                                                        FStar_Syntax_Syntax.bv_to_name in
-                                                   (a', uu____11831) in
+                                                   (a', uu____11496) in
                                                  FStar_Syntax_Syntax.NT
-                                                   uu____11824 in
-                                               let uu____11847 =
-                                                 let uu____11850 =
-                                                   let uu____11851 =
-                                                     let uu____11858 =
-                                                       let uu____11861 =
+                                                   uu____11489 in
+                                               let uu____11512 =
+                                                 let uu____11515 =
+                                                   let uu____11516 =
+                                                     let uu____11523 =
+                                                       let uu____11526 =
                                                          FStar_All.pipe_right
                                                            b
                                                            FStar_Pervasives_Native.fst in
                                                        FStar_All.pipe_right
-                                                         uu____11861
+                                                         uu____11526
                                                          FStar_Syntax_Syntax.bv_to_name in
-                                                     (b', uu____11858) in
+                                                     (b', uu____11523) in
                                                    FStar_Syntax_Syntax.NT
-                                                     uu____11851 in
-                                                 [uu____11850] in
-                                               uu____11823 :: uu____11847 in
+                                                     uu____11516 in
+                                                 [uu____11515] in
+                                               uu____11488 :: uu____11512 in
                                              FStar_Syntax_Subst.subst_binders
-                                               uu____11820 in
-                                           FStar_All.pipe_right uu____11740
-                                             uu____11807)
-                                  | uu____11882 ->
-                                      let uu____11883 =
-                                        let uu____11889 =
-                                          let uu____11891 =
+                                               uu____11485 in
+                                           FStar_All.pipe_right uu____11405
+                                             uu____11472)
+                                  | uu____11547 ->
+                                      let uu____11548 =
+                                        let uu____11554 =
+                                          let uu____11556 =
                                             FStar_Syntax_Print.tag_of_term
                                               ty1 in
-                                          let uu____11893 =
+                                          let uu____11558 =
                                             FStar_Syntax_Print.term_to_string
                                               ty1 in
                                           FStar_Util.format3
                                             "Type of %s is not an arrow with >= 4 binders (%s::%s)"
-                                            eff_name uu____11891 uu____11893 in
+                                            eff_name uu____11556 uu____11558 in
                                         (FStar_Errors.Fatal_UnexpectedEffect,
-                                          uu____11889) in
-                                      FStar_Errors.raise_error uu____11883 r in
+                                          uu____11554) in
+                                      FStar_Errors.raise_error uu____11548 r in
                                 let bs = a :: b :: rest_bs in
-                                let uu____11926 =
-                                  let uu____11937 =
-                                    let uu____11942 =
+                                let uu____11591 =
+                                  let uu____11602 =
+                                    let uu____11607 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         bs in
-                                    let uu____11943 =
-                                      let uu____11944 =
+                                    let uu____11608 =
+                                      let uu____11609 =
                                         FStar_All.pipe_right a
                                           FStar_Pervasives_Native.fst in
-                                      FStar_All.pipe_right uu____11944
+                                      FStar_All.pipe_right uu____11609
                                         FStar_Syntax_Syntax.bv_to_name in
                                     FStar_TypeChecker_Util.fresh_effect_repr_en
-                                      uu____11942 r m u_a uu____11943 in
-                                  match uu____11937 with
+                                      uu____11607 r m u_a uu____11608 in
+                                  match uu____11602 with
                                   | (repr, g) ->
-                                      let uu____11965 =
-                                        let uu____11972 =
+                                      let uu____11630 =
+                                        let uu____11637 =
                                           FStar_Syntax_Syntax.gen_bv "f"
                                             FStar_Pervasives_Native.None repr in
-                                        FStar_All.pipe_right uu____11972
+                                        FStar_All.pipe_right uu____11637
                                           FStar_Syntax_Syntax.mk_binder in
-                                      (uu____11965, g) in
-                                (match uu____11926 with
+                                      (uu____11630, g) in
+                                (match uu____11591 with
                                  | (f, guard_f) ->
-                                     let uu____12004 =
+                                     let uu____11669 =
                                        let x_a =
-                                         let uu____12022 =
-                                           let uu____12023 =
-                                             let uu____12024 =
+                                         let uu____11687 =
+                                           let uu____11688 =
+                                             let uu____11689 =
                                                FStar_All.pipe_right a
                                                  FStar_Pervasives_Native.fst in
-                                             FStar_All.pipe_right uu____12024
+                                             FStar_All.pipe_right uu____11689
                                                FStar_Syntax_Syntax.bv_to_name in
                                            FStar_Syntax_Syntax.gen_bv "x"
                                              FStar_Pervasives_Native.None
-                                             uu____12023 in
-                                         FStar_All.pipe_right uu____12022
+                                             uu____11688 in
+                                         FStar_All.pipe_right uu____11687
                                            FStar_Syntax_Syntax.mk_binder in
-                                       let uu____12040 =
-                                         let uu____12045 =
+                                       let uu____11705 =
+                                         let uu____11710 =
                                            FStar_TypeChecker_Env.push_binders
                                              env1
                                              (FStar_List.append bs [x_a]) in
-                                         let uu____12064 =
-                                           let uu____12065 =
+                                         let uu____11729 =
+                                           let uu____11730 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst in
-                                           FStar_All.pipe_right uu____12065
+                                           FStar_All.pipe_right uu____11730
                                              FStar_Syntax_Syntax.bv_to_name in
                                          FStar_TypeChecker_Util.fresh_effect_repr_en
-                                           uu____12045 r n u_b uu____12064 in
-                                       match uu____12040 with
+                                           uu____11710 r n u_b uu____11729 in
+                                       match uu____11705 with
                                        | (repr, g) ->
-                                           let uu____12086 =
-                                             let uu____12093 =
-                                               let uu____12094 =
-                                                 let uu____12095 =
-                                                   let uu____12098 =
-                                                     let uu____12101 =
+                                           let uu____11751 =
+                                             let uu____11758 =
+                                               let uu____11759 =
+                                                 let uu____11760 =
+                                                   let uu____11763 =
+                                                     let uu____11766 =
                                                        FStar_TypeChecker_Env.new_u_univ
                                                          () in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____12101 in
+                                                       uu____11766 in
                                                    FStar_Syntax_Syntax.mk_Total'
-                                                     repr uu____12098 in
+                                                     repr uu____11763 in
                                                  FStar_Syntax_Util.arrow
-                                                   [x_a] uu____12095 in
+                                                   [x_a] uu____11760 in
                                                FStar_Syntax_Syntax.gen_bv "g"
                                                  FStar_Pervasives_Native.None
-                                                 uu____12094 in
-                                             FStar_All.pipe_right uu____12093
+                                                 uu____11759 in
+                                             FStar_All.pipe_right uu____11758
                                                FStar_Syntax_Syntax.mk_binder in
-                                           (uu____12086, g) in
-                                     (match uu____12004 with
+                                           (uu____11751, g) in
+                                     (match uu____11669 with
                                       | (g, guard_g) ->
-                                          let uu____12145 =
-                                            let uu____12150 =
+                                          let uu____11810 =
+                                            let uu____11815 =
                                               FStar_TypeChecker_Env.push_binders
                                                 env1 bs in
-                                            let uu____12151 =
-                                              let uu____12152 =
+                                            let uu____11816 =
+                                              let uu____11817 =
                                                 FStar_All.pipe_right b
                                                   FStar_Pervasives_Native.fst in
                                               FStar_All.pipe_right
-                                                uu____12152
+                                                uu____11817
                                                 FStar_Syntax_Syntax.bv_to_name in
                                             FStar_TypeChecker_Util.fresh_effect_repr_en
-                                              uu____12150 r p u_b uu____12151 in
-                                          (match uu____12145 with
+                                              uu____11815 r p u_b uu____11816 in
+                                          (match uu____11810 with
                                            | (repr, guard_repr) ->
-                                               let uu____12167 =
-                                                 let uu____12172 =
+                                               let uu____11832 =
+                                                 let uu____11837 =
                                                    FStar_TypeChecker_Env.push_binders
                                                      env1 bs in
-                                                 let uu____12173 =
+                                                 let uu____11838 =
                                                    FStar_Util.format1
                                                      "implicit for pure_wp in checking %s"
                                                      eff_name in
-                                                 pure_wp_uvar uu____12172
-                                                   repr uu____12173 r in
-                                               (match uu____12167 with
+                                                 pure_wp_uvar uu____11837
+                                                   repr uu____11838 r in
+                                               (match uu____11832 with
                                                 | (pure_wp_uvar1,
                                                    g_pure_wp_uvar) ->
                                                     let k =
-                                                      let uu____12185 =
-                                                        let uu____12188 =
-                                                          let uu____12189 =
-                                                            let uu____12190 =
+                                                      let uu____11850 =
+                                                        let uu____11853 =
+                                                          let uu____11854 =
+                                                            let uu____11855 =
                                                               FStar_TypeChecker_Env.new_u_univ
                                                                 () in
-                                                            [uu____12190] in
-                                                          let uu____12191 =
-                                                            let uu____12202 =
+                                                            [uu____11855] in
+                                                          let uu____11856 =
+                                                            let uu____11867 =
                                                               FStar_All.pipe_right
                                                                 pure_wp_uvar1
                                                                 FStar_Syntax_Syntax.as_arg in
-                                                            [uu____12202] in
+                                                            [uu____11867] in
                                                           {
                                                             FStar_Syntax_Syntax.comp_univs
-                                                              = uu____12189;
+                                                              = uu____11854;
                                                             FStar_Syntax_Syntax.effect_name
                                                               =
                                                               FStar_Parser_Const.effect_PURE_lid;
                                                             FStar_Syntax_Syntax.result_typ
                                                               = repr;
                                                             FStar_Syntax_Syntax.effect_args
-                                                              = uu____12191;
+                                                              = uu____11856;
                                                             FStar_Syntax_Syntax.flags
                                                               = []
                                                           } in
                                                         FStar_Syntax_Syntax.mk_Comp
-                                                          uu____12188 in
+                                                          uu____11853 in
                                                       FStar_Syntax_Util.arrow
                                                         (FStar_List.append bs
                                                            [f; g])
-                                                        uu____12185 in
+                                                        uu____11850 in
                                                     let guard_eq =
                                                       FStar_TypeChecker_Rel.teq
                                                         env1 ty1 k in
@@ -5412,44 +5180,44 @@ let (tc_polymonadic_bind :
                                                        guard_repr;
                                                        g_pure_wp_uvar;
                                                        guard_eq];
-                                                     (let uu____12262 =
+                                                     (let uu____11927 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env1)
                                                           FStar_Options.Extreme in
-                                                      if uu____12262
+                                                      if uu____11927
                                                       then
-                                                        let uu____12266 =
+                                                        let uu____11931 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, t) in
-                                                        let uu____12272 =
+                                                        let uu____11937 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, k) in
                                                         FStar_Util.print3
                                                           "Polymonadic bind %s after typechecking (%s::%s)\n"
                                                           eff_name
-                                                          uu____12266
-                                                          uu____12272
+                                                          uu____11931
+                                                          uu____11937
                                                       else ());
-                                                     (let uu____12282 =
-                                                        let uu____12288 =
+                                                     (let uu____11947 =
+                                                        let uu____11953 =
                                                           FStar_Util.format1
                                                             "Polymonadic binds (%s in this case) is a bleeding edge F* feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                                             eff_name in
                                                         (FStar_Errors.Warning_BleedingEdge_Feature,
-                                                          uu____12288) in
+                                                          uu____11953) in
                                                       FStar_Errors.log_issue
-                                                        r uu____12282);
-                                                     (let uu____12292 =
-                                                        let uu____12293 =
-                                                          let uu____12296 =
+                                                        r uu____11947);
+                                                     (let uu____11957 =
+                                                        let uu____11958 =
+                                                          let uu____11961 =
                                                             FStar_All.pipe_right
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env1) in
                                                           FStar_All.pipe_right
-                                                            uu____12296
+                                                            uu____11961
                                                             (FStar_Syntax_Subst.close_univ_vars
                                                                us1) in
-                                                        (us1, uu____12293) in
-                                                      ((us1, t), uu____12292)))))))))))
+                                                        (us1, uu____11958) in
+                                                      ((us1, t), uu____11957)))))))))))

--- a/src/parser/parse.fsy
+++ b/src/parser/parse.fsy
@@ -25,6 +25,7 @@ open FStar.String
 let logic_qualifier_deprecation_warning =
   "logic qualifier is deprecated, please remove it from the source program. In case your program verifies with the qualifier annotated but not without it, please try to minimize the example and file a github issue"
 
+
 let mk_meta_tac m = Meta (Arg_qualifier_meta_tac m)
 let mk_meta_attr m = Meta (Arg_qualifier_meta_attr m)
 
@@ -2505,4 +2506,5 @@ in
    ( x :: xs )}
 
 %%
+
 

--- a/src/syntax/FStar.Syntax.Print.fs
+++ b/src/syntax/FStar.Syntax.Print.fs
@@ -653,15 +653,13 @@ let layered_eff_combinators_to_string combs =
       (tscheme_to_string ts_t) (tscheme_to_string ts_ty) in
 
   U.format "{\n\
-    l_base_effect = %s\n\
   ; l_repr = %s\n\
   ; l_return = %s\n\
   ; l_bind = %s\n\
   ; l_subcomp = %s\n\
   ; l_if_then_else = %s\n
   }\n"
-    [ Ident.string_of_lid combs.l_base_effect;
-      to_str combs.l_repr;
+    [ to_str combs.l_repr;
       to_str combs.l_return;
       to_str combs.l_bind;
       to_str combs.l_subcomp;

--- a/src/syntax/FStar.Syntax.Syntax.fs
+++ b/src/syntax/FStar.Syntax.Syntax.fs
@@ -377,7 +377,6 @@ type wp_eff_combinators = {
 }
 
 type layered_eff_combinators = {
-  l_base_effect  : lident;
   l_repr         : (tscheme * tscheme);
   l_return       : (tscheme * tscheme);
   l_bind         : (tscheme * tscheme);

--- a/src/syntax/FStar.Syntax.Syntax.fsi
+++ b/src/syntax/FStar.Syntax.Syntax.fsi
@@ -398,7 +398,6 @@ type wp_eff_combinators = {
  * Similarly the base effect name is also "" after desugaring, and is set by the typechecker
  *)
 type layered_eff_combinators = {
-  l_base_effect  : lident;
   l_repr         : (tscheme * tscheme);
   l_return       : (tscheme * tscheme);
   l_bind         : (tscheme * tscheme);

--- a/src/syntax/FStar.Syntax.Util.fs
+++ b/src/syntax/FStar.Syntax.Util.fs
@@ -2143,8 +2143,7 @@ let apply_wp_eff_combinators (f:tscheme -> tscheme) (combs:wp_eff_combinators)
 let apply_layered_eff_combinators (f:tscheme -> tscheme) (combs:layered_eff_combinators)
 : layered_eff_combinators
 = let map_tuple (ts1, ts2) = (f ts1, f ts2) in
-  { l_base_effect = combs.l_base_effect;
-    l_repr = map_tuple combs.l_repr;
+  { l_repr = map_tuple combs.l_repr;
     l_return = map_tuple combs.l_return;
     l_bind = map_tuple combs.l_bind;
     l_subcomp = map_tuple combs.l_subcomp;
@@ -2226,8 +2225,3 @@ let get_stronger_repr (ed:eff_decl) : option<tscheme> =
   | Primitive_eff _
   | DM4F_eff _ -> None
   | Layered_eff combs -> combs.l_subcomp |> fst |> Some
-
-let get_layered_effect_base (ed:eff_decl) : option<lident> =
-  match ed.combinators with
-  | Layered_eff combs -> combs.l_base_effect |> Some
-  | _ -> None

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -2600,7 +2600,6 @@ let rec desugar_effect env d (quals: qualifiers) (is_layered:bool) eff_name eff_
         //setting the second component to dummy_ts, typechecker fills them in
         let to_comb (us, t) = (us, t), dummy_tscheme in
         Layered_eff ({
-          l_base_effect = Ident.lid_of_str "";
           l_repr = lookup "repr" |> to_comb;
           l_return = lookup "return" |> to_comb;
           l_bind = lookup "bind" |> to_comb;

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fs
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fs
@@ -192,35 +192,10 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
    * The repr must have the type:
    *   a:Type -> <binders for effect indices> -> Type  //polymorphic in one universe (that of a)
    *)
-  let repr, underlying_effect_lid =
+  let repr =
     let repr_ts = ed |> U.get_eff_repr |> must in
     let r = (snd repr_ts).pos in
     let repr_us, repr_t, repr_ty = check_and_gen "repr" 1 repr_ts in
-
-    let underlying_effect_lid =
-      let repr_t =
-        N.normalize
-          [Env.UnfoldUntil (S.Delta_constant_at_level 0); Env.AllowUnboundUniverses]
-          env0 repr_t in
-        match (SS.compress repr_t).n with
-        | Tm_abs (_, t, _) ->
-          (match (SS.compress t).n with
-           | Tm_arrow (_, c) -> c |> U.comp_effect_name |> Env.norm_eff_name env0
-           | _ -> 
-             raise_error (Errors.Fatal_UnexpectedEffect,
-               BU.format2 "repr body for %s is not an arrow (%s)"
-               (ed.mname |> Ident.string_of_lid) (Print.term_to_string t)) r)
-        | _ ->
-          raise_error (Errors.Fatal_UnexpectedEffect,
-            BU.format2 "repr for %s is not an abstraction (%s)"
-              (ed.mname |> Ident.string_of_lid) (Print.term_to_string repr_t)) r in
-
-    //check that if the effect is marked total, then the underlying effect is also total
-    if quals |> List.contains TotalEffect &&
-       not (Env.is_total_effect env0 underlying_effect_lid)
-    then raise_error (Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                      BU.format2 "Effect %s is marked total but its underlying effect %s is not total"
-                        (ed.mname |> Ident.string_of_lid) (underlying_effect_lid |> Ident.string_of_lid)) r;
 
     
     let us, ty = SS.open_univ_vars repr_us repr_ty in
@@ -234,8 +209,8 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
     let k = U.arrow bs (U.type_u () |> (fun (t, u) -> S.mk_Total' t (Some (new_u_univ ())))) in  //note the universe of Tot need not be u
     let g = Rel.teq env ty k in
     Rel.force_trivial_guard env g;
-    (repr_us, repr_t, SS.close_univ_vars us (k |> N.remove_uvar_solutions env)),
-    underlying_effect_lid in
+    (repr_us, repr_t, SS.close_univ_vars us (k |> N.remove_uvar_solutions env))
+  in
 
   log_combinator "repr" repr;
 
@@ -687,7 +662,6 @@ let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list<qualifier>) =
   let tschemes_of (us, t, ty) : tscheme * tscheme = (us, t), (us, ty) in
 
   let combinators = Layered_eff ({
-    l_base_effect = underlying_effect_lid;
     l_repr = tschemes_of repr;
     l_return = tschemes_of return_repr;
     l_bind = tschemes_of bind_repr;
@@ -1143,20 +1117,6 @@ let tc_layered_lift env0 (sub:S.sub_eff) : S.sub_eff =
 
   let lift_ts = sub.lift |> must in
   let r = (lift_ts |> snd).pos in
-
-  begin
-    let src_ed = Env.get_effect_decl env0 sub.source in
-    let tgt_ed = Env.get_effect_decl env0 sub.target in
-    if (src_ed |> U.is_layered &&  //source is a layered effect
-        lid_equals (src_ed |> U.get_layered_effect_base |> must) tgt_ed.mname) ||  //and target is its underlying effect, or
-       (tgt_ed |> U.is_layered &&  // target is a layered effect
-        lid_equals (tgt_ed |> U.get_layered_effect_base |> must) src_ed.mname &&  //and source is its underlying effect 
-        not (lid_equals src_ed.mname PC.effect_PURE_lid))  //and source is not PURE
-    then
-      raise_error (Errors.Fatal_EffectsCannotBeComposed,
-                   BU.format2 "Lifts cannot be defined from a layered effect to its repr or vice versa (%s and %s here)"
-                     (src_ed.mname |> Ident.string_of_lid) (tgt_ed.mname |> Ident.string_of_lid)) r
-  end;
 
   let us, lift, lift_ty = check_and_gen env0 "" "lift" 1 lift_ts in
 

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -701,4 +701,4 @@ let labeled (r: range) (msg: string) (b: Type) : Type = b
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 26
+let __cache_version_number__ = 27


### PR DESCRIPTION
This PR supports writing effect definition based on abstract representation types. Previously, we requires the representation to be a concrete type so that we could extract from it whether or not it contained computation types marked with the divergence effect. 

However, that does not seem necessary and the generality afforded by abstract effect representations is worthwhile (we are using that in Steel.PCM.Effect).

Here's a slack chat with @aseemr showing our thinking.

nik: Hi Aseem, I'm thinking to remove l_base_effect in layered_eff_combinators. It doesn't seem to be needed and removing it would more easily support adding abstract effects
9:38
Also, is this check necessary at all?
//check that if the effect is marked total, then the underlying effect is also total
    if quals |> List.contains TotalEffect &&
       not (Env.is_total_effect env0 underlying_effect_lid)
    then raise_error (Errors.Fatal_DivergentComputationCannotBeIncludedInTotal,
                      BU.format2 "Effect %s is marked total but its underlying effect %s is not total"
                        (ed.mname |> Ident.string_of_lid) (underlying_effect_lid |> Ident.string_of_lid)) r;
9:39
from our discussion yesterday, i'm not sure what purpose it achieves, since the notions of the totality check and the totality of the underlying representation are disconnected anyway

aseem  9:39 AM
My understanding was that if the underlying effect is total, then the layered effect can be both total and div, but if the underlying effect is div, then the layered effect has to be div

nik  9:41 AM
i'm not sure about that. E.g. suppose I picked my representation type to be unit -> Dv a.
9:41
I can define a bind, return etc. for all this building divergent thunks, but the divergence only happens when I reify and force the thunk

aseem  9:42 AM
Yeah, I think that makes sense, was just thinking the same, div is thunked
9:42
so reification still gives Tot terms, that have thunked div computations

nik  9:42 AM
yes
9:42
e.g., removing this check would allow defining a a total abstract effect
9:42
and if you disable the totality check, then reification immediately gives you at least div

aseem  9:42 AM
Sorry but one more question on this
9:44
So suppose I build a total effect layered on unit -> Dv a, what does totality of the layered effect mean here ... totality usually means that all well-typed computations terminate when executed, is that the case here
9:44
Since the way layered effect executes is via reification

nik  9:48 AM
it doesn't mean too much.
9:48
: )
9:49
all computations terminate in unit -> Dv a. if you want to go further, then you need to force the thunk and that may loop
9:50
in this case, that doesn't give you anything. But, I could have a representation like (bool * (unit -> Dv a) and mark it total. This means that you can build a computation, run it and definitely get at least a bool.
9:50
then perhaps you'll also get an a ... or loop

aseem  9:52 AM
Suppose we had state: st -> Dv (a * st) as the repr, then what you are saying is that running an effectful computation builds the thunk that's ready to forced with a state argument, but it's just a lambda, so terminates? (edited) 

nik  9:53 AM
yeah

aseem  9:53 AM
Passing a state argument is outside of running the effectful computation itself

nik  9:53 AM
yeah

aseem  9:55 AM
Sounds fine ...
9:55
Then removing base effect and this check should be fine too
9:55
And effect termination is totally disconnected
9:55
from that of repr

nik  9:56 AM
yeah. let me try in a branch and open a PR

aseem  9:56 AM
Actually then every layered effect (with any repr) can be marked total, right?
9:56
(Thanks!)

nik  9:56 AM
yeah, it's totally up to the user whether to mark it total or not

nik  10:02 AM
sorry, i missed this:
    let src_ed = Env.get_effect_decl env0 sub.source in
    let tgt_ed = Env.get_effect_decl env0 sub.target in
    if (src_ed |> U.is_layered &&  //source is a layered effect
        lid_equals (src_ed |> U.get_layered_effect_base |> must) tgt_ed.mname) ||  //and target is its underlying effect, or
       (tgt_ed |> U.is_layered &&  // target is a layered effect
        lid_equals (tgt_ed |> U.get_layered_effect_base |> must) src_ed.mname &&  //and source is its underlying effect 
        not (lid_equals src_ed.mname PC.effect_PURE_lid))  //and source is not PURE
    then
      raise_error (Errors.Fatal_EffectsCannotBeComposed,
                   BU.format2 "Lifts cannot be defined from a layered effect to its repr or vice versa (%s and %s here)"
                     (src_ed.mname |> Ident.string_of_lid) (tgt_ed.mname |> Ident.string_of_lid)) r
which relies on l_base_effect
10:03
what's its purpose?

aseem  10:04 AM
Try to disallow defining a lift from base effect to the layered effect (use reflect)
10:04
and vice versa

nik  10:04 AM
is it necessary?
10:06
the l_base_effect is just the effect label. So, in our previous example with M.repr = unit -> Dv a, what would go wrong if I defined a lift from Dv to M?

aseem  10:07 AM
I had coherence on my mind, now there are two ways to go from Dv to M, reflect and lift

nik  10:07 AM
but reflect is explicit

aseem  10:07 AM
yeah
10:08
So even if they yield different M types, its explicit and not picked by the typechecker
10:08
?

nik  10:08 AM
yeah, i think coherence only matters if there are non-deterministic choices being made on behalf of the programmer
10:09
(btw, these are all good checks ... don't mean to poke holes or whatever. just trying to understand how to generalize to abstract effects and what we lose/gain by it)

aseem  10:09 AM
Yeah, totally, good to get feedback on this!
10:12
May be fine to remove it, most of the times it won't even be possible to define such a lift (i.e. lift all underlying computations to the layered effect)