### PR TITLE
Simplify <, >, <= and >= when they're tautologies

### DIFF
--- a/src/typechecker/FStar.TypeChecker.Cfg.fs
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fs
@@ -768,6 +768,46 @@ let built_in_primitive_steps : prim_step_set =
                  NBETerm.binary_op
                    NBETerm.arg_as_bounded_int
                    (fun (int_to_t, x) (_, y) -> NBETerm.int_as_bounded int_to_t (Z.mult_big_int x y)));
+             (PC.p2l ["FStar"; m; "lt"],
+                 2,
+                 0,
+                 (fun res _ args ->
+                   let r = res.psc_range in
+                   match args with
+                   | [ { n = Tm_name x }, _; { n = Tm_name y }, _ ] when S.bv_eq x y ->
+                       Some (mk (Tm_constant (Const_bool false)) r)
+                   | _ -> None),
+                (fun _ -> None));
+             (PC.p2l ["FStar"; m; "gt"],
+                 2,
+                 0,
+                 (fun res _ args ->
+                   let r = res.psc_range in
+                   match args with
+                   | [ { n = Tm_name x }, _; { n = Tm_name y }, _ ] when S.bv_eq x y ->
+                       Some (mk (Tm_constant (Const_bool false)) r)
+                   | _ -> None),
+                (fun _ -> None));
+             (PC.p2l ["FStar"; m; "lte"],
+                 2,
+                 0,
+                 (fun res _ args ->
+                   let r = res.psc_range in
+                   match args with
+                   | [ { n = Tm_name x }, _; { n = Tm_name y }, _ ] when S.bv_eq x y ->
+                       Some (mk (Tm_constant (Const_bool true)) r)
+                   | _ -> None),
+                (fun _ -> None));
+             (PC.p2l ["FStar"; m; "gte"],
+                 2,
+                 0,
+                 (fun res _ args ->
+                   let r = res.psc_range in
+                   match args with
+                   | [ { n = Tm_name x }, _; { n = Tm_name y }, _ ] when S.bv_eq x y ->
+                       Some (mk (Tm_constant (Const_bool true)) r)
+                   | _ -> None),
+                (fun _ -> None));
               (PC.p2l ["FStar"; m; "v"],
                   1,
                   0,


### PR DESCRIPTION
This came up when looking in detail at @polubelova's bignum code.

As usual, we're trying to meta-program everything as much as we can. As such, a helper function may contain a check `(x < y)` for the general case, but may end up being used at call-site with `x == y`, then further inlined at extraction-time, hence generating `if (x < x) { ...` in the C code.

Tautologies of that sort are harmless, but C compilers are very unhappy about them and throw warnings. It's not just a matter of disabling such warnings either: Mozilla has been asking for one occurrence of this pattern in Poly1305 to disappear (@beurdouche can correct me if I'm wrong).

This would be helpful on the road to cleaner code for Election Guard.

Thanks,

Jonathan