### PR TITLE
No talking about counterexamples that don't really exist

### DIFF
--- a/src/smtencoding/FStar.SMTEncoding.Solver.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fs
@@ -293,7 +293,7 @@ let errors_to_report (settings : query_settings) : list<Errors.error> =
     let format_smt_error msg =
       BU.format1 "SMT solver says:\n\t%s;\n\t\
                   Note: 'canceled' or 'resource limits reached' means the SMT query timed out, so you might want to increase the rlimit;\n\t\
-                  'incomplete quantifiers' means a (partial) counterexample was found, so try to spell your proof out in greater detail, increase fuel or ifuel\n\t\
+                  'incomplete quantifiers' means Z3 could not prove the query, so try to spell your proof out in greater detail, increase fuel or ifuel\n\t\
                   'unknown' means Z3 provided no further reason for the proof failing"
         msg
     in
@@ -338,7 +338,7 @@ let errors_to_report (settings : query_settings) : list<Errors.error> =
               ) (0, 0, 0) settings.query_errors
             in
             (match incomplete_count, canceled_count, unknown_count with
-             | _, 0, 0 when incomplete_count > 0 -> "The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel"
+             | _, 0, 0 when incomplete_count > 0 -> "The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel"
              | 0, _, 0 when canceled_count > 0   -> "The SMT query timed out, you might want to increase the rlimit"
              | _, _, _                           -> "Try with --query_stats to get more details") |> Inl
         in

--- a/tests/error-messages/Basic.fst.expected
+++ b/tests/error-messages/Basic.fst.expected
@@ -2,37 +2,37 @@
 Basic.fst(4,13-4,17): (Error 189) Expected expression of type "Prims.int"; got expression "true" of type "Prims.bool"
 >>]
 >> Got issues: [
-Basic.fst(6,38-6,44): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(6,45-6,50))
+Basic.fst(6,38-6,44): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(6,45-6,50))
 >>]
 >> Got issues: [
-Basic.fst(7,38-7,44): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(7,45-7,50))
+Basic.fst(7,38-7,44): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(7,45-7,50))
 >>]
 >> Got issues: [
-Basic.fst(8,38-8,44): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(8,45-8,50))
+Basic.fst(8,38-8,44): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(8,45-8,50))
 >>]
 >> Got issues: [
-Basic.fst(9,38-9,44): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(9,45-9,50))
+Basic.fst(9,38-9,44): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(9,45-9,50))
 >>]
 >> Got issues: [
-Basic.fst(11,38-11,49): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(11,50-11,55))
+Basic.fst(11,38-11,49): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(11,50-11,55))
 >>]
 >> Got issues: [
-Basic.fst(12,38-12,49): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(12,50-12,55))
+Basic.fst(12,38-12,49): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(12,50-12,55))
 >>]
 >> Got issues: [
-Basic.fst(13,38-13,49): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(13,50-13,55))
+Basic.fst(13,38-13,49): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(13,50-13,55))
 >>]
 >> Got issues: [
-Basic.fst(14,38-14,49): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(14,50-14,55))
+Basic.fst(14,38-14,49): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Basic.fst(14,50-14,55))
 >>]
 >> Got issues: [
-Basic.fst(17,29-17,31): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Basic.fst(17,29-17,31): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Basic.fst(20,29-20,31): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Basic.fst(20,29-20,31): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Basic.fst(23,46-23,48): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Basic.fst(23,46-23,48): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 Verified module: Basic
 All verification conditions discharged successfully

--- a/tests/error-messages/Bug1997.fst.expected
+++ b/tests/error-messages/Bug1997.fst.expected
@@ -479,79 +479,79 @@ Exports: [
 ]
 
 >> Got issues: [
-Bug1997.fst(13,19-13,55): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(13,19-13,55): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(21,19-21,67): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(21,19-21,67): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(29,19-29,63): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(29,19-29,63): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(38,19-38,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(38,19-38,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(39,19-39,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(39,19-39,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(40,19-40,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(40,19-40,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(41,19-41,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(41,19-41,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(42,19-42,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(42,19-42,65): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(51,19-51,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(51,19-51,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(52,19-52,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(52,19-52,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(53,19-53,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(53,19-53,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(54,19-54,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(54,19-54,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(55,19-55,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(55,19-55,59): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(63,19-63,51): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(63,19-63,51): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(64,19-64,51): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(64,19-64,51): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(75,19-75,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(75,19-75,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(76,19-76,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(76,19-76,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(77,19-77,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(77,19-77,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(78,19-78,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(78,19-78,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(87,19-87,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(87,19-87,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(88,19-88,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(88,19-88,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(89,19-89,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(89,19-89,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(90,19-90,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(90,19-90,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(91,19-91,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(91,19-91,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Bug1997.fst(92,19-92,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Bug1997.fst(92,19-92,49): (Error 19) assertion failed (Also see: prims.fst(89,32-89,42)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 Module after type checking:
 module Bug1997

--- a/tests/error-messages/Calc.fst.expected
+++ b/tests/error-messages/Calc.fst.expected
@@ -1,35 +1,35 @@
 >> Got issues: [
-Calc.fst(12,2-17,23): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,44-29,49)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Calc.fst(12,2-17,23): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,44-29,49)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Calc.fst(22,2-28,3): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,2-29,49))(Other related locations: Calc.fst(22,7-22,11)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Calc.fst(22,2-28,3): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,2-29,49))(Other related locations: Calc.fst(22,7-22,11)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Calc.fst(33,2-35,3): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,2-29,49))(Other related locations: Calc.fst(33,7-33,10)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Calc.fst(33,2-35,3): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,2-29,49))(Other related locations: Calc.fst(33,7-33,10)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Calc.fst(40,2-44,3): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,2-29,49))(Other related locations: Calc.fst(40,7-40,10)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Calc.fst(40,2-44,3): (Error 19) Could not prove that this calc-chain is compatible (Also see: FStar.Calc.fst(29,2-29,49))(Other related locations: Calc.fst(40,7-40,10)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-Calc.fst(51,6-51,8): (Error 19) Subtyping check failed; expected type Prims.squash (1 == 2); got type Prims.unit; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(51,3-51,5))
+Calc.fst(51,6-51,8): (Error 19) Subtyping check failed; expected type Prims.squash (1 == 2); got type Prims.unit; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(51,3-51,5))
 >>]
 >> Got issues: [
-Calc.fst(65,6-65,8): (Error 19) Subtyping check failed; expected type Prims.squash (2 == 3); got type Prims.unit; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(65,3-65,5))
+Calc.fst(65,6-65,8): (Error 19) Subtyping check failed; expected type Prims.squash (2 == 3); got type Prims.unit; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(65,3-65,5))
 >>]
 >> Got issues: [
-Calc.fst(79,6-79,8): (Error 19) Subtyping check failed; expected type Prims.squash (3 == 4); got type Prims.unit; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(79,3-79,5))
+Calc.fst(79,6-79,8): (Error 19) Subtyping check failed; expected type Prims.squash (3 == 4); got type Prims.unit; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(79,3-79,5))
 >>]
 >> Got issues: [
-Calc.fst(93,42-93,44): (Error 19) Subtyping check failed; expected type Prims.squash Calc.q; got type Prims.unit; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(91,20-91,21))
+Calc.fst(93,42-93,44): (Error 19) Subtyping check failed; expected type Prims.squash Calc.q; got type Prims.unit; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(91,20-91,21))
 >>]
 >> Got issues: [
-Calc.fst(100,10-100,12): (Error 19) Subtyping check failed; expected type Prims.squash Calc.q; got type Prims.unit; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(101,4-101,5))
+Calc.fst(100,10-100,12): (Error 19) Subtyping check failed; expected type Prims.squash Calc.q; got type Prims.unit; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(101,4-101,5))
 >>]
 >> Got issues: [
-Calc.fst(114,17-114,25): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(105,12-105,17))
+Calc.fst(114,17-114,25): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(105,12-105,17))
 >>]
 >> Got issues: [
-Calc.fst(121,9-121,17): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(105,12-105,17))
+Calc.fst(121,9-121,17): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Calc.fst(105,12-105,17))
 >>]
 Verified module: Calc
 All verification conditions discharged successfully

--- a/tests/error-messages/Coercions.fst.expected
+++ b/tests/error-messages/Coercions.fst.expected
@@ -5,19 +5,19 @@ Coercions.fst(6,38-6,39): (Error 34) Computed type "Prims.int" and effect "GTot"
 Coercions.fst(19,37-19,38): (Error 34) Computed type "'a" and effect "GTot" is not compatible with the annotated type "'a" effect "Tot"
 >>]
 >> Got issues: [
-Coercions.fst(71,4-71,8): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+Coercions.fst(71,4-71,8): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-Coercions.fst(74,49-74,57): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+Coercions.fst(74,49-74,57): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-Coercions.fst(76,55-76,56): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+Coercions.fst(76,55-76,56): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-Coercions.fst(78,50-78,51): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+Coercions.fst(78,50-78,51): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-Coercions.fst(80,51-80,52): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+Coercions.fst(80,51-80,52): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 Verified module: Coercions
 All verification conditions discharged successfully

--- a/tests/error-messages/ExpectFailure.fst.expected
+++ b/tests/error-messages/ExpectFailure.fst.expected
@@ -5,10 +5,10 @@ ExpectFailure.fst(20,12-20,15): (Error 189) Expected expression of type "Prims.i
 ExpectFailure.fst(24,12-24,15): (Error 189) Expected expression of type "Prims.int"; got expression "'a'" of type "FStar.Char.char"
 >>]
 >> Got issues: [
-ExpectFailure.fst(28,8-28,14): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also ExpectFailure.fst(28,15-28,20))
+ExpectFailure.fst(28,8-28,14): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also ExpectFailure.fst(28,15-28,20))
 >>]
 >> Got issues: [
-ExpectFailure.fst(30,8-30,14): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also ExpectFailure.fst(30,15-30,20))
+ExpectFailure.fst(30,8-30,14): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also ExpectFailure.fst(30,15-30,20))
 >>]
 >> Got issues: [
 ExpectFailure.fst(43,12-43,15): (Error 189) Expected expression of type "Prims.int"; got expression "'a'" of type "FStar.Char.char"

--- a/tests/error-messages/Inference.fst.expected
+++ b/tests/error-messages/Inference.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-Inference.fst(20,14-20,15): (Error 19) Subtyping check failed; expected type Prims.eqtype; got type Type0; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(45,23-45,30))
+Inference.fst(20,14-20,15): (Error 19) Subtyping check failed; expected type Prims.eqtype; got type Type0; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(45,23-45,30))
 >>]
 Verified module: Inference
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.BST.fst.expected
+++ b/tests/error-messages/NegativeTests.BST.fst.expected
@@ -2,19 +2,19 @@
 NegativeTests.BST.fst(37,38-37,42): (Error 19) Subtyping check failed; expected type right:
 FStar.Pervasives.Native.option (NegativeTests.BST.tree 2)
   { 0 <= 1 /\ 1 <= 2 /\ (None? right <==> 1 = 2) /\
-    (None? (FStar.Pervasives.Native.None) <==> 1 = 0) }; got type FStar.Pervasives.Native.option (NegativeTests.BST.tree 2); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.BST.fst(27,37-27,48))
+    (None? (FStar.Pervasives.Native.None) <==> 1 = 0) }; got type FStar.Pervasives.Native.option (NegativeTests.BST.tree 2); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.BST.fst(27,37-27,48))
 >>]
 >> Got issues: [
 NegativeTests.BST.fst(40,61-40,65): (Error 19) Subtyping check failed; expected type right:
 FStar.Pervasives.Native.option (NegativeTests.BST.tree (l + 1))
   { l <= l /\ l <= l + 1 /\ (None? right <==> l = l + 1) /\
-    (None? (FStar.Pervasives.Native.Some t) <==> l = l) }; got type FStar.Pervasives.Native.option (NegativeTests.BST.tree (l + 1)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.BST.fst(27,36-27,58))
+    (None? (FStar.Pervasives.Native.Some t) <==> l = l) }; got type FStar.Pervasives.Native.option (NegativeTests.BST.tree (l + 1)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.BST.fst(27,36-27,58))
 >>]
 >> Got issues: [
 NegativeTests.BST.fst(43,78-43,87): (Error 19) Subtyping check failed; expected type right:
 FStar.Pervasives.Native.option (NegativeTests.BST.tree (l + 1))
   { l <= l + 1 /\ l + 1 <= l + 1 /\ (None? right <==> l + 1 = l + 1) /\
-    (None? (FStar.Pervasives.Native.Some t1) <==> l + 1 = l) }; got type FStar.Pervasives.Native.option (NegativeTests.BST.tree (l + 1)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.BST.fst(27,37-27,48))
+    (None? (FStar.Pervasives.Native.Some t1) <==> l + 1 = l) }; got type FStar.Pervasives.Native.option (NegativeTests.BST.tree (l + 1)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.BST.fst(27,37-27,48))
 >>]
 Verified module: NegativeTests.BST
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.Bug260.fst.expected
+++ b/tests/error-messages/NegativeTests.Bug260.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-NegativeTests.Bug260.fst(26,12-26,19): (Error 19) Subtyping check failed; expected type NegativeTests.Bug260.validity (NegativeTests.Bug260.S (NegativeTests.Bug260.S t)); got type NegativeTests.Bug260.validity (NegativeTests.Bug260.S t); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Bug260.fst(23,37-26,9))
+NegativeTests.Bug260.fst(26,12-26,19): (Error 19) Subtyping check failed; expected type NegativeTests.Bug260.validity (NegativeTests.Bug260.S (NegativeTests.Bug260.S t)); got type NegativeTests.Bug260.validity (NegativeTests.Bug260.S t); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Bug260.fst(23,37-26,9))
 >>]
 NegativeTests.Bug260.fst(23,4-23,7): (Warning 240) Admitting NegativeTests.Bug260.bad without a definition
 Verified module: NegativeTests.Bug260

--- a/tests/error-messages/NegativeTests.False.fst.expected
+++ b/tests/error-messages/NegativeTests.False.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-NegativeTests.False.fst(23,13-23,33): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(383,54-383,66))
+NegativeTests.False.fst(23,13-23,33): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(383,54-383,66))
 >>]
 >> Got issues: [
 NegativeTests.False.fst(30,18-30,35): (Error 12) Expected type "Prims.l_True \/ Prims.l_True"; but "Prims.Left (Prims.T)" has type "Prims.c_or (*?u1*) _ Prims.l_True"

--- a/tests/error-messages/NegativeTests.Heap.fst.expected
+++ b/tests/error-messages/NegativeTests.Heap.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-NegativeTests.Heap.fst(26,21-26,54): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.Heap.fst(26,21-26,54): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 Verified module: NegativeTests.Heap
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.Neg.fst.expected
+++ b/tests/error-messages/NegativeTests.Neg.fst.expected
@@ -1,29 +1,29 @@
 >> Got issues: [
-NegativeTests.Neg.fst(20,8-20,10): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+NegativeTests.Neg.fst(20,8-20,10): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(24,8-24,10): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+NegativeTests.Neg.fst(24,8-24,10): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(27,30-27,35): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.Neg.fst(27,30-27,35): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(30,28-31,15): (Error 19) Patterns are incomplete; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.Neg.fst(30,28-31,15): (Error 19) Patterns are incomplete; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(38,32-38,42): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Neg.fst(33,44-33,57))
+NegativeTests.Neg.fst(38,32-38,42): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Neg.fst(33,44-33,57))
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(42,33-42,34): (Error 19) could not prove post-condition; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Neg.fst(40,83-40,88))
+NegativeTests.Neg.fst(42,33-42,34): (Error 19) could not prove post-condition; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Neg.fst(40,83-40,88))
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(46,30-46,31): (Error 19) Subtyping check failed; expected type _: FStar.Pervasives.Native.option 'a {Some? _}; got type FStar.Pervasives.Native.option 'a; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.Pervasives.Native.fst(33,4-33,8))
+NegativeTests.Neg.fst(46,30-46,31): (Error 19) Subtyping check failed; expected type _: FStar.Pervasives.Native.option 'a {Some? _}; got type FStar.Pervasives.Native.option 'a; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.Pervasives.Native.fst(33,4-33,8))
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(50,45-50,47): (Error 19) Subtyping check failed; expected type _: FStar.Pervasives.result Prims.int {V? _}; got type FStar.Pervasives.result Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.Pervasives.fsti(239,4-239,5))
+NegativeTests.Neg.fst(50,45-50,47): (Error 19) Subtyping check failed; expected type _: FStar.Pervasives.result Prims.int {V? _}; got type FStar.Pervasives.result Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.Pervasives.fsti(239,4-239,5))
 >>]
 >> Got issues: [
-NegativeTests.Neg.fst(55,25-55,26): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+NegativeTests.Neg.fst(55,25-55,26): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
 NegativeTests.Neg.fst(59,0-60,17): (Error 309) Type annotation _: Type0{NegativeTests.Neg.phi_1510} for inductive NegativeTests.Neg.t is not Type or eqtype, or it is eqtype but contains unopteq qualifier

--- a/tests/error-messages/NegativeTests.Set.fst.expected
+++ b/tests/error-messages/NegativeTests.Set.fst.expected
@@ -1,11 +1,11 @@
 >> Got issues: [
-NegativeTests.Set.fst(28,9-28,30): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.Set.fst(28,9-28,30): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-NegativeTests.Set.fst(33,9-33,67): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.Set.fst(33,9-33,67): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-NegativeTests.Set.fst(38,9-38,52): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.Set.fst(38,9-38,52): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 NegativeTests.Set.fst(25,4-25,16): (Warning 240) Admitting NegativeTests.Set.should_fail1 without a definition
 NegativeTests.Set.fst(30,4-30,16): (Warning 240) Admitting NegativeTests.Set.should_fail2 without a definition

--- a/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
+++ b/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
@@ -1,8 +1,8 @@
 >> Got issues: [
-NegativeTests.ShortCircuiting.fst(21,16-21,33): (Error 19) Subtyping check failed; expected type b: Prims.bool{NegativeTests.ShortCircuiting.bad_p b}; got type Prims.bool; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.ShortCircuiting.fst(19,31-19,38))
+NegativeTests.ShortCircuiting.fst(21,16-21,33): (Error 19) Subtyping check failed; expected type b: Prims.bool{NegativeTests.ShortCircuiting.bad_p b}; got type Prims.bool; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.ShortCircuiting.fst(19,31-19,38))
 >>]
 >> Got issues: [
-NegativeTests.ShortCircuiting.fst(25,11-25,36): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.ShortCircuiting.fst(25,11-25,36): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 NegativeTests.ShortCircuiting.fst(19,4-19,7): (Warning 240) Admitting NegativeTests.ShortCircuiting.bad without a definition
 NegativeTests.ShortCircuiting.fst(23,4-23,6): (Warning 240) Admitting NegativeTests.ShortCircuiting.ff without a definition

--- a/tests/error-messages/NegativeTests.Termination.fst.expected
+++ b/tests/error-messages/NegativeTests.Termination.fst.expected
@@ -1,32 +1,32 @@
 >> Got issues: [
-NegativeTests.Termination.fst(21,28-21,29): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(21,20-21,29))
+NegativeTests.Termination.fst(21,28-21,29): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(21,20-21,29))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(28,26-28,35): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(26,2-28,35))
+NegativeTests.Termination.fst(28,26-28,35): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(26,2-28,35))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(35,43-35,44): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(34,2-36,54))
+NegativeTests.Termination.fst(35,43-35,44): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(34,2-36,54))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(42,28-42,29): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(40,23-42,29))
+NegativeTests.Termination.fst(42,28-42,29): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(40,23-42,29))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(55,15-55,29): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(53,2-55,29))
+NegativeTests.Termination.fst(55,15-55,29): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(53,2-55,29))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(67,19-67,29): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(64,2-67,29))
+NegativeTests.Termination.fst(67,19-67,29): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(64,2-67,29))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(75,34-75,35): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(72,2-75,35))
+NegativeTests.Termination.fst(75,34-75,35): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(72,2-75,35))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(80,2-82,14): (Error 19) Patterns are incomplete; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+NegativeTests.Termination.fst(80,2-82,14): (Error 19) Patterns are incomplete; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(89,29-89,31): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(87,2-89,31))
+NegativeTests.Termination.fst(89,29-89,31): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(87,2-89,31))
 >>]
 >> Got issues: [
-NegativeTests.Termination.fst(96,20-96,26): (Error 19) Could not prove termination of this recursive call; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(94,2-96,26))
+NegativeTests.Termination.fst(96,20-96,26): (Error 19) Could not prove termination of this recursive call; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also NegativeTests.Termination.fst(94,2-96,26))
 >>]
 NegativeTests.Termination.fst(18,4-18,9): (Warning 240) Admitting NegativeTests.Termination.bug15 without a definition
 NegativeTests.Termination.fst(23,4-23,18): (Warning 240) Admitting NegativeTests.Termination.repeat_diverge without a definition

--- a/tests/error-messages/OptionStack.fst.expected
+++ b/tests/error-messages/OptionStack.fst.expected
@@ -1,8 +1,8 @@
 >> Got issues: [
-OptionStack.fst(19,8-19,14): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also OptionStack.fst(19,15-19,20))
+OptionStack.fst(19,8-19,14): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also OptionStack.fst(19,15-19,20))
 >>]
 >> Got issues: [
-OptionStack.fst(28,8-28,14): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also OptionStack.fst(28,15-28,20))
+OptionStack.fst(28,8-28,14): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also OptionStack.fst(28,15-28,20))
 >>]
 Verified module: OptionStack
 All verification conditions discharged successfully

--- a/tests/error-messages/PatAnnot.fst.expected
+++ b/tests/error-messages/PatAnnot.fst.expected
@@ -1,20 +1,20 @@
 >> Got issues: [
-PatAnnot.fst(25,8-25,9): (Error 19) Subtyping check failed; expected type Prims.squash Prims.l_False; got type Prims.unit; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also PatAnnot.fst(25,19-25,24))
+PatAnnot.fst(25,8-25,9): (Error 19) Subtyping check failed; expected type Prims.squash Prims.l_False; got type Prims.unit; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also PatAnnot.fst(25,19-25,24))
 >>]
 >> Got issues: [
-PatAnnot.fst(28,0-30,14): (Error 19) assertion failed (Also see: prims.fst(383,54-383,66)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+PatAnnot.fst(28,0-30,14): (Error 19) assertion failed (Also see: prims.fst(383,54-383,66)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-PatAnnot.fst(33,0-35,14): (Error 19) assertion failed (Also see: prims.fst(383,54-383,66)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+PatAnnot.fst(33,0-35,14): (Error 19) assertion failed (Also see: prims.fst(383,54-383,66)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-PatAnnot.fst(39,10-39,12): (Error 19) Subtyping check failed; expected type Prims.squash Prims.l_False; got type Prims.unit; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also PatAnnot.fst(40,26-40,31))
+PatAnnot.fst(39,10-39,12): (Error 19) Subtyping check failed; expected type Prims.squash Prims.l_False; got type Prims.unit; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also PatAnnot.fst(40,26-40,31))
 >>]
 >> Got issues: [
-PatAnnot.fst(46,10-46,11): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+PatAnnot.fst(46,10-46,11): (Error 19) Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-PatAnnot.fst(55,36-55,39): (Error 19) Type annotation on parameter incompatible with the expected type; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+PatAnnot.fst(55,36-55,39): (Error 19) Type annotation on parameter incompatible with the expected type; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 Verified module: PatAnnot
 All verification conditions discharged successfully

--- a/tests/error-messages/PatternMatch.fst.expected
+++ b/tests/error-messages/PatternMatch.fst.expected
@@ -1,11 +1,11 @@
 >> Got issues: [
-(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(21,4-21,8)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(21,4-21,8)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(24,4-24,11)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(24,4-24,11)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(29,4-29,8)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(29,4-29,8)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
 PatternMatch.fst(32,4-32,9): (Error 114) Type of pattern (Prims.bool) does not match type of scrutinee (Prims.int)
@@ -14,7 +14,7 @@ PatternMatch.fst(32,4-32,9): (Error 114) Type of pattern (Prims.bool) does not m
 PatternMatch.fst(35,4-35,5): (Error 114) Type of pattern (PatternMatch.ab) does not match type of scrutinee (Prims.int); head mismatch PatternMatch.ab vs Prims.int
 >>]
 >> Got issues: [
-(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(38,4-38,5)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(38,4-38,5)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
 PatternMatch.fst(55,4-55,8): (Error 114) Type of pattern (Prims.bool) does not match type of scrutinee (Prims.int)
@@ -23,10 +23,10 @@ PatternMatch.fst(55,4-55,8): (Error 114) Type of pattern (Prims.bool) does not m
 PatternMatch.fst(58,4-58,16): (Error 114) Type of pattern (Prims.bool) does not match type of scrutinee (Prims.int)
 >>]
 >> Got issues: [
-(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(61,5-61,12)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(61,5-61,12)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
-(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(64,5-64,20)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+(Error 19) Patterns are incomplete (Also see: PatternMatch.fst(64,5-64,20)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 >> Got issues: [
 PatternMatch.fst(69,5-69,15): (Error 114) Type of pattern (Prims.bool) does not match type of scrutinee (Prims.int)

--- a/tests/error-messages/QuickTestNBE.fst.expected
+++ b/tests/error-messages/QuickTestNBE.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-QuickTestNBE.fst(127,2-130,34): (Error 19)  (Also see: QuickTestNBE(1,2-3,4))(Other related locations: QuickTestNBE.fst(111,12-111,15)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+QuickTestNBE.fst(127,2-130,34): (Error 19)  (Also see: QuickTestNBE(1,2-3,4))(Other related locations: QuickTestNBE.fst(111,12-111,15)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 Verified module: QuickTestNBE
 All verification conditions discharged successfully

--- a/tests/error-messages/StrictUnfolding.fst.expected
+++ b/tests/error-messages/StrictUnfolding.fst.expected
@@ -19,7 +19,7 @@ Goal 1/1:
 (_: Prims.unit), (return_val: x: FStar.Pervasives.Native.option Prims.int {Some? x}), (_: return_val == FStar.Pervasives.Native.Some 0), (any_result: Prims.int), (_: StrictUnfolding.project (FStar.Pervasives.Native.Some 0) == any_result), (any_result'0: Prims.logical), (_: StrictUnfolding.project (FStar.Pervasives.Native.Some 0) == 0 == any_result'0) |- _ : Prims.squash (0 == 0)
 
 >> Got issues: [
-StrictUnfolding.fst(50,2-50,8): (Error 19) Could not prove goal #1; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also StrictUnfolding.fst(50,48-50,72))
+StrictUnfolding.fst(50,2-50,8): (Error 19) Could not prove goal #1; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also StrictUnfolding.fst(50,48-50,72))
 >>]
 Verified module: StrictUnfolding
 All verification conditions discharged successfully

--- a/tests/error-messages/StringNormalization.fst.expected
+++ b/tests/error-messages/StringNormalization.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-StringNormalization.fst(83,2-83,8): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also StringNormalization.fst(83,9-83,58))
+StringNormalization.fst(83,2-83,8): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also StringNormalization.fst(83,9-83,58))
 >>]
 Verified module: StringNormalization
 All verification conditions discharged successfully

--- a/tests/error-messages/Test.FunctionalExtensionality.fst.expected
+++ b/tests/error-messages/Test.FunctionalExtensionality.fst.expected
@@ -1,14 +1,14 @@
 >> Got issues: [
-Test.FunctionalExtensionality.fst(36,49-36,50): (Error 19) Subtyping check failed; expected type Prims.nat ^-> Prims.int; got type Prims.int ^-> Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.FunctionalExtensionality.fsti(103,60-103,77))
+Test.FunctionalExtensionality.fst(36,49-36,50): (Error 19) Subtyping check failed; expected type Prims.nat ^-> Prims.int; got type Prims.int ^-> Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.FunctionalExtensionality.fsti(103,60-103,77))
 >>]
 >> Got issues: [
-Test.FunctionalExtensionality.fst(80,2-80,8): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also Test.FunctionalExtensionality.fst(80,9-80,43))
+Test.FunctionalExtensionality.fst(80,2-80,8): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also Test.FunctionalExtensionality.fst(80,9-80,43))
 >>]
 >> Got issues: [
-Test.FunctionalExtensionality.fst(92,36-92,47): (Error 19) Subtyping check failed; expected type _: Prims.int -> Prims.Tot Prims.int; got type Prims.nat ^-> Prims.int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
+Test.FunctionalExtensionality.fst(92,36-92,47): (Error 19) Subtyping check failed; expected type _: Prims.int -> Prims.Tot Prims.int; got type Prims.nat ^-> Prims.int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also prims.fst(646,18-646,24))
 >>]
 >> Got issues: [
-Test.FunctionalExtensionality.fst(142,57-142,58): (Error 19) Subtyping check failed; expected type Prims.int ^-> Prims.int; got type Prims.int ^-> Prims.nat; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.FunctionalExtensionality.fsti(103,60-103,77))
+Test.FunctionalExtensionality.fst(142,57-142,58): (Error 19) Subtyping check failed; expected type Prims.int ^-> Prims.int; got type Prims.int ^-> Prims.nat; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also FStar.FunctionalExtensionality.fsti(103,60-103,77))
 >>]
 Verified module: Test.FunctionalExtensionality
 All verification conditions discharged successfully

--- a/tests/error-messages/TestHasEq.fst.expected
+++ b/tests/error-messages/TestHasEq.fst.expected
@@ -1,8 +1,8 @@
 >> Got issues: [
-TestHasEq.fst(58,10-58,11): (Error 19) Failed to prove that the type 'TestHasEq.t3' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also TestHasEq.fst(57,0-58,19))
+TestHasEq.fst(58,10-58,11): (Error 19) Failed to prove that the type 'TestHasEq.t3' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also TestHasEq.fst(57,0-58,19))
 >>]
 >> Got issues: [
-TestHasEq.fst(84,10-84,70): (Error 19) Subtyping check failed; expected type Prims.eqtype; got type Type0; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel (see also TestHasEq.fst(84,12-84,22))
+TestHasEq.fst(84,10-84,70): (Error 19) Subtyping check failed; expected type Prims.eqtype; got type Type0; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel (see also TestHasEq.fst(84,12-84,22))
 >>]
 >> Got issues: [
 TestHasEq.fst(88,8-89,30): (Error 162) Incompatible attributes and qualifiers: erasable types do not support decidable equality and must be marked `noeq`

--- a/tests/error-messages/Unit2.fst.expected
+++ b/tests/error-messages/Unit2.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-Unit2.fst(37,21-38,60): (Error 19) assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+Unit2.fst(37,21-38,60): (Error 19) assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 Verified module: Unit2
 All verification conditions discharged successfully

--- a/tests/error-messages/WPExtensionality.fst.expected
+++ b/tests/error-messages/WPExtensionality.fst.expected
@@ -1,5 +1,5 @@
 >> Got issues: [
-WPExtensionality.fst(118,3-118,34): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
+WPExtensionality.fst(118,3-118,34): (Error 19) assertion failed (Also see: prims.fst(379,31-379,43))(Other related locations: prims.fst(376,70-376,82)); The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel
 >>]
 Verified module: WPExtensionality
 All verification conditions discharged successfully

--- a/tests/interactive/backtracking.refinements.out.expected
+++ b/tests/interactive/backtracking.refinements.out.expected
@@ -16,15 +16,15 @@
 {"kind": "response", "query-id": "15", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "16", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "17", "response": [], "status": "success"}
-{"kind": "response", "query-id": "18", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 2}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "18", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 2}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "19", "response": [], "status": "success"}
 {"kind": "response", "query-id": "20", "response": [], "status": "success"}
-{"kind": "response", "query-id": "21", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 1}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "21", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 1}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "22", "response": [], "status": "success"}
 {"kind": "response", "query-id": "23", "response": [], "status": "success"}
 {"kind": "response", "query-id": "24", "response": null, "status": "success"}
 {"kind": "response", "query-id": "25", "response": [], "status": "success"}
-{"kind": "response", "query-id": "26", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 0}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "26", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 0}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "27", "response": [], "status": "success"}
 {"kind": "response", "query-id": "28", "response": [], "status": "success"}
 {"kind": "response", "query-id": "29", "response": [], "status": "success"}
@@ -43,7 +43,7 @@
 {"kind": "response", "query-id": "42", "response": [], "status": "success"}
 {"kind": "response", "query-id": "43", "response": [], "status": "success"}
 {"kind": "response", "query-id": "44", "response": [], "status": "success"}
-{"kind": "response", "query-id": "45", "response": [{"level": "error", "message": "Subtyping check failed; expected type b: nat{b > 1}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "45", "response": [{"level": "error", "message": "Subtyping check failed; expected type b: nat{b > 1}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "46", "response": [], "status": "success"}
 {"kind": "response", "query-id": "47", "response": [], "status": "success"}
 {"kind": "response", "query-id": "48", "response": [], "status": "success"}
@@ -53,7 +53,7 @@
 {"kind": "response", "query-id": "52", "response": [], "status": "success"}
 {"kind": "response", "query-id": "53", "response": null, "status": "success"}
 {"kind": "response", "query-id": "54", "response": [], "status": "success"}
-{"kind": "response", "query-id": "55", "response": [{"level": "error", "message": "Subtyping check failed; expected type b: nat{b > 1}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "55", "response": [{"level": "error", "message": "Subtyping check failed; expected type b: nat{b > 1}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "56", "response": null, "status": "success"}
 {"kind": "response", "query-id": "57", "response": [], "status": "success"}
 {"kind": "response", "query-id": "58", "response": [], "status": "success"}
@@ -61,12 +61,12 @@
 {"kind": "response", "query-id": "60", "response": null, "status": "success"}
 {"kind": "response", "query-id": "61", "response": null, "status": "success"}
 {"kind": "response", "query-id": "62", "response": [], "status": "success"}
-{"kind": "response", "query-id": "63", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 0}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "63", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 0}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "64", "response": [], "status": "success"}
-{"kind": "response", "query-id": "65", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 0}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "65", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 0}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "66", "response": [], "status": "success"}
 {"kind": "response", "query-id": "67", "response": [], "status": "success"}
-{"kind": "response", "query-id": "68", "response": [{"level": "error", "message": "Subtyping check failed; expected type b: nat{b > 1}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "68", "response": [{"level": "error", "message": "Subtyping check failed; expected type b: nat{b > 1}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "69", "response": null, "status": "success"}
 {"kind": "response", "query-id": "70", "response": [], "status": "success"}
 {"kind": "response", "query-id": "71", "response": [], "status": "success"}

--- a/tests/interactive/integration.push-pop.out.expected
+++ b/tests/interactive/integration.push-pop.out.expected
@@ -78,17 +78,17 @@
 {"kind": "response", "query-id": "80", "response": [], "status": "success"}
 {"kind": "response", "query-id": "91", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [12, 0], "end": [12, 0], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "98", "response": [], "status": "success"}
-{"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "107", "response": [], "status": "success"}
 {"kind": "response", "query-id": "108", "response": [], "status": "success"}
 {"kind": "response", "query-id": "112", "response": null, "status": "success"}
 {"kind": "response", "query-id": "114", "response": [], "status": "success"}
-{"kind": "response", "query-id": "116", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "116", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "118", "response": [], "status": "success"}
 {"kind": "response", "query-id": "119", "response": [], "status": "success"}
 {"kind": "response", "query-id": "122", "response": null, "status": "success"}
 {"kind": "response", "query-id": "124", "response": [], "status": "success"}
-{"kind": "response", "query-id": "126", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "126", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "128", "response": [], "status": "success"}
 {"kind": "response", "query-id": "130", "response": [], "status": "success"}
 {"kind": "response", "query-id": "133", "response": [], "status": "success"}
@@ -96,20 +96,20 @@
 {"kind": "response", "query-id": "159", "response": [{"level": "error", "message": "Expected expression of type \"Type0\"; got expression \"Integration.xx\" of type \"nat\"", "number": 189, "ranges": [{"beg": [13, 15], "end": [13, 20], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "163", "response": [], "status": "success"}
 {"kind": "response", "query-id": "164", "response": [], "status": "success"}
-{"kind": "response", "query-id": "165", "response": [{"level": "error", "message": "assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 23], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "165", "response": [{"level": "error", "message": "assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 23], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "170", "response": [], "status": "success"}
 {"kind": "response", "query-id": "175", "response": [{"level": "error", "message": "Unexpected numeric literal.  Restart F* to load FStar.UInt8.", "number": 201, "ranges": [{"beg": [13, 22], "end": [13, 24], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "179", "response": [], "status": "success"}
-{"kind": "response", "query-id": "180", "response": [{"level": "error", "message": "assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 24], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "180", "response": [{"level": "error", "message": "assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 24], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "185", "response": [], "status": "success"}
 {"kind": "response", "query-id": "186", "response": [], "status": "success"}
 {"kind": "response", "query-id": "191", "response": null, "status": "success"}
 {"kind": "response", "query-id": "192", "response": null, "status": "success"}
 {"kind": "response", "query-id": "194", "response": [], "status": "success"}
-{"kind": "response", "query-id": "198", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "198", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [646, 18], "end": [646, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "200", "response": [], "status": "success"}
 {"kind": "response", "query-id": "204", "response": [], "status": "success"}
-{"kind": "response", "query-id": "205", "response": [{"level": "error", "message": "assertion failed; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 23], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "205", "response": [{"level": "error", "message": "assertion failed; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 23], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "211", "response": [], "status": "success"}
 {"kind": "response", "query-id": "213", "response": [], "status": "success"}
 {"kind": "response", "query-id": "214", "response": [], "status": "success"}

--- a/tests/interactive/number.interface-violation-and-fix.out.expected
+++ b/tests/interactive/number.interface-violation-and-fix.out.expected
@@ -1,7 +1,7 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": null, "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
-{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: int{a > 0}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}
+{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: int{a > 0}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}
 {"kind": "response", "query-id": "4", "response": null, "status": "success"}
 {"kind": "response", "query-id": "5", "response": null, "status": "success"}
 {"kind": "response", "query-id": "6", "response": [], "status": "success"}

--- a/tests/interactive/number.interface-violation.out.expected
+++ b/tests/interactive/number.interface-violation.out.expected
@@ -1,4 +1,4 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": null, "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
-{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: int{a > 0}; got type int; The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}
+{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: int{a > 0}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}


### PR DESCRIPTION
I've seen too many users very puzzled by the first part of this error message:
```
The solver found a (partial) counterexample, try to spell your proof in more detail or increase fuel/ifuel
```
When users see this message they would really like to see the counterexample:
https://fstar.zulipchat.com/#narrow/stream/184683-questions-and.20help/topic/The.20solver.20found.20a.20(partial).20counterexample
yet the partial models that Z3 produces are not at all guaranteed to be real counterexamples, and we have no way to translate them back to F* or to check them.

So I tried to change to a more neutral message that doesn't mislead users with the "counterexample" word.