### PR TITLE
Remove duplicated statement of substitution_preserves_typing in tutorial

### DIFF
--- a/doc/tutorial/code/exercises/Ex07a.fst
+++ b/doc/tutorial/code/exercises/Ex07a.fst
@@ -188,8 +188,7 @@ val substitution_preserves_typing : x:int -> e:exp -> v:exp ->
       Lemma
         (requires ( Some? (typing empty v) /\
               Some? (typing (extend g x (Some?.v (typing empty v))) e)))
-        (ensures (Some? (typing empty v) /\
-                  typing g (subst x v e) ==
+        (ensures (typing g (subst x v e) ==
                   typing (extend g x (Some?.v (typing empty v))) e))
 let rec substitution_preserves_typing x e v g =
   let Some t_x = typing empty v in

--- a/doc/tutorial/code/solutions/Ex07a.fst
+++ b/doc/tutorial/code/solutions/Ex07a.fst
@@ -188,8 +188,7 @@ val substitution_preserves_typing : x:int -> e:exp -> v:exp ->
       Lemma
         (requires ( Some? (typing empty v) /\
               Some? (typing (extend g x (Some?.v (typing empty v))) e)))
-        (ensures (Some? (typing empty v) /\
-                  typing g (subst x v e) ==
+        (ensures (typing g (subst x v e) ==
                   typing (extend g x (Some?.v (typing empty v))) e))
 let rec substitution_preserves_typing x e v g =
   let Some t_x = typing empty v in

--- a/doc/tutorial/tutorial.mdk
+++ b/doc/tutorial/tutorial.mdk
@@ -2591,8 +2591,7 @@ We can use these results to show the following substitution lemma:
 val substitution_preserves_typing : x:int -> e:exp -> v:exp -> g:env -> Lemma
   (requires (Some? (typing empty v) /\
              Some? (typing (extend g x (Some?.v (typing empty v))) e)))
-  (ensures (Some? (typing empty v) /\
-            typing g (subst x v e) ==
+  (ensures (typing g (subst x v e) ==
             typing (extend g x (Some?.v (typing empty v))) e))
 let rec substitution_preserves_typing x e v g =
   let Some t_x = typing empty v in


### PR DESCRIPTION
Since `Some? (typing empty v)` is included in `requires`, it doesn't seem to be necessary in `ensures`.