### PR TITLE
Fix typo in tutorial.mdk; make STLC variable has type int, not undefined type var

### DIFF
--- a/doc/tutorial/tutorial.mdk
+++ b/doc/tutorial/tutorial.mdk
@@ -2215,9 +2215,9 @@ $\mathsf{bool} \to \mathsf{bool}$ in paper notation.
 We represent the expressions of STLC by the datatype `exp`.
 ```
 type exp =
-  | EVar   : v:var -> exp
+  | EVar   : v:int -> exp
   | EApp   : fn:exp -> arg:exp -> exp
-  | EAbs   : v:var -> vty:ty -> body:exp -> exp
+  | EAbs   : v:int -> vty:ty -> body:exp -> exp
   | ETrue  : exp
   | EFalse : exp
   | EIf    : test:exp -> btrue:exp -> bfalse:exp -> exp


### PR DESCRIPTION
Although type `var` is used in the text, it is not defined. I think `int` is suitable here because the exercises use the following definition of type `exp`:

```
type exp =
  | EVar   : int -> exp
  | EApp   : exp -> exp -> exp
  | EAbs   : int -> ty -> exp -> exp
  | ETrue  : exp
  | EFalse : exp
  | EIf    : exp -> exp -> exp -> exp
```