### PR TITLE
Make `noextract` not extract

### DIFF
--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -367,6 +367,7 @@ type raw_error =
   | Error_UnexpectedUnresolvedUvar
   | Warning_UnfoldPlugin
   | Error_LayeredMissingAnnot
+  | Error_CallToErased
 
 type flag = error_flag
 type error_setting = raw_error * error_flag * int
@@ -713,6 +714,7 @@ let default_settings : list<error_setting> =
     Error_UnexpectedUnresolvedUvar                    , CAlwaysError, 339;
     Warning_UnfoldPlugin                              , CWarning, 340;
     Error_LayeredMissingAnnot                         , CAlwaysError, 341;
+    Error_CallToErased                                , CError, 342;
     ]
 module BU = FStar.Util
 

--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -742,6 +742,7 @@ let error_number (_, _, i) = i
 
 let warn_on_use_errno = error_number (lookup_error default_settings Warning_WarnOnUse)
 let defensive_errno   = error_number (lookup_error default_settings Warning_Defensive)
+let call_to_erased_errno = error_number (lookup_error default_settings Error_CallToErased)
 
 let update_flags (l:list<(error_flag * string)>)
   : list<error_setting>

--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -368,6 +368,7 @@ type raw_error =
   | Warning_UnfoldPlugin
   | Error_LayeredMissingAnnot
   | Error_CallToErased
+  | Error_ErasedCtor
 
 type flag = error_flag
 type error_setting = raw_error * error_flag * int
@@ -715,6 +716,7 @@ let default_settings : list<error_setting> =
     Warning_UnfoldPlugin                              , CWarning, 340;
     Error_LayeredMissingAnnot                         , CAlwaysError, 341;
     Error_CallToErased                                , CError, 342;
+    Error_ErasedCtor                                  , CError, 343;
     ]
 module BU = FStar.Util
 

--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -1651,15 +1651,18 @@ let cache_off                    () = get_cache_off                   ()
 let print_cache_version          () = get_print_cache_version         ()
 let cmi                          () = get_cmi                         ()
 type codegen_t = | OCaml | FSharp | Kremlin | Plugin
+
+let parse_codegen =
+  function
+  | "OCaml" -> Some OCaml
+  | "FSharp" -> Some FSharp
+  | "Kremlin" -> Some Kremlin
+  | "Plugin" -> Some Plugin
+  | _ -> None
+
 let codegen                      () =
-    Util.map_opt
-           (get_codegen())
-           (function
-            | "OCaml" -> OCaml
-            | "FSharp" -> FSharp
-            | "Kremlin" -> Kremlin
-            | "Plugin" -> Plugin
-            | _ -> failwith "Impossible")
+    Util.map_opt (get_codegen())
+                 (fun s -> parse_codegen s |> must)
 
 let codegen_libs                 () = get_codegen_lib () |> List.map (fun x -> Util.split x ".")
 let debug_any                    () = get_debug () <> []

--- a/src/basic/FStar.Options.fsi
+++ b/src/basic/FStar.Options.fsi
@@ -111,6 +111,7 @@ val cmi                         : unit    -> bool
 type codegen_t =
     | OCaml | FSharp | Kremlin | Plugin
 val codegen                     : unit    -> option<codegen_t>
+val parse_codegen               : string  -> option<codegen_t>
 val codegen_libs                : unit    -> list<list<string>>
 val profile_enabled             : module_name:option<string> -> profile_phase:string -> bool
 val profile_group_by_decls      : unit    -> bool

--- a/src/extraction/FStar.Extraction.ML.Modul.fs
+++ b/src/extraction/FStar.Extraction.ML.Modul.fs
@@ -588,13 +588,27 @@ let get_noextract_to (se:sigelt) (backend:option<Options.codegen_t>) : bool =
     | _ -> false
   ) se.sigattrs
 
-// We extract all definitions, unless:
-// 1- it has the `noextract` qualifier, and we are not extracting for Kremlin
-//    (kremlin needs the stub anyway, so we ignore the qualifier in that special case)
+// We extract all definitions, unless if we're in one of the following cases:
+// 1- it has the `noextract` qualifier
 // 2- it has a noextract_to attribute matching the current backend.
+//
+// *and* we are not extracting for Kremlin
+// (kremlin needs the stubs, so we ignore the qualifier in that special case)
 let sigelt_has_noextract (se:sigelt) : bool =
-  List.contains S.NoExtract se.sigquals && Options.codegen () <> Some Options.Kremlin
-  || (get_noextract_to se (Options.codegen ()))
+  Options.codegen () <> Some Options.Kremlin
+  && (List.contains S.NoExtract se.sigquals
+      || get_noextract_to se (Options.codegen ()))
+
+// If this sigelt had [@@ noextract_to "Kremlin"] and we are indeed
+// extracting to Kremlin, then we will still process it: it's the
+// kremlin pipeline which will later drop the body. It checks for the
+// NoExtract qualifier to decide that, so we add it here.
+let kremlin_fixup_qual (se:sigelt) : sigelt =
+ if Options.codegen () = Some Options.Kremlin
+    && get_noextract_to se (Some Options.Kremlin)
+    && not (List.contains S.NoExtract se.sigquals)
+ then { se with sigquals = S.NoExtract :: se.sigquals }
+ else se
 
 let mark_sigelt_erased (se:sigelt) (g:uenv) : uenv =
   debug g (fun u -> BU.print1 ">>>> NOT extracting %s \n" (Print.sigelt_to_string_short se));
@@ -608,6 +622,7 @@ let extract_sigelt_iface (g:uenv) (se:sigelt) : uenv * iface =
       let g = mark_sigelt_erased se g in
       g, empty_iface
     else
+    let se = kremlin_fixup_qual se in
 
     match se.sigel with
     | Sig_bundle _
@@ -828,6 +843,7 @@ let rec extract_sig (g:env_t) (se:sigelt) : env_t * list<mlmodule1> =
        let g = mark_sigelt_erased se g in
        g, []
      else
+    let se = kremlin_fixup_qual se in
 
      match se.sigel with
         | Sig_bundle _

--- a/src/extraction/FStar.Extraction.ML.Modul.fs
+++ b/src/extraction/FStar.Extraction.ML.Modul.fs
@@ -784,12 +784,36 @@ let maybe_register_plugin (g:env_t) (se:sigelt) : list<mlmodule1> =
            | _ -> []
            end
 
+let get_noextract_to (se:sigelt) (backend:option<Options.codegen_t>) : bool =
+  BU.for_some (function attr ->
+    let hd, args = U.head_and_args attr in
+    match (SS.compress hd).n, args with
+    | Tm_fvar fv, [(a, _)] when S.fv_eq_lid fv PC.noextract_to_attr ->
+        begin match EMB.unembed EMB.e_string a false EMB.id_norm_cb with
+        | Some s ->
+          Option.isSome backend && Options.parse_codegen s = backend
+        | None ->
+          false
+        end
+    | _ -> false
+  ) se.sigattrs
+
 (*****************************************************************************)
 (* Extracting the top-level definitions in a module                          *)
 (*****************************************************************************)
 let rec extract_sig (g:env_t) (se:sigelt) : env_t * list<mlmodule1> =
   Errors.with_ctx (BU.format1 "While extracting top-level definition `%s`" (Print.sigelt_to_string_short se)) (fun () ->
      debug g (fun u -> BU.print1 ">>>> extract_sig %s \n" (Print.sigelt_to_string_short se));
+
+     // Extract this definition, unless
+     // 1- it has the `noextract` qualifier, and we are not extracting for Kremlin
+     //    (kremlin needs the stub anyway, so we ignore the qualifier in that special case)
+     // 2- it has a noextract_to attribute matching the current backend.
+     if (List.contains S.NoExtract se.sigquals && Options.codegen () <> Some Options.Kremlin)
+        || (get_noextract_to se (Options.codegen ()))
+     then g, []
+     else
+
      match se.sigel with
         | Sig_bundle _
         | Sig_inductive_typ _

--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -875,9 +875,16 @@ let rec extract_one_pat (imp : bool)
         g, None, true
 
     | Pat_cons (f, pats) ->
-        let d, tys = match lookup_fv g f with
-            | {exp_b_expr={expr=MLE_Name n}; exp_b_tscheme=ttys} -> n, ttys
-            | _ -> failwith "Expected a constructor" in
+        let d, tys =
+          match try_lookup_fv p.p g f with
+          | Some ({exp_b_expr={expr=MLE_Name n}; exp_b_tscheme=ttys}) -> n, ttys
+          | Some _ -> failwith "Expected a constructor"
+          | None ->
+            Errors.raise_error (Errors.Error_ErasedCtor,
+                                BU.format1 "Cannot extract this pattern, the %s constructor was erased"
+                                            (Print.fv_to_string f))
+                               f.fv_name.p
+        in
         let nTyVars = List.length (fst tys) in
         let tysVarPats, restPats =  BU.first_N nTyVars pats in
         let f_ty_opt =
@@ -1212,7 +1219,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
           ml_unit, E_PURE, ml_unit_ty
 
         | Tm_quoted (qt, { qkind = Quote_dynamic }) ->
-          let ({exp_b_expr=fw}) = UEnv.lookup_fv g (S.lid_as_fv PC.failwith_lid delta_constant None) in
+          let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv PC.failwith_lid delta_constant None) in
           with_ty ml_int_ty <| MLE_App(fw, [with_ty ml_string_ty <| MLE_Const (MLC_String "Cannot evaluate open quotation at runtime")]),
           E_PURE,
           ml_int_ty
@@ -1284,10 +1291,8 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
           then ml_unit, E_PURE, ml_unit_ty //Erase type argument
           else
           begin
-               match try_lookup_fv g fv with
+               match try_lookup_fv t.pos g fv with
                | None -> //it's been erased
-                 Errors.log_issue t.pos (Errors.Error_CallToErased,
-                                         BU.format1 "Attempting to extract a call into erased function %s" (Print.fv_to_string fv));
                  ml_unit, E_PURE, MLTY_Erased
 
                | Some {exp_b_expr=x; exp_b_tscheme=mltys} ->
@@ -1518,7 +1523,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
               then ml_unit, E_PURE, ml_unit_ty //Erase type argument: TODO: FIXME, this could be effectful
               else match (U.un_uinst head).n with
                    | Tm_fvar fv ->
-                     (match try_lookup_fv g fv with
+                     (match try_lookup_fv t.pos g fv with
                       | None -> //erased head
                         ml_unit, E_PURE, MLTY_Erased
                       | _ ->
@@ -1732,7 +1737,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
                            with_ty t_e <| MLE_Coerce (e, t_e, MLTY_Top)) in
              begin match mlbranches with
                 | [] ->
-                    let ({exp_b_expr=fw}) = UEnv.lookup_fv g (S.lid_as_fv PC.failwith_lid delta_constant None) in
+                    let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv PC.failwith_lid delta_constant None) in
                     with_ty ml_int_ty <| MLE_App(fw, [with_ty ml_string_ty <| MLE_Const (MLC_String "unreachable")]),
                     E_PURE,
                     ml_int_ty

--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -1286,6 +1286,8 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
           begin
                match try_lookup_fv g fv with
                | None -> //it's been erased
+                 Errors.log_issue t.pos (Errors.Error_CallToErased,
+                                         BU.format1 "Attempting to extract a call into erased function %s" (Print.fv_to_string fv));
                  ml_unit, E_PURE, MLTY_Erased
 
                | Some {exp_b_expr=x; exp_b_tscheme=mltys} ->

--- a/src/extraction/FStar.Extraction.ML.UEnv.fs
+++ b/src/extraction/FStar.Extraction.ML.UEnv.fs
@@ -91,10 +91,14 @@ type ty_or_exp_b = either<ty_binding, exp_binding>
 
     [Fv]: An F* top-level fv is associated with an ML term binding.
           Type definitions are maintained separately, see [tydef].
+
+    [ErasedFv]: An F* top-level name that was erased. Only to give
+                proper errors.
   *)
 type binding =
   | Bv  of bv * ty_or_exp_b
   | Fv  of fv * exp_binding
+  | ErasedFv of fv
 
 (** A top-level F* type definition, i.e., a type abbreviation,
     corresponds to a [tydef] in ML.
@@ -176,22 +180,50 @@ let print_mlpath_map (g:uenv) =
 
 (** Scans the list of bindings for an fv:
     - it's always mapped to an ML expression
+  Takes a range for error reporting.
   *)
-let try_lookup_fv (g:uenv) (fv:fv) : option<exp_binding> =
-    BU.find_map
-      g.env_bindings
+
+// Inr b: success
+// Inl true: was erased
+// Inl false: not found
+let lookup_fv_generic (g:uenv) (fv:fv) : either<bool, exp_binding> =
+  let v =
+    BU.find_map g.env_bindings
       (function
-        | Fv (fv', t) when fv_eq fv fv' -> Some t
-        | _ -> None)
+       | Fv (fv', t) when fv_eq fv fv' -> Some (Inr t)
+       | ErasedFv fv' when fv_eq fv fv' -> Some (Inl true)
+       | _ -> None)
+  in
+  match v with
+  | Some r -> r
+  | None -> Inl false
+
+let try_lookup_fv (r:Range.range) (g:uenv) (fv:fv) : option<exp_binding> =
+  match lookup_fv_generic g fv with
+  | Inr r -> Some r
+  | Inl true ->
+    (* Log an error/warning and return None *)
+    Errors.log_issue r
+      (Errors.Error_CallToErased,
+       BU.format1 "Attempting to extract erased variable `%s`" (Print.fv_to_string fv));
+    None
+  | Inl false ->
+    None
 
 (** Fatal failure version of try_lookup_fv *)
-let lookup_fv (g:uenv) (fv:fv) : exp_binding =
-    match try_lookup_fv g fv with
-    | None ->
-      failwith (BU.format2 "(%s) free Variable %s not found\n"
-                           (Range.string_of_range fv.fv_name.p)
-                           (Print.lid_to_string fv.fv_name.v))
-    | Some y -> y
+let lookup_fv (r:Range.range) (g:uenv) (fv:fv) : exp_binding =
+  match lookup_fv_generic g fv with
+  | Inr t -> t
+  | Inl true ->
+    (* Fail hard *)
+    Errors.raise_error
+      (Errors.Error_CallToErased,
+       BU.format1 "Cannot extract variable `%s`, it was erased." (Print.fv_to_string fv))
+      r
+  | Inl false ->
+    failwith (BU.format2 "Internal error: (%s) free variable %s not found during extraction\n"
+              (Range.string_of_range fv.fv_name.p)
+              (Print.lid_to_string fv.fv_name.v))
 
 (** An F* local variable (bv) can be mapped either to
     a ML type variable or a term variable *)
@@ -213,7 +245,7 @@ let lookup_bv (g:uenv) (bv:bv) : ty_or_exp_b =
 let lookup_term g (t:term) =
     match t.n with
     | Tm_name x -> lookup_bv g x, None
-    | Tm_fvar x -> Inr (lookup_fv g x), x.fv_qual
+    | Tm_fvar x -> Inr (lookup_fv t.pos g x), x.fv_qual
     | _ -> failwith "Impossible: lookup_term for a non-name"
 
 (** Lookup an local variable mapped to a ML type variable *)
@@ -491,6 +523,9 @@ let extend_fv (g:uenv) (x:fv) (t_x:mltyscheme) (add_unit:bool)
         let mlident_map = BU.psmap_add g.env_mlident_map mlsymbol "" in
         {g with env_bindings=gamma; env_mlident_map=mlident_map}, mlsymbol, exp_binding
     else failwith "freevars found"
+
+let extend_erased_fv (g:uenv) (f:fv) : uenv =
+  { g with env_bindings = ErasedFv f :: g.env_bindings }
 
 (** Extend with a let binding, either local or top-level *)
 let extend_lb (g:uenv) (l:lbname) (t:typ) (t_x:mltyscheme) (add_unit:bool)

--- a/src/extraction/FStar.Extraction.ML.UEnv.fsi
+++ b/src/extraction/FStar.Extraction.ML.UEnv.fsi
@@ -50,6 +50,7 @@ type ty_or_exp_b = either<ty_binding, exp_binding>
 type binding =
   | Bv  of bv * ty_or_exp_b
   | Fv  of fv * exp_binding
+  | ErasedFv of fv
 
 (** Type abbreviations, aka definitions *)
 type tydef
@@ -73,9 +74,14 @@ val new_uenv : e:TypeChecker.Env.env -> uenv
 
 (*** Looking up identifiers *)
 
-(** Lookup a top-level term identifier *)
-val try_lookup_fv: g:uenv -> fv:fv -> option<exp_binding>
-val lookup_fv: g:uenv -> fv:fv -> exp_binding
+(** Lookup a top-level term identifier. Raises an error/warning when the
+FV has been erased, using the given range. *)
+val try_lookup_fv: Range.range -> g:uenv -> fv:fv -> option<exp_binding>
+
+(* As above, but will abort if the variable is not found or was erased.
+Only use this for variables that must be in the environment, such as
+definitions in Prims. *)
+val lookup_fv: Range.range -> g:uenv -> fv:fv -> exp_binding
 
 (** Lookup a local term or type variable *)
 val lookup_bv: g:uenv -> bv: bv -> ty_or_exp_b
@@ -137,6 +143,12 @@ val extend_fv:
     mltyscheme ->
     add_unit:bool ->
     uenv * mlident * exp_binding
+
+(** Extend the fv environment by marking that a variable was erased. *)
+val extend_erased_fv:
+    uenv ->
+    fv ->
+    uenv
 
 (** Extend with a local or top-level let binding, maybe thunked *)
 val extend_lb: 

--- a/src/fstar/FStar.Universal.fs
+++ b/src/fstar/FStar.Universal.fs
@@ -493,7 +493,8 @@ let batch_mode_tc filenames dep_graph =
   end;
   let env = FStar.Extraction.ML.UEnv.new_uenv (init_env dep_graph) in
   let all_mods, mllibs, env = tc_fold_interleave dep_graph ([], [], env) filenames in
-  emit mllibs;
+  if FStar.Errors.get_err_count() = 0 then
+    emit mllibs;
   let solver_refresh env =
       snd <|
       with_tcenv_of_env env (fun tcenv ->

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -368,6 +368,8 @@ type raw_error =
   | Error_UnexpectedUnresolvedUvar 
   | Warning_UnfoldPlugin 
   | Error_LayeredMissingAnnot 
+  | Error_CallToErased 
+  | Error_ErasedCtor 
 let (uu___is_Error_DependencyAnalysisFailed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1846,6 +1848,12 @@ let (uu___is_Warning_UnfoldPlugin : raw_error -> Prims.bool) =
 let (uu___is_Error_LayeredMissingAnnot : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with | Error_LayeredMissingAnnot -> true | uu___ -> false
+let (uu___is_Error_CallToErased : raw_error -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Error_CallToErased -> true | uu___ -> false
+let (uu___is_Error_ErasedCtor : raw_error -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Error_ErasedCtor -> true | uu___ -> false
 type flag = error_flag
 type error_setting = (raw_error * error_flag * Prims.int)
 let (default_settings : error_setting Prims.list) =
@@ -2195,7 +2203,9 @@ let (default_settings : error_setting Prims.list) =
   (Error_BadSplice, CError, (Prims.of_int (338)));
   (Error_UnexpectedUnresolvedUvar, CAlwaysError, (Prims.of_int (339)));
   (Warning_UnfoldPlugin, CWarning, (Prims.of_int (340)));
-  (Error_LayeredMissingAnnot, CAlwaysError, (Prims.of_int (341)))]
+  (Error_LayeredMissingAnnot, CAlwaysError, (Prims.of_int (341)));
+  (Error_CallToErased, CError, (Prims.of_int (342)));
+  (Error_ErasedCtor, CError, (Prims.of_int (343)))]
 let lookup_error :
   'uuuuu 'uuuuu1 'uuuuu2 .
     ('uuuuu * 'uuuuu1 * 'uuuuu2) Prims.list ->

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -2245,6 +2245,9 @@ let (warn_on_use_errno : Prims.int) =
 let (defensive_errno : Prims.int) =
   let uu___ = lookup_error default_settings Warning_Defensive in
   error_number uu___
+let (call_to_erased_errno : Prims.int) =
+  let uu___ = lookup_error default_settings Error_CallToErased in
+  error_number uu___
 let (update_flags :
   (error_flag * Prims.string) Prims.list -> error_setting Prims.list) =
   fun l ->

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -956,7 +956,9 @@ let (extract_reifiable_effect :
              let mlp =
                FStar_Extraction_ML_UEnv.mlpath_of_lident g
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             let uu___2 = FStar_Extraction_ML_UEnv.lookup_fv g fv in
+             let uu___2 =
+               FStar_Extraction_ML_UEnv.lookup_fv tm.FStar_Syntax_Syntax.pos
+                 g fv in
              (match uu___2 with
               | { FStar_Extraction_ML_UEnv.exp_b_name = uu___3;
                   FStar_Extraction_ML_UEnv.exp_b_expr = uu___4;
@@ -1174,84 +1176,153 @@ let (extract_let_rec_types :
                  FStar_All.pipe_right (FStar_List.rev impls)
                    FStar_List.flatten in
                (env1, uu___3, uu___4))
+let (get_noextract_to :
+  FStar_Syntax_Syntax.sigelt ->
+    FStar_Options.codegen_t FStar_Pervasives_Native.option -> Prims.bool)
+  =
+  fun se ->
+    fun backend ->
+      FStar_Util.for_some
+        (fun uu___ ->
+           let uu___1 = FStar_Syntax_Util.head_and_args uu___ in
+           match uu___1 with
+           | (hd, args) ->
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Subst.compress hd in
+                   uu___4.FStar_Syntax_Syntax.n in
+                 (uu___3, args) in
+               (match uu___2 with
+                | (FStar_Syntax_Syntax.Tm_fvar fv, (a, uu___3)::[]) when
+                    FStar_Syntax_Syntax.fv_eq_lid fv
+                      FStar_Parser_Const.noextract_to_attr
+                    ->
+                    let uu___4 =
+                      let uu___5 =
+                        FStar_Syntax_Embeddings.unembed
+                          FStar_Syntax_Embeddings.e_string a in
+                      uu___5 false FStar_Syntax_Embeddings.id_norm_cb in
+                    (match uu___4 with
+                     | FStar_Pervasives_Native.Some s ->
+                         (FStar_Option.isSome backend) &&
+                           (let uu___5 = FStar_Options.parse_codegen s in
+                            uu___5 = backend)
+                     | FStar_Pervasives_Native.None -> false)
+                | uu___3 -> false)) se.FStar_Syntax_Syntax.sigattrs
+let (sigelt_has_noextract : FStar_Syntax_Syntax.sigelt -> Prims.bool) =
+  fun se ->
+    ((FStar_List.contains FStar_Syntax_Syntax.NoExtract
+        se.FStar_Syntax_Syntax.sigquals)
+       &&
+       (let uu___ = FStar_Options.codegen () in
+        uu___ <> (FStar_Pervasives_Native.Some FStar_Options.Kremlin)))
+      || (let uu___ = FStar_Options.codegen () in get_noextract_to se uu___)
+let (mark_sigelt_erased :
+  FStar_Syntax_Syntax.sigelt ->
+    FStar_Extraction_ML_UEnv.uenv -> FStar_Extraction_ML_UEnv.uenv)
+  =
+  fun se ->
+    fun g ->
+      FStar_Extraction_ML_UEnv.debug g
+        (fun u ->
+           let uu___1 = FStar_Syntax_Print.sigelt_to_string_short se in
+           FStar_Util.print1 ">>>> NOT extracting %s \n" uu___1);
+      FStar_List.fold_right
+        (fun lid ->
+           fun g1 ->
+             let uu___1 =
+               FStar_Syntax_Syntax.lid_as_fv lid
+                 FStar_Syntax_Syntax.delta_constant
+                 FStar_Pervasives_Native.None in
+             FStar_Extraction_ML_UEnv.extend_erased_fv g1 uu___1)
+        (FStar_Syntax_Util.lids_of_sigelt se) g
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.sigelt -> (FStar_Extraction_ML_UEnv.uenv * iface))
   =
   fun g ->
     fun se ->
-      match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu___ -> extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu___ ->
-          extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu___ -> extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
-          FStar_Extraction_ML_Term.is_arity g t ->
-          let uu___ =
-            extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
-              se.FStar_Syntax_Syntax.sigattrs univs t in
-          (match uu___ with | (env, iface1, uu___1) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___) when
-          FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu___1 =
-            extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
-              se.FStar_Syntax_Syntax.sigattrs lb in
-          (match uu___1 with | (env, iface1, uu___2) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___) when
-          FStar_Util.for_some
-            (fun lb ->
-               FStar_Extraction_ML_Term.is_arity g
-                 lb.FStar_Syntax_Syntax.lbtyp) lbs
-          ->
-          let uu___1 = extract_let_rec_types se g lbs in
-          (match uu___1 with | (env, iface1, uu___2) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_declare_typ (lid, _univs, t) ->
-          let quals = se.FStar_Syntax_Syntax.sigquals in
-          let uu___ =
-            (FStar_All.pipe_right quals
-               (FStar_List.contains FStar_Syntax_Syntax.Assumption))
-              &&
-              (let uu___1 =
-                 let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                 FStar_TypeChecker_Util.must_erase_for_extraction uu___2 t in
-               Prims.op_Negation uu___1) in
-          if uu___
-          then
-            let uu___1 =
-              let uu___2 =
-                let uu___3 = let uu___4 = always_fail lid t in [uu___4] in
-                (false, uu___3) in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu___2 in
-            (match uu___1 with
-             | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
-          else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs, uu___) ->
-          let uu___1 = FStar_Extraction_ML_Term.extract_lb_iface g lbs in
-          (match uu___1 with
-           | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_assume uu___ -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu___ -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu___ -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___ -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___ -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_pragma p ->
-          (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
-           (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu___ ->
-          failwith "impossible: trying to extract splice"
-      | FStar_Syntax_Syntax.Sig_fail uu___ ->
-          failwith "impossible: trying to extract Sig_fail"
-      | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu___ =
-            (let uu___1 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-             FStar_TypeChecker_Env.is_reifiable_effect uu___1
-               ed.FStar_Syntax_Syntax.mname)
-              && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders) in
-          if uu___
-          then
-            let uu___1 = extract_reifiable_effect g ed in
-            (match uu___1 with | (env, iface1, uu___2) -> (env, iface1))
-          else (g, empty_iface)
+      let uu___ = sigelt_has_noextract se in
+      if uu___
+      then let g1 = mark_sigelt_erased se g in (g1, empty_iface)
+      else
+        (match se.FStar_Syntax_Syntax.sigel with
+         | FStar_Syntax_Syntax.Sig_bundle uu___2 -> extract_bundle_iface g se
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 ->
+             extract_bundle_iface g se
+         | FStar_Syntax_Syntax.Sig_datacon uu___2 ->
+             extract_bundle_iface g se
+         | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
+             FStar_Extraction_ML_Term.is_arity g t ->
+             let uu___2 =
+               extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
+                 se.FStar_Syntax_Syntax.sigattrs univs t in
+             (match uu___2 with | (env, iface1, uu___3) -> (env, iface1))
+         | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___2) when
+             FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
+             ->
+             let uu___3 =
+               extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
+                 se.FStar_Syntax_Syntax.sigattrs lb in
+             (match uu___3 with | (env, iface1, uu___4) -> (env, iface1))
+         | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___2) when
+             FStar_Util.for_some
+               (fun lb ->
+                  FStar_Extraction_ML_Term.is_arity g
+                    lb.FStar_Syntax_Syntax.lbtyp) lbs
+             ->
+             let uu___3 = extract_let_rec_types se g lbs in
+             (match uu___3 with | (env, iface1, uu___4) -> (env, iface1))
+         | FStar_Syntax_Syntax.Sig_declare_typ (lid, _univs, t) ->
+             let quals = se.FStar_Syntax_Syntax.sigquals in
+             let uu___2 =
+               (FStar_All.pipe_right quals
+                  (FStar_List.contains FStar_Syntax_Syntax.Assumption))
+                 &&
+                 (let uu___3 =
+                    let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                    FStar_TypeChecker_Util.must_erase_for_extraction uu___4 t in
+                  Prims.op_Negation uu___3) in
+             if uu___2
+             then
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = let uu___6 = always_fail lid t in [uu___6] in
+                   (false, uu___5) in
+                 FStar_Extraction_ML_Term.extract_lb_iface g uu___4 in
+               (match uu___3 with
+                | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
+             else (g, empty_iface)
+         | FStar_Syntax_Syntax.Sig_let (lbs, uu___2) ->
+             let uu___3 = FStar_Extraction_ML_Term.extract_lb_iface g lbs in
+             (match uu___3 with
+              | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
+         | FStar_Syntax_Syntax.Sig_assume uu___2 -> (g, empty_iface)
+         | FStar_Syntax_Syntax.Sig_sub_effect uu___2 -> (g, empty_iface)
+         | FStar_Syntax_Syntax.Sig_effect_abbrev uu___2 -> (g, empty_iface)
+         | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___2 ->
+             (g, empty_iface)
+         | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___2 ->
+             (g, empty_iface)
+         | FStar_Syntax_Syntax.Sig_pragma p ->
+             (FStar_Syntax_Util.process_pragma p
+                se.FStar_Syntax_Syntax.sigrng;
+              (g, empty_iface))
+         | FStar_Syntax_Syntax.Sig_splice uu___2 ->
+             failwith "impossible: trying to extract splice"
+         | FStar_Syntax_Syntax.Sig_fail uu___2 ->
+             failwith "impossible: trying to extract Sig_fail"
+         | FStar_Syntax_Syntax.Sig_new_effect ed ->
+             let uu___2 =
+               (let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                FStar_TypeChecker_Env.is_reifiable_effect uu___3
+                  ed.FStar_Syntax_Syntax.mname)
+                 && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders) in
+             if uu___2
+             then
+               let uu___3 = extract_reifiable_effect g ed in
+               (match uu___3 with | (env, iface1, uu___4) -> (env, iface1))
+             else (g, empty_iface))
 let (extract_iface' :
   env_t ->
     FStar_Syntax_Syntax.modul -> (FStar_Extraction_ML_UEnv.uenv * iface))
@@ -1591,393 +1662,407 @@ let rec (extract_sig :
              (fun u ->
                 let uu___3 = FStar_Syntax_Print.sigelt_to_string_short se in
                 FStar_Util.print1 ">>>> extract_sig %s \n" uu___3);
-           (match se.FStar_Syntax_Syntax.sigel with
-            | FStar_Syntax_Syntax.Sig_bundle uu___3 -> extract_bundle g se
-            | FStar_Syntax_Syntax.Sig_inductive_typ uu___3 ->
-                extract_bundle g se
-            | FStar_Syntax_Syntax.Sig_datacon uu___3 -> extract_bundle g se
-            | FStar_Syntax_Syntax.Sig_new_effect ed when
-                let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                FStar_TypeChecker_Env.is_reifiable_effect uu___3
-                  ed.FStar_Syntax_Syntax.mname
-                ->
-                let uu___3 = extract_reifiable_effect g ed in
-                (match uu___3 with | (env, _iface, impl) -> (env, impl))
-            | FStar_Syntax_Syntax.Sig_splice uu___3 ->
-                failwith "impossible: trying to extract splice"
-            | FStar_Syntax_Syntax.Sig_fail uu___3 ->
-                failwith "impossible: trying to extract Sig_fail"
-            | FStar_Syntax_Syntax.Sig_new_effect uu___3 -> (g, [])
-            | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
-                FStar_Extraction_ML_Term.is_arity g t ->
-                let uu___3 =
-                  extract_type_declaration g lid
-                    se.FStar_Syntax_Syntax.sigquals
-                    se.FStar_Syntax_Syntax.sigattrs univs t in
-                (match uu___3 with | (env, uu___4, impl) -> (env, impl))
-            | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___3) when
-                FStar_Extraction_ML_Term.is_arity g
-                  lb.FStar_Syntax_Syntax.lbtyp
-                ->
-                let uu___4 =
-                  extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
-                    se.FStar_Syntax_Syntax.sigattrs lb in
-                (match uu___4 with | (env, uu___5, impl) -> (env, impl))
-            | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___3) when
-                FStar_Util.for_some
-                  (fun lb ->
-                     FStar_Extraction_ML_Term.is_arity g
-                       lb.FStar_Syntax_Syntax.lbtyp) lbs
-                ->
-                let uu___4 = extract_let_rec_types se g lbs in
-                (match uu___4 with | (env, uu___5, impl) -> (env, impl))
-            | FStar_Syntax_Syntax.Sig_let (lbs, uu___3) ->
-                let attrs = se.FStar_Syntax_Syntax.sigattrs in
-                let quals = se.FStar_Syntax_Syntax.sigquals in
-                let uu___4 =
-                  let uu___5 =
-                    FStar_Syntax_Util.extract_attr'
-                      FStar_Parser_Const.postprocess_extr_with attrs in
-                  match uu___5 with
-                  | FStar_Pervasives_Native.None ->
-                      (attrs, FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some
-                      (ats, (tau, FStar_Pervasives_Native.None)::uu___6) ->
-                      (ats, (FStar_Pervasives_Native.Some tau))
-                  | FStar_Pervasives_Native.Some (ats, args) ->
-                      (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
-                         (FStar_Errors.Warning_UnrecognizedAttribute,
-                           "Ill-formed application of `postprocess_for_extraction_with`");
-                       (attrs, FStar_Pervasives_Native.None)) in
-                (match uu___4 with
-                 | (attrs1, post_tau) ->
-                     let postprocess_lb tau lb =
-                       let lbdef =
-                         let uu___5 =
-                           FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                         FStar_TypeChecker_Env.postprocess uu___5 tau
-                           lb.FStar_Syntax_Syntax.lbtyp
-                           lb.FStar_Syntax_Syntax.lbdef in
-                       let uu___5 = lb in
-                       {
-                         FStar_Syntax_Syntax.lbname =
-                           (uu___5.FStar_Syntax_Syntax.lbname);
-                         FStar_Syntax_Syntax.lbunivs =
-                           (uu___5.FStar_Syntax_Syntax.lbunivs);
-                         FStar_Syntax_Syntax.lbtyp =
-                           (uu___5.FStar_Syntax_Syntax.lbtyp);
-                         FStar_Syntax_Syntax.lbeff =
-                           (uu___5.FStar_Syntax_Syntax.lbeff);
-                         FStar_Syntax_Syntax.lbdef = lbdef;
-                         FStar_Syntax_Syntax.lbattrs =
-                           (uu___5.FStar_Syntax_Syntax.lbattrs);
-                         FStar_Syntax_Syntax.lbpos =
-                           (uu___5.FStar_Syntax_Syntax.lbpos)
-                       } in
-                     let lbs1 =
-                       let uu___5 =
-                         match post_tau with
-                         | FStar_Pervasives_Native.Some tau ->
-                             FStar_List.map (postprocess_lb tau)
-                               (FStar_Pervasives_Native.snd lbs)
-                         | FStar_Pervasives_Native.None ->
-                             FStar_Pervasives_Native.snd lbs in
-                       ((FStar_Pervasives_Native.fst lbs), uu___5) in
-                     let uu___5 =
-                       let uu___6 =
-                         FStar_Syntax_Syntax.mk
-                           (FStar_Syntax_Syntax.Tm_let
-                              (lbs1, FStar_Syntax_Util.exp_false_bool))
-                           se.FStar_Syntax_Syntax.sigrng in
-                       FStar_Extraction_ML_Term.term_as_mlexpr g uu___6 in
-                     (match uu___5 with
-                      | (ml_let, uu___6, uu___7) ->
-                          (match ml_let.FStar_Extraction_ML_Syntax.expr with
-                           | FStar_Extraction_ML_Syntax.MLE_Let
-                               ((flavor, bindings), uu___8) ->
-                               let flags =
-                                 FStar_List.choose flag_of_qual quals in
-                               let flags' = extract_metadata attrs1 in
-                               let uu___9 =
-                                 FStar_List.fold_left2
-                                   (fun uu___10 ->
-                                      fun ml_lb ->
-                                        fun uu___11 ->
-                                          match (uu___10, uu___11) with
-                                          | ((env, ml_lbs),
-                                             {
-                                               FStar_Syntax_Syntax.lbname =
-                                                 lbname;
-                                               FStar_Syntax_Syntax.lbunivs =
-                                                 uu___12;
-                                               FStar_Syntax_Syntax.lbtyp = t;
-                                               FStar_Syntax_Syntax.lbeff =
-                                                 uu___13;
-                                               FStar_Syntax_Syntax.lbdef =
-                                                 uu___14;
-                                               FStar_Syntax_Syntax.lbattrs =
-                                                 uu___15;
-                                               FStar_Syntax_Syntax.lbpos =
-                                                 uu___16;_})
-                                              ->
-                                              let uu___17 =
-                                                FStar_All.pipe_right
-                                                  ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
-                                                  (FStar_List.contains
-                                                     FStar_Extraction_ML_Syntax.Erased) in
-                                              if uu___17
-                                              then (env, ml_lbs)
-                                              else
-                                                (let lb_lid =
-                                                   let uu___19 =
-                                                     let uu___20 =
-                                                       FStar_Util.right
-                                                         lbname in
-                                                     uu___20.FStar_Syntax_Syntax.fv_name in
-                                                   uu___19.FStar_Syntax_Syntax.v in
-                                                 let flags'' =
-                                                   let uu___19 =
-                                                     let uu___20 =
-                                                       FStar_Syntax_Subst.compress
-                                                         t in
-                                                     uu___20.FStar_Syntax_Syntax.n in
-                                                   match uu___19 with
-                                                   | FStar_Syntax_Syntax.Tm_arrow
-                                                       (uu___20,
-                                                        {
-                                                          FStar_Syntax_Syntax.n
-                                                            =
-                                                            FStar_Syntax_Syntax.Comp
-                                                            {
-                                                              FStar_Syntax_Syntax.comp_univs
-                                                                = uu___21;
-                                                              FStar_Syntax_Syntax.effect_name
-                                                                = e;
-                                                              FStar_Syntax_Syntax.result_typ
-                                                                = uu___22;
-                                                              FStar_Syntax_Syntax.effect_args
-                                                                = uu___23;
-                                                              FStar_Syntax_Syntax.flags
-                                                                = uu___24;_};
-                                                          FStar_Syntax_Syntax.pos
-                                                            = uu___25;
-                                                          FStar_Syntax_Syntax.vars
-                                                            = uu___26;_})
-                                                       when
-                                                       let uu___27 =
-                                                         FStar_Ident.string_of_lid
-                                                           e in
-                                                       uu___27 =
-                                                         "FStar.HyperStack.ST.StackInline"
-                                                       ->
-                                                       [FStar_Extraction_ML_Syntax.StackInline]
-                                                   | uu___20 -> [] in
-                                                 let meta =
-                                                   FStar_List.append flags
-                                                     (FStar_List.append
-                                                        flags' flags'') in
-                                                 let ml_lb1 =
-                                                   let uu___19 = ml_lb in
-                                                   {
-                                                     FStar_Extraction_ML_Syntax.mllb_name
-                                                       =
-                                                       (uu___19.FStar_Extraction_ML_Syntax.mllb_name);
-                                                     FStar_Extraction_ML_Syntax.mllb_tysc
-                                                       =
-                                                       (uu___19.FStar_Extraction_ML_Syntax.mllb_tysc);
-                                                     FStar_Extraction_ML_Syntax.mllb_add_unit
-                                                       =
-                                                       (uu___19.FStar_Extraction_ML_Syntax.mllb_add_unit);
-                                                     FStar_Extraction_ML_Syntax.mllb_def
-                                                       =
-                                                       (uu___19.FStar_Extraction_ML_Syntax.mllb_def);
-                                                     FStar_Extraction_ML_Syntax.mllb_meta
-                                                       = meta;
-                                                     FStar_Extraction_ML_Syntax.print_typ
-                                                       =
-                                                       (uu___19.FStar_Extraction_ML_Syntax.print_typ)
-                                                   } in
+           (let uu___3 = sigelt_has_noextract se in
+            if uu___3
+            then let g1 = mark_sigelt_erased se g in (g1, [])
+            else
+              (match se.FStar_Syntax_Syntax.sigel with
+               | FStar_Syntax_Syntax.Sig_bundle uu___5 -> extract_bundle g se
+               | FStar_Syntax_Syntax.Sig_inductive_typ uu___5 ->
+                   extract_bundle g se
+               | FStar_Syntax_Syntax.Sig_datacon uu___5 ->
+                   extract_bundle g se
+               | FStar_Syntax_Syntax.Sig_new_effect ed when
+                   let uu___5 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                   FStar_TypeChecker_Env.is_reifiable_effect uu___5
+                     ed.FStar_Syntax_Syntax.mname
+                   ->
+                   let uu___5 = extract_reifiable_effect g ed in
+                   (match uu___5 with | (env, _iface, impl) -> (env, impl))
+               | FStar_Syntax_Syntax.Sig_splice uu___5 ->
+                   failwith "impossible: trying to extract splice"
+               | FStar_Syntax_Syntax.Sig_fail uu___5 ->
+                   failwith "impossible: trying to extract Sig_fail"
+               | FStar_Syntax_Syntax.Sig_new_effect uu___5 -> (g, [])
+               | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
+                   FStar_Extraction_ML_Term.is_arity g t ->
+                   let uu___5 =
+                     extract_type_declaration g lid
+                       se.FStar_Syntax_Syntax.sigquals
+                       se.FStar_Syntax_Syntax.sigattrs univs t in
+                   (match uu___5 with | (env, uu___6, impl) -> (env, impl))
+               | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___5) when
+                   FStar_Extraction_ML_Term.is_arity g
+                     lb.FStar_Syntax_Syntax.lbtyp
+                   ->
+                   let uu___6 =
+                     extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
+                       se.FStar_Syntax_Syntax.sigattrs lb in
+                   (match uu___6 with | (env, uu___7, impl) -> (env, impl))
+               | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___5) when
+                   FStar_Util.for_some
+                     (fun lb ->
+                        FStar_Extraction_ML_Term.is_arity g
+                          lb.FStar_Syntax_Syntax.lbtyp) lbs
+                   ->
+                   let uu___6 = extract_let_rec_types se g lbs in
+                   (match uu___6 with | (env, uu___7, impl) -> (env, impl))
+               | FStar_Syntax_Syntax.Sig_let (lbs, uu___5) ->
+                   let attrs = se.FStar_Syntax_Syntax.sigattrs in
+                   let quals = se.FStar_Syntax_Syntax.sigquals in
+                   let uu___6 =
+                     let uu___7 =
+                       FStar_Syntax_Util.extract_attr'
+                         FStar_Parser_Const.postprocess_extr_with attrs in
+                     match uu___7 with
+                     | FStar_Pervasives_Native.None ->
+                         (attrs, FStar_Pervasives_Native.None)
+                     | FStar_Pervasives_Native.Some
+                         (ats, (tau, FStar_Pervasives_Native.None)::uu___8)
+                         -> (ats, (FStar_Pervasives_Native.Some tau))
+                     | FStar_Pervasives_Native.Some (ats, args) ->
+                         (FStar_Errors.log_issue
+                            se.FStar_Syntax_Syntax.sigrng
+                            (FStar_Errors.Warning_UnrecognizedAttribute,
+                              "Ill-formed application of `postprocess_for_extraction_with`");
+                          (attrs, FStar_Pervasives_Native.None)) in
+                   (match uu___6 with
+                    | (attrs1, post_tau) ->
+                        let postprocess_lb tau lb =
+                          let lbdef =
+                            let uu___7 =
+                              FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                            FStar_TypeChecker_Env.postprocess uu___7 tau
+                              lb.FStar_Syntax_Syntax.lbtyp
+                              lb.FStar_Syntax_Syntax.lbdef in
+                          let uu___7 = lb in
+                          {
+                            FStar_Syntax_Syntax.lbname =
+                              (uu___7.FStar_Syntax_Syntax.lbname);
+                            FStar_Syntax_Syntax.lbunivs =
+                              (uu___7.FStar_Syntax_Syntax.lbunivs);
+                            FStar_Syntax_Syntax.lbtyp =
+                              (uu___7.FStar_Syntax_Syntax.lbtyp);
+                            FStar_Syntax_Syntax.lbeff =
+                              (uu___7.FStar_Syntax_Syntax.lbeff);
+                            FStar_Syntax_Syntax.lbdef = lbdef;
+                            FStar_Syntax_Syntax.lbattrs =
+                              (uu___7.FStar_Syntax_Syntax.lbattrs);
+                            FStar_Syntax_Syntax.lbpos =
+                              (uu___7.FStar_Syntax_Syntax.lbpos)
+                          } in
+                        let lbs1 =
+                          let uu___7 =
+                            match post_tau with
+                            | FStar_Pervasives_Native.Some tau ->
+                                FStar_List.map (postprocess_lb tau)
+                                  (FStar_Pervasives_Native.snd lbs)
+                            | FStar_Pervasives_Native.None ->
+                                FStar_Pervasives_Native.snd lbs in
+                          ((FStar_Pervasives_Native.fst lbs), uu___7) in
+                        let uu___7 =
+                          let uu___8 =
+                            FStar_Syntax_Syntax.mk
+                              (FStar_Syntax_Syntax.Tm_let
+                                 (lbs1, FStar_Syntax_Util.exp_false_bool))
+                              se.FStar_Syntax_Syntax.sigrng in
+                          FStar_Extraction_ML_Term.term_as_mlexpr g uu___8 in
+                        (match uu___7 with
+                         | (ml_let, uu___8, uu___9) ->
+                             (match ml_let.FStar_Extraction_ML_Syntax.expr
+                              with
+                              | FStar_Extraction_ML_Syntax.MLE_Let
+                                  ((flavor, bindings), uu___10) ->
+                                  let flags =
+                                    FStar_List.choose flag_of_qual quals in
+                                  let flags' = extract_metadata attrs1 in
+                                  let uu___11 =
+                                    FStar_List.fold_left2
+                                      (fun uu___12 ->
+                                         fun ml_lb ->
+                                           fun uu___13 ->
+                                             match (uu___12, uu___13) with
+                                             | ((env, ml_lbs),
+                                                {
+                                                  FStar_Syntax_Syntax.lbname
+                                                    = lbname;
+                                                  FStar_Syntax_Syntax.lbunivs
+                                                    = uu___14;
+                                                  FStar_Syntax_Syntax.lbtyp =
+                                                    t;
+                                                  FStar_Syntax_Syntax.lbeff =
+                                                    uu___15;
+                                                  FStar_Syntax_Syntax.lbdef =
+                                                    uu___16;
+                                                  FStar_Syntax_Syntax.lbattrs
+                                                    = uu___17;
+                                                  FStar_Syntax_Syntax.lbpos =
+                                                    uu___18;_})
+                                                 ->
                                                  let uu___19 =
-                                                   let uu___20 =
-                                                     FStar_All.pipe_right
-                                                       quals
-                                                       (FStar_Util.for_some
-                                                          (fun uu___21 ->
-                                                             match uu___21
-                                                             with
-                                                             | FStar_Syntax_Syntax.Projector
-                                                                 uu___22 ->
-                                                                 true
-                                                             | uu___22 ->
-                                                                 false)) in
-                                                   if uu___20
-                                                   then
-                                                     let uu___21 =
-                                                       let uu___22 =
-                                                         FStar_Util.right
-                                                           lbname in
-                                                       let uu___23 =
-                                                         FStar_Util.must
-                                                           ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
-                                                       FStar_Extraction_ML_UEnv.extend_fv
-                                                         env uu___22 uu___23
-                                                         ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                                     match uu___21 with
-                                                     | (env1, mls, uu___22)
-                                                         ->
-                                                         (env1,
-                                                           (let uu___23 =
-                                                              ml_lb1 in
-                                                            {
-                                                              FStar_Extraction_ML_Syntax.mllb_name
-                                                                = mls;
-                                                              FStar_Extraction_ML_Syntax.mllb_tysc
-                                                                =
-                                                                (uu___23.FStar_Extraction_ML_Syntax.mllb_tysc);
-                                                              FStar_Extraction_ML_Syntax.mllb_add_unit
-                                                                =
-                                                                (uu___23.FStar_Extraction_ML_Syntax.mllb_add_unit);
-                                                              FStar_Extraction_ML_Syntax.mllb_def
-                                                                =
-                                                                (uu___23.FStar_Extraction_ML_Syntax.mllb_def);
-                                                              FStar_Extraction_ML_Syntax.mllb_meta
-                                                                =
-                                                                (uu___23.FStar_Extraction_ML_Syntax.mllb_meta);
-                                                              FStar_Extraction_ML_Syntax.print_typ
-                                                                =
-                                                                (uu___23.FStar_Extraction_ML_Syntax.print_typ)
-                                                            }))
-                                                   else
-                                                     (let uu___22 =
+                                                   FStar_All.pipe_right
+                                                     ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
+                                                     (FStar_List.contains
+                                                        FStar_Extraction_ML_Syntax.Erased) in
+                                                 if uu___19
+                                                 then (env, ml_lbs)
+                                                 else
+                                                   (let lb_lid =
+                                                      let uu___21 =
+                                                        let uu___22 =
+                                                          FStar_Util.right
+                                                            lbname in
+                                                        uu___22.FStar_Syntax_Syntax.fv_name in
+                                                      uu___21.FStar_Syntax_Syntax.v in
+                                                    let flags'' =
+                                                      let uu___21 =
+                                                        let uu___22 =
+                                                          FStar_Syntax_Subst.compress
+                                                            t in
+                                                        uu___22.FStar_Syntax_Syntax.n in
+                                                      match uu___21 with
+                                                      | FStar_Syntax_Syntax.Tm_arrow
+                                                          (uu___22,
+                                                           {
+                                                             FStar_Syntax_Syntax.n
+                                                               =
+                                                               FStar_Syntax_Syntax.Comp
+                                                               {
+                                                                 FStar_Syntax_Syntax.comp_univs
+                                                                   = uu___23;
+                                                                 FStar_Syntax_Syntax.effect_name
+                                                                   = e;
+                                                                 FStar_Syntax_Syntax.result_typ
+                                                                   = uu___24;
+                                                                 FStar_Syntax_Syntax.effect_args
+                                                                   = uu___25;
+                                                                 FStar_Syntax_Syntax.flags
+                                                                   = uu___26;_};
+                                                             FStar_Syntax_Syntax.pos
+                                                               = uu___27;
+                                                             FStar_Syntax_Syntax.vars
+                                                               = uu___28;_})
+                                                          when
+                                                          let uu___29 =
+                                                            FStar_Ident.string_of_lid
+                                                              e in
+                                                          uu___29 =
+                                                            "FStar.HyperStack.ST.StackInline"
+                                                          ->
+                                                          [FStar_Extraction_ML_Syntax.StackInline]
+                                                      | uu___22 -> [] in
+                                                    let meta =
+                                                      FStar_List.append flags
+                                                        (FStar_List.append
+                                                           flags' flags'') in
+                                                    let ml_lb1 =
+                                                      let uu___21 = ml_lb in
+                                                      {
+                                                        FStar_Extraction_ML_Syntax.mllb_name
+                                                          =
+                                                          (uu___21.FStar_Extraction_ML_Syntax.mllb_name);
+                                                        FStar_Extraction_ML_Syntax.mllb_tysc
+                                                          =
+                                                          (uu___21.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                        FStar_Extraction_ML_Syntax.mllb_add_unit
+                                                          =
+                                                          (uu___21.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                        FStar_Extraction_ML_Syntax.mllb_def
+                                                          =
+                                                          (uu___21.FStar_Extraction_ML_Syntax.mllb_def);
+                                                        FStar_Extraction_ML_Syntax.mllb_meta
+                                                          = meta;
+                                                        FStar_Extraction_ML_Syntax.print_typ
+                                                          =
+                                                          (uu___21.FStar_Extraction_ML_Syntax.print_typ)
+                                                      } in
+                                                    let uu___21 =
+                                                      let uu___22 =
+                                                        FStar_All.pipe_right
+                                                          quals
+                                                          (FStar_Util.for_some
+                                                             (fun uu___23 ->
+                                                                match uu___23
+                                                                with
+                                                                | FStar_Syntax_Syntax.Projector
+                                                                    uu___24
+                                                                    -> true
+                                                                | uu___24 ->
+                                                                    false)) in
+                                                      if uu___22
+                                                      then
                                                         let uu___23 =
-                                                          FStar_Util.must
-                                                            ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
-                                                        FStar_Extraction_ML_UEnv.extend_lb
-                                                          env lbname t
-                                                          uu___23
-                                                          ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                                      match uu___22 with
-                                                      | (env1, uu___23,
-                                                         uu___24) ->
-                                                          (env1, ml_lb1)) in
-                                                 match uu___19 with
-                                                 | (g1, ml_lb2) ->
-                                                     (g1, (ml_lb2 :: ml_lbs))))
-                                   (g, []) bindings
-                                   (FStar_Pervasives_Native.snd lbs1) in
-                               (match uu___9 with
-                                | (g1, ml_lbs') ->
-                                    let uu___10 =
-                                      let uu___11 =
-                                        let uu___12 =
-                                          let uu___13 =
-                                            FStar_Extraction_ML_Util.mlloc_of_range
-                                              se.FStar_Syntax_Syntax.sigrng in
-                                          FStar_Extraction_ML_Syntax.MLM_Loc
-                                            uu___13 in
-                                        [uu___12;
-                                        FStar_Extraction_ML_Syntax.MLM_Let
-                                          (flavor, (FStar_List.rev ml_lbs'))] in
-                                      let uu___12 =
-                                        maybe_register_plugin g1 se in
-                                      FStar_List.append uu___11 uu___12 in
-                                    (g1, uu___10))
-                           | uu___8 ->
+                                                          let uu___24 =
+                                                            FStar_Util.right
+                                                              lbname in
+                                                          let uu___25 =
+                                                            FStar_Util.must
+                                                              ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
+                                                          FStar_Extraction_ML_UEnv.extend_fv
+                                                            env uu___24
+                                                            uu___25
+                                                            ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
+                                                        match uu___23 with
+                                                        | (env1, mls,
+                                                           uu___24) ->
+                                                            (env1,
+                                                              (let uu___25 =
+                                                                 ml_lb1 in
+                                                               {
+                                                                 FStar_Extraction_ML_Syntax.mllb_name
+                                                                   = mls;
+                                                                 FStar_Extraction_ML_Syntax.mllb_tysc
+                                                                   =
+                                                                   (uu___25.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
+                                                                   =
+                                                                   (uu___25.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                                 FStar_Extraction_ML_Syntax.mllb_def
+                                                                   =
+                                                                   (uu___25.FStar_Extraction_ML_Syntax.mllb_def);
+                                                                 FStar_Extraction_ML_Syntax.mllb_meta
+                                                                   =
+                                                                   (uu___25.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                                 FStar_Extraction_ML_Syntax.print_typ
+                                                                   =
+                                                                   (uu___25.FStar_Extraction_ML_Syntax.print_typ)
+                                                               }))
+                                                      else
+                                                        (let uu___24 =
+                                                           let uu___25 =
+                                                             FStar_Util.must
+                                                               ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
+                                                           FStar_Extraction_ML_UEnv.extend_lb
+                                                             env lbname t
+                                                             uu___25
+                                                             ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
+                                                         match uu___24 with
+                                                         | (env1, uu___25,
+                                                            uu___26) ->
+                                                             (env1, ml_lb1)) in
+                                                    match uu___21 with
+                                                    | (g1, ml_lb2) ->
+                                                        (g1, (ml_lb2 ::
+                                                          ml_lbs)))) 
+                                      (g, []) bindings
+                                      (FStar_Pervasives_Native.snd lbs1) in
+                                  (match uu___11 with
+                                   | (g1, ml_lbs') ->
+                                       let uu___12 =
+                                         let uu___13 =
+                                           let uu___14 =
+                                             let uu___15 =
+                                               FStar_Extraction_ML_Util.mlloc_of_range
+                                                 se.FStar_Syntax_Syntax.sigrng in
+                                             FStar_Extraction_ML_Syntax.MLM_Loc
+                                               uu___15 in
+                                           [uu___14;
+                                           FStar_Extraction_ML_Syntax.MLM_Let
+                                             (flavor,
+                                               (FStar_List.rev ml_lbs'))] in
+                                         let uu___14 =
+                                           maybe_register_plugin g1 se in
+                                         FStar_List.append uu___13 uu___14 in
+                                       (g1, uu___12))
+                              | uu___10 ->
+                                  let uu___11 =
+                                    let uu___12 =
+                                      let uu___13 =
+                                        FStar_Extraction_ML_UEnv.current_module_of_uenv
+                                          g in
+                                      FStar_Extraction_ML_Code.string_of_mlexpr
+                                        uu___13 ml_let in
+                                    FStar_Util.format1
+                                      "Impossible: Translated a let to a non-let: %s"
+                                      uu___12 in
+                                  failwith uu___11)))
+               | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___5, t) ->
+                   let quals = se.FStar_Syntax_Syntax.sigquals in
+                   let uu___6 =
+                     (FStar_All.pipe_right quals
+                        (FStar_List.contains FStar_Syntax_Syntax.Assumption))
+                       &&
+                       (let uu___7 =
+                          let uu___8 =
+                            FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                          FStar_TypeChecker_Util.must_erase_for_extraction
+                            uu___8 t in
+                        Prims.op_Negation uu___7) in
+                   if uu___6
+                   then
+                     let always_fail1 =
+                       let uu___7 = se in
+                       let uu___8 =
+                         let uu___9 =
+                           let uu___10 =
+                             let uu___11 =
+                               let uu___12 = always_fail lid t in [uu___12] in
+                             (false, uu___11) in
+                           (uu___10, []) in
+                         FStar_Syntax_Syntax.Sig_let uu___9 in
+                       {
+                         FStar_Syntax_Syntax.sigel = uu___8;
+                         FStar_Syntax_Syntax.sigrng =
+                           (uu___7.FStar_Syntax_Syntax.sigrng);
+                         FStar_Syntax_Syntax.sigquals =
+                           (uu___7.FStar_Syntax_Syntax.sigquals);
+                         FStar_Syntax_Syntax.sigmeta =
+                           (uu___7.FStar_Syntax_Syntax.sigmeta);
+                         FStar_Syntax_Syntax.sigattrs =
+                           (uu___7.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopts =
+                           (uu___7.FStar_Syntax_Syntax.sigopts)
+                       } in
+                     let uu___7 = extract_sig g always_fail1 in
+                     (match uu___7 with
+                      | (g1, mlm) ->
+                          let uu___8 =
+                            FStar_Util.find_map quals
+                              (fun uu___9 ->
+                                 match uu___9 with
+                                 | FStar_Syntax_Syntax.Discriminator l ->
+                                     FStar_Pervasives_Native.Some l
+                                 | uu___10 -> FStar_Pervasives_Native.None) in
+                          (match uu___8 with
+                           | FStar_Pervasives_Native.Some l ->
                                let uu___9 =
                                  let uu___10 =
                                    let uu___11 =
-                                     FStar_Extraction_ML_UEnv.current_module_of_uenv
-                                       g in
-                                   FStar_Extraction_ML_Code.string_of_mlexpr
-                                     uu___11 ml_let in
-                                 FStar_Util.format1
-                                   "Impossible: Translated a let to a non-let: %s"
-                                   uu___10 in
-                               failwith uu___9)))
-            | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___3, t) ->
-                let quals = se.FStar_Syntax_Syntax.sigquals in
-                let uu___4 =
-                  (FStar_All.pipe_right quals
-                     (FStar_List.contains FStar_Syntax_Syntax.Assumption))
-                    &&
-                    (let uu___5 =
-                       let uu___6 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                       FStar_TypeChecker_Util.must_erase_for_extraction
-                         uu___6 t in
-                     Prims.op_Negation uu___5) in
-                if uu___4
-                then
-                  let always_fail1 =
-                    let uu___5 = se in
-                    let uu___6 =
-                      let uu___7 =
-                        let uu___8 =
-                          let uu___9 =
-                            let uu___10 = always_fail lid t in [uu___10] in
-                          (false, uu___9) in
-                        (uu___8, []) in
-                      FStar_Syntax_Syntax.Sig_let uu___7 in
-                    {
-                      FStar_Syntax_Syntax.sigel = uu___6;
-                      FStar_Syntax_Syntax.sigrng =
-                        (uu___5.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals =
-                        (uu___5.FStar_Syntax_Syntax.sigquals);
-                      FStar_Syntax_Syntax.sigmeta =
-                        (uu___5.FStar_Syntax_Syntax.sigmeta);
-                      FStar_Syntax_Syntax.sigattrs =
-                        (uu___5.FStar_Syntax_Syntax.sigattrs);
-                      FStar_Syntax_Syntax.sigopts =
-                        (uu___5.FStar_Syntax_Syntax.sigopts)
-                    } in
-                  let uu___5 = extract_sig g always_fail1 in
-                  (match uu___5 with
-                   | (g1, mlm) ->
-                       let uu___6 =
-                         FStar_Util.find_map quals
-                           (fun uu___7 ->
-                              match uu___7 with
-                              | FStar_Syntax_Syntax.Discriminator l ->
-                                  FStar_Pervasives_Native.Some l
-                              | uu___8 -> FStar_Pervasives_Native.None) in
-                       (match uu___6 with
-                        | FStar_Pervasives_Native.Some l ->
-                            let uu___7 =
-                              let uu___8 =
-                                let uu___9 =
-                                  FStar_Extraction_ML_Util.mlloc_of_range
-                                    se.FStar_Syntax_Syntax.sigrng in
-                                FStar_Extraction_ML_Syntax.MLM_Loc uu___9 in
-                              let uu___9 =
-                                let uu___10 =
-                                  FStar_Extraction_ML_Term.ind_discriminator_body
-                                    g1 lid l in
-                                [uu___10] in
-                              uu___8 :: uu___9 in
-                            (g1, uu___7)
-                        | uu___7 ->
-                            let uu___8 =
-                              FStar_Util.find_map quals
-                                (fun uu___9 ->
-                                   match uu___9 with
-                                   | FStar_Syntax_Syntax.Projector
-                                       (l, uu___10) ->
-                                       FStar_Pervasives_Native.Some l
-                                   | uu___10 -> FStar_Pervasives_Native.None) in
-                            (match uu___8 with
-                             | FStar_Pervasives_Native.Some uu___9 ->
-                                 (g1, [])
-                             | uu___9 -> (g1, mlm))))
-                else (g, [])
-            | FStar_Syntax_Syntax.Sig_assume uu___3 -> (g, [])
-            | FStar_Syntax_Syntax.Sig_sub_effect uu___3 -> (g, [])
-            | FStar_Syntax_Syntax.Sig_effect_abbrev uu___3 -> (g, [])
-            | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___3 -> (g, [])
-            | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___3 -> (g, [])
-            | FStar_Syntax_Syntax.Sig_pragma p ->
-                (FStar_Syntax_Util.process_pragma p
-                   se.FStar_Syntax_Syntax.sigrng;
-                 (g, []))))
+                                     FStar_Extraction_ML_Util.mlloc_of_range
+                                       se.FStar_Syntax_Syntax.sigrng in
+                                   FStar_Extraction_ML_Syntax.MLM_Loc uu___11 in
+                                 let uu___11 =
+                                   let uu___12 =
+                                     FStar_Extraction_ML_Term.ind_discriminator_body
+                                       g1 lid l in
+                                   [uu___12] in
+                                 uu___10 :: uu___11 in
+                               (g1, uu___9)
+                           | uu___9 ->
+                               let uu___10 =
+                                 FStar_Util.find_map quals
+                                   (fun uu___11 ->
+                                      match uu___11 with
+                                      | FStar_Syntax_Syntax.Projector
+                                          (l, uu___12) ->
+                                          FStar_Pervasives_Native.Some l
+                                      | uu___12 ->
+                                          FStar_Pervasives_Native.None) in
+                               (match uu___10 with
+                                | FStar_Pervasives_Native.Some uu___11 ->
+                                    (g1, [])
+                                | uu___11 -> (g1, mlm))))
+                   else (g, [])
+               | FStar_Syntax_Syntax.Sig_assume uu___5 -> (g, [])
+               | FStar_Syntax_Syntax.Sig_sub_effect uu___5 -> (g, [])
+               | FStar_Syntax_Syntax.Sig_effect_abbrev uu___5 -> (g, [])
+               | FStar_Syntax_Syntax.Sig_polymonadic_bind uu___5 -> (g, [])
+               | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___5 ->
+                   (g, [])
+               | FStar_Syntax_Syntax.Sig_pragma p ->
+                   (FStar_Syntax_Util.process_pragma p
+                      se.FStar_Syntax_Syntax.sigrng;
+                    (g, [])))))
 let (extract' :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.modul ->

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -1211,12 +1211,37 @@ let (get_noextract_to :
                 | uu___3 -> false)) se.FStar_Syntax_Syntax.sigattrs
 let (sigelt_has_noextract : FStar_Syntax_Syntax.sigelt -> Prims.bool) =
   fun se ->
-    ((FStar_List.contains FStar_Syntax_Syntax.NoExtract
-        se.FStar_Syntax_Syntax.sigquals)
-       &&
-       (let uu___ = FStar_Options.codegen () in
-        uu___ <> (FStar_Pervasives_Native.Some FStar_Options.Kremlin)))
-      || (let uu___ = FStar_Options.codegen () in get_noextract_to se uu___)
+    (let uu___ = FStar_Options.codegen () in
+     uu___ <> (FStar_Pervasives_Native.Some FStar_Options.Kremlin)) &&
+      ((FStar_List.contains FStar_Syntax_Syntax.NoExtract
+          se.FStar_Syntax_Syntax.sigquals)
+         ||
+         (let uu___ = FStar_Options.codegen () in get_noextract_to se uu___))
+let (kremlin_fixup_qual :
+  FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt) =
+  fun se ->
+    let uu___ =
+      ((let uu___1 = FStar_Options.codegen () in
+        uu___1 = (FStar_Pervasives_Native.Some FStar_Options.Kremlin)) &&
+         (get_noextract_to se
+            (FStar_Pervasives_Native.Some FStar_Options.Kremlin)))
+        &&
+        (Prims.op_Negation
+           (FStar_List.contains FStar_Syntax_Syntax.NoExtract
+              se.FStar_Syntax_Syntax.sigquals)) in
+    if uu___
+    then
+      let uu___1 = se in
+      {
+        FStar_Syntax_Syntax.sigel = (uu___1.FStar_Syntax_Syntax.sigel);
+        FStar_Syntax_Syntax.sigrng = (uu___1.FStar_Syntax_Syntax.sigrng);
+        FStar_Syntax_Syntax.sigquals = (FStar_Syntax_Syntax.NoExtract ::
+          (se.FStar_Syntax_Syntax.sigquals));
+        FStar_Syntax_Syntax.sigmeta = (uu___1.FStar_Syntax_Syntax.sigmeta);
+        FStar_Syntax_Syntax.sigattrs = (uu___1.FStar_Syntax_Syntax.sigattrs);
+        FStar_Syntax_Syntax.sigopts = (uu___1.FStar_Syntax_Syntax.sigopts)
+      }
+    else se
 let (mark_sigelt_erased :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Extraction_ML_UEnv.uenv -> FStar_Extraction_ML_UEnv.uenv)
@@ -1246,24 +1271,27 @@ let (extract_sigelt_iface :
       if uu___
       then let g1 = mark_sigelt_erased se g in (g1, empty_iface)
       else
-        (match se.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_bundle uu___2 -> extract_bundle_iface g se
+        (let se1 = kremlin_fixup_qual se in
+         match se1.FStar_Syntax_Syntax.sigel with
+         | FStar_Syntax_Syntax.Sig_bundle uu___2 ->
+             extract_bundle_iface g se1
          | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 ->
-             extract_bundle_iface g se
+             extract_bundle_iface g se1
          | FStar_Syntax_Syntax.Sig_datacon uu___2 ->
-             extract_bundle_iface g se
+             extract_bundle_iface g se1
          | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
              FStar_Extraction_ML_Term.is_arity g t ->
              let uu___2 =
-               extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
-                 se.FStar_Syntax_Syntax.sigattrs univs t in
+               extract_type_declaration g lid
+                 se1.FStar_Syntax_Syntax.sigquals
+                 se1.FStar_Syntax_Syntax.sigattrs univs t in
              (match uu___2 with | (env, iface1, uu___3) -> (env, iface1))
          | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___2) when
              FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
              ->
              let uu___3 =
-               extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
-                 se.FStar_Syntax_Syntax.sigattrs lb in
+               extract_typ_abbrev g se1.FStar_Syntax_Syntax.sigquals
+                 se1.FStar_Syntax_Syntax.sigattrs lb in
              (match uu___3 with | (env, iface1, uu___4) -> (env, iface1))
          | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___2) when
              FStar_Util.for_some
@@ -1271,10 +1299,10 @@ let (extract_sigelt_iface :
                   FStar_Extraction_ML_Term.is_arity g
                     lb.FStar_Syntax_Syntax.lbtyp) lbs
              ->
-             let uu___3 = extract_let_rec_types se g lbs in
+             let uu___3 = extract_let_rec_types se1 g lbs in
              (match uu___3 with | (env, iface1, uu___4) -> (env, iface1))
          | FStar_Syntax_Syntax.Sig_declare_typ (lid, _univs, t) ->
-             let quals = se.FStar_Syntax_Syntax.sigquals in
+             let quals = se1.FStar_Syntax_Syntax.sigquals in
              let uu___2 =
                (FStar_All.pipe_right quals
                   (FStar_List.contains FStar_Syntax_Syntax.Assumption))
@@ -1306,7 +1334,7 @@ let (extract_sigelt_iface :
              (g, empty_iface)
          | FStar_Syntax_Syntax.Sig_pragma p ->
              (FStar_Syntax_Util.process_pragma p
-                se.FStar_Syntax_Syntax.sigrng;
+                se1.FStar_Syntax_Syntax.sigrng;
               (g, empty_iface))
          | FStar_Syntax_Syntax.Sig_splice uu___2 ->
              failwith "impossible: trying to extract splice"
@@ -1666,12 +1694,14 @@ let rec (extract_sig :
             if uu___3
             then let g1 = mark_sigelt_erased se g in (g1, [])
             else
-              (match se.FStar_Syntax_Syntax.sigel with
-               | FStar_Syntax_Syntax.Sig_bundle uu___5 -> extract_bundle g se
+              (let se1 = kremlin_fixup_qual se in
+               match se1.FStar_Syntax_Syntax.sigel with
+               | FStar_Syntax_Syntax.Sig_bundle uu___5 ->
+                   extract_bundle g se1
                | FStar_Syntax_Syntax.Sig_inductive_typ uu___5 ->
-                   extract_bundle g se
+                   extract_bundle g se1
                | FStar_Syntax_Syntax.Sig_datacon uu___5 ->
-                   extract_bundle g se
+                   extract_bundle g se1
                | FStar_Syntax_Syntax.Sig_new_effect ed when
                    let uu___5 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
                    FStar_TypeChecker_Env.is_reifiable_effect uu___5
@@ -1688,16 +1718,16 @@ let rec (extract_sig :
                    FStar_Extraction_ML_Term.is_arity g t ->
                    let uu___5 =
                      extract_type_declaration g lid
-                       se.FStar_Syntax_Syntax.sigquals
-                       se.FStar_Syntax_Syntax.sigattrs univs t in
+                       se1.FStar_Syntax_Syntax.sigquals
+                       se1.FStar_Syntax_Syntax.sigattrs univs t in
                    (match uu___5 with | (env, uu___6, impl) -> (env, impl))
                | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu___5) when
                    FStar_Extraction_ML_Term.is_arity g
                      lb.FStar_Syntax_Syntax.lbtyp
                    ->
                    let uu___6 =
-                     extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
-                       se.FStar_Syntax_Syntax.sigattrs lb in
+                     extract_typ_abbrev g se1.FStar_Syntax_Syntax.sigquals
+                       se1.FStar_Syntax_Syntax.sigattrs lb in
                    (match uu___6 with | (env, uu___7, impl) -> (env, impl))
                | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu___5) when
                    FStar_Util.for_some
@@ -1705,11 +1735,11 @@ let rec (extract_sig :
                         FStar_Extraction_ML_Term.is_arity g
                           lb.FStar_Syntax_Syntax.lbtyp) lbs
                    ->
-                   let uu___6 = extract_let_rec_types se g lbs in
+                   let uu___6 = extract_let_rec_types se1 g lbs in
                    (match uu___6 with | (env, uu___7, impl) -> (env, impl))
                | FStar_Syntax_Syntax.Sig_let (lbs, uu___5) ->
-                   let attrs = se.FStar_Syntax_Syntax.sigattrs in
-                   let quals = se.FStar_Syntax_Syntax.sigquals in
+                   let attrs = se1.FStar_Syntax_Syntax.sigattrs in
+                   let quals = se1.FStar_Syntax_Syntax.sigquals in
                    let uu___6 =
                      let uu___7 =
                        FStar_Syntax_Util.extract_attr'
@@ -1722,7 +1752,7 @@ let rec (extract_sig :
                          -> (ats, (FStar_Pervasives_Native.Some tau))
                      | FStar_Pervasives_Native.Some (ats, args) ->
                          (FStar_Errors.log_issue
-                            se.FStar_Syntax_Syntax.sigrng
+                            se1.FStar_Syntax_Syntax.sigrng
                             (FStar_Errors.Warning_UnrecognizedAttribute,
                               "Ill-formed application of `postprocess_for_extraction_with`");
                           (attrs, FStar_Pervasives_Native.None)) in
@@ -1765,7 +1795,7 @@ let rec (extract_sig :
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_let
                                  (lbs1, FStar_Syntax_Util.exp_false_bool))
-                              se.FStar_Syntax_Syntax.sigrng in
+                              se1.FStar_Syntax_Syntax.sigrng in
                           FStar_Extraction_ML_Term.term_as_mlexpr g uu___8 in
                         (match uu___7 with
                          | (ml_let, uu___8, uu___9) ->
@@ -1953,7 +1983,7 @@ let rec (extract_sig :
                                            let uu___14 =
                                              let uu___15 =
                                                FStar_Extraction_ML_Util.mlloc_of_range
-                                                 se.FStar_Syntax_Syntax.sigrng in
+                                                 se1.FStar_Syntax_Syntax.sigrng in
                                              FStar_Extraction_ML_Syntax.MLM_Loc
                                                uu___15 in
                                            [uu___14;
@@ -1961,7 +1991,7 @@ let rec (extract_sig :
                                              (flavor,
                                                (FStar_List.rev ml_lbs'))] in
                                          let uu___14 =
-                                           maybe_register_plugin g1 se in
+                                           maybe_register_plugin g1 se1 in
                                          FStar_List.append uu___13 uu___14 in
                                        (g1, uu___12))
                               | uu___10 ->
@@ -1977,7 +2007,7 @@ let rec (extract_sig :
                                       uu___12 in
                                   failwith uu___11)))
                | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu___5, t) ->
-                   let quals = se.FStar_Syntax_Syntax.sigquals in
+                   let quals = se1.FStar_Syntax_Syntax.sigquals in
                    let uu___6 =
                      (FStar_All.pipe_right quals
                         (FStar_List.contains FStar_Syntax_Syntax.Assumption))
@@ -1991,7 +2021,7 @@ let rec (extract_sig :
                    if uu___6
                    then
                      let always_fail1 =
-                       let uu___7 = se in
+                       let uu___7 = se1 in
                        let uu___8 =
                          let uu___9 =
                            let uu___10 =
@@ -2029,7 +2059,7 @@ let rec (extract_sig :
                                  let uu___10 =
                                    let uu___11 =
                                      FStar_Extraction_ML_Util.mlloc_of_range
-                                       se.FStar_Syntax_Syntax.sigrng in
+                                       se1.FStar_Syntax_Syntax.sigrng in
                                    FStar_Extraction_ML_Syntax.MLM_Loc uu___11 in
                                  let uu___11 =
                                    let uu___12 =
@@ -2061,7 +2091,7 @@ let rec (extract_sig :
                    (g, [])
                | FStar_Syntax_Syntax.Sig_pragma p ->
                    (FStar_Syntax_Util.process_pragma p
-                      se.FStar_Syntax_Syntax.sigrng;
+                      se1.FStar_Syntax_Syntax.sigrng;
                     (g, [])))))
 let (extract' :
   FStar_Extraction_ML_UEnv.uenv ->

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -1378,18 +1378,32 @@ let rec (extract_one_pat :
                 (g, FStar_Pervasives_Native.None, true)
             | FStar_Syntax_Syntax.Pat_cons (f, pats) ->
                 let uu___ =
-                  let uu___1 = FStar_Extraction_ML_UEnv.lookup_fv g f in
+                  let uu___1 =
+                    FStar_Extraction_ML_UEnv.try_lookup_fv
+                      p.FStar_Syntax_Syntax.p g f in
                   match uu___1 with
-                  | { FStar_Extraction_ML_UEnv.exp_b_name = uu___2;
-                      FStar_Extraction_ML_UEnv.exp_b_expr =
-                        {
-                          FStar_Extraction_ML_Syntax.expr =
-                            FStar_Extraction_ML_Syntax.MLE_Name n;
-                          FStar_Extraction_ML_Syntax.mlty = uu___3;
-                          FStar_Extraction_ML_Syntax.loc = uu___4;_};
-                      FStar_Extraction_ML_UEnv.exp_b_tscheme = ttys;_} ->
-                      (n, ttys)
-                  | uu___2 -> failwith "Expected a constructor" in
+                  | FStar_Pervasives_Native.Some
+                      { FStar_Extraction_ML_UEnv.exp_b_name = uu___2;
+                        FStar_Extraction_ML_UEnv.exp_b_expr =
+                          {
+                            FStar_Extraction_ML_Syntax.expr =
+                              FStar_Extraction_ML_Syntax.MLE_Name n;
+                            FStar_Extraction_ML_Syntax.mlty = uu___3;
+                            FStar_Extraction_ML_Syntax.loc = uu___4;_};
+                        FStar_Extraction_ML_UEnv.exp_b_tscheme = ttys;_}
+                      -> (n, ttys)
+                  | FStar_Pervasives_Native.Some uu___2 ->
+                      failwith "Expected a constructor"
+                  | FStar_Pervasives_Native.None ->
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 = FStar_Syntax_Print.fv_to_string f in
+                          FStar_Util.format1
+                            "Cannot extract this pattern, the %s constructor was erased"
+                            uu___4 in
+                        (FStar_Errors.Error_ErasedCtor, uu___3) in
+                      FStar_Errors.raise_error uu___2
+                        (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.p in
                 (match uu___ with
                  | (d, tys) ->
                      let nTyVars =
@@ -2345,7 +2359,8 @@ and (term_as_mlexpr' :
                FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.failwith_lid
                  FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None in
-             FStar_Extraction_ML_UEnv.lookup_fv g uu___3 in
+             FStar_Extraction_ML_UEnv.lookup_fv t.FStar_Syntax_Syntax.pos g
+               uu___3 in
            (match uu___2 with
             | { FStar_Extraction_ML_UEnv.exp_b_name = uu___3;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
@@ -2492,7 +2507,9 @@ and (term_as_mlexpr' :
                FStar_Extraction_ML_Syntax.E_PURE,
                FStar_Extraction_ML_Syntax.ml_unit_ty)
            else
-             (let uu___3 = FStar_Extraction_ML_UEnv.try_lookup_fv g fv in
+             (let uu___3 =
+                FStar_Extraction_ML_UEnv.try_lookup_fv
+                  t.FStar_Syntax_Syntax.pos g fv in
               match uu___3 with
               | FStar_Pervasives_Native.None ->
                   (FStar_Extraction_ML_Syntax.ml_unit,
@@ -3106,7 +3123,8 @@ and (term_as_mlexpr' :
                    match uu___5 with
                    | FStar_Syntax_Syntax.Tm_fvar fv ->
                        let uu___6 =
-                         FStar_Extraction_ML_UEnv.try_lookup_fv g fv in
+                         FStar_Extraction_ML_UEnv.try_lookup_fv
+                           t.FStar_Syntax_Syntax.pos g fv in
                        (match uu___6 with
                         | FStar_Pervasives_Native.None ->
                             (FStar_Extraction_ML_Syntax.ml_unit,
@@ -3643,8 +3661,8 @@ and (term_as_mlexpr' :
                                        FStar_Parser_Const.failwith_lid
                                        FStar_Syntax_Syntax.delta_constant
                                        FStar_Pervasives_Native.None in
-                                   FStar_Extraction_ML_UEnv.lookup_fv g
-                                     uu___6 in
+                                   FStar_Extraction_ML_UEnv.lookup_fv
+                                     t.FStar_Syntax_Syntax.pos g uu___6 in
                                  (match uu___5 with
                                   | {
                                       FStar_Extraction_ML_UEnv.exp_b_name =

--- a/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_UEnv.ml
@@ -246,8 +246,12 @@ let (try_lookup_fv :
             ((let uu___2 =
                 let uu___3 =
                   let uu___4 = FStar_Syntax_Print.fv_to_string fv in
-                  FStar_Util.format1
-                    "Attempting to extract erased variable `%s`" uu___4 in
+                  let uu___5 =
+                    FStar_Util.string_of_int
+                      FStar_Errors.call_to_erased_errno in
+                  FStar_Util.format2
+                    "Will not extract reference to variable `%s` since it is noextract; either remove its qualifier or add it to this definition. This error can be ignored with `--warn_error -%s`."
+                    uu___4 uu___5 in
                 (FStar_Errors.Error_CallToErased, uu___3) in
               FStar_Errors.log_issue r uu___2);
              FStar_Pervasives_Native.None)
@@ -260,15 +264,7 @@ let (lookup_fv :
         let uu___ = lookup_fv_generic g fv in
         match uu___ with
         | FStar_Util.Inr t -> t
-        | FStar_Util.Inl (true) ->
-            let uu___1 =
-              let uu___2 =
-                let uu___3 = FStar_Syntax_Print.fv_to_string fv in
-                FStar_Util.format1
-                  "Cannot extract variable `%s`, it was erased." uu___3 in
-              (FStar_Errors.Error_CallToErased, uu___2) in
-            FStar_Errors.raise_error uu___1 r
-        | FStar_Util.Inl (false) ->
+        | FStar_Util.Inl b ->
             let uu___1 =
               let uu___2 =
                 FStar_Range.string_of_range
@@ -276,9 +272,10 @@ let (lookup_fv :
               let uu___3 =
                 FStar_Syntax_Print.lid_to_string
                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-              FStar_Util.format2
-                "Internal error: (%s) free variable %s not found during extraction\n"
-                uu___2 uu___3 in
+              let uu___4 = FStar_Util.string_of_bool b in
+              FStar_Util.format3
+                "Internal error: (%s) free variable %s not found during extraction (erased=%s)\n"
+                uu___2 uu___3 uu___4 in
             failwith uu___1
 let (lookup_bv : uenv -> FStar_Syntax_Syntax.bv -> ty_or_exp_b) =
   fun g ->

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -1716,17 +1716,22 @@ let (uu___is_Kremlin : codegen_t -> Prims.bool) =
   fun projectee -> match projectee with | Kremlin -> true | uu___ -> false
 let (uu___is_Plugin : codegen_t -> Prims.bool) =
   fun projectee -> match projectee with | Plugin -> true | uu___ -> false
+let (parse_codegen :
+  Prims.string -> codegen_t FStar_Pervasives_Native.option) =
+  fun uu___ ->
+    match uu___ with
+    | "OCaml" -> FStar_Pervasives_Native.Some OCaml
+    | "FSharp" -> FStar_Pervasives_Native.Some FSharp
+    | "Kremlin" -> FStar_Pervasives_Native.Some Kremlin
+    | "Plugin" -> FStar_Pervasives_Native.Some Plugin
+    | uu___1 -> FStar_Pervasives_Native.None
 let (codegen : unit -> codegen_t FStar_Pervasives_Native.option) =
   fun uu___ ->
     let uu___1 = get_codegen () in
     FStar_Util.map_opt uu___1
-      (fun uu___2 ->
-         match uu___2 with
-         | "OCaml" -> OCaml
-         | "FSharp" -> FSharp
-         | "Kremlin" -> Kremlin
-         | "Plugin" -> Plugin
-         | uu___3 -> failwith "Impossible")
+      (fun s ->
+         let uu___2 = parse_codegen s in
+         FStar_All.pipe_right uu___2 FStar_Util.must)
 let (codegen_libs : unit -> Prims.string Prims.list Prims.list) =
   fun uu___ ->
     let uu___1 = get_codegen_lib () in

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -271,6 +271,7 @@ let (comment_attr : FStar_Ident.lident) =
 let (fail_attr : FStar_Ident.lident) = psconst "expect_failure"
 let (fail_lax_attr : FStar_Ident.lident) = psconst "expect_lax_failure"
 let (tcdecltime_attr : FStar_Ident.lident) = psconst "tcdecltime"
+let (noextract_to_attr : FStar_Ident.lident) = psconst "noextract_to"
 let (assume_strictly_positive_attr_lid : FStar_Ident.lident) =
   psconst "assume_strictly_positive"
 let (unifier_hint_injective_lid : FStar_Ident.lident) =

--- a/src/ocaml-output/FStar_Pervasives.ml
+++ b/src/ocaml-output/FStar_Pervasives.ml
@@ -187,6 +187,7 @@ let (uu___is_CMacro : __internal_ocaml_attributes -> Prims.bool) =
 
 
 
+
 let normalize_term : 'uuuuu . 'uuuuu -> 'uuuuu = fun x -> x
 type 'a normalize = 'a
 type norm_step =

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -1260,7 +1260,10 @@ let (batch_mode_tc :
        let uu___1 = tc_fold_interleave dep_graph ([], [], env) filenames in
        match uu___1 with
        | (all_mods, mllibs, env1) ->
-           (emit mllibs;
+           ((let uu___3 =
+               let uu___4 = FStar_Errors.get_err_count () in
+               uu___4 = Prims.int_zero in
+             if uu___3 then emit mllibs else ());
             (let solver_refresh env2 =
                let uu___3 =
                  with_tcenv_of_env env2

--- a/src/parser/FStar.Parser.Const.fs
+++ b/src/parser/FStar.Parser.Const.fs
@@ -321,6 +321,7 @@ let comment_attr = p2l ["FStar"; "Pervasives"; "Comment"]
 let fail_attr      = psconst "expect_failure"
 let fail_lax_attr  = psconst "expect_lax_failure"
 let tcdecltime_attr = psconst "tcdecltime"
+let noextract_to_attr = psconst "noextract_to"
 let assume_strictly_positive_attr_lid = psconst "assume_strictly_positive"
 let unifier_hint_injective_lid = psconst "unifier_hint_injective"
 let postprocess_with = p2l ["FStar"; "Tactics"; "Effect"; "postprocess_with"]

--- a/ulib/FStar.Endianness.fsti
+++ b/ulib/FStar.Endianness.fsti
@@ -27,7 +27,7 @@ module U64 = FStar.UInt64
 module Math = FStar.Math.Lemmas
 module S = FStar.Seq
 
-noextract
+[@@ noextract_to "Kremlin"]
 type bytes = S.seq U8.t
 
 open FStar.Mul

--- a/ulib/FStar.Integers.fst
+++ b/ulib/FStar.Integers.fst
@@ -57,6 +57,7 @@ let width_of_sw = function
   | Unsigned w -> w
 
 [@@mark_for_norm]
+noextract
 inline_for_extraction
 let int_t sw : Tot Type0 =
   match sw with
@@ -74,6 +75,7 @@ let int_t sw : Tot Type0 =
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let within_bounds' sw (x:int) =
   match sw, nat_of_width (width_of_sw sw) with
   | Signed _,   None   -> True
@@ -85,6 +87,7 @@ let within_bounds sw x = norm (within_bounds' sw x)
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let v #sw (x:int_t sw)
   : Tot (y:int_t (Signed Winfinite){within_bounds sw y})
   = match sw with
@@ -106,6 +109,7 @@ let v #sw (x:int_t sw)
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let u    #sw
         (x:int_t (Signed Winfinite){within_bounds sw x})
   : Tot (y:int_t sw{norm (v x == v y)})
@@ -127,6 +131,7 @@ let u    #sw
        | W128 -> FStar.Int128.int_to_t x)
 
 irreducible
+noextract
 let cast #sw #sw'
          (from:int_t sw{within_bounds sw' (v from)})
    : Tot (to:int_t sw'{norm (v from == v to)})
@@ -134,10 +139,12 @@ let cast #sw #sw'
 
 [@@mark_for_norm]
 unfold
+noextract
 let cast_ok #from to (x:int_t from) = within_bounds to (v x)
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( + ) #sw
           (x:int_t sw)
           (y:int_t sw{within_bounds sw (v x + v y)})
@@ -157,6 +164,7 @@ let ( + ) #sw
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( +? ) (#w:fixed_width)
            (x:int_t (Unsigned w))
            (y:int_t (Unsigned w))
@@ -169,6 +177,7 @@ let ( +? ) (#w:fixed_width)
     | W128 -> FStar.UInt128.(x +?^ y)
 
 [@@mark_for_norm; strict_on_arguments [0]]
+noextract
 let modulo sw (x:int) (y:pos{Signed? sw ==> y%2=0}) =
   match sw with
   | Unsigned _ ->  x % y
@@ -176,6 +185,7 @@ let modulo sw (x:int) (y:pos{Signed? sw ==> y%2=0}) =
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( +% ) (#sw:_{Unsigned? sw})
            (x:int_t sw)
            (y:int_t sw)
@@ -190,6 +200,7 @@ let ( +% ) (#sw:_{Unsigned? sw})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let op_Subtraction #sw
                    (x:int_t sw)
                    (y:int_t sw{within_bounds sw (v x - v y)})
@@ -209,6 +220,7 @@ let op_Subtraction #sw
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let op_Subtraction_Question
         (#sw:_{Unsigned? sw})
         (x:int_t sw)
@@ -224,6 +236,7 @@ let op_Subtraction_Question
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let op_Subtraction_Percent
          (#sw:_{Unsigned? sw})
          (x:int_t sw)
@@ -239,6 +252,7 @@ let op_Subtraction_Percent
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let op_Minus
          (#sw:_{Signed? sw})
          (x:int_t sw{within_bounds sw (0 - v x)})
@@ -255,6 +269,7 @@ let op_Minus
 open FStar.Mul
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( * ) (#sw:signed_width{width_of_sw sw <> W128})
           (x:int_t sw)
           (y:int_t sw{within_bounds sw (v x * v y)})
@@ -273,6 +288,7 @@ let ( * ) (#sw:signed_width{width_of_sw sw <> W128})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( *? ) (#sw:_{Unsigned? sw /\ width_of_sw sw <> W128})
            (x:int_t sw)
            (y:int_t sw)
@@ -286,6 +302,7 @@ let ( *? ) (#sw:_{Unsigned? sw /\ width_of_sw sw <> W128})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( *% ) (#sw:_{Unsigned? sw /\ width_of_sw sw <> W128})
            (x:int_t sw)
            (y:int_t sw)
@@ -299,6 +316,7 @@ let ( *% ) (#sw:_{Unsigned? sw /\ width_of_sw sw <> W128})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( > ) #sw (x:int_t sw) (y:int_t sw) : bool =
     match sw with
     | Signed Winfinite -> x > y
@@ -315,6 +333,7 @@ let ( > ) #sw (x:int_t sw) (y:int_t sw) : bool =
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( >= ) #sw (x:int_t sw) (y:int_t sw) : bool =
     match sw with
     | Signed Winfinite -> x >= y
@@ -332,6 +351,7 @@ let ( >= ) #sw (x:int_t sw) (y:int_t sw) : bool =
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( < ) #sw (x:int_t sw) (y:int_t sw) : bool =
     match sw with
     | Signed Winfinite -> x < y
@@ -348,6 +368,7 @@ let ( < ) #sw (x:int_t sw) (y:int_t sw) : bool =
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( <= ) #sw (x:int_t sw) (y:int_t sw) : bool =
     match sw with
     | Signed Winfinite -> x <= y
@@ -364,6 +385,7 @@ let ( <= ) #sw (x:int_t sw) (y:int_t sw) : bool =
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( / ) (#sw:signed_width{sw <> Unsigned W128})
           (x:int_t sw)
           (y:int_t sw{0 <> (v y <: Prims.int) /\
@@ -385,6 +407,7 @@ let ( / ) (#sw:signed_width{sw <> Unsigned W128})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( % ) (#sw:signed_width{sw <> Unsigned W128})
           (x:int_t sw)
           (y:int_t sw{0 <> (v y <: Prims.int) /\
@@ -408,6 +431,7 @@ let ( % ) (#sw:signed_width{sw <> Unsigned W128})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( ^^ ) #sw (x:int_t sw) (y:int_t sw{width_of_sw sw <> Winfinite})
     : Tot (int_t sw)
     = match sw with
@@ -424,6 +448,7 @@ let ( ^^ ) #sw (x:int_t sw) (y:int_t sw{width_of_sw sw <> Winfinite})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( &^ ) #sw (x:int_t sw) (y:int_t sw{width_of_sw sw <> Winfinite})
     : Tot (int_t sw)
     = match sw with
@@ -440,6 +465,7 @@ let ( &^ ) #sw (x:int_t sw) (y:int_t sw{width_of_sw sw <> Winfinite})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( |^ ) #sw (x:int_t sw) (y:int_t sw{width_of_sw sw <> Winfinite})
     : Tot (int_t sw)
     = match sw with
@@ -456,6 +482,7 @@ let ( |^ ) #sw (x:int_t sw) (y:int_t sw{width_of_sw sw <> Winfinite})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( <<^ ) #sw (x:int_t sw{0 <= v x})
                 (y:int_t (Unsigned W32){width_of_sw sw <> Winfinite /\ v y < nat_of_fixed_width (width_of_sw sw) /\ (Signed? sw ==> within_bounds sw (v x * pow2 (v y)))})
     : Tot (int_t sw)
@@ -473,6 +500,7 @@ let ( <<^ ) #sw (x:int_t sw{0 <= v x})
 
 [@@mark_for_norm; strict_on_arguments [0]]
 unfold
+noextract
 let ( >>^ ) #sw (x:int_t sw{0 <= v x})
                 (y:int_t (Unsigned W32){width_of_sw sw <> Winfinite /\ v y < nat_of_fixed_width (width_of_sw sw)})
     : Tot (int_t sw)

--- a/ulib/FStar.Pervasives.fst
+++ b/ulib/FStar.Pervasives.fst
@@ -74,6 +74,8 @@ let allow_informative_binders = ()
 
 let commute_nested_matches = ()
 
+let noextract_to _ = ()
+
 let normalize_term #_ x = x
 
 let normalize a = a

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -720,6 +720,13 @@ val allow_informative_binders : unit
   *)
 val commute_nested_matches : unit
 
+(** This attribute controls extraction: it can be used to disable
+    extraction of a given top-level definition into a specific backend,
+    such as "OCaml". If any extracted code must call into an erased
+    function, an error will be raised (code 340).
+  *)
+val noextract_to (backend:string) : Tot unit
+
 ///  Controlling normalization
 
 (** In any invocation of the F* normalizer, every occurrence of

--- a/ulib/FStar.Seq.Base.fst
+++ b/ulib/FStar.Seq.Base.fst
@@ -165,7 +165,7 @@ let rec lemma_index_app2' (#a:Type) (s1:seq a) (s2:seq a) (i:nat{i < length s1 +
 
 let lemma_index_app2 = lemma_index_app2'
 
-#push-options "--z3rlimit 20 --ifuel 0 --fuel 1"
+#push-options "--z3rlimit 20 --ifuel 1 --fuel 1"
 let rec lemma_index_slice' (#a:Type) (s:seq a) (i:nat) (j:nat{i <= j /\ j <= length s}) (k:nat{k < j - i})
 : Lemma
   (requires True)

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -38,7 +38,7 @@ let t = uint128
 let _ = intro_ambient n
 let _ = intro_ambient t
 
-noextract
+[@@ noextract_to "Kremlin"]
 let v x = U64.v x.low + (U64.v x.high) * (pow2 64)
 
 let div_mod (x:nat) (k:nat{k > 0}) : Lemma (x / k * k + x % k == x) = ()

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -289,7 +289,9 @@ val to_vec_append : #n1:nat{n1 > 0} -> #n2:nat{n2 > 0} -> num1:UInt.uint_t n1 ->
 let to_vec_append #n1 #n2 num1 num2 =
   UInt.append_lemma (UInt.to_vec num2) (UInt.to_vec num1)
 
+[@@ noextract_to "Kremlin"]
 let vec128 (a: t) : BV.bv_t 128 = UInt.to_vec #128 (v a)
+
 let vec64 (a: U64.t) : BV.bv_t 64 = UInt.to_vec (U64.v a)
 
 let to_vec_v (a: t) :

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -289,9 +289,7 @@ val to_vec_append : #n1:nat{n1 > 0} -> #n2:nat{n2 > 0} -> num1:UInt.uint_t n1 ->
 let to_vec_append #n1 #n2 num1 num2 =
   UInt.append_lemma (UInt.to_vec num2) (UInt.to_vec num1)
 
-[@@ noextract_to "Kremlin"]
 let vec128 (a: t) : BV.bv_t 128 = UInt.to_vec #128 (v a)
-
 let vec64 (a: U64.t) : BV.bv_t 64 = UInt.to_vec (U64.v a)
 
 let to_vec_v (a: t) :

--- a/ulib/FStar.UInt128.fsti
+++ b/ulib/FStar.UInt128.fsti
@@ -26,10 +26,10 @@ let n = 128
 
 val t: (x:Type0{hasEq x})
 
-noextract
+[@@ noextract_to "Kremlin"]
 val v (x:t) : Tot (uint_t n)
 
-noextract
+[@@ noextract_to "Kremlin"]
 val uint_to_t: x:uint_t n -> Pure t
   (requires True)
   (ensures (fun y -> v y = x))

--- a/ulib/FStar.UInt128.fsti
+++ b/ulib/FStar.UInt128.fsti
@@ -89,6 +89,7 @@ val lognot: a:t -> Pure t
 //eliminating the verification overhead of the wrapper
 private
 unfold
+[@@ noextract_to "Kremlin"]
 let __uint_to_t (x:int) : Tot t =
       assume (fits x 128);
       uint_to_t x

--- a/ulib/FStar.UInt128.fsti
+++ b/ulib/FStar.UInt128.fsti
@@ -89,7 +89,6 @@ val lognot: a:t -> Pure t
 //eliminating the verification overhead of the wrapper
 private
 unfold
-[@@ noextract_to "Kremlin"]
 let __uint_to_t (x:int) : Tot t =
       assume (fits x 128);
       uint_to_t x

--- a/ulib/Makefile
+++ b/ulib/Makefile
@@ -21,7 +21,8 @@ extra: .cache
 include $(FSTAR_HOME)/ulib/ml/Makefile.include
 include $(FSTAR_HOME)/.common.mk
 
-fstarlib.mgen: *.fst *.fsti
+# GM: These dependencies suck, but are needed.
+fstarlib.mgen: *.fst *.fsti experimental/*.fst experimental/*.fsti legacy/*.fst legacy/*.fsti
 	mkdir -p ml/extracted
 	rm -f .depend.extract
 	+OUTPUT_DIRECTORY=ml/extracted \

--- a/ulib/experimental/FStar.ConstantTime.Integers.fst
+++ b/ulib/experimental/FStar.ConstantTime.Integers.fst
@@ -61,6 +61,8 @@ let promote #sl #l0 #s x l1 =
 /// Note, with our choice of representation, it is impossible to
 /// implement functions that break basic IFC guarantees, e.g., we
 /// cannot implement a boolean comparison function on secret_ints
+noextract
+inline_for_extraction
 let addition #sl (#l:lattice_element sl) #s
              (x : secret_int l s)
              (y : secret_int l s {ok ( + ) (m x) (m y)})
@@ -69,6 +71,8 @@ let addition #sl (#l:lattice_element sl) #s
       b <-- y ;
       return l (a + b)
 
+noextract
+inline_for_extraction
 let addition_mod (#sl:sl)
                  (#l:lattice_element sl)
                  (#sw: _ {Unsigned? sw /\ width_of_sw sw <> W128})

--- a/ulib/experimental/FStar.ConstantTime.Integers.fsti
+++ b/ulib/experimental/FStar.ConstantTime.Integers.fsti
@@ -89,6 +89,8 @@ val promote (#sl:sl)
 /// cannot implement a boolean comparison function on secret_ints
 
 (** Bounds-respecting addition *)
+noextract
+inline_for_extraction
 val addition (#sl:sl)
              (#l:lattice_element sl)
              (#s:sw)
@@ -97,6 +99,8 @@ val addition (#sl:sl)
     : Tot (z:secret_int l s{m z == m x + m y})
 
 (** Addition modulo *)
+noextract
+inline_for_extraction
 val addition_mod (#sl:sl)
                  (#l:lattice_element sl)
                  (#sw: _ {Unsigned? sw /\ width_of_sw sw <> W128})
@@ -164,6 +168,8 @@ let as_public (#q:qual{Public? q}) (x:t q)
 (** Lifting addition to work over both secret and public integers *)
 [@@mark_for_norm]
 unfold
+noextract
+inline_for_extraction
 let ( + ) (#q:qual) (x:t q) (y:t q{ok (+) (i x) (i y)})
     : Tot (t q)
     = match q with
@@ -173,6 +179,8 @@ let ( + ) (#q:qual) (x:t q) (y:t q{ok (+) (i x) (i y)})
 (** Lifting addition modulo to work over both secret and public integers *)
 [@@mark_for_norm]
 unfold
+noextract
+inline_for_extraction
 let ( +% ) (#q:qual{norm (Unsigned? (sw_qual q) /\ width_of_sw (sw_qual q) <> W128)})
            (x:t q)
            (y:t q)


### PR DESCRIPTION
Currently, `noextract` is only meaningful for Kremlin extraction (see these links for reference: [wiki](https://github.com/FStarLang/FStar/wiki/Qualifiers-for-definitions-and-declarations#noextract), https://github.com/FStarLang/FStar/issues/1221, https://github.com/FStarLang/kremlin/issues/54).

This PR makes F* not extract any definition marked with `noextract` in any backend. The only exception is Kremlin, since it needs to have the stubs present.

Mostly posting this for discussion. We probably want

1. To enforce `inline_for_extraction` for definitions marked `noextract`? Otherwise they turn into `magic`s at in the extracted code.

2. Have backend-specific knobs, such as `[@@ noextract "kremlin"]`.