### PR TITLE
Prevent deferring implicits to a tactic when calling the unifier from a tactic

### DIFF
--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -357,13 +357,110 @@ let (do_unify :
                       "--debug_level Rel --debug_level RelCheck" in
                   ()))
               else ());
-             (let uu____1044 = __do_unify env1 t1 t2 in
+             (let uu____1044 =
+                __do_unify
+                  (let uu___205_1049 = env1 in
+                   {
+                     FStar_TypeChecker_Env.solver =
+                       (uu___205_1049.FStar_TypeChecker_Env.solver);
+                     FStar_TypeChecker_Env.range =
+                       (uu___205_1049.FStar_TypeChecker_Env.range);
+                     FStar_TypeChecker_Env.curmodule =
+                       (uu___205_1049.FStar_TypeChecker_Env.curmodule);
+                     FStar_TypeChecker_Env.gamma =
+                       (uu___205_1049.FStar_TypeChecker_Env.gamma);
+                     FStar_TypeChecker_Env.gamma_sig =
+                       (uu___205_1049.FStar_TypeChecker_Env.gamma_sig);
+                     FStar_TypeChecker_Env.gamma_cache =
+                       (uu___205_1049.FStar_TypeChecker_Env.gamma_cache);
+                     FStar_TypeChecker_Env.modules =
+                       (uu___205_1049.FStar_TypeChecker_Env.modules);
+                     FStar_TypeChecker_Env.expected_typ =
+                       (uu___205_1049.FStar_TypeChecker_Env.expected_typ);
+                     FStar_TypeChecker_Env.sigtab =
+                       (uu___205_1049.FStar_TypeChecker_Env.sigtab);
+                     FStar_TypeChecker_Env.attrtab =
+                       (uu___205_1049.FStar_TypeChecker_Env.attrtab);
+                     FStar_TypeChecker_Env.instantiate_imp =
+                       (uu___205_1049.FStar_TypeChecker_Env.instantiate_imp);
+                     FStar_TypeChecker_Env.effects =
+                       (uu___205_1049.FStar_TypeChecker_Env.effects);
+                     FStar_TypeChecker_Env.generalize =
+                       (uu___205_1049.FStar_TypeChecker_Env.generalize);
+                     FStar_TypeChecker_Env.letrecs =
+                       (uu___205_1049.FStar_TypeChecker_Env.letrecs);
+                     FStar_TypeChecker_Env.top_level =
+                       (uu___205_1049.FStar_TypeChecker_Env.top_level);
+                     FStar_TypeChecker_Env.check_uvars =
+                       (uu___205_1049.FStar_TypeChecker_Env.check_uvars);
+                     FStar_TypeChecker_Env.use_eq =
+                       (uu___205_1049.FStar_TypeChecker_Env.use_eq);
+                     FStar_TypeChecker_Env.use_eq_strict =
+                       (uu___205_1049.FStar_TypeChecker_Env.use_eq_strict);
+                     FStar_TypeChecker_Env.is_iface =
+                       (uu___205_1049.FStar_TypeChecker_Env.is_iface);
+                     FStar_TypeChecker_Env.admit =
+                       (uu___205_1049.FStar_TypeChecker_Env.admit);
+                     FStar_TypeChecker_Env.lax =
+                       (uu___205_1049.FStar_TypeChecker_Env.lax);
+                     FStar_TypeChecker_Env.lax_universes =
+                       (uu___205_1049.FStar_TypeChecker_Env.lax_universes);
+                     FStar_TypeChecker_Env.phase1 =
+                       (uu___205_1049.FStar_TypeChecker_Env.phase1);
+                     FStar_TypeChecker_Env.failhard =
+                       (uu___205_1049.FStar_TypeChecker_Env.failhard);
+                     FStar_TypeChecker_Env.nosynth =
+                       (uu___205_1049.FStar_TypeChecker_Env.nosynth);
+                     FStar_TypeChecker_Env.uvar_subtyping =
+                       (uu___205_1049.FStar_TypeChecker_Env.uvar_subtyping);
+                     FStar_TypeChecker_Env.tc_term =
+                       (uu___205_1049.FStar_TypeChecker_Env.tc_term);
+                     FStar_TypeChecker_Env.type_of =
+                       (uu___205_1049.FStar_TypeChecker_Env.type_of);
+                     FStar_TypeChecker_Env.universe_of =
+                       (uu___205_1049.FStar_TypeChecker_Env.universe_of);
+                     FStar_TypeChecker_Env.check_type_of =
+                       (uu___205_1049.FStar_TypeChecker_Env.check_type_of);
+                     FStar_TypeChecker_Env.use_bv_sorts =
+                       (uu___205_1049.FStar_TypeChecker_Env.use_bv_sorts);
+                     FStar_TypeChecker_Env.qtbl_name_and_index =
+                       (uu___205_1049.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     FStar_TypeChecker_Env.normalized_eff_names =
+                       (uu___205_1049.FStar_TypeChecker_Env.normalized_eff_names);
+                     FStar_TypeChecker_Env.fv_delta_depths =
+                       (uu___205_1049.FStar_TypeChecker_Env.fv_delta_depths);
+                     FStar_TypeChecker_Env.proof_ns =
+                       (uu___205_1049.FStar_TypeChecker_Env.proof_ns);
+                     FStar_TypeChecker_Env.synth_hook =
+                       (uu___205_1049.FStar_TypeChecker_Env.synth_hook);
+                     FStar_TypeChecker_Env.try_solve_implicits_hook =
+                       (uu___205_1049.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     FStar_TypeChecker_Env.splice =
+                       (uu___205_1049.FStar_TypeChecker_Env.splice);
+                     FStar_TypeChecker_Env.mpreprocess =
+                       (uu___205_1049.FStar_TypeChecker_Env.mpreprocess);
+                     FStar_TypeChecker_Env.postprocess =
+                       (uu___205_1049.FStar_TypeChecker_Env.postprocess);
+                     FStar_TypeChecker_Env.identifier_info =
+                       (uu___205_1049.FStar_TypeChecker_Env.identifier_info);
+                     FStar_TypeChecker_Env.tc_hooks =
+                       (uu___205_1049.FStar_TypeChecker_Env.tc_hooks);
+                     FStar_TypeChecker_Env.dsenv =
+                       (uu___205_1049.FStar_TypeChecker_Env.dsenv);
+                     FStar_TypeChecker_Env.nbe =
+                       (uu___205_1049.FStar_TypeChecker_Env.nbe);
+                     FStar_TypeChecker_Env.strict_args_tab =
+                       (uu___205_1049.FStar_TypeChecker_Env.strict_args_tab);
+                     FStar_TypeChecker_Env.erasable_types_tab =
+                       (uu___205_1049.FStar_TypeChecker_Env.erasable_types_tab);
+                     FStar_TypeChecker_Env.enable_defer_to_tac = false
+                   }) t1 t2 in
               FStar_Tactics_Monad.bind uu____1044
                 (fun r ->
-                   (let uu____1051 =
+                   (let uu____1054 =
                       FStar_TypeChecker_Env.debug env1
                         (FStar_Options.Other "1346") in
-                    if uu____1051 then FStar_Options.pop () else ());
+                    if uu____1054 then FStar_Options.pop () else ());
                    FStar_Tactics_Monad.ret r)))
 let (do_match :
   FStar_TypeChecker_Env.env ->
@@ -373,24 +470,24 @@ let (do_match :
   fun env1 ->
     fun t1 ->
       fun t2 ->
-        let uu____1072 =
+        let uu____1075 =
           FStar_Tactics_Monad.mk_tac
             (fun ps ->
                let tx = FStar_Syntax_Unionfind.new_transaction () in
                FStar_Tactics_Result.Success (tx, ps)) in
-        FStar_Tactics_Monad.bind uu____1072
+        FStar_Tactics_Monad.bind uu____1075
           (fun tx ->
              let uvs1 = FStar_Syntax_Free.uvars_uncached t1 in
-             let uu____1086 = do_unify env1 t1 t2 in
-             FStar_Tactics_Monad.bind uu____1086
+             let uu____1089 = do_unify env1 t1 t2 in
+             FStar_Tactics_Monad.bind uu____1089
                (fun r ->
                   if r
                   then
                     let uvs2 = FStar_Syntax_Free.uvars_uncached t1 in
-                    let uu____1099 =
-                      let uu____1100 = FStar_Util.set_eq uvs1 uvs2 in
-                      Prims.op_Negation uu____1100 in
-                    (if uu____1099
+                    let uu____1102 =
+                      let uu____1103 = FStar_Util.set_eq uvs1 uvs2 in
+                      Prims.op_Negation uu____1103 in
+                    (if uu____1102
                      then
                        (FStar_Syntax_Unionfind.rollback tx;
                         FStar_Tactics_Monad.ret false)
@@ -404,29 +501,29 @@ let (do_match_on_lhs :
   fun env1 ->
     fun t1 ->
       fun t2 ->
-        let uu____1125 =
+        let uu____1128 =
           FStar_Tactics_Monad.mk_tac
             (fun ps ->
                let tx = FStar_Syntax_Unionfind.new_transaction () in
                FStar_Tactics_Result.Success (tx, ps)) in
-        FStar_Tactics_Monad.bind uu____1125
+        FStar_Tactics_Monad.bind uu____1128
           (fun tx ->
-             let uu____1135 = destruct_eq t1 in
-             match uu____1135 with
+             let uu____1138 = destruct_eq t1 in
+             match uu____1138 with
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "do_match_on_lhs: not an eq"
-             | FStar_Pervasives_Native.Some (lhs, uu____1149) ->
+             | FStar_Pervasives_Native.Some (lhs, uu____1152) ->
                  let uvs1 = FStar_Syntax_Free.uvars_uncached lhs in
-                 let uu____1157 = do_unify env1 t1 t2 in
-                 FStar_Tactics_Monad.bind uu____1157
+                 let uu____1160 = do_unify env1 t1 t2 in
+                 FStar_Tactics_Monad.bind uu____1160
                    (fun r ->
                       if r
                       then
                         let uvs2 = FStar_Syntax_Free.uvars_uncached lhs in
-                        let uu____1170 =
-                          let uu____1171 = FStar_Util.set_eq uvs1 uvs2 in
-                          Prims.op_Negation uu____1171 in
-                        (if uu____1170
+                        let uu____1173 =
+                          let uu____1174 = FStar_Util.set_eq uvs1 uvs2 in
+                          Prims.op_Negation uu____1174 in
+                        (if uu____1173
                          then
                            (FStar_Syntax_Unionfind.rollback tx;
                             FStar_Tactics_Monad.ret false)
@@ -438,16 +535,16 @@ let (set_solution :
   =
   fun goal ->
     fun solution ->
-      let uu____1191 =
+      let uu____1194 =
         FStar_Syntax_Unionfind.find
           (goal.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-      match uu____1191 with
-      | FStar_Pervasives_Native.Some uu____1196 ->
-          let uu____1197 =
-            let uu____1198 =
+      match uu____1194 with
+      | FStar_Pervasives_Native.Some uu____1199 ->
+          let uu____1200 =
+            let uu____1201 =
               FStar_Tactics_Printing.goal_to_string_verbose goal in
-            FStar_Util.format1 "Goal %s is already solved" uu____1198 in
-          FStar_Tactics_Monad.fail uu____1197
+            FStar_Util.format1 "Goal %s is already solved" uu____1201 in
+          FStar_Tactics_Monad.fail uu____1200
       | FStar_Pervasives_Native.None ->
           (FStar_Syntax_Unionfind.change
              (goal.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head
@@ -459,9 +556,9 @@ let (trysolve :
   =
   fun goal ->
     fun solution ->
-      let uu____1214 = FStar_Tactics_Types.goal_env goal in
-      let uu____1215 = FStar_Tactics_Types.goal_witness goal in
-      do_unify uu____1214 solution uu____1215
+      let uu____1217 = FStar_Tactics_Types.goal_env goal in
+      let uu____1218 = FStar_Tactics_Types.goal_witness goal in
+      do_unify uu____1217 solution uu____1218
 let (solve :
   FStar_Tactics_Types.goal ->
     FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -470,140 +567,140 @@ let (solve :
     fun solution ->
       let e = FStar_Tactics_Types.goal_env goal in
       FStar_Tactics_Monad.mlog
-        (fun uu____1234 ->
-           let uu____1235 =
-             let uu____1236 = FStar_Tactics_Types.goal_witness goal in
-             FStar_Syntax_Print.term_to_string uu____1236 in
-           let uu____1237 = FStar_Syntax_Print.term_to_string solution in
-           FStar_Util.print2 "solve %s := %s\n" uu____1235 uu____1237)
-        (fun uu____1240 ->
-           let uu____1241 = trysolve goal solution in
-           FStar_Tactics_Monad.bind uu____1241
+        (fun uu____1237 ->
+           let uu____1238 =
+             let uu____1239 = FStar_Tactics_Types.goal_witness goal in
+             FStar_Syntax_Print.term_to_string uu____1239 in
+           let uu____1240 = FStar_Syntax_Print.term_to_string solution in
+           FStar_Util.print2 "solve %s := %s\n" uu____1238 uu____1240)
+        (fun uu____1243 ->
+           let uu____1244 = trysolve goal solution in
+           FStar_Tactics_Monad.bind uu____1244
              (fun b ->
                 if b
                 then
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____1249 ->
+                    (fun uu____1252 ->
                        FStar_Tactics_Monad.remove_solved_goals)
                 else
-                  (let uu____1251 =
-                     let uu____1252 =
-                       let uu____1253 = FStar_Tactics_Types.goal_env goal in
-                       tts uu____1253 solution in
-                     let uu____1254 =
-                       let uu____1255 = FStar_Tactics_Types.goal_env goal in
-                       let uu____1256 = FStar_Tactics_Types.goal_witness goal in
-                       tts uu____1255 uu____1256 in
+                  (let uu____1254 =
+                     let uu____1255 =
+                       let uu____1256 = FStar_Tactics_Types.goal_env goal in
+                       tts uu____1256 solution in
                      let uu____1257 =
                        let uu____1258 = FStar_Tactics_Types.goal_env goal in
-                       let uu____1259 = FStar_Tactics_Types.goal_type goal in
+                       let uu____1259 = FStar_Tactics_Types.goal_witness goal in
                        tts uu____1258 uu____1259 in
+                     let uu____1260 =
+                       let uu____1261 = FStar_Tactics_Types.goal_env goal in
+                       let uu____1262 = FStar_Tactics_Types.goal_type goal in
+                       tts uu____1261 uu____1262 in
                      FStar_Util.format3 "%s does not solve %s : %s"
-                       uu____1252 uu____1254 uu____1257 in
-                   FStar_Tactics_Monad.fail uu____1251)))
+                       uu____1255 uu____1257 uu____1260 in
+                   FStar_Tactics_Monad.fail uu____1254)))
 let (solve' :
   FStar_Tactics_Types.goal ->
     FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
   =
   fun goal ->
     fun solution ->
-      let uu____1274 = set_solution goal solution in
-      FStar_Tactics_Monad.bind uu____1274
-        (fun uu____1278 ->
+      let uu____1277 = set_solution goal solution in
+      FStar_Tactics_Monad.bind uu____1277
+        (fun uu____1281 ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-             (fun uu____1280 -> FStar_Tactics_Monad.remove_solved_goals))
+             (fun uu____1283 -> FStar_Tactics_Monad.remove_solved_goals))
 let (is_true : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____1287 = FStar_Syntax_Util.un_squash t1 in
-    match uu____1287 with
+    let uu____1290 = FStar_Syntax_Util.un_squash t1 in
+    match uu____1290 with
     | FStar_Pervasives_Native.Some t' ->
         let t'1 = FStar_Syntax_Util.unascribe t' in
-        let uu____1298 =
-          let uu____1299 = FStar_Syntax_Subst.compress t'1 in
-          uu____1299.FStar_Syntax_Syntax.n in
-        (match uu____1298 with
+        let uu____1301 =
+          let uu____1302 = FStar_Syntax_Subst.compress t'1 in
+          uu____1302.FStar_Syntax_Syntax.n in
+        (match uu____1301 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
-         | uu____1303 -> false)
-    | uu____1304 -> false
+         | uu____1306 -> false)
+    | uu____1307 -> false
 let (is_false : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____1314 = FStar_Syntax_Util.un_squash t in
-    match uu____1314 with
+    let uu____1317 = FStar_Syntax_Util.un_squash t in
+    match uu____1317 with
     | FStar_Pervasives_Native.Some t' ->
-        let uu____1324 =
-          let uu____1325 = FStar_Syntax_Subst.compress t' in
-          uu____1325.FStar_Syntax_Syntax.n in
-        (match uu____1324 with
+        let uu____1327 =
+          let uu____1328 = FStar_Syntax_Subst.compress t' in
+          uu____1328.FStar_Syntax_Syntax.n in
+        (match uu____1327 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.false_lid
-         | uu____1329 -> false)
-    | uu____1330 -> false
+         | uu____1332 -> false)
+    | uu____1333 -> false
 let (tadmit_t : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
-    let uu____1344 =
+    let uu____1347 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g ->
-                (let uu____1353 =
-                   let uu____1354 = FStar_Tactics_Types.goal_type g in
-                   uu____1354.FStar_Syntax_Syntax.pos in
-                 let uu____1357 =
-                   let uu____1362 =
-                     let uu____1363 =
+                (let uu____1356 =
+                   let uu____1357 = FStar_Tactics_Types.goal_type g in
+                   uu____1357.FStar_Syntax_Syntax.pos in
+                 let uu____1360 =
+                   let uu____1365 =
+                     let uu____1366 =
                        FStar_Tactics_Printing.goal_to_string ""
                          FStar_Pervasives_Native.None ps g in
                      FStar_Util.format1 "Tactics admitted goal <%s>\n\n"
-                       uu____1363 in
-                   (FStar_Errors.Warning_TacAdmit, uu____1362) in
-                 FStar_Errors.log_issue uu____1353 uu____1357);
+                       uu____1366 in
+                   (FStar_Errors.Warning_TacAdmit, uu____1365) in
+                 FStar_Errors.log_issue uu____1356 uu____1360);
                 solve' g t)) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tadmit_t") uu____1344
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tadmit_t") uu____1347
 let (fresh : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
-  fun uu____1378 ->
+  fun uu____1381 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          let n = ps.FStar_Tactics_Types.freshness in
          let ps1 =
-           let uu___277_1388 = ps in
+           let uu___279_1391 = ps in
            {
              FStar_Tactics_Types.main_context =
-               (uu___277_1388.FStar_Tactics_Types.main_context);
+               (uu___279_1391.FStar_Tactics_Types.main_context);
              FStar_Tactics_Types.all_implicits =
-               (uu___277_1388.FStar_Tactics_Types.all_implicits);
+               (uu___279_1391.FStar_Tactics_Types.all_implicits);
              FStar_Tactics_Types.goals =
-               (uu___277_1388.FStar_Tactics_Types.goals);
+               (uu___279_1391.FStar_Tactics_Types.goals);
              FStar_Tactics_Types.smt_goals =
-               (uu___277_1388.FStar_Tactics_Types.smt_goals);
+               (uu___279_1391.FStar_Tactics_Types.smt_goals);
              FStar_Tactics_Types.depth =
-               (uu___277_1388.FStar_Tactics_Types.depth);
+               (uu___279_1391.FStar_Tactics_Types.depth);
              FStar_Tactics_Types.__dump =
-               (uu___277_1388.FStar_Tactics_Types.__dump);
+               (uu___279_1391.FStar_Tactics_Types.__dump);
              FStar_Tactics_Types.psc =
-               (uu___277_1388.FStar_Tactics_Types.psc);
+               (uu___279_1391.FStar_Tactics_Types.psc);
              FStar_Tactics_Types.entry_range =
-               (uu___277_1388.FStar_Tactics_Types.entry_range);
+               (uu___279_1391.FStar_Tactics_Types.entry_range);
              FStar_Tactics_Types.guard_policy =
-               (uu___277_1388.FStar_Tactics_Types.guard_policy);
+               (uu___279_1391.FStar_Tactics_Types.guard_policy);
              FStar_Tactics_Types.freshness = (n + Prims.int_one);
              FStar_Tactics_Types.tac_verb_dbg =
-               (uu___277_1388.FStar_Tactics_Types.tac_verb_dbg);
+               (uu___279_1391.FStar_Tactics_Types.tac_verb_dbg);
              FStar_Tactics_Types.local_state =
-               (uu___277_1388.FStar_Tactics_Types.local_state)
+               (uu___279_1391.FStar_Tactics_Types.local_state)
            } in
-         let uu____1389 = FStar_Tactics_Monad.set ps1 in
-         FStar_Tactics_Monad.bind uu____1389
-           (fun uu____1394 ->
-              let uu____1395 = FStar_BigInt.of_int_fs n in
-              FStar_Tactics_Monad.ret uu____1395))
+         let uu____1392 = FStar_Tactics_Monad.set ps1 in
+         FStar_Tactics_Monad.bind uu____1392
+           (fun uu____1397 ->
+              let uu____1398 = FStar_BigInt.of_int_fs n in
+              FStar_Tactics_Monad.ret uu____1398))
 let (curms : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
-  fun uu____1402 ->
-    let uu____1405 =
-      let uu____1406 = FStar_Util.now_ms () in
-      FStar_All.pipe_right uu____1406 FStar_BigInt.of_int_fs in
-    FStar_Tactics_Monad.ret uu____1405
+  fun uu____1405 ->
+    let uu____1408 =
+      let uu____1409 = FStar_Util.now_ms () in
+      FStar_All.pipe_right uu____1409 FStar_BigInt.of_int_fs in
+    FStar_Tactics_Monad.ret uu____1408
 let (__tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -615,131 +712,131 @@ let (__tc :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1449 ->
-                let uu____1450 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc(%s)\n" uu____1450)
-             (fun uu____1453 ->
+             (fun uu____1452 ->
+                let uu____1453 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc(%s)\n" uu____1453)
+             (fun uu____1456 ->
                 let e1 =
-                  let uu___286_1455 = e in
+                  let uu___288_1458 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___286_1455.FStar_TypeChecker_Env.solver);
+                      (uu___288_1458.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___286_1455.FStar_TypeChecker_Env.range);
+                      (uu___288_1458.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___286_1455.FStar_TypeChecker_Env.curmodule);
+                      (uu___288_1458.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___286_1455.FStar_TypeChecker_Env.gamma);
+                      (uu___288_1458.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___286_1455.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___288_1458.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___286_1455.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___288_1458.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___286_1455.FStar_TypeChecker_Env.modules);
+                      (uu___288_1458.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___286_1455.FStar_TypeChecker_Env.expected_typ);
+                      (uu___288_1458.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___286_1455.FStar_TypeChecker_Env.sigtab);
+                      (uu___288_1458.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___286_1455.FStar_TypeChecker_Env.attrtab);
+                      (uu___288_1458.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___286_1455.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___288_1458.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___286_1455.FStar_TypeChecker_Env.effects);
+                      (uu___288_1458.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___286_1455.FStar_TypeChecker_Env.generalize);
+                      (uu___288_1458.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___286_1455.FStar_TypeChecker_Env.letrecs);
+                      (uu___288_1458.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___286_1455.FStar_TypeChecker_Env.top_level);
+                      (uu___288_1458.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___286_1455.FStar_TypeChecker_Env.check_uvars);
+                      (uu___288_1458.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___286_1455.FStar_TypeChecker_Env.use_eq);
+                      (uu___288_1458.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___286_1455.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___288_1458.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___286_1455.FStar_TypeChecker_Env.is_iface);
+                      (uu___288_1458.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___286_1455.FStar_TypeChecker_Env.admit);
+                      (uu___288_1458.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___286_1455.FStar_TypeChecker_Env.lax);
+                      (uu___288_1458.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___286_1455.FStar_TypeChecker_Env.lax_universes);
+                      (uu___288_1458.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___286_1455.FStar_TypeChecker_Env.phase1);
+                      (uu___288_1458.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___286_1455.FStar_TypeChecker_Env.failhard);
+                      (uu___288_1458.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___286_1455.FStar_TypeChecker_Env.nosynth);
+                      (uu___288_1458.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___286_1455.FStar_TypeChecker_Env.tc_term);
+                      (uu___288_1458.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___286_1455.FStar_TypeChecker_Env.type_of);
+                      (uu___288_1458.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___286_1455.FStar_TypeChecker_Env.universe_of);
+                      (uu___288_1458.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___286_1455.FStar_TypeChecker_Env.check_type_of);
+                      (uu___288_1458.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___286_1455.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___288_1458.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___286_1455.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___288_1458.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___286_1455.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___288_1458.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___286_1455.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___288_1458.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___286_1455.FStar_TypeChecker_Env.proof_ns);
+                      (uu___288_1458.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___286_1455.FStar_TypeChecker_Env.synth_hook);
+                      (uu___288_1458.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___286_1455.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___288_1458.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___286_1455.FStar_TypeChecker_Env.splice);
+                      (uu___288_1458.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___286_1455.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___288_1458.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___286_1455.FStar_TypeChecker_Env.postprocess);
+                      (uu___288_1458.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___286_1455.FStar_TypeChecker_Env.identifier_info);
+                      (uu___288_1458.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___286_1455.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___288_1458.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___286_1455.FStar_TypeChecker_Env.dsenv);
+                      (uu___288_1458.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___286_1455.FStar_TypeChecker_Env.nbe);
+                      (uu___288_1458.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___286_1455.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___288_1458.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___286_1455.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___288_1458.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___286_1455.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___288_1458.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___290_1466 ->
+                  (fun uu___292_1469 ->
                      match () with
                      | () ->
-                         let uu____1475 =
+                         let uu____1478 =
                            FStar_TypeChecker_TcTerm.type_of_tot_term e1 t in
-                         FStar_Tactics_Monad.ret uu____1475) ()
+                         FStar_Tactics_Monad.ret uu____1478) ()
                 with
-                | FStar_Errors.Err (uu____1502, msg) ->
-                    let uu____1504 = tts e1 t in
-                    let uu____1505 =
-                      let uu____1506 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1506
+                | FStar_Errors.Err (uu____1505, msg) ->
+                    let uu____1507 = tts e1 t in
+                    let uu____1508 =
+                      let uu____1509 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1509
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1504 uu____1505 msg
-                | FStar_Errors.Error (uu____1513, msg, uu____1515) ->
-                    let uu____1516 = tts e1 t in
-                    let uu____1517 =
-                      let uu____1518 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1518
+                      uu____1507 uu____1508 msg
+                | FStar_Errors.Error (uu____1516, msg, uu____1518) ->
+                    let uu____1519 = tts e1 t in
+                    let uu____1520 =
+                      let uu____1521 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1521
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1516 uu____1517 msg))
+                      uu____1519 uu____1520 msg))
 let (__tc_ghost :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -751,135 +848,135 @@ let (__tc_ghost :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1567 ->
-                let uu____1568 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc_ghost(%s)\n" uu____1568)
-             (fun uu____1571 ->
+             (fun uu____1570 ->
+                let uu____1571 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc_ghost(%s)\n" uu____1571)
+             (fun uu____1574 ->
                 let e1 =
-                  let uu___307_1573 = e in
+                  let uu___309_1576 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___307_1573.FStar_TypeChecker_Env.solver);
+                      (uu___309_1576.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___307_1573.FStar_TypeChecker_Env.range);
+                      (uu___309_1576.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___307_1573.FStar_TypeChecker_Env.curmodule);
+                      (uu___309_1576.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___307_1573.FStar_TypeChecker_Env.gamma);
+                      (uu___309_1576.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___307_1573.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___309_1576.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___307_1573.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___309_1576.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___307_1573.FStar_TypeChecker_Env.modules);
+                      (uu___309_1576.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___307_1573.FStar_TypeChecker_Env.expected_typ);
+                      (uu___309_1576.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___307_1573.FStar_TypeChecker_Env.sigtab);
+                      (uu___309_1576.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___307_1573.FStar_TypeChecker_Env.attrtab);
+                      (uu___309_1576.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___307_1573.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___309_1576.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___307_1573.FStar_TypeChecker_Env.effects);
+                      (uu___309_1576.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___307_1573.FStar_TypeChecker_Env.generalize);
+                      (uu___309_1576.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___307_1573.FStar_TypeChecker_Env.letrecs);
+                      (uu___309_1576.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___307_1573.FStar_TypeChecker_Env.top_level);
+                      (uu___309_1576.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___307_1573.FStar_TypeChecker_Env.check_uvars);
+                      (uu___309_1576.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___307_1573.FStar_TypeChecker_Env.use_eq);
+                      (uu___309_1576.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___307_1573.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___309_1576.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___307_1573.FStar_TypeChecker_Env.is_iface);
+                      (uu___309_1576.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___307_1573.FStar_TypeChecker_Env.admit);
+                      (uu___309_1576.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___307_1573.FStar_TypeChecker_Env.lax);
+                      (uu___309_1576.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___307_1573.FStar_TypeChecker_Env.lax_universes);
+                      (uu___309_1576.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___307_1573.FStar_TypeChecker_Env.phase1);
+                      (uu___309_1576.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___307_1573.FStar_TypeChecker_Env.failhard);
+                      (uu___309_1576.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___307_1573.FStar_TypeChecker_Env.nosynth);
+                      (uu___309_1576.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___307_1573.FStar_TypeChecker_Env.tc_term);
+                      (uu___309_1576.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___307_1573.FStar_TypeChecker_Env.type_of);
+                      (uu___309_1576.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___307_1573.FStar_TypeChecker_Env.universe_of);
+                      (uu___309_1576.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___307_1573.FStar_TypeChecker_Env.check_type_of);
+                      (uu___309_1576.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___307_1573.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___309_1576.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___307_1573.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___309_1576.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___307_1573.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___309_1576.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___307_1573.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___309_1576.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___307_1573.FStar_TypeChecker_Env.proof_ns);
+                      (uu___309_1576.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___307_1573.FStar_TypeChecker_Env.synth_hook);
+                      (uu___309_1576.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___307_1573.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___309_1576.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___307_1573.FStar_TypeChecker_Env.splice);
+                      (uu___309_1576.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___307_1573.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___309_1576.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___307_1573.FStar_TypeChecker_Env.postprocess);
+                      (uu___309_1576.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___307_1573.FStar_TypeChecker_Env.identifier_info);
+                      (uu___309_1576.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___307_1573.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___309_1576.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___307_1573.FStar_TypeChecker_Env.dsenv);
+                      (uu___309_1576.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___307_1573.FStar_TypeChecker_Env.nbe);
+                      (uu___309_1576.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___307_1573.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___309_1576.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___307_1573.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___309_1576.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___307_1573.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___309_1576.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___311_1587 ->
+                  (fun uu___313_1590 ->
                      match () with
                      | () ->
-                         let uu____1596 =
+                         let uu____1599 =
                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term e1 t in
-                         (match uu____1596 with
+                         (match uu____1599 with
                           | (t1, lc, g) ->
                               FStar_Tactics_Monad.ret
                                 (t1, (lc.FStar_TypeChecker_Common.res_typ),
                                   g))) ()
                 with
-                | FStar_Errors.Err (uu____1634, msg) ->
-                    let uu____1636 = tts e1 t in
-                    let uu____1637 =
-                      let uu____1638 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1638
+                | FStar_Errors.Err (uu____1637, msg) ->
+                    let uu____1639 = tts e1 t in
+                    let uu____1640 =
+                      let uu____1641 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1641
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1636 uu____1637 msg
-                | FStar_Errors.Error (uu____1645, msg, uu____1647) ->
-                    let uu____1648 = tts e1 t in
-                    let uu____1649 =
-                      let uu____1650 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1650
+                      uu____1639 uu____1640 msg
+                | FStar_Errors.Error (uu____1648, msg, uu____1650) ->
+                    let uu____1651 = tts e1 t in
+                    let uu____1652 =
+                      let uu____1653 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1653
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1648 uu____1649 msg))
+                      uu____1651 uu____1652 msg))
 let (__tc_lax :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -891,228 +988,228 @@ let (__tc_lax :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1699 ->
-                let uu____1700 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc_lax(%s)\n" uu____1700)
-             (fun uu____1704 ->
+             (fun uu____1702 ->
+                let uu____1703 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc_lax(%s)\n" uu____1703)
+             (fun uu____1707 ->
                 let e1 =
-                  let uu___332_1706 = e in
+                  let uu___334_1709 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___332_1706.FStar_TypeChecker_Env.solver);
+                      (uu___334_1709.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___332_1706.FStar_TypeChecker_Env.range);
+                      (uu___334_1709.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___332_1706.FStar_TypeChecker_Env.curmodule);
+                      (uu___334_1709.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___332_1706.FStar_TypeChecker_Env.gamma);
+                      (uu___334_1709.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___332_1706.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___334_1709.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___332_1706.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___334_1709.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___332_1706.FStar_TypeChecker_Env.modules);
+                      (uu___334_1709.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___332_1706.FStar_TypeChecker_Env.expected_typ);
+                      (uu___334_1709.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___332_1706.FStar_TypeChecker_Env.sigtab);
+                      (uu___334_1709.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___332_1706.FStar_TypeChecker_Env.attrtab);
+                      (uu___334_1709.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___332_1706.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___334_1709.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___332_1706.FStar_TypeChecker_Env.effects);
+                      (uu___334_1709.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___332_1706.FStar_TypeChecker_Env.generalize);
+                      (uu___334_1709.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___332_1706.FStar_TypeChecker_Env.letrecs);
+                      (uu___334_1709.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___332_1706.FStar_TypeChecker_Env.top_level);
+                      (uu___334_1709.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___332_1706.FStar_TypeChecker_Env.check_uvars);
+                      (uu___334_1709.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___332_1706.FStar_TypeChecker_Env.use_eq);
+                      (uu___334_1709.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___332_1706.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___334_1709.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___332_1706.FStar_TypeChecker_Env.is_iface);
+                      (uu___334_1709.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___332_1706.FStar_TypeChecker_Env.admit);
+                      (uu___334_1709.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___332_1706.FStar_TypeChecker_Env.lax);
+                      (uu___334_1709.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___332_1706.FStar_TypeChecker_Env.lax_universes);
+                      (uu___334_1709.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___332_1706.FStar_TypeChecker_Env.phase1);
+                      (uu___334_1709.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___332_1706.FStar_TypeChecker_Env.failhard);
+                      (uu___334_1709.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___332_1706.FStar_TypeChecker_Env.nosynth);
+                      (uu___334_1709.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___332_1706.FStar_TypeChecker_Env.tc_term);
+                      (uu___334_1709.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___332_1706.FStar_TypeChecker_Env.type_of);
+                      (uu___334_1709.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___332_1706.FStar_TypeChecker_Env.universe_of);
+                      (uu___334_1709.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___332_1706.FStar_TypeChecker_Env.check_type_of);
+                      (uu___334_1709.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___332_1706.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___334_1709.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___332_1706.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___334_1709.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___332_1706.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___334_1709.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___332_1706.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___334_1709.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___332_1706.FStar_TypeChecker_Env.proof_ns);
+                      (uu___334_1709.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___332_1706.FStar_TypeChecker_Env.synth_hook);
+                      (uu___334_1709.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___332_1706.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___334_1709.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___332_1706.FStar_TypeChecker_Env.splice);
+                      (uu___334_1709.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___332_1706.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___334_1709.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___332_1706.FStar_TypeChecker_Env.postprocess);
+                      (uu___334_1709.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___332_1706.FStar_TypeChecker_Env.identifier_info);
+                      (uu___334_1709.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___332_1706.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___334_1709.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___332_1706.FStar_TypeChecker_Env.dsenv);
+                      (uu___334_1709.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___332_1706.FStar_TypeChecker_Env.nbe);
+                      (uu___334_1709.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___332_1706.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___334_1709.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___332_1706.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___334_1709.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___332_1706.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___334_1709.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 let e2 =
-                  let uu___335_1708 = e1 in
+                  let uu___337_1711 = e1 in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___335_1708.FStar_TypeChecker_Env.solver);
+                      (uu___337_1711.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___335_1708.FStar_TypeChecker_Env.range);
+                      (uu___337_1711.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___335_1708.FStar_TypeChecker_Env.curmodule);
+                      (uu___337_1711.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___335_1708.FStar_TypeChecker_Env.gamma);
+                      (uu___337_1711.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___335_1708.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___337_1711.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___335_1708.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___337_1711.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___335_1708.FStar_TypeChecker_Env.modules);
+                      (uu___337_1711.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___335_1708.FStar_TypeChecker_Env.expected_typ);
+                      (uu___337_1711.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___335_1708.FStar_TypeChecker_Env.sigtab);
+                      (uu___337_1711.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___335_1708.FStar_TypeChecker_Env.attrtab);
+                      (uu___337_1711.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___335_1708.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___337_1711.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___335_1708.FStar_TypeChecker_Env.effects);
+                      (uu___337_1711.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___335_1708.FStar_TypeChecker_Env.generalize);
+                      (uu___337_1711.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___335_1708.FStar_TypeChecker_Env.letrecs);
+                      (uu___337_1711.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___335_1708.FStar_TypeChecker_Env.top_level);
+                      (uu___337_1711.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___335_1708.FStar_TypeChecker_Env.check_uvars);
+                      (uu___337_1711.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___335_1708.FStar_TypeChecker_Env.use_eq);
+                      (uu___337_1711.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___335_1708.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___337_1711.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___335_1708.FStar_TypeChecker_Env.is_iface);
+                      (uu___337_1711.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___335_1708.FStar_TypeChecker_Env.admit);
+                      (uu___337_1711.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax = true;
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___335_1708.FStar_TypeChecker_Env.lax_universes);
+                      (uu___337_1711.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___335_1708.FStar_TypeChecker_Env.phase1);
+                      (uu___337_1711.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___335_1708.FStar_TypeChecker_Env.failhard);
+                      (uu___337_1711.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___335_1708.FStar_TypeChecker_Env.nosynth);
+                      (uu___337_1711.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping =
-                      (uu___335_1708.FStar_TypeChecker_Env.uvar_subtyping);
+                      (uu___337_1711.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___335_1708.FStar_TypeChecker_Env.tc_term);
+                      (uu___337_1711.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___335_1708.FStar_TypeChecker_Env.type_of);
+                      (uu___337_1711.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___335_1708.FStar_TypeChecker_Env.universe_of);
+                      (uu___337_1711.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___335_1708.FStar_TypeChecker_Env.check_type_of);
+                      (uu___337_1711.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___335_1708.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___337_1711.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___335_1708.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___337_1711.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___335_1708.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___337_1711.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___335_1708.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___337_1711.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___335_1708.FStar_TypeChecker_Env.proof_ns);
+                      (uu___337_1711.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___335_1708.FStar_TypeChecker_Env.synth_hook);
+                      (uu___337_1711.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___335_1708.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___337_1711.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___335_1708.FStar_TypeChecker_Env.splice);
+                      (uu___337_1711.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___335_1708.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___337_1711.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___335_1708.FStar_TypeChecker_Env.postprocess);
+                      (uu___337_1711.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___335_1708.FStar_TypeChecker_Env.identifier_info);
+                      (uu___337_1711.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___335_1708.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___337_1711.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___335_1708.FStar_TypeChecker_Env.dsenv);
+                      (uu___337_1711.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___335_1708.FStar_TypeChecker_Env.nbe);
+                      (uu___337_1711.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___335_1708.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___337_1711.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___335_1708.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___337_1711.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___335_1708.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___337_1711.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___339_1719 ->
+                  (fun uu___341_1722 ->
                      match () with
                      | () ->
-                         let uu____1728 =
+                         let uu____1731 =
                            FStar_TypeChecker_TcTerm.tc_term e2 t in
-                         FStar_Tactics_Monad.ret uu____1728) ()
+                         FStar_Tactics_Monad.ret uu____1731) ()
                 with
-                | FStar_Errors.Err (uu____1755, msg) ->
-                    let uu____1757 = tts e2 t in
-                    let uu____1758 =
-                      let uu____1759 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_All.pipe_right uu____1759
+                | FStar_Errors.Err (uu____1758, msg) ->
+                    let uu____1760 = tts e2 t in
+                    let uu____1761 =
+                      let uu____1762 = FStar_TypeChecker_Env.all_binders e2 in
+                      FStar_All.pipe_right uu____1762
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1757 uu____1758 msg
-                | FStar_Errors.Error (uu____1766, msg, uu____1768) ->
-                    let uu____1769 = tts e2 t in
-                    let uu____1770 =
-                      let uu____1771 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_All.pipe_right uu____1771
+                      uu____1760 uu____1761 msg
+                | FStar_Errors.Error (uu____1769, msg, uu____1771) ->
+                    let uu____1772 = tts e2 t in
+                    let uu____1773 =
+                      let uu____1774 = FStar_TypeChecker_Env.all_binders e2 in
+                      FStar_All.pipe_right uu____1774
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1769 uu____1770 msg))
+                      uu____1772 uu____1773 msg))
 let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e ->
     fun t ->
@@ -1126,7 +1223,7 @@ let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
       let t1 = normalize steps e t in is_true t1
 let (get_guard_policy :
   unit -> FStar_Tactics_Types.guard_policy FStar_Tactics_Monad.tac) =
-  fun uu____1798 ->
+  fun uu____1801 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps -> FStar_Tactics_Monad.ret ps.FStar_Tactics_Types.guard_policy)
 let (set_guard_policy :
@@ -1135,31 +1232,31 @@ let (set_guard_policy :
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          FStar_Tactics_Monad.set
-           (let uu___360_1816 = ps in
+           (let uu___362_1819 = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___360_1816.FStar_Tactics_Types.main_context);
+                (uu___362_1819.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___360_1816.FStar_Tactics_Types.all_implicits);
+                (uu___362_1819.FStar_Tactics_Types.all_implicits);
               FStar_Tactics_Types.goals =
-                (uu___360_1816.FStar_Tactics_Types.goals);
+                (uu___362_1819.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals =
-                (uu___360_1816.FStar_Tactics_Types.smt_goals);
+                (uu___362_1819.FStar_Tactics_Types.smt_goals);
               FStar_Tactics_Types.depth =
-                (uu___360_1816.FStar_Tactics_Types.depth);
+                (uu___362_1819.FStar_Tactics_Types.depth);
               FStar_Tactics_Types.__dump =
-                (uu___360_1816.FStar_Tactics_Types.__dump);
+                (uu___362_1819.FStar_Tactics_Types.__dump);
               FStar_Tactics_Types.psc =
-                (uu___360_1816.FStar_Tactics_Types.psc);
+                (uu___362_1819.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___360_1816.FStar_Tactics_Types.entry_range);
+                (uu___362_1819.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy = pol;
               FStar_Tactics_Types.freshness =
-                (uu___360_1816.FStar_Tactics_Types.freshness);
+                (uu___362_1819.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___360_1816.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___362_1819.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___360_1816.FStar_Tactics_Types.local_state)
+                (uu___362_1819.FStar_Tactics_Types.local_state)
             }))
 let with_policy :
   'a .
@@ -1168,27 +1265,27 @@ let with_policy :
   =
   fun pol ->
     fun t ->
-      let uu____1840 = get_guard_policy () in
-      FStar_Tactics_Monad.bind uu____1840
+      let uu____1843 = get_guard_policy () in
+      FStar_Tactics_Monad.bind uu____1843
         (fun old_pol ->
-           let uu____1846 = set_guard_policy pol in
-           FStar_Tactics_Monad.bind uu____1846
-             (fun uu____1850 ->
+           let uu____1849 = set_guard_policy pol in
+           FStar_Tactics_Monad.bind uu____1849
+             (fun uu____1853 ->
                 FStar_Tactics_Monad.bind t
                   (fun r ->
-                     let uu____1854 = set_guard_policy old_pol in
-                     FStar_Tactics_Monad.bind uu____1854
-                       (fun uu____1858 -> FStar_Tactics_Monad.ret r))))
+                     let uu____1857 = set_guard_policy old_pol in
+                     FStar_Tactics_Monad.bind uu____1857
+                       (fun uu____1861 -> FStar_Tactics_Monad.ret r))))
 let (getopts : FStar_Options.optionstate FStar_Tactics_Monad.tac) =
-  let uu____1861 = trytac FStar_Tactics_Monad.cur_goal in
-  FStar_Tactics_Monad.bind uu____1861
-    (fun uu___0_1870 ->
-       match uu___0_1870 with
+  let uu____1864 = trytac FStar_Tactics_Monad.cur_goal in
+  FStar_Tactics_Monad.bind uu____1864
+    (fun uu___0_1873 ->
+       match uu___0_1873 with
        | FStar_Pervasives_Native.Some g ->
            FStar_Tactics_Monad.ret g.FStar_Tactics_Types.opts
        | FStar_Pervasives_Native.None ->
-           let uu____1876 = FStar_Options.peek () in
-           FStar_Tactics_Monad.ret uu____1876)
+           let uu____1879 = FStar_Options.peek () in
+           FStar_Tactics_Monad.ret uu____1879)
 let (proc_guard :
   Prims.string ->
     env -> FStar_TypeChecker_Common.guard_t -> unit FStar_Tactics_Monad.tac)
@@ -1197,27 +1294,27 @@ let (proc_guard :
     fun e ->
       fun g ->
         FStar_Tactics_Monad.mlog
-          (fun uu____1898 ->
-             let uu____1899 = FStar_TypeChecker_Rel.guard_to_string e g in
-             FStar_Util.print2 "Processing guard (%s:%s)\n" reason uu____1899)
-          (fun uu____1902 ->
-             let uu____1903 =
+          (fun uu____1901 ->
+             let uu____1902 = FStar_TypeChecker_Rel.guard_to_string e g in
+             FStar_Util.print2 "Processing guard (%s:%s)\n" reason uu____1902)
+          (fun uu____1905 ->
+             let uu____1906 =
                FStar_Tactics_Monad.add_implicits
                  g.FStar_TypeChecker_Common.implicits in
-             FStar_Tactics_Monad.bind uu____1903
-               (fun uu____1907 ->
+             FStar_Tactics_Monad.bind uu____1906
+               (fun uu____1910 ->
                   FStar_Tactics_Monad.bind getopts
                     (fun opts ->
-                       let uu____1911 =
-                         let uu____1912 =
+                       let uu____1914 =
+                         let uu____1915 =
                            FStar_TypeChecker_Rel.simplify_guard e g in
-                         uu____1912.FStar_TypeChecker_Common.guard_f in
-                       match uu____1911 with
+                         uu____1915.FStar_TypeChecker_Common.guard_f in
+                       match uu____1914 with
                        | FStar_TypeChecker_Common.Trivial ->
                            FStar_Tactics_Monad.ret ()
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____1916 = istrivial e f in
-                           if uu____1916
+                           let uu____1919 = istrivial e f in
+                           if uu____1919
                            then FStar_Tactics_Monad.ret ()
                            else
                              FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
@@ -1225,127 +1322,127 @@ let (proc_guard :
                                   match ps.FStar_Tactics_Types.guard_policy
                                   with
                                   | FStar_Tactics_Types.Drop ->
-                                      ((let uu____1926 =
-                                          let uu____1931 =
-                                            let uu____1932 =
+                                      ((let uu____1929 =
+                                          let uu____1934 =
+                                            let uu____1935 =
                                               FStar_TypeChecker_Rel.guard_to_string
                                                 e g in
                                             FStar_Util.format1
                                               "Tactics admitted guard <%s>\n\n"
-                                              uu____1932 in
+                                              uu____1935 in
                                           (FStar_Errors.Warning_TacAdmit,
-                                            uu____1931) in
+                                            uu____1934) in
                                         FStar_Errors.log_issue
                                           e.FStar_TypeChecker_Env.range
-                                          uu____1926);
+                                          uu____1929);
                                        FStar_Tactics_Monad.ret ())
                                   | FStar_Tactics_Types.Goal ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1935 ->
-                                           let uu____1936 =
+                                        (fun uu____1938 ->
+                                           let uu____1939 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Making guard (%s:%s) into a goal\n"
-                                             reason uu____1936)
-                                        (fun uu____1939 ->
-                                           let uu____1940 =
+                                             reason uu____1939)
+                                        (fun uu____1942 ->
+                                           let uu____1943 =
                                              FStar_Tactics_Monad.mk_irrelevant_goal
                                                reason e f opts "" in
                                            FStar_Tactics_Monad.bind
-                                             uu____1940
+                                             uu____1943
                                              (fun goal ->
                                                 let goal1 =
-                                                  let uu___389_1947 = goal in
+                                                  let uu___391_1950 = goal in
                                                   {
                                                     FStar_Tactics_Types.goal_main_env
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.goal_main_env);
+                                                      (uu___391_1950.FStar_Tactics_Types.goal_main_env);
                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.goal_ctx_uvar);
+                                                      (uu___391_1950.FStar_Tactics_Types.goal_ctx_uvar);
                                                     FStar_Tactics_Types.opts
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.opts);
+                                                      (uu___391_1950.FStar_Tactics_Types.opts);
                                                     FStar_Tactics_Types.is_guard
                                                       = true;
                                                     FStar_Tactics_Types.label
                                                       =
-                                                      (uu___389_1947.FStar_Tactics_Types.label)
+                                                      (uu___391_1950.FStar_Tactics_Types.label)
                                                   } in
                                                 FStar_Tactics_Monad.push_goals
                                                   [goal1]))
                                   | FStar_Tactics_Types.SMT ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1950 ->
-                                           let uu____1951 =
+                                        (fun uu____1953 ->
+                                           let uu____1954 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Sending guard (%s:%s) to SMT goal\n"
-                                             reason uu____1951)
-                                        (fun uu____1954 ->
-                                           let uu____1955 =
+                                             reason uu____1954)
+                                        (fun uu____1957 ->
+                                           let uu____1958 =
                                              FStar_Tactics_Monad.mk_irrelevant_goal
                                                reason e f opts "" in
                                            FStar_Tactics_Monad.bind
-                                             uu____1955
+                                             uu____1958
                                              (fun goal ->
                                                 let goal1 =
-                                                  let uu___396_1962 = goal in
+                                                  let uu___398_1965 = goal in
                                                   {
                                                     FStar_Tactics_Types.goal_main_env
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.goal_main_env);
+                                                      (uu___398_1965.FStar_Tactics_Types.goal_main_env);
                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.goal_ctx_uvar);
+                                                      (uu___398_1965.FStar_Tactics_Types.goal_ctx_uvar);
                                                     FStar_Tactics_Types.opts
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.opts);
+                                                      (uu___398_1965.FStar_Tactics_Types.opts);
                                                     FStar_Tactics_Types.is_guard
                                                       = true;
                                                     FStar_Tactics_Types.label
                                                       =
-                                                      (uu___396_1962.FStar_Tactics_Types.label)
+                                                      (uu___398_1965.FStar_Tactics_Types.label)
                                                   } in
                                                 FStar_Tactics_Monad.push_smt_goals
                                                   [goal1]))
                                   | FStar_Tactics_Types.Force ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1965 ->
-                                           let uu____1966 =
+                                        (fun uu____1968 ->
+                                           let uu____1969 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Forcing guard (%s:%s)\n" reason
-                                             uu____1966)
-                                        (fun uu____1968 ->
+                                             uu____1969)
+                                        (fun uu____1971 ->
                                            try
-                                             (fun uu___403_1973 ->
+                                             (fun uu___405_1976 ->
                                                 match () with
                                                 | () ->
-                                                    let uu____1976 =
-                                                      let uu____1977 =
-                                                        let uu____1978 =
+                                                    let uu____1979 =
+                                                      let uu____1980 =
+                                                        let uu____1981 =
                                                           FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                             e g in
                                                         FStar_All.pipe_left
                                                           FStar_TypeChecker_Env.is_trivial
-                                                          uu____1978 in
+                                                          uu____1981 in
                                                       Prims.op_Negation
-                                                        uu____1977 in
-                                                    if uu____1976
+                                                        uu____1980 in
+                                                    if uu____1979
                                                     then
                                                       FStar_Tactics_Monad.mlog
-                                                        (fun uu____1983 ->
-                                                           let uu____1984 =
+                                                        (fun uu____1986 ->
+                                                           let uu____1987 =
                                                              FStar_TypeChecker_Rel.guard_to_string
                                                                e g in
                                                            FStar_Util.print1
                                                              "guard = %s\n"
-                                                             uu____1984)
-                                                        (fun uu____1986 ->
+                                                             uu____1987)
+                                                        (fun uu____1989 ->
                                                            fail1
                                                              "Forcing the guard failed (%s)"
                                                              reason)
@@ -1353,16 +1450,16 @@ let (proc_guard :
                                                       FStar_Tactics_Monad.ret
                                                         ()) ()
                                            with
-                                           | uu___402_1989 ->
+                                           | uu___404_1992 ->
                                                FStar_Tactics_Monad.mlog
-                                                 (fun uu____1994 ->
-                                                    let uu____1995 =
+                                                 (fun uu____1997 ->
+                                                    let uu____1998 =
                                                       FStar_TypeChecker_Rel.guard_to_string
                                                         e g in
                                                     FStar_Util.print1
                                                       "guard = %s\n"
-                                                      uu____1995)
-                                                 (fun uu____1997 ->
+                                                      uu____1998)
+                                                 (fun uu____2000 ->
                                                     fail1
                                                       "Forcing the guard failed (%s)"
                                                       reason))))))
@@ -1373,18 +1470,18 @@ let (tcc :
   =
   fun e ->
     fun t ->
-      let uu____2012 =
-        let uu____2015 = __tc_lax e t in
-        FStar_Tactics_Monad.bind uu____2015
-          (fun uu____2035 ->
-             match uu____2035 with
-             | (uu____2044, lc, uu____2046) ->
-                 let uu____2047 =
-                   let uu____2048 = FStar_TypeChecker_Common.lcomp_comp lc in
-                   FStar_All.pipe_right uu____2048
+      let uu____2015 =
+        let uu____2018 = __tc_lax e t in
+        FStar_Tactics_Monad.bind uu____2018
+          (fun uu____2038 ->
+             match uu____2038 with
+             | (uu____2047, lc, uu____2049) ->
+                 let uu____2050 =
+                   let uu____2051 = FStar_TypeChecker_Common.lcomp_comp lc in
+                   FStar_All.pipe_right uu____2051
                      FStar_Pervasives_Native.fst in
-                 FStar_Tactics_Monad.ret uu____2047) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tcc") uu____2012
+                 FStar_Tactics_Monad.ret uu____2050) in
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tcc") uu____2015
 let (tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -1392,27 +1489,27 @@ let (tc :
   =
   fun e ->
     fun t ->
-      let uu____2075 =
-        let uu____2080 = tcc e t in
-        FStar_Tactics_Monad.bind uu____2080
+      let uu____2078 =
+        let uu____2083 = tcc e t in
+        FStar_Tactics_Monad.bind uu____2083
           (fun c -> FStar_Tactics_Monad.ret (FStar_Syntax_Util.comp_result c)) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tc") uu____2075
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tc") uu____2078
 let (trivial : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____2103 ->
+  fun uu____2106 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____2109 =
-           let uu____2110 = FStar_Tactics_Types.goal_env goal in
-           let uu____2111 = FStar_Tactics_Types.goal_type goal in
-           istrivial uu____2110 uu____2111 in
-         if uu____2109
+         let uu____2112 =
+           let uu____2113 = FStar_Tactics_Types.goal_env goal in
+           let uu____2114 = FStar_Tactics_Types.goal_type goal in
+           istrivial uu____2113 uu____2114 in
+         if uu____2112
          then solve' goal FStar_Syntax_Util.exp_unit
          else
-           (let uu____2115 =
-              let uu____2116 = FStar_Tactics_Types.goal_env goal in
-              let uu____2117 = FStar_Tactics_Types.goal_type goal in
-              tts uu____2116 uu____2117 in
-            fail1 "Not a trivial goal: %s" uu____2115))
+           (let uu____2118 =
+              let uu____2119 = FStar_Tactics_Types.goal_env goal in
+              let uu____2120 = FStar_Tactics_Types.goal_type goal in
+              tts uu____2119 uu____2120 in
+            fail1 "Not a trivial goal: %s" uu____2118))
 let divide :
   'a 'b .
     FStar_BigInt.t ->
@@ -1424,101 +1521,101 @@ let divide :
       fun r ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun p ->
-             let uu____2166 =
+             let uu____2169 =
                try
-                 (fun uu___454_2189 ->
+                 (fun uu___456_2192 ->
                     match () with
                     | () ->
-                        let uu____2200 =
-                          let uu____2209 = FStar_BigInt.to_int_fs n in
-                          FStar_List.splitAt uu____2209
+                        let uu____2203 =
+                          let uu____2212 = FStar_BigInt.to_int_fs n in
+                          FStar_List.splitAt uu____2212
                             p.FStar_Tactics_Types.goals in
-                        FStar_Tactics_Monad.ret uu____2200) ()
+                        FStar_Tactics_Monad.ret uu____2203) ()
                with
-               | uu___453_2219 ->
+               | uu___455_2222 ->
                    FStar_Tactics_Monad.fail "divide: not enough goals" in
-             FStar_Tactics_Monad.bind uu____2166
-               (fun uu____2255 ->
-                  match uu____2255 with
+             FStar_Tactics_Monad.bind uu____2169
+               (fun uu____2258 ->
+                  match uu____2258 with
                   | (lgs, rgs) ->
                       let lp =
-                        let uu___436_2281 = p in
+                        let uu___438_2284 = p in
                         {
                           FStar_Tactics_Types.main_context =
-                            (uu___436_2281.FStar_Tactics_Types.main_context);
+                            (uu___438_2284.FStar_Tactics_Types.main_context);
                           FStar_Tactics_Types.all_implicits =
-                            (uu___436_2281.FStar_Tactics_Types.all_implicits);
+                            (uu___438_2284.FStar_Tactics_Types.all_implicits);
                           FStar_Tactics_Types.goals = lgs;
                           FStar_Tactics_Types.smt_goals = [];
                           FStar_Tactics_Types.depth =
-                            (uu___436_2281.FStar_Tactics_Types.depth);
+                            (uu___438_2284.FStar_Tactics_Types.depth);
                           FStar_Tactics_Types.__dump =
-                            (uu___436_2281.FStar_Tactics_Types.__dump);
+                            (uu___438_2284.FStar_Tactics_Types.__dump);
                           FStar_Tactics_Types.psc =
-                            (uu___436_2281.FStar_Tactics_Types.psc);
+                            (uu___438_2284.FStar_Tactics_Types.psc);
                           FStar_Tactics_Types.entry_range =
-                            (uu___436_2281.FStar_Tactics_Types.entry_range);
+                            (uu___438_2284.FStar_Tactics_Types.entry_range);
                           FStar_Tactics_Types.guard_policy =
-                            (uu___436_2281.FStar_Tactics_Types.guard_policy);
+                            (uu___438_2284.FStar_Tactics_Types.guard_policy);
                           FStar_Tactics_Types.freshness =
-                            (uu___436_2281.FStar_Tactics_Types.freshness);
+                            (uu___438_2284.FStar_Tactics_Types.freshness);
                           FStar_Tactics_Types.tac_verb_dbg =
-                            (uu___436_2281.FStar_Tactics_Types.tac_verb_dbg);
+                            (uu___438_2284.FStar_Tactics_Types.tac_verb_dbg);
                           FStar_Tactics_Types.local_state =
-                            (uu___436_2281.FStar_Tactics_Types.local_state)
+                            (uu___438_2284.FStar_Tactics_Types.local_state)
                         } in
-                      let uu____2282 = FStar_Tactics_Monad.set lp in
-                      FStar_Tactics_Monad.bind uu____2282
-                        (fun uu____2290 ->
+                      let uu____2285 = FStar_Tactics_Monad.set lp in
+                      FStar_Tactics_Monad.bind uu____2285
+                        (fun uu____2293 ->
                            FStar_Tactics_Monad.bind l
                              (fun a1 ->
                                 FStar_Tactics_Monad.bind
                                   FStar_Tactics_Monad.get
                                   (fun lp' ->
                                      let rp =
-                                       let uu___442_2306 = lp' in
+                                       let uu___444_2309 = lp' in
                                        {
                                          FStar_Tactics_Types.main_context =
-                                           (uu___442_2306.FStar_Tactics_Types.main_context);
+                                           (uu___444_2309.FStar_Tactics_Types.main_context);
                                          FStar_Tactics_Types.all_implicits =
-                                           (uu___442_2306.FStar_Tactics_Types.all_implicits);
+                                           (uu___444_2309.FStar_Tactics_Types.all_implicits);
                                          FStar_Tactics_Types.goals = rgs;
                                          FStar_Tactics_Types.smt_goals = [];
                                          FStar_Tactics_Types.depth =
-                                           (uu___442_2306.FStar_Tactics_Types.depth);
+                                           (uu___444_2309.FStar_Tactics_Types.depth);
                                          FStar_Tactics_Types.__dump =
-                                           (uu___442_2306.FStar_Tactics_Types.__dump);
+                                           (uu___444_2309.FStar_Tactics_Types.__dump);
                                          FStar_Tactics_Types.psc =
-                                           (uu___442_2306.FStar_Tactics_Types.psc);
+                                           (uu___444_2309.FStar_Tactics_Types.psc);
                                          FStar_Tactics_Types.entry_range =
-                                           (uu___442_2306.FStar_Tactics_Types.entry_range);
+                                           (uu___444_2309.FStar_Tactics_Types.entry_range);
                                          FStar_Tactics_Types.guard_policy =
-                                           (uu___442_2306.FStar_Tactics_Types.guard_policy);
+                                           (uu___444_2309.FStar_Tactics_Types.guard_policy);
                                          FStar_Tactics_Types.freshness =
-                                           (uu___442_2306.FStar_Tactics_Types.freshness);
+                                           (uu___444_2309.FStar_Tactics_Types.freshness);
                                          FStar_Tactics_Types.tac_verb_dbg =
-                                           (uu___442_2306.FStar_Tactics_Types.tac_verb_dbg);
+                                           (uu___444_2309.FStar_Tactics_Types.tac_verb_dbg);
                                          FStar_Tactics_Types.local_state =
-                                           (uu___442_2306.FStar_Tactics_Types.local_state)
+                                           (uu___444_2309.FStar_Tactics_Types.local_state)
                                        } in
-                                     let uu____2307 =
+                                     let uu____2310 =
                                        FStar_Tactics_Monad.set rp in
-                                     FStar_Tactics_Monad.bind uu____2307
-                                       (fun uu____2315 ->
+                                     FStar_Tactics_Monad.bind uu____2310
+                                       (fun uu____2318 ->
                                           FStar_Tactics_Monad.bind r
                                             (fun b1 ->
                                                FStar_Tactics_Monad.bind
                                                  FStar_Tactics_Monad.get
                                                  (fun rp' ->
                                                     let p' =
-                                                      let uu___448_2331 = rp' in
+                                                      let uu___450_2334 = rp' in
                                                       {
                                                         FStar_Tactics_Types.main_context
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.main_context);
+                                                          (uu___450_2334.FStar_Tactics_Types.main_context);
                                                         FStar_Tactics_Types.all_implicits
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.all_implicits);
+                                                          (uu___450_2334.FStar_Tactics_Types.all_implicits);
                                                         FStar_Tactics_Types.goals
                                                           =
                                                           (FStar_List.append
@@ -1533,46 +1630,46 @@ let divide :
                                                                 p.FStar_Tactics_Types.smt_goals));
                                                         FStar_Tactics_Types.depth
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.depth);
+                                                          (uu___450_2334.FStar_Tactics_Types.depth);
                                                         FStar_Tactics_Types.__dump
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.__dump);
+                                                          (uu___450_2334.FStar_Tactics_Types.__dump);
                                                         FStar_Tactics_Types.psc
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.psc);
+                                                          (uu___450_2334.FStar_Tactics_Types.psc);
                                                         FStar_Tactics_Types.entry_range
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.entry_range);
+                                                          (uu___450_2334.FStar_Tactics_Types.entry_range);
                                                         FStar_Tactics_Types.guard_policy
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.guard_policy);
+                                                          (uu___450_2334.FStar_Tactics_Types.guard_policy);
                                                         FStar_Tactics_Types.freshness
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.freshness);
+                                                          (uu___450_2334.FStar_Tactics_Types.freshness);
                                                         FStar_Tactics_Types.tac_verb_dbg
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.tac_verb_dbg);
+                                                          (uu___450_2334.FStar_Tactics_Types.tac_verb_dbg);
                                                         FStar_Tactics_Types.local_state
                                                           =
-                                                          (uu___448_2331.FStar_Tactics_Types.local_state)
+                                                          (uu___450_2334.FStar_Tactics_Types.local_state)
                                                       } in
-                                                    let uu____2332 =
+                                                    let uu____2335 =
                                                       FStar_Tactics_Monad.set
                                                         p' in
                                                     FStar_Tactics_Monad.bind
-                                                      uu____2332
-                                                      (fun uu____2340 ->
+                                                      uu____2335
+                                                      (fun uu____2343 ->
                                                          FStar_Tactics_Monad.bind
                                                            FStar_Tactics_Monad.remove_solved_goals
-                                                           (fun uu____2346 ->
+                                                           (fun uu____2349 ->
                                                               FStar_Tactics_Monad.ret
                                                                 (a1, b1)))))))))))
 let focus : 'a . 'a FStar_Tactics_Monad.tac -> 'a FStar_Tactics_Monad.tac =
   fun f ->
-    let uu____2367 = divide FStar_BigInt.one f FStar_Tactics_Monad.idtac in
-    FStar_Tactics_Monad.bind uu____2367
-      (fun uu____2380 ->
-         match uu____2380 with | (a1, ()) -> FStar_Tactics_Monad.ret a1)
+    let uu____2370 = divide FStar_BigInt.one f FStar_Tactics_Monad.idtac in
+    FStar_Tactics_Monad.bind uu____2370
+      (fun uu____2383 ->
+         match uu____2383 with | (a1, ()) -> FStar_Tactics_Monad.ret a1)
 let rec map :
   'a . 'a FStar_Tactics_Monad.tac -> 'a Prims.list FStar_Tactics_Monad.tac =
   fun tau ->
@@ -1580,13 +1677,13 @@ let rec map :
       (fun p ->
          match p.FStar_Tactics_Types.goals with
          | [] -> FStar_Tactics_Monad.ret []
-         | uu____2417::uu____2418 ->
-             let uu____2421 =
-               let uu____2430 = map tau in
-               divide FStar_BigInt.one tau uu____2430 in
-             FStar_Tactics_Monad.bind uu____2421
-               (fun uu____2448 ->
-                  match uu____2448 with
+         | uu____2420::uu____2421 ->
+             let uu____2424 =
+               let uu____2433 = map tau in
+               divide FStar_BigInt.one tau uu____2433 in
+             FStar_Tactics_Monad.bind uu____2424
+               (fun uu____2451 ->
+                  match uu____2451 with
                   | (h, t) -> FStar_Tactics_Monad.ret (h :: t)))
 let (seq :
   unit FStar_Tactics_Monad.tac ->
@@ -1594,168 +1691,168 @@ let (seq :
   =
   fun t1 ->
     fun t2 ->
-      let uu____2489 =
+      let uu____2492 =
         FStar_Tactics_Monad.bind t1
-          (fun uu____2494 ->
-             let uu____2495 = map t2 in
-             FStar_Tactics_Monad.bind uu____2495
-               (fun uu____2503 -> FStar_Tactics_Monad.ret ())) in
-      focus uu____2489
+          (fun uu____2497 ->
+             let uu____2498 = map t2 in
+             FStar_Tactics_Monad.bind uu____2498
+               (fun uu____2506 -> FStar_Tactics_Monad.ret ())) in
+      focus uu____2492
 let (intro : unit -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac) =
-  fun uu____2512 ->
-    let uu____2515 =
+  fun uu____2515 ->
+    let uu____2518 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____2524 =
-             let uu____2531 =
-               let uu____2532 = FStar_Tactics_Types.goal_env goal in
-               let uu____2533 = FStar_Tactics_Types.goal_type goal in
-               whnf uu____2532 uu____2533 in
-             FStar_Syntax_Util.arrow_one uu____2531 in
-           match uu____2524 with
+           let uu____2527 =
+             let uu____2534 =
+               let uu____2535 = FStar_Tactics_Types.goal_env goal in
+               let uu____2536 = FStar_Tactics_Types.goal_type goal in
+               whnf uu____2535 uu____2536 in
+             FStar_Syntax_Util.arrow_one uu____2534 in
+           match uu____2527 with
            | FStar_Pervasives_Native.Some (b, c) ->
-               let uu____2542 =
-                 let uu____2543 = FStar_Syntax_Util.is_total_comp c in
-                 Prims.op_Negation uu____2543 in
-               if uu____2542
+               let uu____2545 =
+                 let uu____2546 = FStar_Syntax_Util.is_total_comp c in
+                 Prims.op_Negation uu____2546 in
+               if uu____2545
                then FStar_Tactics_Monad.fail "Codomain is effectful"
                else
                  (let env' =
-                    let uu____2548 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.push_binders uu____2548 [b] in
+                    let uu____2551 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.push_binders uu____2551 [b] in
                   let typ' = FStar_Syntax_Util.comp_result c in
-                  let uu____2564 =
+                  let uu____2567 =
                     FStar_Tactics_Monad.new_uvar "intro" env' typ' in
-                  FStar_Tactics_Monad.bind uu____2564
-                    (fun uu____2580 ->
-                       match uu____2580 with
+                  FStar_Tactics_Monad.bind uu____2567
+                    (fun uu____2583 ->
+                       match uu____2583 with
                        | (body, ctx_uvar) ->
                            let sol =
                              FStar_Syntax_Util.abs [b] body
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)) in
-                           let uu____2604 = set_solution goal sol in
-                           FStar_Tactics_Monad.bind uu____2604
-                             (fun uu____2610 ->
+                           let uu____2607 = set_solution goal sol in
+                           FStar_Tactics_Monad.bind uu____2607
+                             (fun uu____2613 ->
                                 let g =
                                   FStar_Tactics_Types.mk_goal env' ctx_uvar
                                     goal.FStar_Tactics_Types.opts
                                     goal.FStar_Tactics_Types.is_guard
                                     goal.FStar_Tactics_Types.label in
-                                let uu____2612 =
-                                  let uu____2615 = bnorm_goal g in
-                                  FStar_Tactics_Monad.replace_cur uu____2615 in
-                                FStar_Tactics_Monad.bind uu____2612
-                                  (fun uu____2617 ->
+                                let uu____2615 =
+                                  let uu____2618 = bnorm_goal g in
+                                  FStar_Tactics_Monad.replace_cur uu____2618 in
+                                FStar_Tactics_Monad.bind uu____2615
+                                  (fun uu____2620 ->
                                      FStar_Tactics_Monad.ret b))))
            | FStar_Pervasives_Native.None ->
-               let uu____2622 =
-                 let uu____2623 = FStar_Tactics_Types.goal_env goal in
-                 let uu____2624 = FStar_Tactics_Types.goal_type goal in
-                 tts uu____2623 uu____2624 in
-               fail1 "goal is not an arrow (%s)" uu____2622) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "intro") uu____2515
+               let uu____2625 =
+                 let uu____2626 = FStar_Tactics_Types.goal_env goal in
+                 let uu____2627 = FStar_Tactics_Types.goal_type goal in
+                 tts uu____2626 uu____2627 in
+               fail1 "goal is not an arrow (%s)" uu____2625) in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "intro") uu____2518
 let (intro_rec :
   unit ->
     (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.binder)
       FStar_Tactics_Monad.tac)
   =
-  fun uu____2639 ->
+  fun uu____2642 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Util.print_string
            "WARNING (intro_rec): calling this is known to cause normalizer loops\n";
          FStar_Util.print_string
            "WARNING (intro_rec): proceed at your own risk...\n";
-         (let uu____2660 =
-            let uu____2667 =
-              let uu____2668 = FStar_Tactics_Types.goal_env goal in
-              let uu____2669 = FStar_Tactics_Types.goal_type goal in
-              whnf uu____2668 uu____2669 in
-            FStar_Syntax_Util.arrow_one uu____2667 in
-          match uu____2660 with
+         (let uu____2663 =
+            let uu____2670 =
+              let uu____2671 = FStar_Tactics_Types.goal_env goal in
+              let uu____2672 = FStar_Tactics_Types.goal_type goal in
+              whnf uu____2671 uu____2672 in
+            FStar_Syntax_Util.arrow_one uu____2670 in
+          match uu____2663 with
           | FStar_Pervasives_Native.Some (b, c) ->
-              let uu____2682 =
-                let uu____2683 = FStar_Syntax_Util.is_total_comp c in
-                Prims.op_Negation uu____2683 in
-              if uu____2682
+              let uu____2685 =
+                let uu____2686 = FStar_Syntax_Util.is_total_comp c in
+                Prims.op_Negation uu____2686 in
+              if uu____2685
               then FStar_Tactics_Monad.fail "Codomain is effectful"
               else
                 (let bv =
-                   let uu____2696 = FStar_Tactics_Types.goal_type goal in
+                   let uu____2699 = FStar_Tactics_Types.goal_type goal in
                    FStar_Syntax_Syntax.gen_bv "__recf"
-                     FStar_Pervasives_Native.None uu____2696 in
+                     FStar_Pervasives_Native.None uu____2699 in
                  let bs =
-                   let uu____2706 = FStar_Syntax_Syntax.mk_binder bv in
-                   [uu____2706; b] in
+                   let uu____2709 = FStar_Syntax_Syntax.mk_binder bv in
+                   [uu____2709; b] in
                  let env' =
-                   let uu____2732 = FStar_Tactics_Types.goal_env goal in
-                   FStar_TypeChecker_Env.push_binders uu____2732 bs in
-                 let uu____2733 =
+                   let uu____2735 = FStar_Tactics_Types.goal_env goal in
+                   FStar_TypeChecker_Env.push_binders uu____2735 bs in
+                 let uu____2736 =
                    FStar_Tactics_Monad.new_uvar "intro_rec" env'
                      (FStar_Syntax_Util.comp_result c) in
-                 FStar_Tactics_Monad.bind uu____2733
-                   (fun uu____2758 ->
-                      match uu____2758 with
+                 FStar_Tactics_Monad.bind uu____2736
+                   (fun uu____2761 ->
+                      match uu____2761 with
                       | (u, ctx_uvar_u) ->
                           let lb =
-                            let uu____2772 =
-                              FStar_Tactics_Types.goal_type goal in
                             let uu____2775 =
+                              FStar_Tactics_Types.goal_type goal in
+                            let uu____2778 =
                               FStar_Syntax_Util.abs [b] u
                                 FStar_Pervasives_Native.None in
                             FStar_Syntax_Util.mk_letbinding
-                              (FStar_Util.Inl bv) [] uu____2772
-                              FStar_Parser_Const.effect_Tot_lid uu____2775 []
+                              (FStar_Util.Inl bv) [] uu____2775
+                              FStar_Parser_Const.effect_Tot_lid uu____2778 []
                               FStar_Range.dummyRange in
                           let body = FStar_Syntax_Syntax.bv_to_name bv in
-                          let uu____2793 =
+                          let uu____2796 =
                             FStar_Syntax_Subst.close_let_rec [lb] body in
-                          (match uu____2793 with
+                          (match uu____2796 with
                            | (lbs, body1) ->
                                let tm =
-                                 let uu____2815 =
-                                   let uu____2816 =
+                                 let uu____2818 =
+                                   let uu____2819 =
                                      FStar_Tactics_Types.goal_witness goal in
-                                   uu____2816.FStar_Syntax_Syntax.pos in
+                                   uu____2819.FStar_Syntax_Syntax.pos in
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_let
-                                      ((true, lbs), body1)) uu____2815 in
-                               let uu____2829 = set_solution goal tm in
-                               FStar_Tactics_Monad.bind uu____2829
-                                 (fun uu____2838 ->
-                                    let uu____2839 =
-                                      let uu____2842 =
+                                      ((true, lbs), body1)) uu____2818 in
+                               let uu____2832 = set_solution goal tm in
+                               FStar_Tactics_Monad.bind uu____2832
+                                 (fun uu____2841 ->
+                                    let uu____2842 =
+                                      let uu____2845 =
                                         bnorm_goal
-                                          (let uu___519_2845 = goal in
+                                          (let uu___521_2848 = goal in
                                            {
                                              FStar_Tactics_Types.goal_main_env
                                                =
-                                               (uu___519_2845.FStar_Tactics_Types.goal_main_env);
+                                               (uu___521_2848.FStar_Tactics_Types.goal_main_env);
                                              FStar_Tactics_Types.goal_ctx_uvar
                                                = ctx_uvar_u;
                                              FStar_Tactics_Types.opts =
-                                               (uu___519_2845.FStar_Tactics_Types.opts);
+                                               (uu___521_2848.FStar_Tactics_Types.opts);
                                              FStar_Tactics_Types.is_guard =
-                                               (uu___519_2845.FStar_Tactics_Types.is_guard);
+                                               (uu___521_2848.FStar_Tactics_Types.is_guard);
                                              FStar_Tactics_Types.label =
-                                               (uu___519_2845.FStar_Tactics_Types.label)
+                                               (uu___521_2848.FStar_Tactics_Types.label)
                                            }) in
                                       FStar_Tactics_Monad.replace_cur
-                                        uu____2842 in
-                                    FStar_Tactics_Monad.bind uu____2839
-                                      (fun uu____2852 ->
-                                         let uu____2853 =
-                                           let uu____2858 =
+                                        uu____2845 in
+                                    FStar_Tactics_Monad.bind uu____2842
+                                      (fun uu____2855 ->
+                                         let uu____2856 =
+                                           let uu____2861 =
                                              FStar_Syntax_Syntax.mk_binder bv in
-                                           (uu____2858, b) in
-                                         FStar_Tactics_Monad.ret uu____2853)))))
+                                           (uu____2861, b) in
+                                         FStar_Tactics_Monad.ret uu____2856)))))
           | FStar_Pervasives_Native.None ->
-              let uu____2867 =
-                let uu____2868 = FStar_Tactics_Types.goal_env goal in
-                let uu____2869 = FStar_Tactics_Types.goal_type goal in
-                tts uu____2868 uu____2869 in
-              fail1 "intro_rec: goal is not an arrow (%s)" uu____2867))
+              let uu____2870 =
+                let uu____2871 = FStar_Tactics_Types.goal_env goal in
+                let uu____2872 = FStar_Tactics_Types.goal_type goal in
+                tts uu____2871 uu____2872 in
+              fail1 "intro_rec: goal is not an arrow (%s)" uu____2870))
 let (norm :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
     unit FStar_Tactics_Monad.tac)
@@ -1764,23 +1861,23 @@ let (norm :
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Tactics_Monad.mlog
-           (fun uu____2891 ->
-              let uu____2892 =
-                let uu____2893 = FStar_Tactics_Types.goal_witness goal in
-                FStar_Syntax_Print.term_to_string uu____2893 in
-              FStar_Util.print1 "norm: witness = %s\n" uu____2892)
-           (fun uu____2898 ->
+           (fun uu____2894 ->
+              let uu____2895 =
+                let uu____2896 = FStar_Tactics_Types.goal_witness goal in
+                FStar_Syntax_Print.term_to_string uu____2896 in
+              FStar_Util.print1 "norm: witness = %s\n" uu____2895)
+           (fun uu____2901 ->
               let steps =
-                let uu____2902 = FStar_TypeChecker_Normalize.tr_norm_steps s in
+                let uu____2905 = FStar_TypeChecker_Normalize.tr_norm_steps s in
                 FStar_List.append
                   [FStar_TypeChecker_Env.Reify;
-                  FStar_TypeChecker_Env.UnfoldTac] uu____2902 in
+                  FStar_TypeChecker_Env.UnfoldTac] uu____2905 in
               let t =
-                let uu____2906 = FStar_Tactics_Types.goal_env goal in
-                let uu____2907 = FStar_Tactics_Types.goal_type goal in
-                normalize steps uu____2906 uu____2907 in
-              let uu____2908 = FStar_Tactics_Types.goal_with_type goal t in
-              FStar_Tactics_Monad.replace_cur uu____2908))
+                let uu____2909 = FStar_Tactics_Types.goal_env goal in
+                let uu____2910 = FStar_Tactics_Types.goal_type goal in
+                normalize steps uu____2909 uu____2910 in
+              let uu____2911 = FStar_Tactics_Types.goal_with_type goal t in
+              FStar_Tactics_Monad.replace_cur uu____2911))
 let (norm_term_env :
   env ->
     FStar_Syntax_Embeddings.norm_step Prims.list ->
@@ -1790,92 +1887,92 @@ let (norm_term_env :
   fun e ->
     fun s ->
       fun t ->
-        let uu____2932 =
+        let uu____2935 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
                let opts =
                  match ps.FStar_Tactics_Types.goals with
-                 | g::uu____2940 -> g.FStar_Tactics_Types.opts
-                 | uu____2943 -> FStar_Options.peek () in
+                 | g::uu____2943 -> g.FStar_Tactics_Types.opts
+                 | uu____2946 -> FStar_Options.peek () in
                FStar_Tactics_Monad.mlog
-                 (fun uu____2948 ->
-                    let uu____2949 = FStar_Syntax_Print.term_to_string t in
-                    FStar_Util.print1 "norm_term_env: t = %s\n" uu____2949)
-                 (fun uu____2952 ->
-                    let uu____2953 = __tc_lax e t in
-                    FStar_Tactics_Monad.bind uu____2953
-                      (fun uu____2974 ->
-                         match uu____2974 with
-                         | (t1, uu____2984, uu____2985) ->
+                 (fun uu____2951 ->
+                    let uu____2952 = FStar_Syntax_Print.term_to_string t in
+                    FStar_Util.print1 "norm_term_env: t = %s\n" uu____2952)
+                 (fun uu____2955 ->
+                    let uu____2956 = __tc_lax e t in
+                    FStar_Tactics_Monad.bind uu____2956
+                      (fun uu____2977 ->
+                         match uu____2977 with
+                         | (t1, uu____2987, uu____2988) ->
                              let steps =
-                               let uu____2989 =
+                               let uu____2992 =
                                  FStar_TypeChecker_Normalize.tr_norm_steps s in
                                FStar_List.append
                                  [FStar_TypeChecker_Env.Reify;
-                                 FStar_TypeChecker_Env.UnfoldTac] uu____2989 in
+                                 FStar_TypeChecker_Env.UnfoldTac] uu____2992 in
                              let t2 =
                                normalize steps
                                  ps.FStar_Tactics_Types.main_context t1 in
                              FStar_Tactics_Monad.mlog
-                               (fun uu____2995 ->
-                                  let uu____2996 =
+                               (fun uu____2998 ->
+                                  let uu____2999 =
                                     FStar_Syntax_Print.term_to_string t2 in
                                   FStar_Util.print1
-                                    "norm_term_env: t' = %s\n" uu____2996)
-                               (fun uu____2998 -> FStar_Tactics_Monad.ret t2)))) in
+                                    "norm_term_env: t' = %s\n" uu____2999)
+                               (fun uu____3001 -> FStar_Tactics_Monad.ret t2)))) in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_term")
-          uu____2932
+          uu____2935
 let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____3009 ->
-    let uu____3012 =
+  fun uu____3012 ->
+    let uu____3015 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____3019 =
-             let uu____3030 = FStar_Tactics_Types.goal_env g in
-             let uu____3031 = FStar_Tactics_Types.goal_type g in
-             FStar_TypeChecker_Rel.base_and_refinement uu____3030 uu____3031 in
-           match uu____3019 with
-           | (uu____3034, FStar_Pervasives_Native.None) ->
+           let uu____3022 =
+             let uu____3033 = FStar_Tactics_Types.goal_env g in
+             let uu____3034 = FStar_Tactics_Types.goal_type g in
+             FStar_TypeChecker_Rel.base_and_refinement uu____3033 uu____3034 in
+           match uu____3022 with
+           | (uu____3037, FStar_Pervasives_Native.None) ->
                FStar_Tactics_Monad.fail "not a refinement"
            | (t, FStar_Pervasives_Native.Some (bv, phi)) ->
                let g1 = FStar_Tactics_Types.goal_with_type g t in
-               let uu____3059 =
-                 let uu____3064 =
-                   let uu____3069 =
-                     let uu____3070 = FStar_Syntax_Syntax.mk_binder bv in
-                     [uu____3070] in
-                   FStar_Syntax_Subst.open_term uu____3069 phi in
-                 match uu____3064 with
+               let uu____3062 =
+                 let uu____3067 =
+                   let uu____3072 =
+                     let uu____3073 = FStar_Syntax_Syntax.mk_binder bv in
+                     [uu____3073] in
+                   FStar_Syntax_Subst.open_term uu____3072 phi in
+                 match uu____3067 with
                  | (bvs, phi1) ->
-                     let uu____3095 =
-                       let uu____3096 = FStar_List.hd bvs in
-                       FStar_Pervasives_Native.fst uu____3096 in
-                     (uu____3095, phi1) in
-               (match uu____3059 with
+                     let uu____3098 =
+                       let uu____3099 = FStar_List.hd bvs in
+                       FStar_Pervasives_Native.fst uu____3099 in
+                     (uu____3098, phi1) in
+               (match uu____3062 with
                 | (bv1, phi1) ->
-                    let uu____3115 =
-                      let uu____3118 = FStar_Tactics_Types.goal_env g in
-                      let uu____3119 =
-                        let uu____3120 =
-                          let uu____3123 =
-                            let uu____3124 =
-                              let uu____3131 =
+                    let uu____3118 =
+                      let uu____3121 = FStar_Tactics_Types.goal_env g in
+                      let uu____3122 =
+                        let uu____3123 =
+                          let uu____3126 =
+                            let uu____3127 =
+                              let uu____3134 =
                                 FStar_Tactics_Types.goal_witness g in
-                              (bv1, uu____3131) in
-                            FStar_Syntax_Syntax.NT uu____3124 in
-                          [uu____3123] in
-                        FStar_Syntax_Subst.subst uu____3120 phi1 in
+                              (bv1, uu____3134) in
+                            FStar_Syntax_Syntax.NT uu____3127 in
+                          [uu____3126] in
+                        FStar_Syntax_Subst.subst uu____3123 phi1 in
                       FStar_Tactics_Monad.mk_irrelevant_goal
-                        "refine_intro refinement" uu____3118 uu____3119
+                        "refine_intro refinement" uu____3121 uu____3122
                         g.FStar_Tactics_Types.opts
                         g.FStar_Tactics_Types.label in
-                    FStar_Tactics_Monad.bind uu____3115
+                    FStar_Tactics_Monad.bind uu____3118
                       (fun g2 ->
                          FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                           (fun uu____3139 ->
+                           (fun uu____3142 ->
                               FStar_Tactics_Monad.add_goals [g1; g2])))) in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "refine_intro")
-      uu____3012
+      uu____3015
 let (__exact_now :
   Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun set_expected_typ ->
@@ -1885,86 +1982,86 @@ let (__exact_now :
            let env1 =
              if set_expected_typ
              then
-               let uu____3163 = FStar_Tactics_Types.goal_env goal in
-               let uu____3164 = FStar_Tactics_Types.goal_type goal in
-               FStar_TypeChecker_Env.set_expected_typ uu____3163 uu____3164
+               let uu____3166 = FStar_Tactics_Types.goal_env goal in
+               let uu____3167 = FStar_Tactics_Types.goal_type goal in
+               FStar_TypeChecker_Env.set_expected_typ uu____3166 uu____3167
              else FStar_Tactics_Types.goal_env goal in
-           let uu____3166 = __tc env1 t in
-           FStar_Tactics_Monad.bind uu____3166
-             (fun uu____3185 ->
-                match uu____3185 with
+           let uu____3169 = __tc env1 t in
+           FStar_Tactics_Monad.bind uu____3169
+             (fun uu____3188 ->
+                match uu____3188 with
                 | (t1, typ, guard) ->
                     FStar_Tactics_Monad.mlog
-                      (fun uu____3200 ->
-                         let uu____3201 =
+                      (fun uu____3203 ->
+                         let uu____3204 =
                            FStar_Syntax_Print.term_to_string typ in
-                         let uu____3202 =
-                           let uu____3203 = FStar_Tactics_Types.goal_env goal in
-                           FStar_TypeChecker_Rel.guard_to_string uu____3203
+                         let uu____3205 =
+                           let uu____3206 = FStar_Tactics_Types.goal_env goal in
+                           FStar_TypeChecker_Rel.guard_to_string uu____3206
                              guard in
                          FStar_Util.print2
                            "__exact_now: got type %s\n__exact_now: and guard %s\n"
-                           uu____3201 uu____3202)
-                      (fun uu____3206 ->
-                         let uu____3207 =
-                           let uu____3210 = FStar_Tactics_Types.goal_env goal in
-                           proc_guard "__exact typing" uu____3210 guard in
-                         FStar_Tactics_Monad.bind uu____3207
-                           (fun uu____3212 ->
+                           uu____3204 uu____3205)
+                      (fun uu____3209 ->
+                         let uu____3210 =
+                           let uu____3213 = FStar_Tactics_Types.goal_env goal in
+                           proc_guard "__exact typing" uu____3213 guard in
+                         FStar_Tactics_Monad.bind uu____3210
+                           (fun uu____3215 ->
                               FStar_Tactics_Monad.mlog
-                                (fun uu____3216 ->
-                                   let uu____3217 =
+                                (fun uu____3219 ->
+                                   let uu____3220 =
                                      FStar_Syntax_Print.term_to_string typ in
-                                   let uu____3218 =
-                                     let uu____3219 =
+                                   let uu____3221 =
+                                     let uu____3222 =
                                        FStar_Tactics_Types.goal_type goal in
                                      FStar_Syntax_Print.term_to_string
-                                       uu____3219 in
+                                       uu____3222 in
                                    FStar_Util.print2
                                      "__exact_now: unifying %s and %s\n"
-                                     uu____3217 uu____3218)
-                                (fun uu____3222 ->
-                                   let uu____3223 =
-                                     let uu____3226 =
+                                     uu____3220 uu____3221)
+                                (fun uu____3225 ->
+                                   let uu____3226 =
+                                     let uu____3229 =
                                        FStar_Tactics_Types.goal_env goal in
-                                     let uu____3227 =
+                                     let uu____3230 =
                                        FStar_Tactics_Types.goal_type goal in
-                                     do_unify uu____3226 typ uu____3227 in
-                                   FStar_Tactics_Monad.bind uu____3223
+                                     do_unify uu____3229 typ uu____3230 in
+                                   FStar_Tactics_Monad.bind uu____3226
                                      (fun b ->
                                         if b
                                         then solve goal t1
                                         else
-                                          (let uu____3233 =
-                                             let uu____3238 =
-                                               let uu____3243 =
+                                          (let uu____3236 =
+                                             let uu____3241 =
+                                               let uu____3246 =
                                                  FStar_Tactics_Types.goal_env
                                                    goal in
-                                               tts uu____3243 in
-                                             let uu____3244 =
+                                               tts uu____3246 in
+                                             let uu____3247 =
                                                FStar_Tactics_Types.goal_type
                                                  goal in
                                              FStar_TypeChecker_Err.print_discrepancy
-                                               uu____3238 typ uu____3244 in
-                                           match uu____3233 with
+                                               uu____3241 typ uu____3247 in
+                                           match uu____3236 with
                                            | (typ1, goalt) ->
-                                               let uu____3249 =
-                                                 let uu____3250 =
-                                                   FStar_Tactics_Types.goal_env
-                                                     goal in
-                                                 tts uu____3250 t1 in
-                                               let uu____3251 =
-                                                 let uu____3252 =
-                                                   FStar_Tactics_Types.goal_env
-                                                     goal in
+                                               let uu____3252 =
                                                  let uu____3253 =
+                                                   FStar_Tactics_Types.goal_env
+                                                     goal in
+                                                 tts uu____3253 t1 in
+                                               let uu____3254 =
+                                                 let uu____3255 =
+                                                   FStar_Tactics_Types.goal_env
+                                                     goal in
+                                                 let uu____3256 =
                                                    FStar_Tactics_Types.goal_witness
                                                      goal in
-                                                 tts uu____3252 uu____3253 in
+                                                 tts uu____3255 uu____3256 in
                                                fail4
                                                  "%s : %s does not exactly solve the goal %s (witness = %s)"
-                                                 uu____3249 typ1 goalt
-                                                 uu____3251)))))))
+                                                 uu____3252 typ1 goalt
+                                                 uu____3254)))))))
 let (t_exact :
   Prims.bool ->
     Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -1972,56 +2069,56 @@ let (t_exact :
   fun try_refine ->
     fun set_expected_typ ->
       fun tm ->
-        let uu____3273 =
+        let uu____3276 =
           FStar_Tactics_Monad.mlog
-            (fun uu____3278 ->
-               let uu____3279 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.print1 "t_exact: tm = %s\n" uu____3279)
-            (fun uu____3282 ->
-               let uu____3283 =
-                 let uu____3290 = __exact_now set_expected_typ tm in
-                 catch uu____3290 in
-               FStar_Tactics_Monad.bind uu____3283
-                 (fun uu___2_3299 ->
-                    match uu___2_3299 with
+            (fun uu____3281 ->
+               let uu____3282 = FStar_Syntax_Print.term_to_string tm in
+               FStar_Util.print1 "t_exact: tm = %s\n" uu____3282)
+            (fun uu____3285 ->
+               let uu____3286 =
+                 let uu____3293 = __exact_now set_expected_typ tm in
+                 catch uu____3293 in
+               FStar_Tactics_Monad.bind uu____3286
+                 (fun uu___2_3302 ->
+                    match uu___2_3302 with
                     | FStar_Util.Inr r -> FStar_Tactics_Monad.ret ()
                     | FStar_Util.Inl e when Prims.op_Negation try_refine ->
                         FStar_Tactics_Monad.traise e
                     | FStar_Util.Inl e ->
                         FStar_Tactics_Monad.mlog
-                          (fun uu____3310 ->
+                          (fun uu____3313 ->
                              FStar_Util.print_string
                                "__exact_now failed, trying refine...\n")
-                          (fun uu____3313 ->
-                             let uu____3314 =
-                               let uu____3321 =
-                                 let uu____3324 =
+                          (fun uu____3316 ->
+                             let uu____3317 =
+                               let uu____3324 =
+                                 let uu____3327 =
                                    norm [FStar_Syntax_Embeddings.Delta] in
-                                 FStar_Tactics_Monad.bind uu____3324
-                                   (fun uu____3329 ->
-                                      let uu____3330 = refine_intro () in
-                                      FStar_Tactics_Monad.bind uu____3330
-                                        (fun uu____3334 ->
+                                 FStar_Tactics_Monad.bind uu____3327
+                                   (fun uu____3332 ->
+                                      let uu____3333 = refine_intro () in
+                                      FStar_Tactics_Monad.bind uu____3333
+                                        (fun uu____3337 ->
                                            __exact_now set_expected_typ tm)) in
-                               catch uu____3321 in
-                             FStar_Tactics_Monad.bind uu____3314
-                               (fun uu___1_3341 ->
-                                  match uu___1_3341 with
+                               catch uu____3324 in
+                             FStar_Tactics_Monad.bind uu____3317
+                               (fun uu___1_3344 ->
+                                  match uu___1_3344 with
                                   | FStar_Util.Inr r ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____3350 ->
+                                        (fun uu____3353 ->
                                            FStar_Util.print_string
                                              "__exact_now: failed after refining too\n")
-                                        (fun uu____3352 ->
-                                           FStar_Tactics_Monad.ret ())
-                                  | FStar_Util.Inl uu____3353 ->
-                                      FStar_Tactics_Monad.mlog
                                         (fun uu____3355 ->
+                                           FStar_Tactics_Monad.ret ())
+                                  | FStar_Util.Inl uu____3356 ->
+                                      FStar_Tactics_Monad.mlog
+                                        (fun uu____3358 ->
                                            FStar_Util.print_string
                                              "__exact_now: was not a refinement\n")
-                                        (fun uu____3357 ->
+                                        (fun uu____3360 ->
                                            FStar_Tactics_Monad.traise e))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "exact") uu____3273
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "exact") uu____3276
 let rec (__try_unify_by_application :
   Prims.bool ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual *
@@ -2039,42 +2136,42 @@ let rec (__try_unify_by_application :
         fun ty1 ->
           fun ty2 ->
             let f = if only_match then do_match else do_unify in
-            let uu____3450 = f e ty2 ty1 in
-            FStar_Tactics_Monad.bind uu____3450
-              (fun uu___3_3462 ->
-                 if uu___3_3462
+            let uu____3453 = f e ty2 ty1 in
+            FStar_Tactics_Monad.bind uu____3453
+              (fun uu___3_3465 ->
+                 if uu___3_3465
                  then FStar_Tactics_Monad.ret acc
                  else
-                   (let uu____3481 = FStar_Syntax_Util.arrow_one ty1 in
-                    match uu____3481 with
+                   (let uu____3484 = FStar_Syntax_Util.arrow_one ty1 in
+                    match uu____3484 with
                     | FStar_Pervasives_Native.None ->
-                        let uu____3502 = term_to_string e ty1 in
-                        let uu____3503 = term_to_string e ty2 in
-                        fail2 "Could not instantiate, %s to %s" uu____3502
-                          uu____3503
+                        let uu____3505 = term_to_string e ty1 in
+                        let uu____3506 = term_to_string e ty2 in
+                        fail2 "Could not instantiate, %s to %s" uu____3505
+                          uu____3506
                     | FStar_Pervasives_Native.Some (b, c) ->
-                        let uu____3518 =
-                          let uu____3519 = FStar_Syntax_Util.is_total_comp c in
-                          Prims.op_Negation uu____3519 in
-                        if uu____3518
+                        let uu____3521 =
+                          let uu____3522 = FStar_Syntax_Util.is_total_comp c in
+                          Prims.op_Negation uu____3522 in
+                        if uu____3521
                         then FStar_Tactics_Monad.fail "Codomain is effectful"
                         else
-                          (let uu____3539 =
+                          (let uu____3542 =
                              FStar_Tactics_Monad.new_uvar "apply arg" e
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                           FStar_Tactics_Monad.bind uu____3539
-                             (fun uu____3563 ->
-                                match uu____3563 with
+                           FStar_Tactics_Monad.bind uu____3542
+                             (fun uu____3566 ->
+                                match uu____3566 with
                                 | (uvt, uv) ->
                                     FStar_Tactics_Monad.mlog
-                                      (fun uu____3590 ->
-                                         let uu____3591 =
+                                      (fun uu____3593 ->
+                                         let uu____3594 =
                                            FStar_Syntax_Print.ctx_uvar_to_string
                                              uv in
                                          FStar_Util.print1
                                            "t_apply: generated uvar %s\n"
-                                           uu____3591)
-                                      (fun uu____3595 ->
+                                           uu____3594)
+                                      (fun uu____3598 ->
                                          let typ =
                                            FStar_Syntax_Util.comp_result c in
                                          let typ' =
@@ -2106,70 +2203,70 @@ let (t_apply :
   fun uopt ->
     fun only_match ->
       fun tm ->
-        let uu____3677 =
+        let uu____3680 =
           FStar_Tactics_Monad.mlog
-            (fun uu____3682 ->
-               let uu____3683 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.print1 "t_apply: tm = %s\n" uu____3683)
             (fun uu____3685 ->
+               let uu____3686 = FStar_Syntax_Print.term_to_string tm in
+               FStar_Util.print1 "t_apply: tm = %s\n" uu____3686)
+            (fun uu____3688 ->
                FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                  (fun goal ->
                     let e = FStar_Tactics_Types.goal_env goal in
                     FStar_Tactics_Monad.mlog
-                      (fun uu____3694 ->
-                         let uu____3695 =
+                      (fun uu____3697 ->
+                         let uu____3698 =
                            FStar_Syntax_Print.term_to_string tm in
-                         let uu____3696 =
+                         let uu____3699 =
                            FStar_Tactics_Printing.goal_to_string_verbose goal in
-                         let uu____3697 =
+                         let uu____3700 =
                            FStar_TypeChecker_Env.print_gamma
                              e.FStar_TypeChecker_Env.gamma in
                          FStar_Util.print3
                            "t_apply: tm = %s\nt_apply: goal = %s\nenv.gamma=%s\n"
-                           uu____3695 uu____3696 uu____3697)
-                      (fun uu____3700 ->
-                         let uu____3701 = __tc e tm in
-                         FStar_Tactics_Monad.bind uu____3701
-                           (fun uu____3722 ->
-                              match uu____3722 with
+                           uu____3698 uu____3699 uu____3700)
+                      (fun uu____3703 ->
+                         let uu____3704 = __tc e tm in
+                         FStar_Tactics_Monad.bind uu____3704
+                           (fun uu____3725 ->
+                              match uu____3725 with
                               | (tm1, typ, guard) ->
                                   let typ1 = bnorm e typ in
-                                  let uu____3735 =
-                                    let uu____3746 =
+                                  let uu____3738 =
+                                    let uu____3749 =
                                       FStar_Tactics_Types.goal_type goal in
                                     try_unify_by_application only_match e
-                                      typ1 uu____3746 in
-                                  FStar_Tactics_Monad.bind uu____3735
+                                      typ1 uu____3749 in
+                                  FStar_Tactics_Monad.bind uu____3738
                                     (fun uvs ->
                                        FStar_Tactics_Monad.mlog
-                                         (fun uu____3767 ->
-                                            let uu____3768 =
+                                         (fun uu____3770 ->
+                                            let uu____3771 =
                                               FStar_Common.string_of_list
-                                                (fun uu____3779 ->
-                                                   match uu____3779 with
-                                                   | (t, uu____3787,
-                                                      uu____3788) ->
+                                                (fun uu____3782 ->
+                                                   match uu____3782 with
+                                                   | (t, uu____3790,
+                                                      uu____3791) ->
                                                        FStar_Syntax_Print.term_to_string
                                                          t) uvs in
                                             FStar_Util.print1
                                               "t_apply: found args = %s\n"
-                                              uu____3768)
-                                         (fun uu____3795 ->
+                                              uu____3771)
+                                         (fun uu____3798 ->
                                             let fix_qual q =
                                               match q with
                                               | FStar_Pervasives_Native.Some
                                                   (FStar_Syntax_Syntax.Meta
-                                                  uu____3810) ->
+                                                  uu____3813) ->
                                                   FStar_Pervasives_Native.Some
                                                     (FStar_Syntax_Syntax.Implicit
                                                        false)
-                                              | uu____3811 -> q in
+                                              | uu____3814 -> q in
                                             let w =
                                               FStar_List.fold_right
-                                                (fun uu____3834 ->
+                                                (fun uu____3837 ->
                                                    fun w ->
-                                                     match uu____3834 with
-                                                     | (uvt, q, uu____3852)
+                                                     match uu____3837 with
+                                                     | (uvt, q, uu____3855)
                                                          ->
                                                          FStar_Syntax_Util.mk_app
                                                            w
@@ -2177,87 +2274,87 @@ let (t_apply :
                                                               (fix_qual q))])
                                                 uvs tm1 in
                                             let uvset =
-                                              let uu____3884 =
+                                              let uu____3887 =
                                                 FStar_Syntax_Free.new_uv_set
                                                   () in
                                               FStar_List.fold_right
-                                                (fun uu____3901 ->
+                                                (fun uu____3904 ->
                                                    fun s ->
-                                                     match uu____3901 with
-                                                     | (uu____3913,
-                                                        uu____3914, uv) ->
-                                                         let uu____3916 =
+                                                     match uu____3904 with
+                                                     | (uu____3916,
+                                                        uu____3917, uv) ->
+                                                         let uu____3919 =
                                                            FStar_Syntax_Free.uvars
                                                              uv.FStar_Syntax_Syntax.ctx_uvar_typ in
                                                          FStar_Util.set_union
-                                                           s uu____3916) uvs
-                                                uu____3884 in
+                                                           s uu____3919) uvs
+                                                uu____3887 in
                                             let free_in_some_goal uv =
                                               FStar_Util.set_mem uv uvset in
-                                            let uu____3925 = solve' goal w in
+                                            let uu____3928 = solve' goal w in
                                             FStar_Tactics_Monad.bind
-                                              uu____3925
-                                              (fun uu____3930 ->
-                                                 let uu____3931 =
+                                              uu____3928
+                                              (fun uu____3933 ->
+                                                 let uu____3934 =
                                                    FStar_Tactics_Monad.mapM
-                                                     (fun uu____3948 ->
-                                                        match uu____3948 with
+                                                     (fun uu____3951 ->
+                                                        match uu____3951 with
                                                         | (uvt, q, uv) ->
-                                                            let uu____3960 =
+                                                            let uu____3963 =
                                                               FStar_Syntax_Unionfind.find
                                                                 uv.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                            (match uu____3960
+                                                            (match uu____3963
                                                              with
                                                              | FStar_Pervasives_Native.Some
-                                                                 uu____3965
+                                                                 uu____3968
                                                                  ->
                                                                  FStar_Tactics_Monad.ret
                                                                    ()
                                                              | FStar_Pervasives_Native.None
                                                                  ->
-                                                                 let uu____3966
+                                                                 let uu____3969
                                                                    =
                                                                    uopt &&
                                                                     (free_in_some_goal
                                                                     uv) in
                                                                  if
-                                                                   uu____3966
+                                                                   uu____3969
                                                                  then
                                                                    FStar_Tactics_Monad.ret
                                                                     ()
                                                                  else
-                                                                   (let uu____3970
+                                                                   (let uu____3973
                                                                     =
-                                                                    let uu____3973
+                                                                    let uu____3976
                                                                     =
                                                                     bnorm_goal
-                                                                    (let uu___682_3976
+                                                                    (let uu___684_3979
                                                                     = goal in
                                                                     {
                                                                     FStar_Tactics_Types.goal_main_env
                                                                     =
-                                                                    (uu___682_3976.FStar_Tactics_Types.goal_main_env);
+                                                                    (uu___684_3979.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     = uv;
                                                                     FStar_Tactics_Types.opts
                                                                     =
-                                                                    (uu___682_3976.FStar_Tactics_Types.opts);
+                                                                    (uu___684_3979.FStar_Tactics_Types.opts);
                                                                     FStar_Tactics_Types.is_guard
                                                                     = false;
                                                                     FStar_Tactics_Types.label
                                                                     =
-                                                                    (uu___682_3976.FStar_Tactics_Types.label)
+                                                                    (uu___684_3979.FStar_Tactics_Types.label)
                                                                     }) in
-                                                                    [uu____3973] in
+                                                                    [uu____3976] in
                                                                     FStar_Tactics_Monad.add_goals
-                                                                    uu____3970)))
+                                                                    uu____3973)))
                                                      uvs in
                                                  FStar_Tactics_Monad.bind
-                                                   uu____3931
-                                                   (fun uu____3980 ->
+                                                   uu____3934
+                                                   (fun uu____3983 ->
                                                       proc_guard
                                                         "apply guard" e guard)))))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply") uu____3677
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply") uu____3680
 let (lemma_or_sq :
   FStar_Syntax_Syntax.comp ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)
@@ -2265,37 +2362,37 @@ let (lemma_or_sq :
   =
   fun c ->
     let ct = FStar_Syntax_Util.comp_to_comp_typ_nouniv c in
-    let uu____4005 =
+    let uu____4008 =
       FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
         FStar_Parser_Const.effect_Lemma_lid in
-    if uu____4005
+    if uu____4008
     then
-      let uu____4012 =
+      let uu____4015 =
         match ct.FStar_Syntax_Syntax.effect_args with
-        | pre::post::uu____4027 ->
+        | pre::post::uu____4030 ->
             ((FStar_Pervasives_Native.fst pre),
               (FStar_Pervasives_Native.fst post))
-        | uu____4080 -> failwith "apply_lemma: impossible: not a lemma" in
-      match uu____4012 with
+        | uu____4083 -> failwith "apply_lemma: impossible: not a lemma" in
+      match uu____4015 with
       | (pre, post) ->
           let post1 =
-            let uu____4112 =
-              let uu____4123 =
+            let uu____4115 =
+              let uu____4126 =
                 FStar_Syntax_Syntax.as_arg FStar_Syntax_Util.exp_unit in
-              [uu____4123] in
-            FStar_Syntax_Util.mk_app post uu____4112 in
+              [uu____4126] in
+            FStar_Syntax_Util.mk_app post uu____4115 in
           FStar_Pervasives_Native.Some (pre, post1)
     else
-      (let uu____4153 =
+      (let uu____4156 =
          (FStar_Syntax_Util.is_pure_effect ct.FStar_Syntax_Syntax.effect_name)
            ||
            (FStar_Syntax_Util.is_ghost_effect
               ct.FStar_Syntax_Syntax.effect_name) in
-       if uu____4153
+       if uu____4156
        then
-         let uu____4160 =
+         let uu____4163 =
            FStar_Syntax_Util.un_squash ct.FStar_Syntax_Syntax.result_typ in
-         FStar_Util.map_opt uu____4160
+         FStar_Util.map_opt uu____4163
            (fun post -> (FStar_Syntax_Util.t_true, post))
        else FStar_Pervasives_Native.None)
 let rec fold_left :
@@ -2309,8 +2406,8 @@ let rec fold_left :
         match xs with
         | [] -> FStar_Tactics_Monad.ret e
         | x::xs1 ->
-            let uu____4237 = f x e in
-            FStar_Tactics_Monad.bind uu____4237
+            let uu____4240 = f x e in
+            FStar_Tactics_Monad.bind uu____4240
               (fun e' -> fold_left f e' xs1)
 let (t_apply_lemma :
   Prims.bool ->
@@ -2319,50 +2416,50 @@ let (t_apply_lemma :
   fun noinst ->
     fun noinst_lhs ->
       fun tm ->
-        let uu____4261 =
-          let uu____4264 =
+        let uu____4264 =
+          let uu____4267 =
             FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
               (fun ps ->
                  FStar_Tactics_Monad.mlog
-                   (fun uu____4271 ->
-                      let uu____4272 = FStar_Syntax_Print.term_to_string tm in
-                      FStar_Util.print1 "apply_lemma: tm = %s\n" uu____4272)
-                   (fun uu____4275 ->
+                   (fun uu____4274 ->
+                      let uu____4275 = FStar_Syntax_Print.term_to_string tm in
+                      FStar_Util.print1 "apply_lemma: tm = %s\n" uu____4275)
+                   (fun uu____4278 ->
                       let is_unit_t t =
-                        let uu____4282 =
-                          let uu____4283 = FStar_Syntax_Subst.compress t in
-                          uu____4283.FStar_Syntax_Syntax.n in
-                        match uu____4282 with
+                        let uu____4285 =
+                          let uu____4286 = FStar_Syntax_Subst.compress t in
+                          uu____4286.FStar_Syntax_Syntax.n in
+                        match uu____4285 with
                         | FStar_Syntax_Syntax.Tm_fvar fv when
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.unit_lid
                             -> true
-                        | uu____4287 -> false in
+                        | uu____4290 -> false in
                       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                         (fun goal ->
                            let env1 = FStar_Tactics_Types.goal_env goal in
-                           let uu____4293 = __tc env1 tm in
-                           FStar_Tactics_Monad.bind uu____4293
-                             (fun uu____4316 ->
-                                match uu____4316 with
+                           let uu____4296 = __tc env1 tm in
+                           FStar_Tactics_Monad.bind uu____4296
+                             (fun uu____4319 ->
+                                match uu____4319 with
                                 | (tm1, t, guard) ->
-                                    let uu____4328 =
+                                    let uu____4331 =
                                       FStar_Syntax_Util.arrow_formals_comp t in
-                                    (match uu____4328 with
+                                    (match uu____4331 with
                                      | (bs, comp) ->
-                                         let uu____4337 = lemma_or_sq comp in
-                                         (match uu____4337 with
+                                         let uu____4340 = lemma_or_sq comp in
+                                         (match uu____4340 with
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Tactics_Monad.fail
                                                 "not a lemma or squashed function"
                                           | FStar_Pervasives_Native.Some
                                               (pre, post) ->
-                                              let uu____4356 =
+                                              let uu____4359 =
                                                 fold_left
-                                                  (fun uu____4418 ->
-                                                     fun uu____4419 ->
-                                                       match (uu____4418,
-                                                               uu____4419)
+                                                  (fun uu____4421 ->
+                                                     fun uu____4422 ->
+                                                       match (uu____4421,
+                                                               uu____4422)
                                                        with
                                                        | ((b, aq),
                                                           (uvs, imps, subst))
@@ -2371,9 +2468,9 @@ let (t_apply_lemma :
                                                              FStar_Syntax_Subst.subst
                                                                subst
                                                                b.FStar_Syntax_Syntax.sort in
-                                                           let uu____4570 =
+                                                           let uu____4573 =
                                                              is_unit_t b_t in
-                                                           if uu____4570
+                                                           if uu____4573
                                                            then
                                                              FStar_All.pipe_left
                                                                FStar_Tactics_Monad.ret
@@ -2385,17 +2482,17 @@ let (t_apply_lemma :
                                                                     FStar_Syntax_Util.exp_unit))
                                                                  :: subst))
                                                            else
-                                                             (let uu____4690
+                                                             (let uu____4693
                                                                 =
                                                                 FStar_Tactics_Monad.new_uvar
                                                                   "apply_lemma"
                                                                   env1 b_t in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____4690
+                                                                uu____4693
                                                                 (fun
-                                                                   uu____4726
+                                                                   uu____4729
                                                                    ->
-                                                                   match uu____4726
+                                                                   match uu____4729
                                                                    with
                                                                    | 
                                                                    (t1, u) ->
@@ -2412,9 +2509,9 @@ let (t_apply_lemma :
                                                                     subst)))))
                                                   ([], [], []) bs in
                                               FStar_Tactics_Monad.bind
-                                                uu____4356
-                                                (fun uu____4914 ->
-                                                   match uu____4914 with
+                                                uu____4359
+                                                (fun uu____4917 ->
+                                                   match uu____4917 with
                                                    | (uvs, implicits1, subst)
                                                        ->
                                                        let implicits2 =
@@ -2439,77 +2536,77 @@ let (t_apply_lemma :
                                                            then
                                                              do_match_on_lhs
                                                            else do_unify in
-                                                       let uu____5042 =
-                                                         let uu____5045 =
+                                                       let uu____5045 =
+                                                         let uu____5048 =
                                                            FStar_Tactics_Types.goal_type
                                                              goal in
-                                                         let uu____5046 =
+                                                         let uu____5049 =
                                                            FStar_Syntax_Util.mk_squash
                                                              post_u post1 in
                                                          cmp_func env1
-                                                           uu____5045
-                                                           uu____5046 in
+                                                           uu____5048
+                                                           uu____5049 in
                                                        FStar_Tactics_Monad.bind
-                                                         uu____5042
+                                                         uu____5045
                                                          (fun b ->
                                                             if
                                                               Prims.op_Negation
                                                                 b
                                                             then
-                                                              let uu____5055
+                                                              let uu____5058
                                                                 =
-                                                                let uu____5060
+                                                                let uu____5063
                                                                   =
                                                                   FStar_Syntax_Util.mk_squash
                                                                     post_u
                                                                     post1 in
-                                                                let uu____5061
+                                                                let uu____5064
                                                                   =
                                                                   FStar_Tactics_Types.goal_type
                                                                     goal in
                                                                 FStar_TypeChecker_Err.print_discrepancy
                                                                   (tts env1)
-                                                                  uu____5060
-                                                                  uu____5061 in
-                                                              match uu____5055
+                                                                  uu____5063
+                                                                  uu____5064 in
+                                                              match uu____5058
                                                               with
                                                               | (post2,
                                                                  goalt) ->
-                                                                  let uu____5066
+                                                                  let uu____5069
                                                                     =
                                                                     tts env1
                                                                     tm1 in
                                                                   fail3
                                                                     "Cannot instantiate lemma %s (with postcondition: %s) to match goal (%s)"
-                                                                    uu____5066
+                                                                    uu____5069
                                                                     post2
                                                                     goalt
                                                             else
-                                                              (let uu____5068
+                                                              (let uu____5071
                                                                  =
                                                                  solve' goal
                                                                    FStar_Syntax_Util.exp_unit in
                                                                FStar_Tactics_Monad.bind
-                                                                 uu____5068
+                                                                 uu____5071
                                                                  (fun
-                                                                    uu____5076
+                                                                    uu____5079
                                                                     ->
                                                                     let is_free_uvar
                                                                     uv t1 =
                                                                     let free_uvars
                                                                     =
-                                                                    let uu____5103
-                                                                    =
                                                                     let uu____5106
+                                                                    =
+                                                                    let uu____5109
                                                                     =
                                                                     FStar_Syntax_Free.uvars
                                                                     t1 in
                                                                     FStar_Util.set_elements
-                                                                    uu____5106 in
+                                                                    uu____5109 in
                                                                     FStar_List.map
                                                                     (fun x ->
                                                                     x.FStar_Syntax_Syntax.ctx_uvar_head)
-                                                                    uu____5103 in
+                                                                    uu____5106 in
                                                                     FStar_List.existsML
                                                                     (fun u ->
                                                                     FStar_Syntax_Unionfind.equiv
@@ -2521,26 +2618,26 @@ let (t_apply_lemma :
                                                                     FStar_List.existsML
                                                                     (fun g'
                                                                     ->
-                                                                    let uu____5143
+                                                                    let uu____5146
                                                                     =
                                                                     FStar_Tactics_Types.goal_type
                                                                     g' in
                                                                     is_free_uvar
                                                                     uv
-                                                                    uu____5143)
+                                                                    uu____5146)
                                                                     goals in
                                                                     let checkone
                                                                     t1 goals
                                                                     =
-                                                                    let uu____5159
+                                                                    let uu____5162
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     t1 in
-                                                                    match uu____5159
+                                                                    match uu____5162
                                                                     with
                                                                     | 
                                                                     (hd,
-                                                                    uu____5177)
+                                                                    uu____5180)
                                                                     ->
                                                                     (match 
                                                                     hd.FStar_Syntax_Syntax.n
@@ -2548,98 +2645,98 @@ let (t_apply_lemma :
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_uvar
                                                                     (uv,
-                                                                    uu____5203)
+                                                                    uu____5206)
                                                                     ->
                                                                     appears
                                                                     uv.FStar_Syntax_Syntax.ctx_uvar_head
                                                                     goals
                                                                     | 
-                                                                    uu____5220
+                                                                    uu____5223
                                                                     -> false) in
-                                                                    let uu____5221
+                                                                    let uu____5224
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     implicits2
                                                                     (FStar_Tactics_Monad.mapM
                                                                     (fun imp
                                                                     ->
-                                                                    let uu____5262
+                                                                    let uu____5265
                                                                     = imp in
-                                                                    match uu____5262
+                                                                    match uu____5265
                                                                     with
                                                                     | 
                                                                     (term,
                                                                     ctx_uvar)
                                                                     ->
-                                                                    let uu____5273
+                                                                    let uu____5276
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     term in
-                                                                    (match uu____5273
+                                                                    (match uu____5276
                                                                     with
                                                                     | 
                                                                     (hd,
-                                                                    uu____5295)
+                                                                    uu____5298)
                                                                     ->
-                                                                    let uu____5320
+                                                                    let uu____5323
                                                                     =
-                                                                    let uu____5321
+                                                                    let uu____5324
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     hd in
-                                                                    uu____5321.FStar_Syntax_Syntax.n in
-                                                                    (match uu____5320
+                                                                    uu____5324.FStar_Syntax_Syntax.n in
+                                                                    (match uu____5323
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_uvar
                                                                     (ctx_uvar1,
-                                                                    uu____5329)
+                                                                    uu____5332)
                                                                     ->
                                                                     let goal1
                                                                     =
                                                                     bnorm_goal
-                                                                    (let uu___808_5349
+                                                                    (let uu___810_5352
                                                                     = goal in
                                                                     {
                                                                     FStar_Tactics_Types.goal_main_env
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.goal_main_env);
+                                                                    (uu___810_5352.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     =
                                                                     ctx_uvar1;
                                                                     FStar_Tactics_Types.opts
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.opts);
+                                                                    (uu___810_5352.FStar_Tactics_Types.opts);
                                                                     FStar_Tactics_Types.is_guard
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.is_guard);
+                                                                    (uu___810_5352.FStar_Tactics_Types.is_guard);
                                                                     FStar_Tactics_Types.label
                                                                     =
-                                                                    (uu___808_5349.FStar_Tactics_Types.label)
+                                                                    (uu___810_5352.FStar_Tactics_Types.label)
                                                                     }) in
                                                                     FStar_Tactics_Monad.ret
                                                                     [goal1]
                                                                     | 
-                                                                    uu____5352
+                                                                    uu____5355
                                                                     ->
                                                                     FStar_Tactics_Monad.mlog
                                                                     (fun
-                                                                    uu____5358
+                                                                    uu____5361
                                                                     ->
-                                                                    let uu____5359
+                                                                    let uu____5362
                                                                     =
                                                                     FStar_Syntax_Print.uvar_to_string
                                                                     ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                                    let uu____5360
+                                                                    let uu____5363
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     term in
                                                                     FStar_Util.print2
                                                                     "apply_lemma: arg %s unified to (%s)\n"
-                                                                    uu____5359
-                                                                    uu____5360)
+                                                                    uu____5362
+                                                                    uu____5363)
                                                                     (fun
-                                                                    uu____5364
+                                                                    uu____5367
                                                                     ->
                                                                     let g_typ
                                                                     =
@@ -2647,40 +2744,40 @@ let (t_apply_lemma :
                                                                     true env1
                                                                     term
                                                                     ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                                    let uu____5366
-                                                                    =
                                                                     let uu____5369
+                                                                    =
+                                                                    let uu____5372
                                                                     =
                                                                     if
                                                                     ps.FStar_Tactics_Types.tac_verb_dbg
                                                                     then
-                                                                    let uu____5370
+                                                                    let uu____5373
                                                                     =
                                                                     FStar_Syntax_Print.ctx_uvar_to_string
                                                                     ctx_uvar in
-                                                                    let uu____5371
+                                                                    let uu____5374
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     term in
                                                                     FStar_Util.format2
                                                                     "apply_lemma solved arg %s to %s\n"
-                                                                    uu____5370
-                                                                    uu____5371
+                                                                    uu____5373
+                                                                    uu____5374
                                                                     else
                                                                     "apply_lemma solved arg" in
                                                                     proc_guard
-                                                                    uu____5369
+                                                                    uu____5372
                                                                     env1
                                                                     g_typ in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5366
+                                                                    uu____5369
                                                                     (fun
-                                                                    uu____5376
+                                                                    uu____5379
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     [])))))) in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5221
+                                                                    uu____5224
                                                                     (fun
                                                                     sub_goals
                                                                     ->
@@ -2696,17 +2793,17 @@ let (t_apply_lemma :
                                                                     [] -> []
                                                                     | 
                                                                     x::xs1 ->
-                                                                    let uu____5438
+                                                                    let uu____5441
                                                                     = f x xs1 in
                                                                     if
-                                                                    uu____5438
+                                                                    uu____5441
                                                                     then
-                                                                    let uu____5441
+                                                                    let uu____5444
                                                                     =
                                                                     filter' f
                                                                     xs1 in x
                                                                     ::
-                                                                    uu____5441
+                                                                    uu____5444
                                                                     else
                                                                     filter' f
                                                                     xs1 in
@@ -2716,51 +2813,51 @@ let (t_apply_lemma :
                                                                     (fun g ->
                                                                     fun goals
                                                                     ->
-                                                                    let uu____5455
+                                                                    let uu____5458
                                                                     =
-                                                                    let uu____5456
+                                                                    let uu____5459
                                                                     =
                                                                     FStar_Tactics_Types.goal_witness
                                                                     g in
                                                                     checkone
-                                                                    uu____5456
+                                                                    uu____5459
                                                                     goals in
                                                                     Prims.op_Negation
-                                                                    uu____5455)
+                                                                    uu____5458)
                                                                     sub_goals1 in
-                                                                    let uu____5457
+                                                                    let uu____5460
                                                                     =
                                                                     proc_guard
                                                                     "apply_lemma guard"
                                                                     env1
                                                                     guard in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5457
+                                                                    uu____5460
                                                                     (fun
-                                                                    uu____5463
+                                                                    uu____5466
                                                                     ->
                                                                     let pre_u
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 pre1 in
-                                                                    let uu____5465
-                                                                    =
                                                                     let uu____5468
                                                                     =
-                                                                    let uu____5469
+                                                                    let uu____5471
                                                                     =
-                                                                    let uu____5470
+                                                                    let uu____5472
+                                                                    =
+                                                                    let uu____5473
                                                                     =
                                                                     FStar_Syntax_Util.mk_squash
                                                                     pre_u
                                                                     pre1 in
                                                                     istrivial
                                                                     env1
-                                                                    uu____5470 in
+                                                                    uu____5473 in
                                                                     Prims.op_Negation
-                                                                    uu____5469 in
+                                                                    uu____5472 in
                                                                     if
-                                                                    uu____5468
+                                                                    uu____5471
                                                                     then
                                                                     FStar_Tactics_Monad.add_irrelevant_goal
                                                                     goal
@@ -2770,15 +2867,15 @@ let (t_apply_lemma :
                                                                     FStar_Tactics_Monad.ret
                                                                     () in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5465
+                                                                    uu____5468
                                                                     (fun
-                                                                    uu____5475
+                                                                    uu____5478
                                                                     ->
                                                                     FStar_Tactics_Monad.add_goals
                                                                     sub_goals2))))))))))))) in
-          focus uu____4264 in
+          focus uu____4267 in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply_lemma")
-          uu____4261
+          uu____4264
 let (split_env :
   FStar_Syntax_Syntax.bv ->
     env ->
@@ -2788,23 +2885,23 @@ let (split_env :
   fun bvar ->
     fun e ->
       let rec aux e1 =
-        let uu____5526 = FStar_TypeChecker_Env.pop_bv e1 in
-        match uu____5526 with
+        let uu____5529 = FStar_TypeChecker_Env.pop_bv e1 in
+        match uu____5529 with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (bv', e') ->
-            let uu____5561 = FStar_Syntax_Syntax.bv_eq bvar bv' in
-            if uu____5561
+            let uu____5564 = FStar_Syntax_Syntax.bv_eq bvar bv' in
+            if uu____5564
             then FStar_Pervasives_Native.Some (e', bv', [])
             else
-              (let uu____5583 = aux e' in
-               FStar_Util.map_opt uu____5583
-                 (fun uu____5614 ->
-                    match uu____5614 with
+              (let uu____5586 = aux e' in
+               FStar_Util.map_opt uu____5586
+                 (fun uu____5617 ->
+                    match uu____5617 with
                     | (e'', bv, bvs) -> (e'', bv, (bv' :: bvs)))) in
-      let uu____5640 = aux e in
-      FStar_Util.map_opt uu____5640
-        (fun uu____5671 ->
-           match uu____5671 with
+      let uu____5643 = aux e in
+      FStar_Util.map_opt uu____5643
+        (fun uu____5674 ->
+           match uu____5674 with
            | (e', bv, bvs) -> (e', bv, (FStar_List.rev bvs)))
 let (push_bvs :
   FStar_TypeChecker_Env.env ->
@@ -2824,39 +2921,39 @@ let (subst_goal :
   fun b1 ->
     fun b2 ->
       fun g ->
-        let uu____5746 =
-          let uu____5757 = FStar_Tactics_Types.goal_env g in
-          split_env b1 uu____5757 in
-        match uu____5746 with
+        let uu____5749 =
+          let uu____5760 = FStar_Tactics_Types.goal_env g in
+          split_env b1 uu____5760 in
+        match uu____5749 with
         | FStar_Pervasives_Native.Some (e0, b11, bvs) ->
             let bs =
               FStar_List.map FStar_Syntax_Syntax.mk_binder (b11 :: bvs) in
             let t = FStar_Tactics_Types.goal_type g in
-            let uu____5797 =
-              let uu____5810 = FStar_Syntax_Subst.close_binders bs in
-              let uu____5819 = FStar_Syntax_Subst.close bs t in
-              (uu____5810, uu____5819) in
-            (match uu____5797 with
+            let uu____5800 =
+              let uu____5813 = FStar_Syntax_Subst.close_binders bs in
+              let uu____5822 = FStar_Syntax_Subst.close bs t in
+              (uu____5813, uu____5822) in
+            (match uu____5800 with
              | (bs', t') ->
                  let bs'1 =
-                   let uu____5863 = FStar_Syntax_Syntax.mk_binder b2 in
-                   let uu____5870 = FStar_List.tail bs' in uu____5863 ::
-                     uu____5870 in
-                 let uu____5891 = FStar_Syntax_Subst.open_term bs'1 t' in
-                 (match uu____5891 with
+                   let uu____5866 = FStar_Syntax_Syntax.mk_binder b2 in
+                   let uu____5873 = FStar_List.tail bs' in uu____5866 ::
+                     uu____5873 in
+                 let uu____5894 = FStar_Syntax_Subst.open_term bs'1 t' in
+                 (match uu____5894 with
                   | (bs'', t'') ->
                       let b21 =
-                        let uu____5907 = FStar_List.hd bs'' in
-                        FStar_Pervasives_Native.fst uu____5907 in
+                        let uu____5910 = FStar_List.hd bs'' in
+                        FStar_Pervasives_Native.fst uu____5910 in
                       let new_env =
-                        let uu____5923 =
+                        let uu____5926 =
                           FStar_List.map FStar_Pervasives_Native.fst bs'' in
-                        push_bvs e0 uu____5923 in
-                      let uu____5934 =
+                        push_bvs e0 uu____5926 in
+                      let uu____5937 =
                         FStar_Tactics_Monad.new_uvar "subst_goal" new_env t'' in
-                      FStar_Tactics_Monad.bind uu____5934
-                        (fun uu____5957 ->
-                           match uu____5957 with
+                      FStar_Tactics_Monad.bind uu____5937
+                        (fun uu____5960 ->
+                           match uu____5960 with
                            | (uvt, uv) ->
                                let goal' =
                                  FStar_Tactics_Types.mk_goal new_env uv
@@ -2864,24 +2961,24 @@ let (subst_goal :
                                    g.FStar_Tactics_Types.is_guard
                                    g.FStar_Tactics_Types.label in
                                let sol =
-                                 let uu____5976 =
+                                 let uu____5979 =
                                    FStar_Syntax_Util.abs bs'' uvt
                                      FStar_Pervasives_Native.None in
-                                 let uu____5979 =
+                                 let uu____5982 =
                                    FStar_List.map
-                                     (fun uu____6000 ->
-                                        match uu____6000 with
+                                     (fun uu____6003 ->
+                                        match uu____6003 with
                                         | (bv, q) ->
-                                            let uu____6013 =
+                                            let uu____6016 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 bv in
                                             FStar_Syntax_Syntax.as_arg
-                                              uu____6013) bs in
-                                 FStar_Syntax_Util.mk_app uu____5976
-                                   uu____5979 in
-                               let uu____6014 = set_solution g sol in
-                               FStar_Tactics_Monad.bind uu____6014
-                                 (fun uu____6024 ->
+                                              uu____6016) bs in
+                                 FStar_Syntax_Util.mk_app uu____5979
+                                   uu____5982 in
+                               let uu____6017 = set_solution g sol in
+                               FStar_Tactics_Monad.bind uu____6017
+                                 (fun uu____6027 ->
                                     FStar_Tactics_Monad.ret
                                       (FStar_Pervasives_Native.Some
                                          (b21, goal'))))))
@@ -2889,82 +2986,82 @@ let (subst_goal :
             FStar_Tactics_Monad.ret FStar_Pervasives_Native.None
 let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun h ->
-    let uu____6062 =
+    let uu____6065 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____6070 = h in
-           match uu____6070 with
-           | (bv, uu____6074) ->
+           let uu____6073 = h in
+           match uu____6073 with
+           | (bv, uu____6077) ->
                FStar_Tactics_Monad.mlog
-                 (fun uu____6082 ->
-                    let uu____6083 = FStar_Syntax_Print.bv_to_string bv in
-                    let uu____6084 =
+                 (fun uu____6085 ->
+                    let uu____6086 = FStar_Syntax_Print.bv_to_string bv in
+                    let uu____6087 =
                       FStar_Syntax_Print.term_to_string
                         bv.FStar_Syntax_Syntax.sort in
-                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu____6083
-                      uu____6084)
-                 (fun uu____6087 ->
-                    let uu____6088 =
-                      let uu____6099 = FStar_Tactics_Types.goal_env goal in
-                      split_env bv uu____6099 in
-                    match uu____6088 with
+                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu____6086
+                      uu____6087)
+                 (fun uu____6090 ->
+                    let uu____6091 =
+                      let uu____6102 = FStar_Tactics_Types.goal_env goal in
+                      split_env bv uu____6102 in
+                    match uu____6091 with
                     | FStar_Pervasives_Native.None ->
                         FStar_Tactics_Monad.fail
                           "binder not found in environment"
                     | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
-                        let uu____6125 =
-                          let uu____6132 =
+                        let uu____6128 =
+                          let uu____6135 =
                             whnf e0 bv1.FStar_Syntax_Syntax.sort in
-                          destruct_eq uu____6132 in
-                        (match uu____6125 with
+                          destruct_eq uu____6135 in
+                        (match uu____6128 with
                          | FStar_Pervasives_Native.Some (x, e) ->
-                             let uu____6141 =
-                               let uu____6142 = FStar_Syntax_Subst.compress x in
-                               uu____6142.FStar_Syntax_Syntax.n in
-                             (match uu____6141 with
+                             let uu____6144 =
+                               let uu____6145 = FStar_Syntax_Subst.compress x in
+                               uu____6145.FStar_Syntax_Syntax.n in
+                             (match uu____6144 with
                               | FStar_Syntax_Syntax.Tm_name x1 ->
                                   let s = [FStar_Syntax_Syntax.NT (x1, e)] in
                                   let t = FStar_Tactics_Types.goal_type goal in
                                   let bs =
                                     FStar_List.map
                                       FStar_Syntax_Syntax.mk_binder bvs in
-                                  let uu____6169 =
-                                    let uu____6174 =
+                                  let uu____6172 =
+                                    let uu____6177 =
                                       FStar_Syntax_Subst.close_binders bs in
-                                    let uu____6175 =
+                                    let uu____6178 =
                                       FStar_Syntax_Subst.close bs t in
-                                    (uu____6174, uu____6175) in
-                                  (match uu____6169 with
+                                    (uu____6177, uu____6178) in
+                                  (match uu____6172 with
                                    | (bs', t') ->
-                                       let uu____6180 =
-                                         let uu____6185 =
+                                       let uu____6183 =
+                                         let uu____6188 =
                                            FStar_Syntax_Subst.subst_binders s
                                              bs' in
-                                         let uu____6186 =
+                                         let uu____6189 =
                                            FStar_Syntax_Subst.subst s t in
-                                         (uu____6185, uu____6186) in
-                                       (match uu____6180 with
+                                         (uu____6188, uu____6189) in
+                                       (match uu____6183 with
                                         | (bs'1, t'1) ->
-                                            let uu____6191 =
+                                            let uu____6194 =
                                               FStar_Syntax_Subst.open_term
                                                 bs'1 t'1 in
-                                            (match uu____6191 with
+                                            (match uu____6194 with
                                              | (bs'', t'') ->
                                                  let new_env =
-                                                   let uu____6201 =
-                                                     let uu____6204 =
+                                                   let uu____6204 =
+                                                     let uu____6207 =
                                                        FStar_List.map
                                                          FStar_Pervasives_Native.fst
                                                          bs'' in
-                                                     bv1 :: uu____6204 in
-                                                   push_bvs e0 uu____6201 in
-                                                 let uu____6215 =
+                                                     bv1 :: uu____6207 in
+                                                   push_bvs e0 uu____6204 in
+                                                 let uu____6218 =
                                                    FStar_Tactics_Monad.new_uvar
                                                      "rewrite" new_env t'' in
                                                  FStar_Tactics_Monad.bind
-                                                   uu____6215
-                                                   (fun uu____6232 ->
-                                                      match uu____6232 with
+                                                   uu____6218
+                                                   (fun uu____6235 ->
+                                                      match uu____6235 with
                                                       | (uvt, uv) ->
                                                           let goal' =
                                                             FStar_Tactics_Types.mk_goal
@@ -2973,172 +3070,172 @@ let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                                               goal.FStar_Tactics_Types.is_guard
                                                               goal.FStar_Tactics_Types.label in
                                                           let sol =
-                                                            let uu____6245 =
+                                                            let uu____6248 =
                                                               FStar_Syntax_Util.abs
                                                                 bs'' uvt
                                                                 FStar_Pervasives_Native.None in
-                                                            let uu____6248 =
+                                                            let uu____6251 =
                                                               FStar_List.map
                                                                 (fun
-                                                                   uu____6269
+                                                                   uu____6272
                                                                    ->
-                                                                   match uu____6269
+                                                                   match uu____6272
                                                                    with
                                                                    | 
                                                                    (bv2,
-                                                                    uu____6277)
+                                                                    uu____6280)
                                                                     ->
-                                                                    let uu____6282
+                                                                    let uu____6285
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv2 in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____6282)
+                                                                    uu____6285)
                                                                 bs in
                                                             FStar_Syntax_Util.mk_app
-                                                              uu____6245
-                                                              uu____6248 in
-                                                          let uu____6283 =
+                                                              uu____6248
+                                                              uu____6251 in
+                                                          let uu____6286 =
                                                             set_solution goal
                                                               sol in
                                                           FStar_Tactics_Monad.bind
-                                                            uu____6283
-                                                            (fun uu____6287
+                                                            uu____6286
+                                                            (fun uu____6290
                                                                ->
                                                                FStar_Tactics_Monad.replace_cur
                                                                  goal')))))
-                              | uu____6288 ->
+                              | uu____6291 ->
                                   FStar_Tactics_Monad.fail
                                     "Not an equality hypothesis with a variable on the LHS")
-                         | uu____6289 ->
+                         | uu____6292 ->
                              FStar_Tactics_Monad.fail
                                "Not an equality hypothesis"))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu____6062
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu____6065
 let (rename_to :
   FStar_Syntax_Syntax.binder ->
     Prims.string -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac)
   =
   fun b ->
     fun s ->
-      let uu____6314 =
+      let uu____6317 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal ->
-             let uu____6336 = b in
-             match uu____6336 with
+             let uu____6339 = b in
+             match uu____6339 with
              | (bv, q) ->
                  let bv' =
-                   let uu____6352 =
-                     let uu___930_6353 = bv in
-                     let uu____6354 =
-                       let uu____6355 =
-                         let uu____6360 =
+                   let uu____6355 =
+                     let uu___932_6356 = bv in
+                     let uu____6357 =
+                       let uu____6358 =
+                         let uu____6363 =
                            FStar_Ident.range_of_id
                              bv.FStar_Syntax_Syntax.ppname in
-                         (s, uu____6360) in
-                       FStar_Ident.mk_ident uu____6355 in
+                         (s, uu____6363) in
+                       FStar_Ident.mk_ident uu____6358 in
                      {
-                       FStar_Syntax_Syntax.ppname = uu____6354;
+                       FStar_Syntax_Syntax.ppname = uu____6357;
                        FStar_Syntax_Syntax.index =
-                         (uu___930_6353.FStar_Syntax_Syntax.index);
+                         (uu___932_6356.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort =
-                         (uu___930_6353.FStar_Syntax_Syntax.sort)
+                         (uu___932_6356.FStar_Syntax_Syntax.sort)
                      } in
-                   FStar_Syntax_Syntax.freshen_bv uu____6352 in
-                 let uu____6361 = subst_goal bv bv' goal in
-                 FStar_Tactics_Monad.bind uu____6361
-                   (fun uu___4_6383 ->
-                      match uu___4_6383 with
+                   FStar_Syntax_Syntax.freshen_bv uu____6355 in
+                 let uu____6364 = subst_goal bv bv' goal in
+                 FStar_Tactics_Monad.bind uu____6364
+                   (fun uu___4_6386 ->
+                      match uu___4_6386 with
                       | FStar_Pervasives_Native.None ->
                           FStar_Tactics_Monad.fail
                             "binder not found in environment"
                       | FStar_Pervasives_Native.Some (bv'1, goal1) ->
-                          let uu____6414 =
+                          let uu____6417 =
                             FStar_Tactics_Monad.replace_cur goal1 in
-                          FStar_Tactics_Monad.bind uu____6414
-                            (fun uu____6424 ->
+                          FStar_Tactics_Monad.bind uu____6417
+                            (fun uu____6427 ->
                                FStar_Tactics_Monad.ret (bv'1, q)))) in
       FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rename_to")
-        uu____6314
+        uu____6317
 let (binder_retype :
   FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
-    let uu____6458 =
+    let uu____6461 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____6467 = b in
-           match uu____6467 with
-           | (bv, uu____6471) ->
-               let uu____6476 =
-                 let uu____6487 = FStar_Tactics_Types.goal_env goal in
-                 split_env bv uu____6487 in
-               (match uu____6476 with
+           let uu____6470 = b in
+           match uu____6470 with
+           | (bv, uu____6474) ->
+               let uu____6479 =
+                 let uu____6490 = FStar_Tactics_Types.goal_env goal in
+                 split_env bv uu____6490 in
+               (match uu____6479 with
                 | FStar_Pervasives_Native.None ->
                     FStar_Tactics_Monad.fail
                       "binder is not present in environment"
                 | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
-                    let uu____6513 = FStar_Syntax_Util.type_u () in
-                    (match uu____6513 with
+                    let uu____6516 = FStar_Syntax_Util.type_u () in
+                    (match uu____6516 with
                      | (ty, u) ->
-                         let uu____6522 =
+                         let uu____6525 =
                            FStar_Tactics_Monad.new_uvar "binder_retype" e0 ty in
-                         FStar_Tactics_Monad.bind uu____6522
-                           (fun uu____6540 ->
-                              match uu____6540 with
+                         FStar_Tactics_Monad.bind uu____6525
+                           (fun uu____6543 ->
+                              match uu____6543 with
                               | (t', u_t') ->
                                   let bv'' =
-                                    let uu___957_6550 = bv1 in
+                                    let uu___959_6553 = bv1 in
                                     {
                                       FStar_Syntax_Syntax.ppname =
-                                        (uu___957_6550.FStar_Syntax_Syntax.ppname);
+                                        (uu___959_6553.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
-                                        (uu___957_6550.FStar_Syntax_Syntax.index);
+                                        (uu___959_6553.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort = t'
                                     } in
                                   let s =
-                                    let uu____6554 =
-                                      let uu____6555 =
-                                        let uu____6562 =
+                                    let uu____6557 =
+                                      let uu____6558 =
+                                        let uu____6565 =
                                           FStar_Syntax_Syntax.bv_to_name bv'' in
-                                        (bv1, uu____6562) in
-                                      FStar_Syntax_Syntax.NT uu____6555 in
-                                    [uu____6554] in
+                                        (bv1, uu____6565) in
+                                      FStar_Syntax_Syntax.NT uu____6558 in
+                                    [uu____6557] in
                                   let bvs1 =
                                     FStar_List.map
                                       (fun b1 ->
-                                         let uu___962_6574 = b1 in
-                                         let uu____6575 =
+                                         let uu___964_6577 = b1 in
+                                         let uu____6578 =
                                            FStar_Syntax_Subst.subst s
                                              b1.FStar_Syntax_Syntax.sort in
                                          {
                                            FStar_Syntax_Syntax.ppname =
-                                             (uu___962_6574.FStar_Syntax_Syntax.ppname);
+                                             (uu___964_6577.FStar_Syntax_Syntax.ppname);
                                            FStar_Syntax_Syntax.index =
-                                             (uu___962_6574.FStar_Syntax_Syntax.index);
+                                             (uu___964_6577.FStar_Syntax_Syntax.index);
                                            FStar_Syntax_Syntax.sort =
-                                             uu____6575
+                                             uu____6578
                                          }) bvs in
                                   let env' = push_bvs e0 (bv'' :: bvs1) in
                                   FStar_Tactics_Monad.bind
                                     FStar_Tactics_Monad.dismiss
-                                    (fun uu____6582 ->
+                                    (fun uu____6585 ->
                                        let new_goal =
-                                         let uu____6584 =
+                                         let uu____6587 =
                                            FStar_Tactics_Types.goal_with_env
                                              goal env' in
-                                         let uu____6585 =
-                                           let uu____6586 =
+                                         let uu____6588 =
+                                           let uu____6589 =
                                              FStar_Tactics_Types.goal_type
                                                goal in
                                            FStar_Syntax_Subst.subst s
-                                             uu____6586 in
+                                             uu____6589 in
                                          FStar_Tactics_Types.goal_with_type
-                                           uu____6584 uu____6585 in
-                                       let uu____6587 =
+                                           uu____6587 uu____6588 in
+                                       let uu____6590 =
                                          FStar_Tactics_Monad.add_goals
                                            [new_goal] in
-                                       FStar_Tactics_Monad.bind uu____6587
-                                         (fun uu____6592 ->
-                                            let uu____6593 =
+                                       FStar_Tactics_Monad.bind uu____6590
+                                         (fun uu____6595 ->
+                                            let uu____6596 =
                                               FStar_Syntax_Util.mk_eq2
                                                 (FStar_Syntax_Syntax.U_succ u)
                                                 ty
@@ -3146,91 +3243,91 @@ let (binder_retype :
                                                 t' in
                                             FStar_Tactics_Monad.add_irrelevant_goal
                                               goal "binder_retype equation"
-                                              e0 uu____6593)))))) in
+                                              e0 uu____6596)))))) in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "binder_retype")
-      uu____6458
+      uu____6461
 let (norm_binder_type :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
     FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac)
   =
   fun s ->
     fun b ->
-      let uu____6616 =
+      let uu____6619 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal ->
-             let uu____6625 = b in
-             match uu____6625 with
-             | (bv, uu____6629) ->
-                 let uu____6634 =
-                   let uu____6645 = FStar_Tactics_Types.goal_env goal in
-                   split_env bv uu____6645 in
-                 (match uu____6634 with
+             let uu____6628 = b in
+             match uu____6628 with
+             | (bv, uu____6632) ->
+                 let uu____6637 =
+                   let uu____6648 = FStar_Tactics_Types.goal_env goal in
+                   split_env bv uu____6648 in
+                 (match uu____6637 with
                   | FStar_Pervasives_Native.None ->
                       FStar_Tactics_Monad.fail
                         "binder is not present in environment"
                   | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
                       let steps =
-                        let uu____6674 =
+                        let uu____6677 =
                           FStar_TypeChecker_Normalize.tr_norm_steps s in
                         FStar_List.append
                           [FStar_TypeChecker_Env.Reify;
-                          FStar_TypeChecker_Env.UnfoldTac] uu____6674 in
+                          FStar_TypeChecker_Env.UnfoldTac] uu____6677 in
                       let sort' =
                         normalize steps e0 bv1.FStar_Syntax_Syntax.sort in
                       let bv' =
-                        let uu___983_6679 = bv1 in
+                        let uu___985_6682 = bv1 in
                         {
                           FStar_Syntax_Syntax.ppname =
-                            (uu___983_6679.FStar_Syntax_Syntax.ppname);
+                            (uu___985_6682.FStar_Syntax_Syntax.ppname);
                           FStar_Syntax_Syntax.index =
-                            (uu___983_6679.FStar_Syntax_Syntax.index);
+                            (uu___985_6682.FStar_Syntax_Syntax.index);
                           FStar_Syntax_Syntax.sort = sort'
                         } in
                       let env' = push_bvs e0 (bv' :: bvs) in
-                      let uu____6681 =
+                      let uu____6684 =
                         FStar_Tactics_Types.goal_with_env goal env' in
-                      FStar_Tactics_Monad.replace_cur uu____6681)) in
+                      FStar_Tactics_Monad.replace_cur uu____6684)) in
       FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_binder_type")
-        uu____6616
+        uu____6619
 let (revert : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____6692 ->
+  fun uu____6695 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____6698 =
-           let uu____6705 = FStar_Tactics_Types.goal_env goal in
-           FStar_TypeChecker_Env.pop_bv uu____6705 in
-         match uu____6698 with
+         let uu____6701 =
+           let uu____6708 = FStar_Tactics_Types.goal_env goal in
+           FStar_TypeChecker_Env.pop_bv uu____6708 in
+         match uu____6701 with
          | FStar_Pervasives_Native.None ->
              FStar_Tactics_Monad.fail "Cannot revert; empty context"
          | FStar_Pervasives_Native.Some (x, env') ->
              let typ' =
-               let uu____6721 =
-                 let uu____6724 = FStar_Tactics_Types.goal_type goal in
-                 FStar_Syntax_Syntax.mk_Total uu____6724 in
+               let uu____6724 =
+                 let uu____6727 = FStar_Tactics_Types.goal_type goal in
+                 FStar_Syntax_Syntax.mk_Total uu____6727 in
                FStar_Syntax_Util.arrow [(x, FStar_Pervasives_Native.None)]
-                 uu____6721 in
-             let uu____6739 = FStar_Tactics_Monad.new_uvar "revert" env' typ' in
-             FStar_Tactics_Monad.bind uu____6739
-               (fun uu____6754 ->
-                  match uu____6754 with
+                 uu____6724 in
+             let uu____6742 = FStar_Tactics_Monad.new_uvar "revert" env' typ' in
+             FStar_Tactics_Monad.bind uu____6742
+               (fun uu____6757 ->
+                  match uu____6757 with
                   | (r, u_r) ->
-                      let uu____6763 =
-                        let uu____6766 =
-                          let uu____6767 =
-                            let uu____6768 =
-                              let uu____6777 =
+                      let uu____6766 =
+                        let uu____6769 =
+                          let uu____6770 =
+                            let uu____6771 =
+                              let uu____6780 =
                                 FStar_Syntax_Syntax.bv_to_name x in
-                              FStar_Syntax_Syntax.as_arg uu____6777 in
-                            [uu____6768] in
-                          let uu____6794 =
-                            let uu____6795 =
+                              FStar_Syntax_Syntax.as_arg uu____6780 in
+                            [uu____6771] in
+                          let uu____6797 =
+                            let uu____6798 =
                               FStar_Tactics_Types.goal_type goal in
-                            uu____6795.FStar_Syntax_Syntax.pos in
-                          FStar_Syntax_Syntax.mk_Tm_app r uu____6767
-                            uu____6794 in
-                        set_solution goal uu____6766 in
-                      FStar_Tactics_Monad.bind uu____6763
-                        (fun uu____6800 ->
+                            uu____6798.FStar_Syntax_Syntax.pos in
+                          FStar_Syntax_Syntax.mk_Tm_app r uu____6770
+                            uu____6797 in
+                        set_solution goal uu____6769 in
+                      FStar_Tactics_Monad.bind uu____6766
+                        (fun uu____6803 ->
                            let g =
                              FStar_Tactics_Types.mk_goal env' u_r
                                goal.FStar_Tactics_Types.opts
@@ -3241,30 +3338,30 @@ let (free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv ->
     fun t ->
-      let uu____6812 = FStar_Syntax_Free.names t in
-      FStar_Util.set_mem bv uu____6812
+      let uu____6815 = FStar_Syntax_Free.names t in
+      FStar_Util.set_mem bv uu____6815
 let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
     let bv = FStar_Pervasives_Native.fst b in
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Tactics_Monad.mlog
-           (fun uu____6832 ->
-              let uu____6833 = FStar_Syntax_Print.binder_to_string b in
-              let uu____6834 =
-                let uu____6835 =
-                  let uu____6836 =
-                    let uu____6845 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.all_binders uu____6845 in
-                  FStar_All.pipe_right uu____6836 FStar_List.length in
-                FStar_All.pipe_right uu____6835 FStar_Util.string_of_int in
+           (fun uu____6835 ->
+              let uu____6836 = FStar_Syntax_Print.binder_to_string b in
+              let uu____6837 =
+                let uu____6838 =
+                  let uu____6839 =
+                    let uu____6848 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.all_binders uu____6848 in
+                  FStar_All.pipe_right uu____6839 FStar_List.length in
+                FStar_All.pipe_right uu____6838 FStar_Util.string_of_int in
               FStar_Util.print2 "Clear of (%s), env has %s binders\n"
-                uu____6833 uu____6834)
-           (fun uu____6862 ->
-              let uu____6863 =
-                let uu____6874 = FStar_Tactics_Types.goal_env goal in
-                split_env bv uu____6874 in
-              match uu____6863 with
+                uu____6836 uu____6837)
+           (fun uu____6865 ->
+              let uu____6866 =
+                let uu____6877 = FStar_Tactics_Types.goal_env goal in
+                split_env bv uu____6877 in
+              match uu____6866 with
               | FStar_Pervasives_Native.None ->
                   FStar_Tactics_Monad.fail
                     "Cannot clear; binder not in environment"
@@ -3273,71 +3370,71 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                     match bvs1 with
                     | [] -> FStar_Tactics_Monad.ret ()
                     | bv'::bvs2 ->
-                        let uu____6918 =
+                        let uu____6921 =
                           free_in bv1 bv'.FStar_Syntax_Syntax.sort in
-                        if uu____6918
+                        if uu____6921
                         then
-                          let uu____6921 =
-                            let uu____6922 =
+                          let uu____6924 =
+                            let uu____6925 =
                               FStar_Syntax_Print.bv_to_string bv' in
                             FStar_Util.format1
                               "Cannot clear; binder present in the type of %s"
-                              uu____6922 in
-                          FStar_Tactics_Monad.fail uu____6921
+                              uu____6925 in
+                          FStar_Tactics_Monad.fail uu____6924
                         else check bvs2 in
-                  let uu____6924 =
-                    let uu____6925 = FStar_Tactics_Types.goal_type goal in
-                    free_in bv1 uu____6925 in
-                  if uu____6924
+                  let uu____6927 =
+                    let uu____6928 = FStar_Tactics_Types.goal_type goal in
+                    free_in bv1 uu____6928 in
+                  if uu____6927
                   then
                     FStar_Tactics_Monad.fail
                       "Cannot clear; binder present in goal"
                   else
-                    (let uu____6929 = check bvs in
-                     FStar_Tactics_Monad.bind uu____6929
-                       (fun uu____6935 ->
+                    (let uu____6932 = check bvs in
+                     FStar_Tactics_Monad.bind uu____6932
+                       (fun uu____6938 ->
                           let env' = push_bvs e' bvs in
-                          let uu____6937 =
-                            let uu____6944 =
+                          let uu____6940 =
+                            let uu____6947 =
                               FStar_Tactics_Types.goal_type goal in
                             FStar_Tactics_Monad.new_uvar "clear.witness" env'
-                              uu____6944 in
-                          FStar_Tactics_Monad.bind uu____6937
-                            (fun uu____6953 ->
-                               match uu____6953 with
+                              uu____6947 in
+                          FStar_Tactics_Monad.bind uu____6940
+                            (fun uu____6956 ->
+                               match uu____6956 with
                                | (ut, uvar_ut) ->
-                                   let uu____6962 = set_solution goal ut in
-                                   FStar_Tactics_Monad.bind uu____6962
-                                     (fun uu____6967 ->
-                                        let uu____6968 =
+                                   let uu____6965 = set_solution goal ut in
+                                   FStar_Tactics_Monad.bind uu____6965
+                                     (fun uu____6970 ->
+                                        let uu____6971 =
                                           FStar_Tactics_Types.mk_goal env'
                                             uvar_ut
                                             goal.FStar_Tactics_Types.opts
                                             goal.FStar_Tactics_Types.is_guard
                                             goal.FStar_Tactics_Types.label in
                                         FStar_Tactics_Monad.replace_cur
-                                          uu____6968))))))
+                                          uu____6971))))))
 let (clear_top : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____6975 ->
+  fun uu____6978 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____6981 =
-           let uu____6988 = FStar_Tactics_Types.goal_env goal in
-           FStar_TypeChecker_Env.pop_bv uu____6988 in
-         match uu____6981 with
+         let uu____6984 =
+           let uu____6991 = FStar_Tactics_Types.goal_env goal in
+           FStar_TypeChecker_Env.pop_bv uu____6991 in
+         match uu____6984 with
          | FStar_Pervasives_Native.None ->
              FStar_Tactics_Monad.fail "Cannot clear; empty context"
-         | FStar_Pervasives_Native.Some (x, uu____6996) ->
-             let uu____7001 = FStar_Syntax_Syntax.mk_binder x in
-             clear uu____7001)
+         | FStar_Pervasives_Native.Some (x, uu____6999) ->
+             let uu____7004 = FStar_Syntax_Syntax.mk_binder x in
+             clear uu____7004)
 let (prune : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
          let ctx = FStar_Tactics_Types.goal_env g in
          let ctx' =
-           let uu____7018 = FStar_Ident.path_of_text s in
-           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7018 in
+           let uu____7021 = FStar_Ident.path_of_text s in
+           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7021 in
          let g' = FStar_Tactics_Types.goal_with_env g ctx' in
          FStar_Tactics_Monad.replace_cur g')
 let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
@@ -3346,8 +3443,8 @@ let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
       (fun g ->
          let ctx = FStar_Tactics_Types.goal_env g in
          let ctx' =
-           let uu____7036 = FStar_Ident.path_of_text s in
-           FStar_TypeChecker_Env.add_proof_ns ctx uu____7036 in
+           let uu____7039 = FStar_Ident.path_of_text s in
+           FStar_TypeChecker_Env.add_proof_ns ctx uu____7039 in
          let g' = FStar_Tactics_Types.goal_with_env g ctx' in
          FStar_Tactics_Monad.replace_cur g')
 let (_trefl :
@@ -3358,112 +3455,112 @@ let (_trefl :
     fun r ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____7055 =
-             let uu____7058 = FStar_Tactics_Types.goal_env g in
-             do_unify uu____7058 l r in
-           FStar_Tactics_Monad.bind uu____7055
+           let uu____7058 =
+             let uu____7061 = FStar_Tactics_Types.goal_env g in
+             do_unify uu____7061 l r in
+           FStar_Tactics_Monad.bind uu____7058
              (fun b ->
                 if b
                 then solve' g FStar_Syntax_Util.exp_unit
                 else
                   (let l1 =
-                     let uu____7065 = FStar_Tactics_Types.goal_env g in
+                     let uu____7068 = FStar_Tactics_Types.goal_env g in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7065 l in
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7068 l in
                    let r1 =
-                     let uu____7067 = FStar_Tactics_Types.goal_env g in
+                     let uu____7070 = FStar_Tactics_Types.goal_env g in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7067 r in
-                   let uu____7068 =
-                     let uu____7071 = FStar_Tactics_Types.goal_env g in
-                     do_unify uu____7071 l1 r1 in
-                   FStar_Tactics_Monad.bind uu____7068
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7070 r in
+                   let uu____7071 =
+                     let uu____7074 = FStar_Tactics_Types.goal_env g in
+                     do_unify uu____7074 l1 r1 in
+                   FStar_Tactics_Monad.bind uu____7071
                      (fun b1 ->
                         if b1
                         then solve' g FStar_Syntax_Util.exp_unit
                         else
-                          (let uu____7077 =
-                             let uu____7082 =
-                               let uu____7087 =
+                          (let uu____7080 =
+                             let uu____7085 =
+                               let uu____7090 =
                                  FStar_Tactics_Types.goal_env g in
-                               tts uu____7087 in
+                               tts uu____7090 in
                              FStar_TypeChecker_Err.print_discrepancy
-                               uu____7082 l1 r1 in
-                           match uu____7077 with
+                               uu____7085 l1 r1 in
+                           match uu____7080 with
                            | (ls, rs) ->
                                fail2 "not a trivial equality ((%s) vs (%s))"
                                  ls rs)))))
 let (trefl : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7098 ->
-    let uu____7101 =
+  fun uu____7101 ->
+    let uu____7104 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____7109 =
-             let uu____7116 =
-               let uu____7117 = FStar_Tactics_Types.goal_env g in
-               let uu____7118 = FStar_Tactics_Types.goal_type g in
-               whnf uu____7117 uu____7118 in
-             destruct_eq uu____7116 in
-           match uu____7109 with
+           let uu____7112 =
+             let uu____7119 =
+               let uu____7120 = FStar_Tactics_Types.goal_env g in
+               let uu____7121 = FStar_Tactics_Types.goal_type g in
+               whnf uu____7120 uu____7121 in
+             destruct_eq uu____7119 in
+           match uu____7112 with
            | FStar_Pervasives_Native.Some (l, r) -> _trefl l r
            | FStar_Pervasives_Native.None ->
-               let uu____7131 =
-                 let uu____7132 = FStar_Tactics_Types.goal_env g in
-                 let uu____7133 = FStar_Tactics_Types.goal_type g in
-                 tts uu____7132 uu____7133 in
-               fail1 "not an equality (%s)" uu____7131) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7101
+               let uu____7134 =
+                 let uu____7135 = FStar_Tactics_Types.goal_env g in
+                 let uu____7136 = FStar_Tactics_Types.goal_type g in
+                 tts uu____7135 uu____7136 in
+               fail1 "not an equality (%s)" uu____7134) in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7104
 let (dup : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7144 ->
+  fun uu____7147 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
          let env1 = FStar_Tactics_Types.goal_env g in
-         let uu____7152 =
-           let uu____7159 = FStar_Tactics_Types.goal_type g in
-           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7159 in
-         FStar_Tactics_Monad.bind uu____7152
-           (fun uu____7168 ->
-              match uu____7168 with
+         let uu____7155 =
+           let uu____7162 = FStar_Tactics_Types.goal_type g in
+           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7162 in
+         FStar_Tactics_Monad.bind uu____7155
+           (fun uu____7171 ->
+              match uu____7171 with
               | (u, u_uvar) ->
                   let g' =
-                    let uu___1069_7178 = g in
+                    let uu___1071_7181 = g in
                     {
                       FStar_Tactics_Types.goal_main_env =
-                        (uu___1069_7178.FStar_Tactics_Types.goal_main_env);
+                        (uu___1071_7181.FStar_Tactics_Types.goal_main_env);
                       FStar_Tactics_Types.goal_ctx_uvar = u_uvar;
                       FStar_Tactics_Types.opts =
-                        (uu___1069_7178.FStar_Tactics_Types.opts);
+                        (uu___1071_7181.FStar_Tactics_Types.opts);
                       FStar_Tactics_Types.is_guard =
-                        (uu___1069_7178.FStar_Tactics_Types.is_guard);
+                        (uu___1071_7181.FStar_Tactics_Types.is_guard);
                       FStar_Tactics_Types.label =
-                        (uu___1069_7178.FStar_Tactics_Types.label)
+                        (uu___1071_7181.FStar_Tactics_Types.label)
                     } in
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____7182 ->
+                    (fun uu____7185 ->
                        let t_eq =
-                         let uu____7184 =
-                           let uu____7185 = FStar_Tactics_Types.goal_type g in
+                         let uu____7187 =
+                           let uu____7188 = FStar_Tactics_Types.goal_type g in
                            env1.FStar_TypeChecker_Env.universe_of env1
-                             uu____7185 in
-                         let uu____7186 = FStar_Tactics_Types.goal_type g in
-                         let uu____7187 = FStar_Tactics_Types.goal_witness g in
-                         FStar_Syntax_Util.mk_eq2 uu____7184 uu____7186 u
-                           uu____7187 in
-                       let uu____7188 =
+                             uu____7188 in
+                         let uu____7189 = FStar_Tactics_Types.goal_type g in
+                         let uu____7190 = FStar_Tactics_Types.goal_witness g in
+                         FStar_Syntax_Util.mk_eq2 uu____7187 uu____7189 u
+                           uu____7190 in
+                       let uu____7191 =
                          FStar_Tactics_Monad.add_irrelevant_goal g
                            "dup equation" env1 t_eq in
-                       FStar_Tactics_Monad.bind uu____7188
-                         (fun uu____7193 ->
-                            let uu____7194 =
+                       FStar_Tactics_Monad.bind uu____7191
+                         (fun uu____7196 ->
+                            let uu____7197 =
                               FStar_Tactics_Monad.add_goals [g'] in
-                            FStar_Tactics_Monad.bind uu____7194
-                              (fun uu____7198 -> FStar_Tactics_Monad.ret ())))))
+                            FStar_Tactics_Monad.bind uu____7197
+                              (fun uu____7201 -> FStar_Tactics_Monad.ret ())))))
 let longest_prefix :
   'a .
     ('a -> 'a -> Prims.bool) ->
@@ -3476,11 +3573,11 @@ let longest_prefix :
         let rec aux acc l11 l21 =
           match (l11, l21) with
           | (x::xs, y::ys) ->
-              let uu____7321 = f x y in
-              if uu____7321 then aux (x :: acc) xs ys else (acc, xs, ys)
-          | uu____7341 -> (acc, l11, l21) in
-        let uu____7356 = aux [] l1 l2 in
-        match uu____7356 with | (pr, t1, t2) -> ((FStar_List.rev pr), t1, t2)
+              let uu____7324 = f x y in
+              if uu____7324 then aux (x :: acc) xs ys else (acc, xs, ys)
+          | uu____7344 -> (acc, l11, l21) in
+        let uu____7359 = aux [] l1 l2 in
+        match uu____7359 with | (pr, t1, t2) -> ((FStar_List.rev pr), t1, t2)
 let (join_goals :
   FStar_Tactics_Types.goal ->
     FStar_Tactics_Types.goal ->
@@ -3494,13 +3591,13 @@ let (join_goals :
              fun f1 ->
                FStar_Syntax_Util.mk_forall_no_univ
                  (FStar_Pervasives_Native.fst b) f1) bs f in
-      let uu____7461 = FStar_Tactics_Types.get_phi g1 in
-      match uu____7461 with
+      let uu____7464 = FStar_Tactics_Types.get_phi g1 in
+      match uu____7464 with
       | FStar_Pervasives_Native.None ->
           FStar_Tactics_Monad.fail "goal 1 is not irrelevant"
       | FStar_Pervasives_Native.Some phi1 ->
-          let uu____7467 = FStar_Tactics_Types.get_phi g2 in
-          (match uu____7467 with
+          let uu____7470 = FStar_Tactics_Types.get_phi g2 in
+          (match uu____7470 with
            | FStar_Pervasives_Native.None ->
                FStar_Tactics_Monad.fail "goal 2 is not irrelevant"
            | FStar_Pervasives_Native.Some phi2 ->
@@ -3508,221 +3605,221 @@ let (join_goals :
                  (g1.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma in
                let gamma2 =
                  (g2.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma in
-               let uu____7479 =
+               let uu____7482 =
                  longest_prefix FStar_Syntax_Syntax.eq_binding
                    (FStar_List.rev gamma1) (FStar_List.rev gamma2) in
-               (match uu____7479 with
+               (match uu____7482 with
                 | (gamma, r1, r2) ->
                     let t1 =
-                      let uu____7510 =
+                      let uu____7513 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r1) in
-                      close_forall_no_univs uu____7510 phi1 in
+                      close_forall_no_univs uu____7513 phi1 in
                     let t2 =
-                      let uu____7520 =
+                      let uu____7523 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r2) in
-                      close_forall_no_univs uu____7520 phi2 in
-                    let uu____7529 =
+                      close_forall_no_univs uu____7523 phi2 in
+                    let uu____7532 =
                       set_solution g1 FStar_Syntax_Util.exp_unit in
-                    FStar_Tactics_Monad.bind uu____7529
-                      (fun uu____7534 ->
-                         let uu____7535 =
+                    FStar_Tactics_Monad.bind uu____7532
+                      (fun uu____7537 ->
+                         let uu____7538 =
                            set_solution g2 FStar_Syntax_Util.exp_unit in
-                         FStar_Tactics_Monad.bind uu____7535
-                           (fun uu____7542 ->
+                         FStar_Tactics_Monad.bind uu____7538
+                           (fun uu____7545 ->
                               let ng = FStar_Syntax_Util.mk_conj t1 t2 in
                               let nenv =
-                                let uu___1121_7547 =
+                                let uu___1123_7550 =
                                   FStar_Tactics_Types.goal_env g1 in
-                                let uu____7548 =
+                                let uu____7551 =
                                   FStar_Util.smap_create (Prims.of_int (100)) in
                                 {
                                   FStar_TypeChecker_Env.solver =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.solver);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.solver);
                                   FStar_TypeChecker_Env.range =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.range);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.range);
                                   FStar_TypeChecker_Env.curmodule =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.curmodule);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.curmodule);
                                   FStar_TypeChecker_Env.gamma =
                                     (FStar_List.rev gamma);
                                   FStar_TypeChecker_Env.gamma_sig =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.gamma_sig);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.gamma_sig);
                                   FStar_TypeChecker_Env.gamma_cache =
-                                    uu____7548;
+                                    uu____7551;
                                   FStar_TypeChecker_Env.modules =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.modules);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.modules);
                                   FStar_TypeChecker_Env.expected_typ =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.expected_typ);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.expected_typ);
                                   FStar_TypeChecker_Env.sigtab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.sigtab);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.sigtab);
                                   FStar_TypeChecker_Env.attrtab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.attrtab);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.attrtab);
                                   FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.instantiate_imp);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.instantiate_imp);
                                   FStar_TypeChecker_Env.effects =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.effects);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.effects);
                                   FStar_TypeChecker_Env.generalize =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.generalize);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.generalize);
                                   FStar_TypeChecker_Env.letrecs =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.letrecs);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.letrecs);
                                   FStar_TypeChecker_Env.top_level =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.top_level);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.top_level);
                                   FStar_TypeChecker_Env.check_uvars =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.check_uvars);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.check_uvars);
                                   FStar_TypeChecker_Env.use_eq =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.use_eq);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.use_eq);
                                   FStar_TypeChecker_Env.use_eq_strict =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.use_eq_strict);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.is_iface);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.admit);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.admit);
                                   FStar_TypeChecker_Env.lax =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.lax);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.lax_universes);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.phase1);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.phase1);
                                   FStar_TypeChecker_Env.failhard =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.failhard);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.failhard);
                                   FStar_TypeChecker_Env.nosynth =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.nosynth);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.nosynth);
                                   FStar_TypeChecker_Env.uvar_subtyping =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.uvar_subtyping);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.tc_term =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.tc_term);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.type_of =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.type_of);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.type_of);
                                   FStar_TypeChecker_Env.universe_of =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.universe_of);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.universe_of);
                                   FStar_TypeChecker_Env.check_type_of =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.check_type_of);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.check_type_of);
                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.use_bv_sorts);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.qtbl_name_and_index);
                                   FStar_TypeChecker_Env.normalized_eff_names
                                     =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.normalized_eff_names);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.normalized_eff_names);
                                   FStar_TypeChecker_Env.fv_delta_depths =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.fv_delta_depths);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.fv_delta_depths);
                                   FStar_TypeChecker_Env.proof_ns =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.proof_ns);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.proof_ns);
                                   FStar_TypeChecker_Env.synth_hook =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.synth_hook);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.synth_hook);
                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                     =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                   FStar_TypeChecker_Env.splice =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.splice);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.splice);
                                   FStar_TypeChecker_Env.mpreprocess =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.mpreprocess);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.mpreprocess);
                                   FStar_TypeChecker_Env.postprocess =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.postprocess);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.postprocess);
                                   FStar_TypeChecker_Env.identifier_info =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.identifier_info);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.identifier_info);
                                   FStar_TypeChecker_Env.tc_hooks =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.tc_hooks);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.tc_hooks);
                                   FStar_TypeChecker_Env.dsenv =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.dsenv);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.dsenv);
                                   FStar_TypeChecker_Env.nbe =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.nbe);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.strict_args_tab);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.strict_args_tab);
                                   FStar_TypeChecker_Env.erasable_types_tab =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.erasable_types_tab);
+                                    (uu___1123_7550.FStar_TypeChecker_Env.erasable_types_tab);
                                   FStar_TypeChecker_Env.enable_defer_to_tac =
-                                    (uu___1121_7547.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                    (uu___1123_7550.FStar_TypeChecker_Env.enable_defer_to_tac)
                                 } in
-                              let uu____7551 =
+                              let uu____7554 =
                                 FStar_Tactics_Monad.mk_irrelevant_goal
                                   "joined" nenv ng
                                   g1.FStar_Tactics_Types.opts
                                   g1.FStar_Tactics_Types.label in
-                              FStar_Tactics_Monad.bind uu____7551
+                              FStar_Tactics_Monad.bind uu____7554
                                 (fun goal ->
                                    FStar_Tactics_Monad.mlog
-                                     (fun uu____7560 ->
-                                        let uu____7561 =
+                                     (fun uu____7563 ->
+                                        let uu____7564 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g1 in
-                                        let uu____7562 =
+                                        let uu____7565 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g2 in
-                                        let uu____7563 =
+                                        let uu____7566 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             goal in
                                         FStar_Util.print3
                                           "join_goals of\n(%s)\nand\n(%s)\n= (%s)\n"
-                                          uu____7561 uu____7562 uu____7563)
-                                     (fun uu____7565 ->
+                                          uu____7564 uu____7565 uu____7566)
+                                     (fun uu____7568 ->
                                         FStar_Tactics_Monad.ret goal))))))
 let (join : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7572 ->
+  fun uu____7575 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          match ps.FStar_Tactics_Types.goals with
          | g1::g2::gs ->
-             let uu____7588 =
+             let uu____7591 =
                FStar_Tactics_Monad.set
-                 (let uu___1136_7593 = ps in
+                 (let uu___1138_7596 = ps in
                   {
                     FStar_Tactics_Types.main_context =
-                      (uu___1136_7593.FStar_Tactics_Types.main_context);
+                      (uu___1138_7596.FStar_Tactics_Types.main_context);
                     FStar_Tactics_Types.all_implicits =
-                      (uu___1136_7593.FStar_Tactics_Types.all_implicits);
+                      (uu___1138_7596.FStar_Tactics_Types.all_implicits);
                     FStar_Tactics_Types.goals = gs;
                     FStar_Tactics_Types.smt_goals =
-                      (uu___1136_7593.FStar_Tactics_Types.smt_goals);
+                      (uu___1138_7596.FStar_Tactics_Types.smt_goals);
                     FStar_Tactics_Types.depth =
-                      (uu___1136_7593.FStar_Tactics_Types.depth);
+                      (uu___1138_7596.FStar_Tactics_Types.depth);
                     FStar_Tactics_Types.__dump =
-                      (uu___1136_7593.FStar_Tactics_Types.__dump);
+                      (uu___1138_7596.FStar_Tactics_Types.__dump);
                     FStar_Tactics_Types.psc =
-                      (uu___1136_7593.FStar_Tactics_Types.psc);
+                      (uu___1138_7596.FStar_Tactics_Types.psc);
                     FStar_Tactics_Types.entry_range =
-                      (uu___1136_7593.FStar_Tactics_Types.entry_range);
+                      (uu___1138_7596.FStar_Tactics_Types.entry_range);
                     FStar_Tactics_Types.guard_policy =
-                      (uu___1136_7593.FStar_Tactics_Types.guard_policy);
+                      (uu___1138_7596.FStar_Tactics_Types.guard_policy);
                     FStar_Tactics_Types.freshness =
-                      (uu___1136_7593.FStar_Tactics_Types.freshness);
+                      (uu___1138_7596.FStar_Tactics_Types.freshness);
                     FStar_Tactics_Types.tac_verb_dbg =
-                      (uu___1136_7593.FStar_Tactics_Types.tac_verb_dbg);
+                      (uu___1138_7596.FStar_Tactics_Types.tac_verb_dbg);
                     FStar_Tactics_Types.local_state =
-                      (uu___1136_7593.FStar_Tactics_Types.local_state)
+                      (uu___1138_7596.FStar_Tactics_Types.local_state)
                   }) in
-             FStar_Tactics_Monad.bind uu____7588
-               (fun uu____7596 ->
-                  let uu____7597 = join_goals g1 g2 in
-                  FStar_Tactics_Monad.bind uu____7597
+             FStar_Tactics_Monad.bind uu____7591
+               (fun uu____7599 ->
+                  let uu____7600 = join_goals g1 g2 in
+                  FStar_Tactics_Monad.bind uu____7600
                     (fun g12 -> FStar_Tactics_Monad.add_goals [g12]))
-         | uu____7602 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
+         | uu____7605 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
 let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s ->
-    let uu____7614 =
+    let uu____7617 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
            FStar_Options.push ();
-           (let uu____7627 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts in
-            FStar_Options.set uu____7627);
+           (let uu____7630 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts in
+            FStar_Options.set uu____7630);
            (let res = FStar_Options.set_options s in
             let opts' = FStar_Options.peek () in
             FStar_Options.pop ();
             (match res with
              | FStar_Getopt.Success ->
                  let g' =
-                   let uu___1147_7634 = g in
+                   let uu___1149_7637 = g in
                    {
                      FStar_Tactics_Types.goal_main_env =
-                       (uu___1147_7634.FStar_Tactics_Types.goal_main_env);
+                       (uu___1149_7637.FStar_Tactics_Types.goal_main_env);
                      FStar_Tactics_Types.goal_ctx_uvar =
-                       (uu___1147_7634.FStar_Tactics_Types.goal_ctx_uvar);
+                       (uu___1149_7637.FStar_Tactics_Types.goal_ctx_uvar);
                      FStar_Tactics_Types.opts = opts';
                      FStar_Tactics_Types.is_guard =
-                       (uu___1147_7634.FStar_Tactics_Types.is_guard);
+                       (uu___1149_7637.FStar_Tactics_Types.is_guard);
                      FStar_Tactics_Types.label =
-                       (uu___1147_7634.FStar_Tactics_Types.label)
+                       (uu___1149_7637.FStar_Tactics_Types.label)
                    } in
                  FStar_Tactics_Monad.replace_cur g'
              | FStar_Getopt.Error err ->
@@ -3730,22 +3827,22 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
              | FStar_Getopt.Help ->
                  fail1 "Setting options `%s` failed (got `Help`?)" s))) in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "set_options")
-      uu____7614
+      uu____7617
 let (top_env : unit -> env FStar_Tactics_Monad.tac) =
-  fun uu____7646 ->
+  fun uu____7649 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          FStar_All.pipe_left FStar_Tactics_Monad.ret
            ps.FStar_Tactics_Types.main_context)
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
-  fun uu____7659 ->
+  fun uu____7662 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
-         let uu____7665 =
+         let uu____7668 =
            (FStar_Options.lax ()) ||
-             (let uu____7667 = FStar_Tactics_Types.goal_env g in
-              uu____7667.FStar_TypeChecker_Env.lax) in
-         FStar_Tactics_Monad.ret uu____7665)
+             (let uu____7670 = FStar_Tactics_Types.goal_env g in
+              uu____7670.FStar_TypeChecker_Env.lax) in
+         FStar_Tactics_Monad.ret uu____7668)
 let (unquote :
   FStar_Reflection_Data.typ ->
     FStar_Syntax_Syntax.term ->
@@ -3753,42 +3850,42 @@ let (unquote :
   =
   fun ty ->
     fun tm ->
-      let uu____7682 =
+      let uu____7685 =
         FStar_Tactics_Monad.mlog
-          (fun uu____7687 ->
-             let uu____7688 = FStar_Syntax_Print.term_to_string tm in
-             FStar_Util.print1 "unquote: tm = %s\n" uu____7688)
           (fun uu____7690 ->
+             let uu____7691 = FStar_Syntax_Print.term_to_string tm in
+             FStar_Util.print1 "unquote: tm = %s\n" uu____7691)
+          (fun uu____7693 ->
              FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                (fun goal ->
                   let env1 =
-                    let uu____7696 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.set_expected_typ uu____7696 ty in
-                  let uu____7697 = __tc_ghost env1 tm in
-                  FStar_Tactics_Monad.bind uu____7697
-                    (fun uu____7716 ->
-                       match uu____7716 with
+                    let uu____7699 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.set_expected_typ uu____7699 ty in
+                  let uu____7700 = __tc_ghost env1 tm in
+                  FStar_Tactics_Monad.bind uu____7700
+                    (fun uu____7719 ->
+                       match uu____7719 with
                        | (tm1, typ, guard) ->
                            FStar_Tactics_Monad.mlog
-                             (fun uu____7730 ->
-                                let uu____7731 =
+                             (fun uu____7733 ->
+                                let uu____7734 =
                                   FStar_Syntax_Print.term_to_string tm1 in
                                 FStar_Util.print1 "unquote: tm' = %s\n"
-                                  uu____7731)
-                             (fun uu____7733 ->
+                                  uu____7734)
+                             (fun uu____7736 ->
                                 FStar_Tactics_Monad.mlog
-                                  (fun uu____7736 ->
-                                     let uu____7737 =
+                                  (fun uu____7739 ->
+                                     let uu____7740 =
                                        FStar_Syntax_Print.term_to_string typ in
                                      FStar_Util.print1 "unquote: typ = %s\n"
-                                       uu____7737)
-                                  (fun uu____7740 ->
-                                     let uu____7741 =
+                                       uu____7740)
+                                  (fun uu____7743 ->
+                                     let uu____7744 =
                                        proc_guard "unquote" env1 guard in
-                                     FStar_Tactics_Monad.bind uu____7741
-                                       (fun uu____7745 ->
+                                     FStar_Tactics_Monad.bind uu____7744
+                                       (fun uu____7748 ->
                                           FStar_Tactics_Monad.ret tm1)))))) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____7682
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____7685
 let (uvar_env :
   env ->
     FStar_Reflection_Data.typ FStar_Pervasives_Native.option ->
@@ -3796,148 +3893,148 @@ let (uvar_env :
   =
   fun env1 ->
     fun ty ->
-      let uu____7768 =
+      let uu____7771 =
         match ty with
         | FStar_Pervasives_Native.Some ty1 -> FStar_Tactics_Monad.ret ty1
         | FStar_Pervasives_Native.None ->
-            let uu____7774 =
-              let uu____7781 =
-                let uu____7782 = FStar_Syntax_Util.type_u () in
-                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7782 in
-              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____7781 in
-            FStar_Tactics_Monad.bind uu____7774
-              (fun uu____7798 ->
-                 match uu____7798 with
+            let uu____7777 =
+              let uu____7784 =
+                let uu____7785 = FStar_Syntax_Util.type_u () in
+                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7785 in
+              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____7784 in
+            FStar_Tactics_Monad.bind uu____7777
+              (fun uu____7801 ->
+                 match uu____7801 with
                  | (typ, uvar_typ) -> FStar_Tactics_Monad.ret typ) in
-      FStar_Tactics_Monad.bind uu____7768
+      FStar_Tactics_Monad.bind uu____7771
         (fun typ ->
-           let uu____7810 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ in
-           FStar_Tactics_Monad.bind uu____7810
-             (fun uu____7824 ->
-                match uu____7824 with
+           let uu____7813 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ in
+           FStar_Tactics_Monad.bind uu____7813
+             (fun uu____7827 ->
+                match uu____7827 with
                 | (t, uvar_t) -> FStar_Tactics_Monad.ret t))
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
-    let uu____7842 =
+    let uu____7845 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            let env1 = ps.FStar_Tactics_Types.main_context in
            let opts =
              match ps.FStar_Tactics_Types.goals with
-             | g::uu____7861 -> g.FStar_Tactics_Types.opts
-             | uu____7864 -> FStar_Options.peek () in
-           let uu____7867 = FStar_Syntax_Util.head_and_args t in
-           match uu____7867 with
+             | g::uu____7864 -> g.FStar_Tactics_Types.opts
+             | uu____7867 -> FStar_Options.peek () in
+           let uu____7870 = FStar_Syntax_Util.head_and_args t in
+           match uu____7870 with
            | ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                  (ctx_uvar, uu____7887);
-                FStar_Syntax_Syntax.pos = uu____7888;
-                FStar_Syntax_Syntax.vars = uu____7889;_},
-              uu____7890) ->
+                  (ctx_uvar, uu____7890);
+                FStar_Syntax_Syntax.pos = uu____7891;
+                FStar_Syntax_Syntax.vars = uu____7892;_},
+              uu____7893) ->
                let env2 =
-                 let uu___1201_7932 = env1 in
+                 let uu___1203_7935 = env1 in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___1201_7932.FStar_TypeChecker_Env.solver);
+                     (uu___1203_7935.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___1201_7932.FStar_TypeChecker_Env.range);
+                     (uu___1203_7935.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___1201_7932.FStar_TypeChecker_Env.curmodule);
+                     (uu___1203_7935.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
                      (ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___1201_7932.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___1203_7935.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___1201_7932.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___1203_7935.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___1201_7932.FStar_TypeChecker_Env.modules);
+                     (uu___1203_7935.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___1201_7932.FStar_TypeChecker_Env.expected_typ);
+                     (uu___1203_7935.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.sigtab);
+                     (uu___1203_7935.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.attrtab);
+                     (uu___1203_7935.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___1201_7932.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___1203_7935.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___1201_7932.FStar_TypeChecker_Env.effects);
+                     (uu___1203_7935.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___1201_7932.FStar_TypeChecker_Env.generalize);
+                     (uu___1203_7935.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___1201_7932.FStar_TypeChecker_Env.letrecs);
+                     (uu___1203_7935.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level =
-                     (uu___1201_7932.FStar_TypeChecker_Env.top_level);
+                     (uu___1203_7935.FStar_TypeChecker_Env.top_level);
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___1201_7932.FStar_TypeChecker_Env.check_uvars);
+                     (uu___1203_7935.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___1201_7932.FStar_TypeChecker_Env.use_eq);
+                     (uu___1203_7935.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.use_eq_strict =
-                     (uu___1201_7932.FStar_TypeChecker_Env.use_eq_strict);
+                     (uu___1203_7935.FStar_TypeChecker_Env.use_eq_strict);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___1201_7932.FStar_TypeChecker_Env.is_iface);
+                     (uu___1203_7935.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___1201_7932.FStar_TypeChecker_Env.admit);
+                     (uu___1203_7935.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___1201_7932.FStar_TypeChecker_Env.lax);
+                     (uu___1203_7935.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___1201_7932.FStar_TypeChecker_Env.lax_universes);
+                     (uu___1203_7935.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___1201_7932.FStar_TypeChecker_Env.phase1);
+                     (uu___1203_7935.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___1201_7932.FStar_TypeChecker_Env.failhard);
+                     (uu___1203_7935.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___1201_7932.FStar_TypeChecker_Env.nosynth);
+                     (uu___1203_7935.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___1201_7932.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___1203_7935.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___1201_7932.FStar_TypeChecker_Env.tc_term);
+                     (uu___1203_7935.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___1201_7932.FStar_TypeChecker_Env.type_of);
+                     (uu___1203_7935.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___1201_7932.FStar_TypeChecker_Env.universe_of);
+                     (uu___1203_7935.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___1201_7932.FStar_TypeChecker_Env.check_type_of);
+                     (uu___1203_7935.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___1201_7932.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___1203_7935.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___1201_7932.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___1203_7935.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___1201_7932.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___1203_7935.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___1201_7932.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___1203_7935.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___1201_7932.FStar_TypeChecker_Env.proof_ns);
+                     (uu___1203_7935.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___1201_7932.FStar_TypeChecker_Env.synth_hook);
+                     (uu___1203_7935.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.try_solve_implicits_hook =
-                     (uu___1201_7932.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     (uu___1203_7935.FStar_TypeChecker_Env.try_solve_implicits_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___1201_7932.FStar_TypeChecker_Env.splice);
+                     (uu___1203_7935.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.mpreprocess =
-                     (uu___1201_7932.FStar_TypeChecker_Env.mpreprocess);
+                     (uu___1203_7935.FStar_TypeChecker_Env.mpreprocess);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___1201_7932.FStar_TypeChecker_Env.postprocess);
+                     (uu___1203_7935.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___1201_7932.FStar_TypeChecker_Env.identifier_info);
+                     (uu___1203_7935.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___1201_7932.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___1203_7935.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___1201_7932.FStar_TypeChecker_Env.dsenv);
+                     (uu___1203_7935.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___1201_7932.FStar_TypeChecker_Env.nbe);
+                     (uu___1203_7935.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.strict_args_tab);
+                     (uu___1203_7935.FStar_TypeChecker_Env.strict_args_tab);
                    FStar_TypeChecker_Env.erasable_types_tab =
-                     (uu___1201_7932.FStar_TypeChecker_Env.erasable_types_tab);
+                     (uu___1203_7935.FStar_TypeChecker_Env.erasable_types_tab);
                    FStar_TypeChecker_Env.enable_defer_to_tac =
-                     (uu___1201_7932.FStar_TypeChecker_Env.enable_defer_to_tac)
+                     (uu___1203_7935.FStar_TypeChecker_Env.enable_defer_to_tac)
                  } in
                let g =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
-               let uu____7934 = let uu____7937 = bnorm_goal g in [uu____7937] in
-               FStar_Tactics_Monad.add_goals uu____7934
-           | uu____7938 -> FStar_Tactics_Monad.fail "not a uvar") in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____7842
+               let uu____7937 = let uu____7940 = bnorm_goal g in [uu____7940] in
+               FStar_Tactics_Monad.add_goals uu____7937
+           | uu____7941 -> FStar_Tactics_Monad.fail "not a uvar") in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____7845
 let (tac_and :
   Prims.bool FStar_Tactics_Monad.tac ->
     Prims.bool FStar_Tactics_Monad.tac -> Prims.bool FStar_Tactics_Monad.tac)
@@ -3947,16 +4044,16 @@ let (tac_and :
       let comp =
         FStar_Tactics_Monad.bind t1
           (fun b ->
-             let uu____7987 = if b then t2 else FStar_Tactics_Monad.ret false in
-             FStar_Tactics_Monad.bind uu____7987
+             let uu____7990 = if b then t2 else FStar_Tactics_Monad.ret false in
+             FStar_Tactics_Monad.bind uu____7990
                (fun b' ->
                   if b'
                   then FStar_Tactics_Monad.ret b'
                   else FStar_Tactics_Monad.fail "")) in
-      let uu____7998 = trytac comp in
-      FStar_Tactics_Monad.bind uu____7998
-        (fun uu___5_8006 ->
-           match uu___5_8006 with
+      let uu____8001 = trytac comp in
+      FStar_Tactics_Monad.bind uu____8001
+        (fun uu___5_8009 ->
+           match uu___5_8009 with
            | FStar_Pervasives_Native.Some (true) ->
                FStar_Tactics_Monad.ret true
            | FStar_Pervasives_Native.Some (false) -> failwith "impossible"
@@ -3969,34 +4066,34 @@ let (match_env :
   fun e ->
     fun t1 ->
       fun t2 ->
-        let uu____8032 =
+        let uu____8035 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
-               let uu____8038 = __tc e t1 in
-               FStar_Tactics_Monad.bind uu____8038
-                 (fun uu____8058 ->
-                    match uu____8058 with
+               let uu____8041 = __tc e t1 in
+               FStar_Tactics_Monad.bind uu____8041
+                 (fun uu____8061 ->
+                    match uu____8061 with
                     | (t11, ty1, g1) ->
-                        let uu____8070 = __tc e t2 in
-                        FStar_Tactics_Monad.bind uu____8070
-                          (fun uu____8090 ->
-                             match uu____8090 with
+                        let uu____8073 = __tc e t2 in
+                        FStar_Tactics_Monad.bind uu____8073
+                          (fun uu____8093 ->
+                             match uu____8093 with
                              | (t21, ty2, g2) ->
-                                 let uu____8102 =
+                                 let uu____8105 =
                                    proc_guard "match_env g1" e g1 in
-                                 FStar_Tactics_Monad.bind uu____8102
-                                   (fun uu____8107 ->
-                                      let uu____8108 =
+                                 FStar_Tactics_Monad.bind uu____8105
+                                   (fun uu____8110 ->
+                                      let uu____8111 =
                                         proc_guard "match_env g2" e g2 in
-                                      FStar_Tactics_Monad.bind uu____8108
-                                        (fun uu____8114 ->
-                                           let uu____8115 =
-                                             do_match e ty1 ty2 in
+                                      FStar_Tactics_Monad.bind uu____8111
+                                        (fun uu____8117 ->
                                            let uu____8118 =
+                                             do_match e ty1 ty2 in
+                                           let uu____8121 =
                                              do_match e t11 t21 in
-                                           tac_and uu____8115 uu____8118))))) in
+                                           tac_and uu____8118 uu____8121))))) in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "match_env")
-          uu____8032
+          uu____8035
 let (unify_env :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -4005,34 +4102,34 @@ let (unify_env :
   fun e ->
     fun t1 ->
       fun t2 ->
-        let uu____8144 =
+        let uu____8147 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
-               let uu____8150 = __tc e t1 in
-               FStar_Tactics_Monad.bind uu____8150
-                 (fun uu____8170 ->
-                    match uu____8170 with
+               let uu____8153 = __tc e t1 in
+               FStar_Tactics_Monad.bind uu____8153
+                 (fun uu____8173 ->
+                    match uu____8173 with
                     | (t11, ty1, g1) ->
-                        let uu____8182 = __tc e t2 in
-                        FStar_Tactics_Monad.bind uu____8182
-                          (fun uu____8202 ->
-                             match uu____8202 with
+                        let uu____8185 = __tc e t2 in
+                        FStar_Tactics_Monad.bind uu____8185
+                          (fun uu____8205 ->
+                             match uu____8205 with
                              | (t21, ty2, g2) ->
-                                 let uu____8214 =
+                                 let uu____8217 =
                                    proc_guard "unify_env g1" e g1 in
-                                 FStar_Tactics_Monad.bind uu____8214
-                                   (fun uu____8219 ->
-                                      let uu____8220 =
+                                 FStar_Tactics_Monad.bind uu____8217
+                                   (fun uu____8222 ->
+                                      let uu____8223 =
                                         proc_guard "unify_env g2" e g2 in
-                                      FStar_Tactics_Monad.bind uu____8220
-                                        (fun uu____8226 ->
-                                           let uu____8227 =
-                                             do_unify e ty1 ty2 in
+                                      FStar_Tactics_Monad.bind uu____8223
+                                        (fun uu____8229 ->
                                            let uu____8230 =
+                                             do_unify e ty1 ty2 in
+                                           let uu____8233 =
                                              do_unify e t11 t21 in
-                                           tac_and uu____8227 uu____8230))))) in
+                                           tac_and uu____8230 uu____8233))))) in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unify_env")
-          uu____8144
+          uu____8147
 let (launch_process :
   Prims.string ->
     Prims.string Prims.list ->
@@ -4042,9 +4139,9 @@ let (launch_process :
     fun args ->
       fun input ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-          (fun uu____8263 ->
-             let uu____8264 = FStar_Options.unsafe_tactic_exec () in
-             if uu____8264
+          (fun uu____8266 ->
+             let uu____8267 = FStar_Options.unsafe_tactic_exec () in
+             if uu____8267
              then
                let s =
                  FStar_Util.run_process "tactic_launch" prog args
@@ -4061,47 +4158,47 @@ let (fresh_bv_named :
   fun nm ->
     fun t ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-        (fun uu____8285 ->
-           let uu____8286 =
+        (fun uu____8288 ->
+           let uu____8289 =
              FStar_Syntax_Syntax.gen_bv nm FStar_Pervasives_Native.None t in
-           FStar_Tactics_Monad.ret uu____8286)
+           FStar_Tactics_Monad.ret uu____8289)
 let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
   fun ty ->
-    let uu____8296 =
+    let uu____8299 =
       FStar_Tactics_Monad.mlog
-        (fun uu____8301 ->
-           let uu____8302 = FStar_Syntax_Print.term_to_string ty in
-           FStar_Util.print1 "change: ty = %s\n" uu____8302)
         (fun uu____8304 ->
+           let uu____8305 = FStar_Syntax_Print.term_to_string ty in
+           FStar_Util.print1 "change: ty = %s\n" uu____8305)
+        (fun uu____8307 ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g ->
-                let uu____8308 =
-                  let uu____8317 = FStar_Tactics_Types.goal_env g in
-                  __tc uu____8317 ty in
-                FStar_Tactics_Monad.bind uu____8308
-                  (fun uu____8329 ->
-                     match uu____8329 with
-                     | (ty1, uu____8339, guard) ->
-                         let uu____8341 =
-                           let uu____8344 = FStar_Tactics_Types.goal_env g in
-                           proc_guard "change" uu____8344 guard in
-                         FStar_Tactics_Monad.bind uu____8341
-                           (fun uu____8347 ->
-                              let uu____8348 =
-                                let uu____8351 =
+                let uu____8311 =
+                  let uu____8320 = FStar_Tactics_Types.goal_env g in
+                  __tc uu____8320 ty in
+                FStar_Tactics_Monad.bind uu____8311
+                  (fun uu____8332 ->
+                     match uu____8332 with
+                     | (ty1, uu____8342, guard) ->
+                         let uu____8344 =
+                           let uu____8347 = FStar_Tactics_Types.goal_env g in
+                           proc_guard "change" uu____8347 guard in
+                         FStar_Tactics_Monad.bind uu____8344
+                           (fun uu____8350 ->
+                              let uu____8351 =
+                                let uu____8354 =
                                   FStar_Tactics_Types.goal_env g in
-                                let uu____8352 =
+                                let uu____8355 =
                                   FStar_Tactics_Types.goal_type g in
-                                do_unify uu____8351 uu____8352 ty1 in
-                              FStar_Tactics_Monad.bind uu____8348
+                                do_unify uu____8354 uu____8355 ty1 in
+                              FStar_Tactics_Monad.bind uu____8351
                                 (fun bb ->
                                    if bb
                                    then
-                                     let uu____8358 =
+                                     let uu____8361 =
                                        FStar_Tactics_Types.goal_with_type g
                                          ty1 in
                                      FStar_Tactics_Monad.replace_cur
-                                       uu____8358
+                                       uu____8361
                                    else
                                      (let steps =
                                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -4109,32 +4206,32 @@ let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
                                           FStar_Syntax_Syntax.delta_constant;
                                         FStar_TypeChecker_Env.Primops] in
                                       let ng =
-                                        let uu____8364 =
-                                          FStar_Tactics_Types.goal_env g in
-                                        let uu____8365 =
-                                          FStar_Tactics_Types.goal_type g in
-                                        normalize steps uu____8364 uu____8365 in
-                                      let nty =
                                         let uu____8367 =
                                           FStar_Tactics_Types.goal_env g in
-                                        normalize steps uu____8367 ty1 in
-                                      let uu____8368 =
-                                        let uu____8371 =
+                                        let uu____8368 =
+                                          FStar_Tactics_Types.goal_type g in
+                                        normalize steps uu____8367 uu____8368 in
+                                      let nty =
+                                        let uu____8370 =
                                           FStar_Tactics_Types.goal_env g in
-                                        do_unify uu____8371 ng nty in
-                                      FStar_Tactics_Monad.bind uu____8368
+                                        normalize steps uu____8370 ty1 in
+                                      let uu____8371 =
+                                        let uu____8374 =
+                                          FStar_Tactics_Types.goal_env g in
+                                        do_unify uu____8374 ng nty in
+                                      FStar_Tactics_Monad.bind uu____8371
                                         (fun b ->
                                            if b
                                            then
-                                             let uu____8377 =
+                                             let uu____8380 =
                                                FStar_Tactics_Types.goal_with_type
                                                  g ty1 in
                                              FStar_Tactics_Monad.replace_cur
-                                               uu____8377
+                                               uu____8380
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible"))))))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8296
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8299
 let failwhen :
   'a .
     Prims.bool ->
@@ -4149,66 +4246,66 @@ let (t_destruct :
       FStar_Tactics_Monad.tac)
   =
   fun s_tm ->
-    let uu____8440 =
+    let uu____8443 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____8458 =
-             let uu____8467 = FStar_Tactics_Types.goal_env g in
-             __tc uu____8467 s_tm in
-           FStar_Tactics_Monad.bind uu____8458
-             (fun uu____8485 ->
-                match uu____8485 with
+           let uu____8461 =
+             let uu____8470 = FStar_Tactics_Types.goal_env g in
+             __tc uu____8470 s_tm in
+           FStar_Tactics_Monad.bind uu____8461
+             (fun uu____8488 ->
+                match uu____8488 with
                 | (s_tm1, s_ty, guard) ->
-                    let uu____8503 =
-                      let uu____8506 = FStar_Tactics_Types.goal_env g in
-                      proc_guard "destruct" uu____8506 guard in
-                    FStar_Tactics_Monad.bind uu____8503
-                      (fun uu____8519 ->
+                    let uu____8506 =
+                      let uu____8509 = FStar_Tactics_Types.goal_env g in
+                      proc_guard "destruct" uu____8509 guard in
+                    FStar_Tactics_Monad.bind uu____8506
+                      (fun uu____8522 ->
                          let s_ty1 =
-                           let uu____8521 = FStar_Tactics_Types.goal_env g in
+                           let uu____8524 = FStar_Tactics_Types.goal_env g in
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.UnfoldTac;
                              FStar_TypeChecker_Env.Weak;
                              FStar_TypeChecker_Env.HNF;
                              FStar_TypeChecker_Env.UnfoldUntil
-                               FStar_Syntax_Syntax.delta_constant] uu____8521
+                               FStar_Syntax_Syntax.delta_constant] uu____8524
                              s_ty in
-                         let uu____8522 =
-                           let uu____8537 = FStar_Syntax_Util.unrefine s_ty1 in
-                           FStar_Syntax_Util.head_and_args' uu____8537 in
-                         match uu____8522 with
+                         let uu____8525 =
+                           let uu____8540 = FStar_Syntax_Util.unrefine s_ty1 in
+                           FStar_Syntax_Util.head_and_args' uu____8540 in
+                         match uu____8525 with
                          | (h, args) ->
-                             let uu____8568 =
-                               let uu____8575 =
-                                 let uu____8576 =
+                             let uu____8571 =
+                               let uu____8578 =
+                                 let uu____8579 =
                                    FStar_Syntax_Subst.compress h in
-                                 uu____8576.FStar_Syntax_Syntax.n in
-                               match uu____8575 with
+                                 uu____8579.FStar_Syntax_Syntax.n in
+                               match uu____8578 with
                                | FStar_Syntax_Syntax.Tm_fvar fv ->
                                    FStar_Tactics_Monad.ret (fv, [])
                                | FStar_Syntax_Syntax.Tm_uinst
                                    ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_fvar fv;
-                                      FStar_Syntax_Syntax.pos = uu____8591;
-                                      FStar_Syntax_Syntax.vars = uu____8592;_},
+                                      FStar_Syntax_Syntax.pos = uu____8594;
+                                      FStar_Syntax_Syntax.vars = uu____8595;_},
                                     us)
                                    -> FStar_Tactics_Monad.ret (fv, us)
-                               | uu____8602 ->
+                               | uu____8605 ->
                                    FStar_Tactics_Monad.fail
                                      "type is not an fv" in
-                             FStar_Tactics_Monad.bind uu____8568
-                               (fun uu____8622 ->
-                                  match uu____8622 with
+                             FStar_Tactics_Monad.bind uu____8571
+                               (fun uu____8625 ->
+                                  match uu____8625 with
                                   | (fv, a_us) ->
                                       let t_lid =
                                         FStar_Syntax_Syntax.lid_of_fv fv in
-                                      let uu____8638 =
-                                        let uu____8641 =
+                                      let uu____8641 =
+                                        let uu____8644 =
                                           FStar_Tactics_Types.goal_env g in
                                         FStar_TypeChecker_Env.lookup_sigelt
-                                          uu____8641 t_lid in
-                                      (match uu____8638 with
+                                          uu____8644 t_lid in
+                                      (match uu____8641 with
                                        | FStar_Pervasives_Native.None ->
                                            FStar_Tactics_Monad.fail
                                              "type not found in environment"
@@ -4223,16 +4320,16 @@ let (t_destruct :
                                                   FStar_Syntax_Util.has_attribute
                                                     se.FStar_Syntax_Syntax.sigattrs
                                                     FStar_Parser_Const.erasable_attr in
-                                                let uu____8680 =
+                                                let uu____8683 =
                                                   erasable &&
-                                                    (let uu____8682 =
+                                                    (let uu____8685 =
                                                        FStar_Tactics_Types.is_irrelevant
                                                          g in
                                                      Prims.op_Negation
-                                                       uu____8682) in
-                                                failwhen uu____8680
+                                                       uu____8685) in
+                                                failwhen uu____8683
                                                   "cannot destruct erasable type to solve proof-relevant goal"
-                                                  (fun uu____8690 ->
+                                                  (fun uu____8693 ->
                                                      failwhen
                                                        ((FStar_List.length
                                                            a_us)
@@ -4240,28 +4337,28 @@ let (t_destruct :
                                                           (FStar_List.length
                                                              t_us))
                                                        "t_us don't match?"
-                                                       (fun uu____8702 ->
-                                                          let uu____8703 =
+                                                       (fun uu____8705 ->
+                                                          let uu____8706 =
                                                             FStar_Syntax_Subst.open_term
                                                               t_ps t_ty in
-                                                          match uu____8703
+                                                          match uu____8706
                                                           with
                                                           | (t_ps1, t_ty1) ->
-                                                              let uu____8718
+                                                              let uu____8721
                                                                 =
                                                                 FStar_Tactics_Monad.mapM
                                                                   (fun c_lid
                                                                     ->
-                                                                    let uu____8746
-                                                                    =
                                                                     let uu____8749
+                                                                    =
+                                                                    let uu____8752
                                                                     =
                                                                     FStar_Tactics_Types.goal_env
                                                                     g in
                                                                     FStar_TypeChecker_Env.lookup_sigelt
-                                                                    uu____8749
+                                                                    uu____8752
                                                                     c_lid in
-                                                                    match uu____8746
+                                                                    match uu____8749
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
@@ -4295,7 +4392,7 @@ let (t_destruct :
                                                                     c_us))
                                                                     "t_us don't match?"
                                                                     (fun
-                                                                    uu____8822
+                                                                    uu____8825
                                                                     ->
                                                                     let s =
                                                                     FStar_TypeChecker_Env.mk_univ_subst
@@ -4304,26 +4401,26 @@ let (t_destruct :
                                                                     =
                                                                     FStar_Syntax_Subst.subst
                                                                     s c_ty in
-                                                                    let uu____8827
+                                                                    let uu____8830
                                                                     =
                                                                     FStar_TypeChecker_Env.inst_tscheme
                                                                     (c_us,
                                                                     c_ty1) in
-                                                                    match uu____8827
+                                                                    match uu____8830
                                                                     with
                                                                     | 
                                                                     (c_us1,
                                                                     c_ty2) ->
-                                                                    let uu____8850
+                                                                    let uu____8853
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     c_ty2 in
-                                                                    (match uu____8850
+                                                                    (match uu____8853
                                                                     with
                                                                     | 
                                                                     (bs,
                                                                     comp) ->
-                                                                    let uu____8869
+                                                                    let uu____8872
                                                                     =
                                                                     let rename_bv
                                                                     bv =
@@ -4332,123 +4429,123 @@ let (t_destruct :
                                                                     bv.FStar_Syntax_Syntax.ppname in
                                                                     let ppname1
                                                                     =
-                                                                    let uu____8892
+                                                                    let uu____8895
                                                                     =
-                                                                    let uu____8897
+                                                                    let uu____8900
                                                                     =
-                                                                    let uu____8898
+                                                                    let uu____8901
                                                                     =
                                                                     FStar_Ident.string_of_id
                                                                     ppname in
                                                                     Prims.op_Hat
                                                                     "a"
-                                                                    uu____8898 in
-                                                                    let uu____8899
+                                                                    uu____8901 in
+                                                                    let uu____8902
                                                                     =
                                                                     FStar_Ident.range_of_id
                                                                     ppname in
-                                                                    (uu____8897,
-                                                                    uu____8899) in
+                                                                    (uu____8900,
+                                                                    uu____8902) in
                                                                     FStar_Ident.mk_ident
-                                                                    uu____8892 in
+                                                                    uu____8895 in
                                                                     FStar_Syntax_Syntax.freshen_bv
-                                                                    (let uu___1343_8902
+                                                                    (let uu___1345_8905
                                                                     = bv in
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     = ppname1;
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1343_8902.FStar_Syntax_Syntax.index);
+                                                                    (uu___1345_8905.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
-                                                                    (uu___1343_8902.FStar_Syntax_Syntax.sort)
+                                                                    (uu___1345_8905.FStar_Syntax_Syntax.sort)
                                                                     }) in
                                                                     let bs' =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____8928
+                                                                    uu____8931
                                                                     ->
-                                                                    match uu____8928
+                                                                    match uu____8931
                                                                     with
                                                                     | 
                                                                     (bv, aq)
                                                                     ->
-                                                                    let uu____8947
+                                                                    let uu____8950
                                                                     =
                                                                     rename_bv
                                                                     bv in
-                                                                    (uu____8947,
+                                                                    (uu____8950,
                                                                     aq)) bs in
                                                                     let subst
                                                                     =
                                                                     FStar_List.map2
                                                                     (fun
-                                                                    uu____8972
+                                                                    uu____8975
                                                                     ->
                                                                     fun
-                                                                    uu____8973
+                                                                    uu____8976
                                                                     ->
                                                                     match 
-                                                                    (uu____8972,
-                                                                    uu____8973)
+                                                                    (uu____8975,
+                                                                    uu____8976)
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____8999),
+                                                                    uu____9002),
                                                                     (bv',
-                                                                    uu____9001))
+                                                                    uu____9004))
                                                                     ->
-                                                                    let uu____9022
+                                                                    let uu____9025
                                                                     =
-                                                                    let uu____9029
+                                                                    let uu____9032
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv' in
                                                                     (bv,
-                                                                    uu____9029) in
+                                                                    uu____9032) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____9022)
+                                                                    uu____9025)
                                                                     bs bs' in
-                                                                    let uu____9034
+                                                                    let uu____9037
                                                                     =
                                                                     FStar_Syntax_Subst.subst_binders
                                                                     subst bs' in
-                                                                    let uu____9043
+                                                                    let uu____9046
                                                                     =
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subst
                                                                     comp in
-                                                                    (uu____9034,
-                                                                    uu____9043) in
-                                                                    (match uu____8869
+                                                                    (uu____9037,
+                                                                    uu____9046) in
+                                                                    (match uu____8872
                                                                     with
                                                                     | 
                                                                     (bs1,
                                                                     comp1) ->
-                                                                    let uu____9090
+                                                                    let uu____9093
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     bs1 in
-                                                                    (match uu____9090
+                                                                    (match uu____9093
                                                                     with
                                                                     | 
                                                                     (d_ps,
                                                                     bs2) ->
-                                                                    let uu____9163
+                                                                    let uu____9166
                                                                     =
-                                                                    let uu____9164
+                                                                    let uu____9167
                                                                     =
                                                                     FStar_Syntax_Util.is_total_comp
                                                                     comp1 in
                                                                     Prims.op_Negation
-                                                                    uu____9164 in
+                                                                    uu____9167 in
                                                                     failwhen
-                                                                    uu____9163
+                                                                    uu____9166
                                                                     "not total?"
                                                                     (fun
-                                                                    uu____9181
+                                                                    uu____9184
                                                                     ->
                                                                     let mk_pat
                                                                     p =
@@ -4460,24 +4557,24 @@ let (t_destruct :
                                                                     (s_tm1.FStar_Syntax_Syntax.pos)
                                                                     } in
                                                                     let is_imp
-                                                                    uu___6_9197
+                                                                    uu___6_9200
                                                                     =
-                                                                    match uu___6_9197
+                                                                    match uu___6_9200
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
-                                                                    uu____9200)
+                                                                    uu____9203)
                                                                     -> true
                                                                     | 
-                                                                    uu____9201
+                                                                    uu____9204
                                                                     -> false in
-                                                                    let uu____9204
+                                                                    let uu____9207
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     args in
-                                                                    match uu____9204
+                                                                    match uu____9207
                                                                     with
                                                                     | 
                                                                     (a_ps,
@@ -4489,7 +4586,7 @@ let (t_destruct :
                                                                     d_ps))
                                                                     "params not match?"
                                                                     (fun
-                                                                    uu____9339
+                                                                    uu____9342
                                                                     ->
                                                                     let d_ps_a_ps
                                                                     =
@@ -4499,15 +4596,15 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9401
+                                                                    uu____9404
                                                                     ->
-                                                                    match uu____9401
+                                                                    match uu____9404
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____9421),
+                                                                    uu____9424),
                                                                     (t,
-                                                                    uu____9423))
+                                                                    uu____9426))
                                                                     ->
                                                                     FStar_Syntax_Syntax.NT
                                                                     (bv, t))
@@ -4519,15 +4616,15 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9491
+                                                                    uu____9494
                                                                     ->
-                                                                    match uu____9491
+                                                                    match uu____9494
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____9517),
+                                                                    uu____9520),
                                                                     (t,
-                                                                    uu____9519))
+                                                                    uu____9522))
                                                                     ->
                                                                     ((mk_pat
                                                                     (FStar_Syntax_Syntax.Pat_dot_term
@@ -4538,9 +4635,9 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9574
+                                                                    uu____9577
                                                                     ->
-                                                                    match uu____9574
+                                                                    match uu____9577
                                                                     with
                                                                     | 
                                                                     (bv, aq)
@@ -4571,171 +4668,171 @@ let (t_destruct :
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1
                                                                     s_ty1 in
-                                                                    let uu____9624
+                                                                    let uu____9627
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_pat
-                                                                    (let uu___1402_9647
+                                                                    (let uu___1404_9650
                                                                     = env1 in
                                                                     {
                                                                     FStar_TypeChecker_Env.solver
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.solver);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.solver);
                                                                     FStar_TypeChecker_Env.range
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.range);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.range);
                                                                     FStar_TypeChecker_Env.curmodule
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.curmodule);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.curmodule);
                                                                     FStar_TypeChecker_Env.gamma
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.gamma);
                                                                     FStar_TypeChecker_Env.gamma_sig
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma_sig);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.gamma_sig);
                                                                     FStar_TypeChecker_Env.gamma_cache
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma_cache);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.gamma_cache);
                                                                     FStar_TypeChecker_Env.modules
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.modules);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.modules);
                                                                     FStar_TypeChecker_Env.expected_typ
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.expected_typ);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.expected_typ);
                                                                     FStar_TypeChecker_Env.sigtab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.sigtab);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.sigtab);
                                                                     FStar_TypeChecker_Env.attrtab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.attrtab);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.attrtab);
                                                                     FStar_TypeChecker_Env.instantiate_imp
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.instantiate_imp);
                                                                     FStar_TypeChecker_Env.effects
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.effects);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.effects);
                                                                     FStar_TypeChecker_Env.generalize
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.generalize);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.generalize);
                                                                     FStar_TypeChecker_Env.letrecs
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.letrecs);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.letrecs);
                                                                     FStar_TypeChecker_Env.top_level
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.top_level);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.top_level);
                                                                     FStar_TypeChecker_Env.check_uvars
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.check_uvars);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.check_uvars);
                                                                     FStar_TypeChecker_Env.use_eq
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_eq);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.use_eq);
                                                                     FStar_TypeChecker_Env.use_eq_strict
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_eq_strict);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.use_eq_strict);
                                                                     FStar_TypeChecker_Env.is_iface
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.is_iface);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.admit);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.admit);
                                                                     FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.lax_universes);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.lax_universes);
                                                                     FStar_TypeChecker_Env.phase1
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.phase1);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.phase1);
                                                                     FStar_TypeChecker_Env.failhard
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.failhard);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.failhard);
                                                                     FStar_TypeChecker_Env.nosynth
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.nosynth);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.nosynth);
                                                                     FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.uvar_subtyping);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.tc_term);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.tc_term);
                                                                     FStar_TypeChecker_Env.type_of
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.type_of);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.type_of);
                                                                     FStar_TypeChecker_Env.universe_of
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.universe_of);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.universe_of);
                                                                     FStar_TypeChecker_Env.check_type_of
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.check_type_of);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.check_type_of);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.use_bv_sorts);
                                                                     FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                     FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.normalized_eff_names);
                                                                     FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.fv_delta_depths);
                                                                     FStar_TypeChecker_Env.proof_ns
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.proof_ns);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.proof_ns);
                                                                     FStar_TypeChecker_Env.synth_hook
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.synth_hook);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.synth_hook);
                                                                     FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                     FStar_TypeChecker_Env.splice
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.splice);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.splice);
                                                                     FStar_TypeChecker_Env.mpreprocess
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.mpreprocess);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.mpreprocess);
                                                                     FStar_TypeChecker_Env.postprocess
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.postprocess);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.postprocess);
                                                                     FStar_TypeChecker_Env.identifier_info
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.identifier_info);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.identifier_info);
                                                                     FStar_TypeChecker_Env.tc_hooks
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.tc_hooks);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.tc_hooks);
                                                                     FStar_TypeChecker_Env.dsenv
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.dsenv);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.dsenv);
                                                                     FStar_TypeChecker_Env.nbe
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.nbe);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.nbe);
                                                                     FStar_TypeChecker_Env.strict_args_tab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.strict_args_tab);
                                                                     FStar_TypeChecker_Env.erasable_types_tab
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.erasable_types_tab);
                                                                     FStar_TypeChecker_Env.enable_defer_to_tac
                                                                     =
-                                                                    (uu___1402_9647.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                    (uu___1404_9650.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                                     }) s_ty1
                                                                     pat in
-                                                                    match uu____9624
+                                                                    match uu____9627
                                                                     with
                                                                     | 
-                                                                    (uu____9660,
-                                                                    uu____9661,
-                                                                    uu____9662,
-                                                                    uu____9663,
-                                                                    pat_t,
+                                                                    (uu____9663,
+                                                                    uu____9664,
                                                                     uu____9665,
+                                                                    uu____9666,
+                                                                    pat_t,
+                                                                    uu____9668,
                                                                     _guard_pat,
                                                                     _erasable)
                                                                     ->
                                                                     let eq_b
                                                                     =
-                                                                    let uu____9677
+                                                                    let uu____9680
                                                                     =
-                                                                    let uu____9678
+                                                                    let uu____9681
                                                                     =
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     equ s_ty1
@@ -4743,46 +4840,46 @@ let (t_destruct :
                                                                     pat_t in
                                                                     FStar_Syntax_Util.mk_squash
                                                                     equ
-                                                                    uu____9678 in
+                                                                    uu____9681 in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "breq"
                                                                     FStar_Pervasives_Native.None
-                                                                    uu____9677 in
+                                                                    uu____9680 in
                                                                     let cod1
                                                                     =
-                                                                    let uu____9682
+                                                                    let uu____9685
                                                                     =
-                                                                    let uu____9691
+                                                                    let uu____9694
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     eq_b in
-                                                                    [uu____9691] in
-                                                                    let uu____9710
+                                                                    [uu____9694] in
+                                                                    let uu____9713
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____9682
-                                                                    uu____9710 in
+                                                                    uu____9685
+                                                                    uu____9713 in
                                                                     let nty =
-                                                                    let uu____9716
+                                                                    let uu____9719
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod1 in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs3
-                                                                    uu____9716 in
-                                                                    let uu____9719
+                                                                    uu____9719 in
+                                                                    let uu____9722
                                                                     =
                                                                     FStar_Tactics_Monad.new_uvar
                                                                     "destruct branch"
                                                                     env1 nty in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9719
+                                                                    uu____9722
                                                                     (fun
-                                                                    uu____9748
+                                                                    uu____9751
                                                                     ->
-                                                                    match uu____9748
+                                                                    match uu____9751
                                                                     with
                                                                     | 
                                                                     (uvt, uv)
@@ -4798,51 +4895,51 @@ let (t_destruct :
                                                                     uvt bs3 in
                                                                     let brt1
                                                                     =
-                                                                    let uu____9774
+                                                                    let uu____9777
                                                                     =
-                                                                    let uu____9785
+                                                                    let uu____9788
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Util.exp_unit in
-                                                                    [uu____9785] in
+                                                                    [uu____9788] in
                                                                     FStar_Syntax_Util.mk_app
                                                                     brt
-                                                                    uu____9774 in
+                                                                    uu____9777 in
                                                                     let br =
                                                                     FStar_Syntax_Subst.close_branch
                                                                     (pat,
                                                                     FStar_Pervasives_Native.None,
                                                                     brt1) in
-                                                                    let uu____9821
+                                                                    let uu____9824
                                                                     =
-                                                                    let uu____9832
+                                                                    let uu____9835
                                                                     =
-                                                                    let uu____9837
+                                                                    let uu____9840
                                                                     =
                                                                     FStar_BigInt.of_int_fs
                                                                     (FStar_List.length
                                                                     bs3) in
                                                                     (fv1,
-                                                                    uu____9837) in
+                                                                    uu____9840) in
                                                                     (g', br,
-                                                                    uu____9832) in
+                                                                    uu____9835) in
                                                                     FStar_Tactics_Monad.ret
-                                                                    uu____9821)))))))
+                                                                    uu____9824)))))))
                                                                     | 
-                                                                    uu____9858
+                                                                    uu____9861
                                                                     ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "impossible: not a ctor"))
                                                                   c_lids in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____8718
+                                                                uu____8721
                                                                 (fun goal_brs
                                                                    ->
-                                                                   let uu____9907
+                                                                   let uu____9910
                                                                     =
                                                                     FStar_List.unzip3
                                                                     goal_brs in
-                                                                   match uu____9907
+                                                                   match uu____9910
                                                                    with
                                                                    | 
                                                                    (goals,
@@ -4854,56 +4951,56 @@ let (t_destruct :
                                                                     (s_tm1,
                                                                     brs))
                                                                     s_tm1.FStar_Syntax_Syntax.pos in
-                                                                    let uu____9980
+                                                                    let uu____9983
                                                                     =
                                                                     solve' g
                                                                     w in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9980
+                                                                    uu____9983
                                                                     (fun
-                                                                    uu____9991
+                                                                    uu____9994
                                                                     ->
-                                                                    let uu____9992
+                                                                    let uu____9995
                                                                     =
                                                                     FStar_Tactics_Monad.add_goals
                                                                     goals in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9992
+                                                                    uu____9995
                                                                     (fun
-                                                                    uu____10002
+                                                                    uu____10005
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     infos)))))
-                                            | uu____10009 ->
+                                            | uu____10012 ->
                                                 FStar_Tactics_Monad.fail
                                                   "not an inductive type")))))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8440
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8443
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
-    | uu____10054::xs -> last xs
+    | uu____10057::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____10082 = init xs in x :: uu____10082
+    | x::xs -> let uu____10085 = init xs in x :: uu____10085
 let rec (inspect :
   FStar_Syntax_Syntax.term ->
     FStar_Reflection_Data.term_view FStar_Tactics_Monad.tac)
   =
   fun t ->
-    let uu____10094 =
-      let uu____10097 = top_env () in
-      FStar_Tactics_Monad.bind uu____10097
+    let uu____10097 =
+      let uu____10100 = top_env () in
+      FStar_Tactics_Monad.bind uu____10100
         (fun e ->
            let t1 = FStar_Syntax_Util.unascribe t in
            let t2 = FStar_Syntax_Util.un_uinst t1 in
            let t3 = FStar_Syntax_Util.unlazy_emb t2 in
            match t3.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_meta (t4, uu____10113) -> inspect t4
+           | FStar_Syntax_Syntax.Tm_meta (t4, uu____10116) -> inspect t4
            | FStar_Syntax_Syntax.Tm_name bv ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Var bv)
@@ -4916,75 +5013,75 @@ let rec (inspect :
            | FStar_Syntax_Syntax.Tm_app (hd, []) ->
                failwith "empty arguments on Tm_app"
            | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-               let uu____10178 = last args in
-               (match uu____10178 with
+               let uu____10181 = last args in
+               (match uu____10181 with
                 | (a, q) ->
                     let q' = FStar_Reflection_Basic.inspect_aqual q in
-                    let uu____10208 =
-                      let uu____10209 =
-                        let uu____10214 =
-                          let uu____10215 = init args in
-                          FStar_Syntax_Syntax.mk_Tm_app hd uu____10215
+                    let uu____10211 =
+                      let uu____10212 =
+                        let uu____10217 =
+                          let uu____10218 = init args in
+                          FStar_Syntax_Syntax.mk_Tm_app hd uu____10218
                             t3.FStar_Syntax_Syntax.pos in
-                        (uu____10214, (a, q')) in
-                      FStar_Reflection_Data.Tv_App uu____10209 in
-                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10208)
-           | FStar_Syntax_Syntax.Tm_abs ([], uu____10226, uu____10227) ->
+                        (uu____10217, (a, q')) in
+                      FStar_Reflection_Data.Tv_App uu____10212 in
+                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10211)
+           | FStar_Syntax_Syntax.Tm_abs ([], uu____10229, uu____10230) ->
                failwith "empty arguments on Tm_abs"
            | FStar_Syntax_Syntax.Tm_abs (bs, t4, k) ->
-               let uu____10279 = FStar_Syntax_Subst.open_term bs t4 in
-               (match uu____10279 with
+               let uu____10282 = FStar_Syntax_Subst.open_term bs t4 in
+               (match uu____10282 with
                 | (bs1, t5) ->
                     (match bs1 with
                      | [] -> failwith "impossible"
                      | b::bs2 ->
-                         let uu____10320 =
-                           let uu____10321 =
-                             let uu____10326 = FStar_Syntax_Util.abs bs2 t5 k in
-                             (b, uu____10326) in
-                           FStar_Reflection_Data.Tv_Abs uu____10321 in
+                         let uu____10323 =
+                           let uu____10324 =
+                             let uu____10329 = FStar_Syntax_Util.abs bs2 t5 k in
+                             (b, uu____10329) in
+                           FStar_Reflection_Data.Tv_Abs uu____10324 in
                          FStar_All.pipe_left FStar_Tactics_Monad.ret
-                           uu____10320))
-           | FStar_Syntax_Syntax.Tm_type uu____10329 ->
+                           uu____10323))
+           | FStar_Syntax_Syntax.Tm_type uu____10332 ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Type ())
            | FStar_Syntax_Syntax.Tm_arrow ([], k) ->
                failwith "empty binders on arrow"
-           | FStar_Syntax_Syntax.Tm_arrow uu____10353 ->
-               let uu____10368 = FStar_Syntax_Util.arrow_one t3 in
-               (match uu____10368 with
+           | FStar_Syntax_Syntax.Tm_arrow uu____10356 ->
+               let uu____10371 = FStar_Syntax_Util.arrow_one t3 in
+               (match uu____10371 with
                 | FStar_Pervasives_Native.Some (b, c) ->
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Arrow (b, c))
                 | FStar_Pervasives_Native.None -> failwith "impossible")
            | FStar_Syntax_Syntax.Tm_refine (bv, t4) ->
                let b = FStar_Syntax_Syntax.mk_binder bv in
-               let uu____10398 = FStar_Syntax_Subst.open_term [b] t4 in
-               (match uu____10398 with
+               let uu____10401 = FStar_Syntax_Subst.open_term [b] t4 in
+               (match uu____10401 with
                 | (b', t5) ->
                     let b1 =
                       match b' with
                       | b'1::[] -> b'1
-                      | uu____10451 -> failwith "impossible" in
+                      | uu____10454 -> failwith "impossible" in
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Refine
                          ((FStar_Pervasives_Native.fst b1), t5)))
            | FStar_Syntax_Syntax.Tm_constant c ->
-               let uu____10463 =
-                 let uu____10464 = FStar_Reflection_Basic.inspect_const c in
-                 FStar_Reflection_Data.Tv_Const uu____10464 in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10463
+               let uu____10466 =
+                 let uu____10467 = FStar_Reflection_Basic.inspect_const c in
+                 FStar_Reflection_Data.Tv_Const uu____10467 in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10466
            | FStar_Syntax_Syntax.Tm_uvar (ctx_u, s) ->
-               let uu____10485 =
-                 let uu____10486 =
-                   let uu____10491 =
-                     let uu____10492 =
+               let uu____10488 =
+                 let uu____10489 =
+                   let uu____10494 =
+                     let uu____10495 =
                        FStar_Syntax_Unionfind.uvar_id
                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                     FStar_BigInt.of_int_fs uu____10492 in
-                   (uu____10491, (ctx_u, s)) in
-                 FStar_Reflection_Data.Tv_Uvar uu____10486 in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10485
+                     FStar_BigInt.of_int_fs uu____10495 in
+                   (uu____10494, (ctx_u, s)) in
+                 FStar_Reflection_Data.Tv_Uvar uu____10489 in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10488
            | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), t21) ->
                if lb.FStar_Syntax_Syntax.lbunivs <> []
                then
@@ -4992,18 +5089,18 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____10526 ->
+                  | FStar_Util.Inr uu____10529 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
                       let b = FStar_Syntax_Syntax.mk_binder bv in
-                      let uu____10531 = FStar_Syntax_Subst.open_term [b] t21 in
-                      (match uu____10531 with
+                      let uu____10534 = FStar_Syntax_Subst.open_term [b] t21 in
+                      (match uu____10534 with
                        | (bs, t22) ->
                            let b1 =
                              match bs with
                              | b1::[] -> b1
-                             | uu____10584 ->
+                             | uu____10587 ->
                                  failwith
                                    "impossible: open_term returned different amount of binders" in
                            FStar_All.pipe_left FStar_Tactics_Monad.ret
@@ -5018,18 +5115,18 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____10620 ->
+                  | FStar_Util.Inr uu____10623 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
-                      let uu____10624 =
+                      let uu____10627 =
                         FStar_Syntax_Subst.open_let_rec [lb] t21 in
-                      (match uu____10624 with
+                      (match uu____10627 with
                        | (lbs, t22) ->
                            (match lbs with
                             | lb1::[] ->
                                 (match lb1.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____10644 ->
+                                 | FStar_Util.Inr uu____10647 ->
                                      FStar_Tactics_Monad.ret
                                        FStar_Reflection_Data.Tv_Unknown
                                  | FStar_Util.Inl bv1 ->
@@ -5041,26 +5138,26 @@ let rec (inspect :
                                             bv1,
                                             (lb1.FStar_Syntax_Syntax.lbdef),
                                             t22)))
-                            | uu____10650 ->
+                            | uu____10653 ->
                                 failwith
                                   "impossible: open_term returned different amount of binders")))
            | FStar_Syntax_Syntax.Tm_match (t4, brs) ->
                let rec inspect_pat p =
                  match p.FStar_Syntax_Syntax.v with
                  | FStar_Syntax_Syntax.Pat_constant c ->
-                     let uu____10704 = FStar_Reflection_Basic.inspect_const c in
-                     FStar_Reflection_Data.Pat_Constant uu____10704
+                     let uu____10707 = FStar_Reflection_Basic.inspect_const c in
+                     FStar_Reflection_Data.Pat_Constant uu____10707
                  | FStar_Syntax_Syntax.Pat_cons (fv, ps) ->
-                     let uu____10723 =
-                       let uu____10734 =
+                     let uu____10726 =
+                       let uu____10737 =
                          FStar_List.map
-                           (fun uu____10755 ->
-                              match uu____10755 with
+                           (fun uu____10758 ->
+                              match uu____10758 with
                               | (p1, b) ->
-                                  let uu____10772 = inspect_pat p1 in
-                                  (uu____10772, b)) ps in
-                       (fv, uu____10734) in
-                     FStar_Reflection_Data.Pat_Cons uu____10723
+                                  let uu____10775 = inspect_pat p1 in
+                                  (uu____10775, b)) ps in
+                       (fv, uu____10737) in
+                     FStar_Reflection_Data.Pat_Cons uu____10726
                  | FStar_Syntax_Syntax.Pat_var bv ->
                      FStar_Reflection_Data.Pat_Var bv
                  | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -5070,30 +5167,30 @@ let rec (inspect :
                let brs1 = FStar_List.map FStar_Syntax_Subst.open_branch brs in
                let brs2 =
                  FStar_List.map
-                   (fun uu___7_10866 ->
-                      match uu___7_10866 with
-                      | (pat, uu____10888, t5) ->
-                          let uu____10906 = inspect_pat pat in
-                          (uu____10906, t5)) brs1 in
+                   (fun uu___7_10869 ->
+                      match uu___7_10869 with
+                      | (pat, uu____10891, t5) ->
+                          let uu____10909 = inspect_pat pat in
+                          (uu____10909, t5)) brs1 in
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Match (t4, brs2))
            | FStar_Syntax_Syntax.Tm_unknown ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____10915 ->
-               ((let uu____10917 =
-                   let uu____10922 =
-                     let uu____10923 = FStar_Syntax_Print.tag_of_term t3 in
-                     let uu____10924 = term_to_string e t3 in
+           | uu____10918 ->
+               ((let uu____10920 =
+                   let uu____10925 =
+                     let uu____10926 = FStar_Syntax_Print.tag_of_term t3 in
+                     let uu____10927 = term_to_string e t3 in
                      FStar_Util.format2
                        "inspect: outside of expected syntax (%s, %s)\n"
-                       uu____10923 uu____10924 in
-                   (FStar_Errors.Warning_CantInspect, uu____10922) in
+                       uu____10926 uu____10927 in
+                   (FStar_Errors.Warning_CantInspect, uu____10925) in
                  FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos
-                   uu____10917);
+                   uu____10920);
                 FStar_All.pipe_left FStar_Tactics_Monad.ret
                   FStar_Reflection_Data.Tv_Unknown)) in
-    FStar_Tactics_Monad.wrap_err "inspect" uu____10094
+    FStar_Tactics_Monad.wrap_err "inspect" uu____10097
 let (pack :
   FStar_Reflection_Data.term_view ->
     FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac)
@@ -5101,72 +5198,72 @@ let (pack :
   fun tv ->
     match tv with
     | FStar_Reflection_Data.Tv_Var bv ->
-        let uu____10937 = FStar_Syntax_Syntax.bv_to_name bv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10937
+        let uu____10940 = FStar_Syntax_Syntax.bv_to_name bv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10940
     | FStar_Reflection_Data.Tv_BVar bv ->
-        let uu____10941 = FStar_Syntax_Syntax.bv_to_tm bv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10941
+        let uu____10944 = FStar_Syntax_Syntax.bv_to_tm bv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10944
     | FStar_Reflection_Data.Tv_FVar fv ->
-        let uu____10945 = FStar_Syntax_Syntax.fv_to_tm fv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10945
+        let uu____10948 = FStar_Syntax_Syntax.fv_to_tm fv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10948
     | FStar_Reflection_Data.Tv_App (l, (r, q)) ->
         let q' = FStar_Reflection_Basic.pack_aqual q in
-        let uu____10952 = FStar_Syntax_Util.mk_app l [(r, q')] in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10952
+        let uu____10955 = FStar_Syntax_Util.mk_app l [(r, q')] in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10955
     | FStar_Reflection_Data.Tv_Abs (b, t) ->
-        let uu____10977 =
+        let uu____10980 =
           FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10977
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10980
     | FStar_Reflection_Data.Tv_Arrow (b, c) ->
-        let uu____10994 = FStar_Syntax_Util.arrow [b] c in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10994
+        let uu____10997 = FStar_Syntax_Util.arrow [b] c in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10997
     | FStar_Reflection_Data.Tv_Type () ->
         FStar_All.pipe_left FStar_Tactics_Monad.ret FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv, t) ->
-        let uu____11013 = FStar_Syntax_Util.refine bv t in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11013
+        let uu____11016 = FStar_Syntax_Util.refine bv t in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11016
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____11017 =
-          let uu____11018 =
-            let uu____11019 = FStar_Reflection_Basic.pack_const c in
-            FStar_Syntax_Syntax.Tm_constant uu____11019 in
-          FStar_Syntax_Syntax.mk uu____11018 FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11017
+        let uu____11020 =
+          let uu____11021 =
+            let uu____11022 = FStar_Reflection_Basic.pack_const c in
+            FStar_Syntax_Syntax.Tm_constant uu____11022 in
+          FStar_Syntax_Syntax.mk uu____11021 FStar_Range.dummyRange in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11020
     | FStar_Reflection_Data.Tv_Uvar (_u, ctx_u_s) ->
-        let uu____11024 =
+        let uu____11027 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11024
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11027
     | FStar_Reflection_Data.Tv_Let (false, attrs, bv, t1, t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange in
-        let uu____11036 =
-          let uu____11037 =
-            let uu____11038 =
-              let uu____11051 =
-                let uu____11054 =
-                  let uu____11055 = FStar_Syntax_Syntax.mk_binder bv in
-                  [uu____11055] in
-                FStar_Syntax_Subst.close uu____11054 t2 in
-              ((false, [lb]), uu____11051) in
-            FStar_Syntax_Syntax.Tm_let uu____11038 in
-          FStar_Syntax_Syntax.mk uu____11037 FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11036
+        let uu____11039 =
+          let uu____11040 =
+            let uu____11041 =
+              let uu____11054 =
+                let uu____11057 =
+                  let uu____11058 = FStar_Syntax_Syntax.mk_binder bv in
+                  [uu____11058] in
+                FStar_Syntax_Subst.close uu____11057 t2 in
+              ((false, [lb]), uu____11054) in
+            FStar_Syntax_Syntax.Tm_let uu____11041 in
+          FStar_Syntax_Syntax.mk uu____11040 FStar_Range.dummyRange in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11039
     | FStar_Reflection_Data.Tv_Let (true, attrs, bv, t1, t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange in
-        let uu____11095 = FStar_Syntax_Subst.close_let_rec [lb] t2 in
-        (match uu____11095 with
+        let uu____11098 = FStar_Syntax_Subst.close_let_rec [lb] t2 in
+        (match uu____11098 with
          | (lbs, body) ->
-             let uu____11110 =
+             let uu____11113 =
                FStar_Syntax_Syntax.mk
                  (FStar_Syntax_Syntax.Tm_let ((true, lbs), body))
                  FStar_Range.dummyRange in
-             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11110)
+             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11113)
     | FStar_Reflection_Data.Tv_Match (t, brs) ->
         let wrap v =
           {
@@ -5176,23 +5273,23 @@ let (pack :
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____11144 =
-                let uu____11145 = FStar_Reflection_Basic.pack_const c in
-                FStar_Syntax_Syntax.Pat_constant uu____11145 in
-              FStar_All.pipe_left wrap uu____11144
+              let uu____11147 =
+                let uu____11148 = FStar_Reflection_Basic.pack_const c in
+                FStar_Syntax_Syntax.Pat_constant uu____11148 in
+              FStar_All.pipe_left wrap uu____11147
           | FStar_Reflection_Data.Pat_Cons (fv, ps) ->
-              let uu____11160 =
-                let uu____11161 =
-                  let uu____11174 =
+              let uu____11163 =
+                let uu____11164 =
+                  let uu____11177 =
                     FStar_List.map
-                      (fun uu____11195 ->
-                         match uu____11195 with
+                      (fun uu____11198 ->
+                         match uu____11198 with
                          | (p1, b) ->
-                             let uu____11206 = pack_pat p1 in
-                             (uu____11206, b)) ps in
-                  (fv, uu____11174) in
-                FStar_Syntax_Syntax.Pat_cons uu____11161 in
-              FStar_All.pipe_left wrap uu____11160
+                             let uu____11209 = pack_pat p1 in
+                             (uu____11209, b)) ps in
+                  (fv, uu____11177) in
+                FStar_Syntax_Syntax.Pat_cons uu____11164 in
+              FStar_All.pipe_left wrap uu____11163
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -5202,51 +5299,51 @@ let (pack :
                 (FStar_Syntax_Syntax.Pat_dot_term (bv, t1)) in
         let brs1 =
           FStar_List.map
-            (fun uu___8_11252 ->
-               match uu___8_11252 with
+            (fun uu___8_11255 ->
+               match uu___8_11255 with
                | (pat, t1) ->
-                   let uu____11269 = pack_pat pat in
-                   (uu____11269, FStar_Pervasives_Native.None, t1)) brs in
+                   let uu____11272 = pack_pat pat in
+                   (uu____11272, FStar_Pervasives_Native.None, t1)) brs in
         let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1 in
-        let uu____11317 =
+        let uu____11320 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11317
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11320
     | FStar_Reflection_Data.Tv_AscribedT (e, t, tacopt) ->
-        let uu____11345 =
+        let uu____11348 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inl t), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11345
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11348
     | FStar_Reflection_Data.Tv_AscribedC (e, c, tacopt) ->
-        let uu____11391 =
+        let uu____11394 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inr c), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11391
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11394
     | FStar_Reflection_Data.Tv_Unknown ->
-        let uu____11430 =
+        let uu____11433 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11430
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11433
 let (lget :
   FStar_Reflection_Data.typ ->
     Prims.string -> FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac)
   =
   fun ty ->
     fun k ->
-      let uu____11447 =
+      let uu____11450 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun ps ->
-             let uu____11453 =
+             let uu____11456 =
                FStar_Util.psmap_try_find ps.FStar_Tactics_Types.local_state k in
-             match uu____11453 with
+             match uu____11456 with
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____11447
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____11450
 let (lset :
   FStar_Reflection_Data.typ ->
     Prims.string -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -5254,41 +5351,41 @@ let (lset :
   fun _ty ->
     fun k ->
       fun t ->
-        let uu____11482 =
+        let uu____11485 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
                let ps1 =
-                 let uu___1707_11489 = ps in
-                 let uu____11490 =
+                 let uu___1709_11492 = ps in
+                 let uu____11493 =
                    FStar_Util.psmap_add ps.FStar_Tactics_Types.local_state k
                      t in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___1707_11489.FStar_Tactics_Types.main_context);
+                     (uu___1709_11492.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___1707_11489.FStar_Tactics_Types.all_implicits);
+                     (uu___1709_11492.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___1707_11489.FStar_Tactics_Types.goals);
+                     (uu___1709_11492.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___1707_11489.FStar_Tactics_Types.smt_goals);
+                     (uu___1709_11492.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___1707_11489.FStar_Tactics_Types.depth);
+                     (uu___1709_11492.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___1707_11489.FStar_Tactics_Types.__dump);
+                     (uu___1709_11492.FStar_Tactics_Types.__dump);
                    FStar_Tactics_Types.psc =
-                     (uu___1707_11489.FStar_Tactics_Types.psc);
+                     (uu___1709_11492.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___1707_11489.FStar_Tactics_Types.entry_range);
+                     (uu___1709_11492.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___1707_11489.FStar_Tactics_Types.guard_policy);
+                     (uu___1709_11492.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
-                     (uu___1707_11489.FStar_Tactics_Types.freshness);
+                     (uu___1709_11492.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___1707_11489.FStar_Tactics_Types.tac_verb_dbg);
-                   FStar_Tactics_Types.local_state = uu____11490
+                     (uu___1709_11492.FStar_Tactics_Types.tac_verb_dbg);
+                   FStar_Tactics_Types.local_state = uu____11493
                  } in
                FStar_Tactics_Monad.set ps1) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____11482
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____11485
 let (goal_of_goal_ty :
   env ->
     FStar_Reflection_Data.typ ->
@@ -5296,218 +5393,218 @@ let (goal_of_goal_ty :
   =
   fun env1 ->
     fun typ ->
-      let uu____11515 =
+      let uu____11518 =
         FStar_TypeChecker_Env.new_implicit_var_aux "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env1 typ
           FStar_Syntax_Syntax.Allow_untyped FStar_Pervasives_Native.None in
-      match uu____11515 with
+      match uu____11518 with
       | (u, ctx_uvars, g_u) ->
-          let uu____11547 = FStar_List.hd ctx_uvars in
-          (match uu____11547 with
-           | (ctx_uvar, uu____11561) ->
+          let uu____11550 = FStar_List.hd ctx_uvars in
+          (match uu____11550 with
+           | (ctx_uvar, uu____11564) ->
                let g =
-                 let uu____11563 = FStar_Options.peek () in
-                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____11563 false
+                 let uu____11566 = FStar_Options.peek () in
+                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____11566 false
                    "" in
                (g, g_u))
 let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env1 ->
-    let uu____11569 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-    match uu____11569 with
-    | (env2, uu____11577) ->
+    let uu____11572 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+    match uu____11572 with
+    | (env2, uu____11580) ->
         let env3 =
-          let uu___1724_11583 = env2 in
+          let uu___1726_11586 = env2 in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1724_11583.FStar_TypeChecker_Env.solver);
+              (uu___1726_11586.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1724_11583.FStar_TypeChecker_Env.range);
+              (uu___1726_11586.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1724_11583.FStar_TypeChecker_Env.curmodule);
+              (uu___1726_11586.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1724_11583.FStar_TypeChecker_Env.gamma);
+              (uu___1726_11586.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1724_11583.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1726_11586.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1724_11583.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1726_11586.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1724_11583.FStar_TypeChecker_Env.modules);
+              (uu___1726_11586.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1724_11583.FStar_TypeChecker_Env.expected_typ);
+              (uu___1726_11586.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1724_11583.FStar_TypeChecker_Env.sigtab);
+              (uu___1726_11586.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1724_11583.FStar_TypeChecker_Env.attrtab);
+              (uu___1726_11586.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp = false;
             FStar_TypeChecker_Env.effects =
-              (uu___1724_11583.FStar_TypeChecker_Env.effects);
+              (uu___1726_11586.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1724_11583.FStar_TypeChecker_Env.generalize);
+              (uu___1726_11586.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1724_11583.FStar_TypeChecker_Env.letrecs);
+              (uu___1726_11586.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1724_11583.FStar_TypeChecker_Env.top_level);
+              (uu___1726_11586.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1724_11583.FStar_TypeChecker_Env.check_uvars);
+              (uu___1726_11586.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1724_11583.FStar_TypeChecker_Env.use_eq);
+              (uu___1726_11586.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1724_11583.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1726_11586.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1724_11583.FStar_TypeChecker_Env.is_iface);
+              (uu___1726_11586.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1724_11583.FStar_TypeChecker_Env.admit);
+              (uu___1726_11586.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1724_11583.FStar_TypeChecker_Env.lax);
+              (uu___1726_11586.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1724_11583.FStar_TypeChecker_Env.lax_universes);
+              (uu___1726_11586.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1724_11583.FStar_TypeChecker_Env.phase1);
+              (uu___1726_11586.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1724_11583.FStar_TypeChecker_Env.failhard);
+              (uu___1726_11586.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1724_11583.FStar_TypeChecker_Env.nosynth);
+              (uu___1726_11586.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1724_11583.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1726_11586.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1724_11583.FStar_TypeChecker_Env.tc_term);
+              (uu___1726_11586.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1724_11583.FStar_TypeChecker_Env.type_of);
+              (uu___1726_11586.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1724_11583.FStar_TypeChecker_Env.universe_of);
+              (uu___1726_11586.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1724_11583.FStar_TypeChecker_Env.check_type_of);
+              (uu___1726_11586.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1724_11583.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1726_11586.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1724_11583.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1726_11586.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1724_11583.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1726_11586.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1724_11583.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1726_11586.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1724_11583.FStar_TypeChecker_Env.proof_ns);
+              (uu___1726_11586.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1724_11583.FStar_TypeChecker_Env.synth_hook);
+              (uu___1726_11586.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1724_11583.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1726_11586.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1724_11583.FStar_TypeChecker_Env.splice);
+              (uu___1726_11586.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1724_11583.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1726_11586.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1724_11583.FStar_TypeChecker_Env.postprocess);
+              (uu___1726_11586.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1724_11583.FStar_TypeChecker_Env.identifier_info);
+              (uu___1726_11586.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1724_11583.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1726_11586.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1724_11583.FStar_TypeChecker_Env.dsenv);
+              (uu___1726_11586.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1724_11583.FStar_TypeChecker_Env.nbe);
+              (uu___1726_11586.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1724_11583.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1726_11586.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1724_11583.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___1726_11586.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___1724_11583.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___1726_11586.FStar_TypeChecker_Env.enable_defer_to_tac)
           } in
         let env4 =
-          let uu___1727_11585 = env3 in
+          let uu___1729_11588 = env3 in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1727_11585.FStar_TypeChecker_Env.solver);
+              (uu___1729_11588.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1727_11585.FStar_TypeChecker_Env.range);
+              (uu___1729_11588.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1727_11585.FStar_TypeChecker_Env.curmodule);
+              (uu___1729_11588.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1727_11585.FStar_TypeChecker_Env.gamma);
+              (uu___1729_11588.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1727_11585.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1729_11588.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1727_11585.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1729_11588.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1727_11585.FStar_TypeChecker_Env.modules);
+              (uu___1729_11588.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1727_11585.FStar_TypeChecker_Env.expected_typ);
+              (uu___1729_11588.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1727_11585.FStar_TypeChecker_Env.sigtab);
+              (uu___1729_11588.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1727_11585.FStar_TypeChecker_Env.attrtab);
+              (uu___1729_11588.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1727_11585.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1729_11588.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1727_11585.FStar_TypeChecker_Env.effects);
+              (uu___1729_11588.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1727_11585.FStar_TypeChecker_Env.generalize);
+              (uu___1729_11588.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1727_11585.FStar_TypeChecker_Env.letrecs);
+              (uu___1729_11588.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1727_11585.FStar_TypeChecker_Env.top_level);
+              (uu___1729_11588.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1727_11585.FStar_TypeChecker_Env.check_uvars);
+              (uu___1729_11588.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1727_11585.FStar_TypeChecker_Env.use_eq);
+              (uu___1729_11588.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1727_11585.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1729_11588.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1727_11585.FStar_TypeChecker_Env.is_iface);
+              (uu___1729_11588.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1727_11585.FStar_TypeChecker_Env.admit);
+              (uu___1729_11588.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1727_11585.FStar_TypeChecker_Env.lax);
+              (uu___1729_11588.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1727_11585.FStar_TypeChecker_Env.lax_universes);
+              (uu___1729_11588.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1727_11585.FStar_TypeChecker_Env.phase1);
+              (uu___1729_11588.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard = true;
             FStar_TypeChecker_Env.nosynth =
-              (uu___1727_11585.FStar_TypeChecker_Env.nosynth);
+              (uu___1729_11588.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1727_11585.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1729_11588.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1727_11585.FStar_TypeChecker_Env.tc_term);
+              (uu___1729_11588.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1727_11585.FStar_TypeChecker_Env.type_of);
+              (uu___1729_11588.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1727_11585.FStar_TypeChecker_Env.universe_of);
+              (uu___1729_11588.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1727_11585.FStar_TypeChecker_Env.check_type_of);
+              (uu___1729_11588.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1727_11585.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1729_11588.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1727_11585.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1729_11588.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1727_11585.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1729_11588.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1727_11585.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1729_11588.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1727_11585.FStar_TypeChecker_Env.proof_ns);
+              (uu___1729_11588.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1727_11585.FStar_TypeChecker_Env.synth_hook);
+              (uu___1729_11588.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1727_11585.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1729_11588.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1727_11585.FStar_TypeChecker_Env.splice);
+              (uu___1729_11588.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1727_11585.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1729_11588.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1727_11585.FStar_TypeChecker_Env.postprocess);
+              (uu___1729_11588.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1727_11585.FStar_TypeChecker_Env.identifier_info);
+              (uu___1729_11588.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1727_11585.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1729_11588.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1727_11585.FStar_TypeChecker_Env.dsenv);
+              (uu___1729_11588.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1727_11585.FStar_TypeChecker_Env.nbe);
+              (uu___1729_11588.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1727_11585.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1729_11588.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1727_11585.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___1729_11588.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___1727_11585.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___1729_11588.FStar_TypeChecker_Env.enable_defer_to_tac)
           } in
         env4
 let (proofstate_of_goals :
@@ -5523,10 +5620,10 @@ let (proofstate_of_goals :
         fun imps ->
           let env2 = tac_env env1 in
           let ps =
-            let uu____11616 =
+            let uu____11619 =
               FStar_TypeChecker_Env.debug env2
                 (FStar_Options.Other "TacVerbose") in
-            let uu____11617 = FStar_Util.psmap_empty () in
+            let uu____11620 = FStar_Util.psmap_empty () in
             {
               FStar_Tactics_Types.main_context = env2;
               FStar_Tactics_Types.all_implicits = imps;
@@ -5539,8 +5636,8 @@ let (proofstate_of_goals :
               FStar_Tactics_Types.entry_range = rng;
               FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
               FStar_Tactics_Types.freshness = Prims.int_zero;
-              FStar_Tactics_Types.tac_verb_dbg = uu____11616;
-              FStar_Tactics_Types.local_state = uu____11617
+              FStar_Tactics_Types.tac_verb_dbg = uu____11619;
+              FStar_Tactics_Types.local_state = uu____11620
             } in
           ps
 let (proofstate_of_goal_ty :
@@ -5553,119 +5650,119 @@ let (proofstate_of_goal_ty :
     fun env1 ->
       fun typ ->
         let env2 = tac_env env1 in
-        let uu____11640 = goal_of_goal_ty env2 typ in
-        match uu____11640 with
+        let uu____11643 = goal_of_goal_ty env2 typ in
+        match uu____11643 with
         | (g, g_u) ->
             let ps =
               proofstate_of_goals rng env2 [g]
                 g_u.FStar_TypeChecker_Common.implicits in
-            let uu____11652 = FStar_Tactics_Types.goal_witness g in
-            (ps, uu____11652)
+            let uu____11655 = FStar_Tactics_Types.goal_witness g in
+            (ps, uu____11655)
 let (goal_of_implicit :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Env.implicit -> FStar_Tactics_Types.goal)
   =
   fun env1 ->
     fun i ->
-      let uu____11663 = FStar_Options.peek () in
+      let uu____11666 = FStar_Options.peek () in
       FStar_Tactics_Types.mk_goal
-        (let uu___1746_11666 = env1 in
+        (let uu___1748_11669 = env1 in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___1746_11666.FStar_TypeChecker_Env.solver);
+             (uu___1748_11669.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___1746_11666.FStar_TypeChecker_Env.range);
+             (uu___1748_11669.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___1746_11666.FStar_TypeChecker_Env.curmodule);
+             (uu___1748_11669.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
              ((i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___1746_11666.FStar_TypeChecker_Env.gamma_sig);
+             (uu___1748_11669.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___1746_11666.FStar_TypeChecker_Env.gamma_cache);
+             (uu___1748_11669.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___1746_11666.FStar_TypeChecker_Env.modules);
+             (uu___1748_11669.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___1746_11666.FStar_TypeChecker_Env.expected_typ);
+             (uu___1748_11669.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___1746_11666.FStar_TypeChecker_Env.sigtab);
+             (uu___1748_11669.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___1746_11666.FStar_TypeChecker_Env.attrtab);
+             (uu___1748_11669.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___1746_11666.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___1748_11669.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___1746_11666.FStar_TypeChecker_Env.effects);
+             (uu___1748_11669.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___1746_11666.FStar_TypeChecker_Env.generalize);
+             (uu___1748_11669.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___1746_11666.FStar_TypeChecker_Env.letrecs);
+             (uu___1748_11669.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___1746_11666.FStar_TypeChecker_Env.top_level);
+             (uu___1748_11669.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___1746_11666.FStar_TypeChecker_Env.check_uvars);
+             (uu___1748_11669.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___1746_11666.FStar_TypeChecker_Env.use_eq);
+             (uu___1748_11669.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___1746_11666.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___1748_11669.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___1746_11666.FStar_TypeChecker_Env.is_iface);
+             (uu___1748_11669.FStar_TypeChecker_Env.is_iface);
            FStar_TypeChecker_Env.admit =
-             (uu___1746_11666.FStar_TypeChecker_Env.admit);
+             (uu___1748_11669.FStar_TypeChecker_Env.admit);
            FStar_TypeChecker_Env.lax =
-             (uu___1746_11666.FStar_TypeChecker_Env.lax);
+             (uu___1748_11669.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___1746_11666.FStar_TypeChecker_Env.lax_universes);
+             (uu___1748_11669.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___1746_11666.FStar_TypeChecker_Env.phase1);
+             (uu___1748_11669.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___1746_11666.FStar_TypeChecker_Env.failhard);
+             (uu___1748_11669.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___1746_11666.FStar_TypeChecker_Env.nosynth);
+             (uu___1748_11669.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___1746_11666.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___1748_11669.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___1746_11666.FStar_TypeChecker_Env.tc_term);
+             (uu___1748_11669.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___1746_11666.FStar_TypeChecker_Env.type_of);
+             (uu___1748_11669.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___1746_11666.FStar_TypeChecker_Env.universe_of);
+             (uu___1748_11669.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___1746_11666.FStar_TypeChecker_Env.check_type_of);
+             (uu___1748_11669.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___1746_11666.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___1748_11669.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___1746_11666.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___1748_11669.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___1746_11666.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___1748_11669.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___1746_11666.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___1748_11669.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___1746_11666.FStar_TypeChecker_Env.proof_ns);
+             (uu___1748_11669.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___1746_11666.FStar_TypeChecker_Env.synth_hook);
+             (uu___1748_11669.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___1746_11666.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___1748_11669.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___1746_11666.FStar_TypeChecker_Env.splice);
+             (uu___1748_11669.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___1746_11666.FStar_TypeChecker_Env.mpreprocess);
+             (uu___1748_11669.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___1746_11666.FStar_TypeChecker_Env.postprocess);
+             (uu___1748_11669.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___1746_11666.FStar_TypeChecker_Env.identifier_info);
+             (uu___1748_11669.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___1746_11666.FStar_TypeChecker_Env.tc_hooks);
+             (uu___1748_11669.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___1746_11666.FStar_TypeChecker_Env.dsenv);
+             (uu___1748_11669.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___1746_11666.FStar_TypeChecker_Env.nbe);
+             (uu___1748_11669.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___1746_11666.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___1748_11669.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___1746_11666.FStar_TypeChecker_Env.erasable_types_tab);
+             (uu___1748_11669.FStar_TypeChecker_Env.erasable_types_tab);
            FStar_TypeChecker_Env.enable_defer_to_tac =
-             (uu___1746_11666.FStar_TypeChecker_Env.enable_defer_to_tac)
-         }) i.FStar_TypeChecker_Common.imp_uvar uu____11663 false
+             (uu___1748_11669.FStar_TypeChecker_Env.enable_defer_to_tac)
+         }) i.FStar_TypeChecker_Common.imp_uvar uu____11666 false
         i.FStar_TypeChecker_Common.imp_reason
 let (proofstate_of_all_implicits :
   FStar_Range.range ->
@@ -5679,13 +5776,13 @@ let (proofstate_of_all_implicits :
         let env2 = tac_env env1 in
         let goals = FStar_List.map (goal_of_implicit env2) imps in
         let w =
-          let uu____11691 = FStar_List.hd goals in
-          FStar_Tactics_Types.goal_witness uu____11691 in
+          let uu____11694 = FStar_List.hd goals in
+          FStar_Tactics_Types.goal_witness uu____11694 in
         let ps =
-          let uu____11693 =
+          let uu____11696 =
             FStar_TypeChecker_Env.debug env2
               (FStar_Options.Other "TacVerbose") in
-          let uu____11694 = FStar_Util.psmap_empty () in
+          let uu____11697 = FStar_Util.psmap_empty () in
           {
             FStar_Tactics_Types.main_context = env2;
             FStar_Tactics_Types.all_implicits = imps;
@@ -5699,7 +5796,7 @@ let (proofstate_of_all_implicits :
             FStar_Tactics_Types.entry_range = rng;
             FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
             FStar_Tactics_Types.freshness = Prims.int_zero;
-            FStar_Tactics_Types.tac_verb_dbg = uu____11693;
-            FStar_Tactics_Types.local_state = uu____11694
+            FStar_Tactics_Types.tac_verb_dbg = uu____11696;
+            FStar_Tactics_Types.local_state = uu____11697
           } in
         (ps, w)

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -357,110 +357,13 @@ let (do_unify :
                       "--debug_level Rel --debug_level RelCheck" in
                   ()))
               else ());
-             (let uu____1044 =
-                __do_unify
-                  (let uu___205_1049 = env1 in
-                   {
-                     FStar_TypeChecker_Env.solver =
-                       (uu___205_1049.FStar_TypeChecker_Env.solver);
-                     FStar_TypeChecker_Env.range =
-                       (uu___205_1049.FStar_TypeChecker_Env.range);
-                     FStar_TypeChecker_Env.curmodule =
-                       (uu___205_1049.FStar_TypeChecker_Env.curmodule);
-                     FStar_TypeChecker_Env.gamma =
-                       (uu___205_1049.FStar_TypeChecker_Env.gamma);
-                     FStar_TypeChecker_Env.gamma_sig =
-                       (uu___205_1049.FStar_TypeChecker_Env.gamma_sig);
-                     FStar_TypeChecker_Env.gamma_cache =
-                       (uu___205_1049.FStar_TypeChecker_Env.gamma_cache);
-                     FStar_TypeChecker_Env.modules =
-                       (uu___205_1049.FStar_TypeChecker_Env.modules);
-                     FStar_TypeChecker_Env.expected_typ =
-                       (uu___205_1049.FStar_TypeChecker_Env.expected_typ);
-                     FStar_TypeChecker_Env.sigtab =
-                       (uu___205_1049.FStar_TypeChecker_Env.sigtab);
-                     FStar_TypeChecker_Env.attrtab =
-                       (uu___205_1049.FStar_TypeChecker_Env.attrtab);
-                     FStar_TypeChecker_Env.instantiate_imp =
-                       (uu___205_1049.FStar_TypeChecker_Env.instantiate_imp);
-                     FStar_TypeChecker_Env.effects =
-                       (uu___205_1049.FStar_TypeChecker_Env.effects);
-                     FStar_TypeChecker_Env.generalize =
-                       (uu___205_1049.FStar_TypeChecker_Env.generalize);
-                     FStar_TypeChecker_Env.letrecs =
-                       (uu___205_1049.FStar_TypeChecker_Env.letrecs);
-                     FStar_TypeChecker_Env.top_level =
-                       (uu___205_1049.FStar_TypeChecker_Env.top_level);
-                     FStar_TypeChecker_Env.check_uvars =
-                       (uu___205_1049.FStar_TypeChecker_Env.check_uvars);
-                     FStar_TypeChecker_Env.use_eq =
-                       (uu___205_1049.FStar_TypeChecker_Env.use_eq);
-                     FStar_TypeChecker_Env.use_eq_strict =
-                       (uu___205_1049.FStar_TypeChecker_Env.use_eq_strict);
-                     FStar_TypeChecker_Env.is_iface =
-                       (uu___205_1049.FStar_TypeChecker_Env.is_iface);
-                     FStar_TypeChecker_Env.admit =
-                       (uu___205_1049.FStar_TypeChecker_Env.admit);
-                     FStar_TypeChecker_Env.lax =
-                       (uu___205_1049.FStar_TypeChecker_Env.lax);
-                     FStar_TypeChecker_Env.lax_universes =
-                       (uu___205_1049.FStar_TypeChecker_Env.lax_universes);
-                     FStar_TypeChecker_Env.phase1 =
-                       (uu___205_1049.FStar_TypeChecker_Env.phase1);
-                     FStar_TypeChecker_Env.failhard =
-                       (uu___205_1049.FStar_TypeChecker_Env.failhard);
-                     FStar_TypeChecker_Env.nosynth =
-                       (uu___205_1049.FStar_TypeChecker_Env.nosynth);
-                     FStar_TypeChecker_Env.uvar_subtyping =
-                       (uu___205_1049.FStar_TypeChecker_Env.uvar_subtyping);
-                     FStar_TypeChecker_Env.tc_term =
-                       (uu___205_1049.FStar_TypeChecker_Env.tc_term);
-                     FStar_TypeChecker_Env.type_of =
-                       (uu___205_1049.FStar_TypeChecker_Env.type_of);
-                     FStar_TypeChecker_Env.universe_of =
-                       (uu___205_1049.FStar_TypeChecker_Env.universe_of);
-                     FStar_TypeChecker_Env.check_type_of =
-                       (uu___205_1049.FStar_TypeChecker_Env.check_type_of);
-                     FStar_TypeChecker_Env.use_bv_sorts =
-                       (uu___205_1049.FStar_TypeChecker_Env.use_bv_sorts);
-                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                       (uu___205_1049.FStar_TypeChecker_Env.qtbl_name_and_index);
-                     FStar_TypeChecker_Env.normalized_eff_names =
-                       (uu___205_1049.FStar_TypeChecker_Env.normalized_eff_names);
-                     FStar_TypeChecker_Env.fv_delta_depths =
-                       (uu___205_1049.FStar_TypeChecker_Env.fv_delta_depths);
-                     FStar_TypeChecker_Env.proof_ns =
-                       (uu___205_1049.FStar_TypeChecker_Env.proof_ns);
-                     FStar_TypeChecker_Env.synth_hook =
-                       (uu___205_1049.FStar_TypeChecker_Env.synth_hook);
-                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                       (uu___205_1049.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                     FStar_TypeChecker_Env.splice =
-                       (uu___205_1049.FStar_TypeChecker_Env.splice);
-                     FStar_TypeChecker_Env.mpreprocess =
-                       (uu___205_1049.FStar_TypeChecker_Env.mpreprocess);
-                     FStar_TypeChecker_Env.postprocess =
-                       (uu___205_1049.FStar_TypeChecker_Env.postprocess);
-                     FStar_TypeChecker_Env.identifier_info =
-                       (uu___205_1049.FStar_TypeChecker_Env.identifier_info);
-                     FStar_TypeChecker_Env.tc_hooks =
-                       (uu___205_1049.FStar_TypeChecker_Env.tc_hooks);
-                     FStar_TypeChecker_Env.dsenv =
-                       (uu___205_1049.FStar_TypeChecker_Env.dsenv);
-                     FStar_TypeChecker_Env.nbe =
-                       (uu___205_1049.FStar_TypeChecker_Env.nbe);
-                     FStar_TypeChecker_Env.strict_args_tab =
-                       (uu___205_1049.FStar_TypeChecker_Env.strict_args_tab);
-                     FStar_TypeChecker_Env.erasable_types_tab =
-                       (uu___205_1049.FStar_TypeChecker_Env.erasable_types_tab);
-                     FStar_TypeChecker_Env.enable_defer_to_tac = false
-                   }) t1 t2 in
+             (let uu____1044 = __do_unify env1 t1 t2 in
               FStar_Tactics_Monad.bind uu____1044
                 (fun r ->
-                   (let uu____1054 =
+                   (let uu____1051 =
                       FStar_TypeChecker_Env.debug env1
                         (FStar_Options.Other "1346") in
-                    if uu____1054 then FStar_Options.pop () else ());
+                    if uu____1051 then FStar_Options.pop () else ());
                    FStar_Tactics_Monad.ret r)))
 let (do_match :
   FStar_TypeChecker_Env.env ->
@@ -470,24 +373,24 @@ let (do_match :
   fun env1 ->
     fun t1 ->
       fun t2 ->
-        let uu____1075 =
+        let uu____1072 =
           FStar_Tactics_Monad.mk_tac
             (fun ps ->
                let tx = FStar_Syntax_Unionfind.new_transaction () in
                FStar_Tactics_Result.Success (tx, ps)) in
-        FStar_Tactics_Monad.bind uu____1075
+        FStar_Tactics_Monad.bind uu____1072
           (fun tx ->
              let uvs1 = FStar_Syntax_Free.uvars_uncached t1 in
-             let uu____1089 = do_unify env1 t1 t2 in
-             FStar_Tactics_Monad.bind uu____1089
+             let uu____1086 = do_unify env1 t1 t2 in
+             FStar_Tactics_Monad.bind uu____1086
                (fun r ->
                   if r
                   then
                     let uvs2 = FStar_Syntax_Free.uvars_uncached t1 in
-                    let uu____1102 =
-                      let uu____1103 = FStar_Util.set_eq uvs1 uvs2 in
-                      Prims.op_Negation uu____1103 in
-                    (if uu____1102
+                    let uu____1099 =
+                      let uu____1100 = FStar_Util.set_eq uvs1 uvs2 in
+                      Prims.op_Negation uu____1100 in
+                    (if uu____1099
                      then
                        (FStar_Syntax_Unionfind.rollback tx;
                         FStar_Tactics_Monad.ret false)
@@ -501,29 +404,29 @@ let (do_match_on_lhs :
   fun env1 ->
     fun t1 ->
       fun t2 ->
-        let uu____1128 =
+        let uu____1125 =
           FStar_Tactics_Monad.mk_tac
             (fun ps ->
                let tx = FStar_Syntax_Unionfind.new_transaction () in
                FStar_Tactics_Result.Success (tx, ps)) in
-        FStar_Tactics_Monad.bind uu____1128
+        FStar_Tactics_Monad.bind uu____1125
           (fun tx ->
-             let uu____1138 = destruct_eq t1 in
-             match uu____1138 with
+             let uu____1135 = destruct_eq t1 in
+             match uu____1135 with
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "do_match_on_lhs: not an eq"
-             | FStar_Pervasives_Native.Some (lhs, uu____1152) ->
+             | FStar_Pervasives_Native.Some (lhs, uu____1149) ->
                  let uvs1 = FStar_Syntax_Free.uvars_uncached lhs in
-                 let uu____1160 = do_unify env1 t1 t2 in
-                 FStar_Tactics_Monad.bind uu____1160
+                 let uu____1157 = do_unify env1 t1 t2 in
+                 FStar_Tactics_Monad.bind uu____1157
                    (fun r ->
                       if r
                       then
                         let uvs2 = FStar_Syntax_Free.uvars_uncached lhs in
-                        let uu____1173 =
-                          let uu____1174 = FStar_Util.set_eq uvs1 uvs2 in
-                          Prims.op_Negation uu____1174 in
-                        (if uu____1173
+                        let uu____1170 =
+                          let uu____1171 = FStar_Util.set_eq uvs1 uvs2 in
+                          Prims.op_Negation uu____1171 in
+                        (if uu____1170
                          then
                            (FStar_Syntax_Unionfind.rollback tx;
                             FStar_Tactics_Monad.ret false)
@@ -535,16 +438,16 @@ let (set_solution :
   =
   fun goal ->
     fun solution ->
-      let uu____1194 =
+      let uu____1191 =
         FStar_Syntax_Unionfind.find
           (goal.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-      match uu____1194 with
-      | FStar_Pervasives_Native.Some uu____1199 ->
-          let uu____1200 =
-            let uu____1201 =
+      match uu____1191 with
+      | FStar_Pervasives_Native.Some uu____1196 ->
+          let uu____1197 =
+            let uu____1198 =
               FStar_Tactics_Printing.goal_to_string_verbose goal in
-            FStar_Util.format1 "Goal %s is already solved" uu____1201 in
-          FStar_Tactics_Monad.fail uu____1200
+            FStar_Util.format1 "Goal %s is already solved" uu____1198 in
+          FStar_Tactics_Monad.fail uu____1197
       | FStar_Pervasives_Native.None ->
           (FStar_Syntax_Unionfind.change
              (goal.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head
@@ -556,9 +459,9 @@ let (trysolve :
   =
   fun goal ->
     fun solution ->
-      let uu____1217 = FStar_Tactics_Types.goal_env goal in
-      let uu____1218 = FStar_Tactics_Types.goal_witness goal in
-      do_unify uu____1217 solution uu____1218
+      let uu____1214 = FStar_Tactics_Types.goal_env goal in
+      let uu____1215 = FStar_Tactics_Types.goal_witness goal in
+      do_unify uu____1214 solution uu____1215
 let (solve :
   FStar_Tactics_Types.goal ->
     FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -567,140 +470,140 @@ let (solve :
     fun solution ->
       let e = FStar_Tactics_Types.goal_env goal in
       FStar_Tactics_Monad.mlog
-        (fun uu____1237 ->
-           let uu____1238 =
-             let uu____1239 = FStar_Tactics_Types.goal_witness goal in
-             FStar_Syntax_Print.term_to_string uu____1239 in
-           let uu____1240 = FStar_Syntax_Print.term_to_string solution in
-           FStar_Util.print2 "solve %s := %s\n" uu____1238 uu____1240)
-        (fun uu____1243 ->
-           let uu____1244 = trysolve goal solution in
-           FStar_Tactics_Monad.bind uu____1244
+        (fun uu____1234 ->
+           let uu____1235 =
+             let uu____1236 = FStar_Tactics_Types.goal_witness goal in
+             FStar_Syntax_Print.term_to_string uu____1236 in
+           let uu____1237 = FStar_Syntax_Print.term_to_string solution in
+           FStar_Util.print2 "solve %s := %s\n" uu____1235 uu____1237)
+        (fun uu____1240 ->
+           let uu____1241 = trysolve goal solution in
+           FStar_Tactics_Monad.bind uu____1241
              (fun b ->
                 if b
                 then
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____1252 ->
+                    (fun uu____1249 ->
                        FStar_Tactics_Monad.remove_solved_goals)
                 else
-                  (let uu____1254 =
-                     let uu____1255 =
-                       let uu____1256 = FStar_Tactics_Types.goal_env goal in
-                       tts uu____1256 solution in
+                  (let uu____1251 =
+                     let uu____1252 =
+                       let uu____1253 = FStar_Tactics_Types.goal_env goal in
+                       tts uu____1253 solution in
+                     let uu____1254 =
+                       let uu____1255 = FStar_Tactics_Types.goal_env goal in
+                       let uu____1256 = FStar_Tactics_Types.goal_witness goal in
+                       tts uu____1255 uu____1256 in
                      let uu____1257 =
                        let uu____1258 = FStar_Tactics_Types.goal_env goal in
-                       let uu____1259 = FStar_Tactics_Types.goal_witness goal in
+                       let uu____1259 = FStar_Tactics_Types.goal_type goal in
                        tts uu____1258 uu____1259 in
-                     let uu____1260 =
-                       let uu____1261 = FStar_Tactics_Types.goal_env goal in
-                       let uu____1262 = FStar_Tactics_Types.goal_type goal in
-                       tts uu____1261 uu____1262 in
                      FStar_Util.format3 "%s does not solve %s : %s"
-                       uu____1255 uu____1257 uu____1260 in
-                   FStar_Tactics_Monad.fail uu____1254)))
+                       uu____1252 uu____1254 uu____1257 in
+                   FStar_Tactics_Monad.fail uu____1251)))
 let (solve' :
   FStar_Tactics_Types.goal ->
     FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
   =
   fun goal ->
     fun solution ->
-      let uu____1277 = set_solution goal solution in
-      FStar_Tactics_Monad.bind uu____1277
-        (fun uu____1281 ->
+      let uu____1274 = set_solution goal solution in
+      FStar_Tactics_Monad.bind uu____1274
+        (fun uu____1278 ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-             (fun uu____1283 -> FStar_Tactics_Monad.remove_solved_goals))
+             (fun uu____1280 -> FStar_Tactics_Monad.remove_solved_goals))
 let (is_true : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let t1 = FStar_Syntax_Util.unascribe t in
-    let uu____1290 = FStar_Syntax_Util.un_squash t1 in
-    match uu____1290 with
+    let uu____1287 = FStar_Syntax_Util.un_squash t1 in
+    match uu____1287 with
     | FStar_Pervasives_Native.Some t' ->
         let t'1 = FStar_Syntax_Util.unascribe t' in
-        let uu____1301 =
-          let uu____1302 = FStar_Syntax_Subst.compress t'1 in
-          uu____1302.FStar_Syntax_Syntax.n in
-        (match uu____1301 with
+        let uu____1298 =
+          let uu____1299 = FStar_Syntax_Subst.compress t'1 in
+          uu____1299.FStar_Syntax_Syntax.n in
+        (match uu____1298 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.true_lid
-         | uu____1306 -> false)
-    | uu____1307 -> false
+         | uu____1303 -> false)
+    | uu____1304 -> false
 let (is_false : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____1317 = FStar_Syntax_Util.un_squash t in
-    match uu____1317 with
+    let uu____1314 = FStar_Syntax_Util.un_squash t in
+    match uu____1314 with
     | FStar_Pervasives_Native.Some t' ->
-        let uu____1327 =
-          let uu____1328 = FStar_Syntax_Subst.compress t' in
-          uu____1328.FStar_Syntax_Syntax.n in
-        (match uu____1327 with
+        let uu____1324 =
+          let uu____1325 = FStar_Syntax_Subst.compress t' in
+          uu____1325.FStar_Syntax_Syntax.n in
+        (match uu____1324 with
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.false_lid
-         | uu____1332 -> false)
-    | uu____1333 -> false
+         | uu____1329 -> false)
+    | uu____1330 -> false
 let (tadmit_t : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
-    let uu____1347 =
+    let uu____1344 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g ->
-                (let uu____1356 =
-                   let uu____1357 = FStar_Tactics_Types.goal_type g in
-                   uu____1357.FStar_Syntax_Syntax.pos in
-                 let uu____1360 =
-                   let uu____1365 =
-                     let uu____1366 =
+                (let uu____1353 =
+                   let uu____1354 = FStar_Tactics_Types.goal_type g in
+                   uu____1354.FStar_Syntax_Syntax.pos in
+                 let uu____1357 =
+                   let uu____1362 =
+                     let uu____1363 =
                        FStar_Tactics_Printing.goal_to_string ""
                          FStar_Pervasives_Native.None ps g in
                      FStar_Util.format1 "Tactics admitted goal <%s>\n\n"
-                       uu____1366 in
-                   (FStar_Errors.Warning_TacAdmit, uu____1365) in
-                 FStar_Errors.log_issue uu____1356 uu____1360);
+                       uu____1363 in
+                   (FStar_Errors.Warning_TacAdmit, uu____1362) in
+                 FStar_Errors.log_issue uu____1353 uu____1357);
                 solve' g t)) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tadmit_t") uu____1347
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tadmit_t") uu____1344
 let (fresh : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
-  fun uu____1381 ->
+  fun uu____1378 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          let n = ps.FStar_Tactics_Types.freshness in
          let ps1 =
-           let uu___279_1391 = ps in
+           let uu___277_1388 = ps in
            {
              FStar_Tactics_Types.main_context =
-               (uu___279_1391.FStar_Tactics_Types.main_context);
+               (uu___277_1388.FStar_Tactics_Types.main_context);
              FStar_Tactics_Types.all_implicits =
-               (uu___279_1391.FStar_Tactics_Types.all_implicits);
+               (uu___277_1388.FStar_Tactics_Types.all_implicits);
              FStar_Tactics_Types.goals =
-               (uu___279_1391.FStar_Tactics_Types.goals);
+               (uu___277_1388.FStar_Tactics_Types.goals);
              FStar_Tactics_Types.smt_goals =
-               (uu___279_1391.FStar_Tactics_Types.smt_goals);
+               (uu___277_1388.FStar_Tactics_Types.smt_goals);
              FStar_Tactics_Types.depth =
-               (uu___279_1391.FStar_Tactics_Types.depth);
+               (uu___277_1388.FStar_Tactics_Types.depth);
              FStar_Tactics_Types.__dump =
-               (uu___279_1391.FStar_Tactics_Types.__dump);
+               (uu___277_1388.FStar_Tactics_Types.__dump);
              FStar_Tactics_Types.psc =
-               (uu___279_1391.FStar_Tactics_Types.psc);
+               (uu___277_1388.FStar_Tactics_Types.psc);
              FStar_Tactics_Types.entry_range =
-               (uu___279_1391.FStar_Tactics_Types.entry_range);
+               (uu___277_1388.FStar_Tactics_Types.entry_range);
              FStar_Tactics_Types.guard_policy =
-               (uu___279_1391.FStar_Tactics_Types.guard_policy);
+               (uu___277_1388.FStar_Tactics_Types.guard_policy);
              FStar_Tactics_Types.freshness = (n + Prims.int_one);
              FStar_Tactics_Types.tac_verb_dbg =
-               (uu___279_1391.FStar_Tactics_Types.tac_verb_dbg);
+               (uu___277_1388.FStar_Tactics_Types.tac_verb_dbg);
              FStar_Tactics_Types.local_state =
-               (uu___279_1391.FStar_Tactics_Types.local_state)
+               (uu___277_1388.FStar_Tactics_Types.local_state)
            } in
-         let uu____1392 = FStar_Tactics_Monad.set ps1 in
-         FStar_Tactics_Monad.bind uu____1392
-           (fun uu____1397 ->
-              let uu____1398 = FStar_BigInt.of_int_fs n in
-              FStar_Tactics_Monad.ret uu____1398))
+         let uu____1389 = FStar_Tactics_Monad.set ps1 in
+         FStar_Tactics_Monad.bind uu____1389
+           (fun uu____1394 ->
+              let uu____1395 = FStar_BigInt.of_int_fs n in
+              FStar_Tactics_Monad.ret uu____1395))
 let (curms : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
-  fun uu____1405 ->
-    let uu____1408 =
-      let uu____1409 = FStar_Util.now_ms () in
-      FStar_All.pipe_right uu____1409 FStar_BigInt.of_int_fs in
-    FStar_Tactics_Monad.ret uu____1408
+  fun uu____1402 ->
+    let uu____1405 =
+      let uu____1406 = FStar_Util.now_ms () in
+      FStar_All.pipe_right uu____1406 FStar_BigInt.of_int_fs in
+    FStar_Tactics_Monad.ret uu____1405
 let (__tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -712,131 +615,131 @@ let (__tc :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1452 ->
-                let uu____1453 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc(%s)\n" uu____1453)
-             (fun uu____1456 ->
+             (fun uu____1449 ->
+                let uu____1450 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc(%s)\n" uu____1450)
+             (fun uu____1453 ->
                 let e1 =
-                  let uu___288_1458 = e in
+                  let uu___286_1455 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___288_1458.FStar_TypeChecker_Env.solver);
+                      (uu___286_1455.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___288_1458.FStar_TypeChecker_Env.range);
+                      (uu___286_1455.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___288_1458.FStar_TypeChecker_Env.curmodule);
+                      (uu___286_1455.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___288_1458.FStar_TypeChecker_Env.gamma);
+                      (uu___286_1455.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___288_1458.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___286_1455.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___288_1458.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___286_1455.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___288_1458.FStar_TypeChecker_Env.modules);
+                      (uu___286_1455.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___288_1458.FStar_TypeChecker_Env.expected_typ);
+                      (uu___286_1455.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___288_1458.FStar_TypeChecker_Env.sigtab);
+                      (uu___286_1455.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___288_1458.FStar_TypeChecker_Env.attrtab);
+                      (uu___286_1455.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___288_1458.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___286_1455.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___288_1458.FStar_TypeChecker_Env.effects);
+                      (uu___286_1455.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___288_1458.FStar_TypeChecker_Env.generalize);
+                      (uu___286_1455.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___288_1458.FStar_TypeChecker_Env.letrecs);
+                      (uu___286_1455.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___288_1458.FStar_TypeChecker_Env.top_level);
+                      (uu___286_1455.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___288_1458.FStar_TypeChecker_Env.check_uvars);
+                      (uu___286_1455.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___288_1458.FStar_TypeChecker_Env.use_eq);
+                      (uu___286_1455.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___288_1458.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___286_1455.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___288_1458.FStar_TypeChecker_Env.is_iface);
+                      (uu___286_1455.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___288_1458.FStar_TypeChecker_Env.admit);
+                      (uu___286_1455.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___288_1458.FStar_TypeChecker_Env.lax);
+                      (uu___286_1455.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___288_1458.FStar_TypeChecker_Env.lax_universes);
+                      (uu___286_1455.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___288_1458.FStar_TypeChecker_Env.phase1);
+                      (uu___286_1455.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___288_1458.FStar_TypeChecker_Env.failhard);
+                      (uu___286_1455.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___288_1458.FStar_TypeChecker_Env.nosynth);
+                      (uu___286_1455.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___288_1458.FStar_TypeChecker_Env.tc_term);
+                      (uu___286_1455.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___288_1458.FStar_TypeChecker_Env.type_of);
+                      (uu___286_1455.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___288_1458.FStar_TypeChecker_Env.universe_of);
+                      (uu___286_1455.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___288_1458.FStar_TypeChecker_Env.check_type_of);
+                      (uu___286_1455.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___288_1458.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___286_1455.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___288_1458.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___286_1455.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___288_1458.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___286_1455.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___288_1458.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___286_1455.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___288_1458.FStar_TypeChecker_Env.proof_ns);
+                      (uu___286_1455.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___288_1458.FStar_TypeChecker_Env.synth_hook);
+                      (uu___286_1455.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___288_1458.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___286_1455.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___288_1458.FStar_TypeChecker_Env.splice);
+                      (uu___286_1455.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___288_1458.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___286_1455.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___288_1458.FStar_TypeChecker_Env.postprocess);
+                      (uu___286_1455.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___288_1458.FStar_TypeChecker_Env.identifier_info);
+                      (uu___286_1455.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___288_1458.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___286_1455.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___288_1458.FStar_TypeChecker_Env.dsenv);
+                      (uu___286_1455.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___288_1458.FStar_TypeChecker_Env.nbe);
+                      (uu___286_1455.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___288_1458.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___286_1455.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___288_1458.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___286_1455.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___288_1458.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___286_1455.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___292_1469 ->
+                  (fun uu___290_1466 ->
                      match () with
                      | () ->
-                         let uu____1478 =
+                         let uu____1475 =
                            FStar_TypeChecker_TcTerm.type_of_tot_term e1 t in
-                         FStar_Tactics_Monad.ret uu____1478) ()
+                         FStar_Tactics_Monad.ret uu____1475) ()
                 with
-                | FStar_Errors.Err (uu____1505, msg) ->
-                    let uu____1507 = tts e1 t in
-                    let uu____1508 =
-                      let uu____1509 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1509
+                | FStar_Errors.Err (uu____1502, msg) ->
+                    let uu____1504 = tts e1 t in
+                    let uu____1505 =
+                      let uu____1506 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1506
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1507 uu____1508 msg
-                | FStar_Errors.Error (uu____1516, msg, uu____1518) ->
-                    let uu____1519 = tts e1 t in
-                    let uu____1520 =
-                      let uu____1521 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1521
+                      uu____1504 uu____1505 msg
+                | FStar_Errors.Error (uu____1513, msg, uu____1515) ->
+                    let uu____1516 = tts e1 t in
+                    let uu____1517 =
+                      let uu____1518 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1518
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1519 uu____1520 msg))
+                      uu____1516 uu____1517 msg))
 let (__tc_ghost :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -848,135 +751,135 @@ let (__tc_ghost :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1570 ->
-                let uu____1571 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc_ghost(%s)\n" uu____1571)
-             (fun uu____1574 ->
+             (fun uu____1567 ->
+                let uu____1568 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc_ghost(%s)\n" uu____1568)
+             (fun uu____1571 ->
                 let e1 =
-                  let uu___309_1576 = e in
+                  let uu___307_1573 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___309_1576.FStar_TypeChecker_Env.solver);
+                      (uu___307_1573.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___309_1576.FStar_TypeChecker_Env.range);
+                      (uu___307_1573.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___309_1576.FStar_TypeChecker_Env.curmodule);
+                      (uu___307_1573.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___309_1576.FStar_TypeChecker_Env.gamma);
+                      (uu___307_1573.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___309_1576.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___307_1573.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___309_1576.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___307_1573.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___309_1576.FStar_TypeChecker_Env.modules);
+                      (uu___307_1573.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___309_1576.FStar_TypeChecker_Env.expected_typ);
+                      (uu___307_1573.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___309_1576.FStar_TypeChecker_Env.sigtab);
+                      (uu___307_1573.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___309_1576.FStar_TypeChecker_Env.attrtab);
+                      (uu___307_1573.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___309_1576.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___307_1573.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___309_1576.FStar_TypeChecker_Env.effects);
+                      (uu___307_1573.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___309_1576.FStar_TypeChecker_Env.generalize);
+                      (uu___307_1573.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___309_1576.FStar_TypeChecker_Env.letrecs);
+                      (uu___307_1573.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___309_1576.FStar_TypeChecker_Env.top_level);
+                      (uu___307_1573.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___309_1576.FStar_TypeChecker_Env.check_uvars);
+                      (uu___307_1573.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___309_1576.FStar_TypeChecker_Env.use_eq);
+                      (uu___307_1573.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___309_1576.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___307_1573.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___309_1576.FStar_TypeChecker_Env.is_iface);
+                      (uu___307_1573.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___309_1576.FStar_TypeChecker_Env.admit);
+                      (uu___307_1573.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___309_1576.FStar_TypeChecker_Env.lax);
+                      (uu___307_1573.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___309_1576.FStar_TypeChecker_Env.lax_universes);
+                      (uu___307_1573.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___309_1576.FStar_TypeChecker_Env.phase1);
+                      (uu___307_1573.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___309_1576.FStar_TypeChecker_Env.failhard);
+                      (uu___307_1573.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___309_1576.FStar_TypeChecker_Env.nosynth);
+                      (uu___307_1573.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___309_1576.FStar_TypeChecker_Env.tc_term);
+                      (uu___307_1573.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___309_1576.FStar_TypeChecker_Env.type_of);
+                      (uu___307_1573.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___309_1576.FStar_TypeChecker_Env.universe_of);
+                      (uu___307_1573.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___309_1576.FStar_TypeChecker_Env.check_type_of);
+                      (uu___307_1573.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___309_1576.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___307_1573.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___309_1576.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___307_1573.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___309_1576.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___307_1573.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___309_1576.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___307_1573.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___309_1576.FStar_TypeChecker_Env.proof_ns);
+                      (uu___307_1573.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___309_1576.FStar_TypeChecker_Env.synth_hook);
+                      (uu___307_1573.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___309_1576.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___307_1573.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___309_1576.FStar_TypeChecker_Env.splice);
+                      (uu___307_1573.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___309_1576.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___307_1573.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___309_1576.FStar_TypeChecker_Env.postprocess);
+                      (uu___307_1573.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___309_1576.FStar_TypeChecker_Env.identifier_info);
+                      (uu___307_1573.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___309_1576.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___307_1573.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___309_1576.FStar_TypeChecker_Env.dsenv);
+                      (uu___307_1573.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___309_1576.FStar_TypeChecker_Env.nbe);
+                      (uu___307_1573.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___309_1576.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___307_1573.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___309_1576.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___307_1573.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___309_1576.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___307_1573.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___313_1590 ->
+                  (fun uu___311_1587 ->
                      match () with
                      | () ->
-                         let uu____1599 =
+                         let uu____1596 =
                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term e1 t in
-                         (match uu____1599 with
+                         (match uu____1596 with
                           | (t1, lc, g) ->
                               FStar_Tactics_Monad.ret
                                 (t1, (lc.FStar_TypeChecker_Common.res_typ),
                                   g))) ()
                 with
-                | FStar_Errors.Err (uu____1637, msg) ->
-                    let uu____1639 = tts e1 t in
-                    let uu____1640 =
-                      let uu____1641 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1641
+                | FStar_Errors.Err (uu____1634, msg) ->
+                    let uu____1636 = tts e1 t in
+                    let uu____1637 =
+                      let uu____1638 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1638
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1639 uu____1640 msg
-                | FStar_Errors.Error (uu____1648, msg, uu____1650) ->
-                    let uu____1651 = tts e1 t in
-                    let uu____1652 =
-                      let uu____1653 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_All.pipe_right uu____1653
+                      uu____1636 uu____1637 msg
+                | FStar_Errors.Error (uu____1645, msg, uu____1647) ->
+                    let uu____1648 = tts e1 t in
+                    let uu____1649 =
+                      let uu____1650 = FStar_TypeChecker_Env.all_binders e1 in
+                      FStar_All.pipe_right uu____1650
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1651 uu____1652 msg))
+                      uu____1648 uu____1649 msg))
 let (__tc_lax :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -988,228 +891,228 @@ let (__tc_lax :
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            FStar_Tactics_Monad.mlog
-             (fun uu____1702 ->
-                let uu____1703 = FStar_Syntax_Print.term_to_string t in
-                FStar_Util.print1 "Tac> __tc_lax(%s)\n" uu____1703)
-             (fun uu____1707 ->
+             (fun uu____1699 ->
+                let uu____1700 = FStar_Syntax_Print.term_to_string t in
+                FStar_Util.print1 "Tac> __tc_lax(%s)\n" uu____1700)
+             (fun uu____1704 ->
                 let e1 =
-                  let uu___334_1709 = e in
+                  let uu___332_1706 = e in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___334_1709.FStar_TypeChecker_Env.solver);
+                      (uu___332_1706.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___334_1709.FStar_TypeChecker_Env.range);
+                      (uu___332_1706.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___334_1709.FStar_TypeChecker_Env.curmodule);
+                      (uu___332_1706.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___334_1709.FStar_TypeChecker_Env.gamma);
+                      (uu___332_1706.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___334_1709.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___332_1706.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___334_1709.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___332_1706.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___334_1709.FStar_TypeChecker_Env.modules);
+                      (uu___332_1706.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___334_1709.FStar_TypeChecker_Env.expected_typ);
+                      (uu___332_1706.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___334_1709.FStar_TypeChecker_Env.sigtab);
+                      (uu___332_1706.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___334_1709.FStar_TypeChecker_Env.attrtab);
+                      (uu___332_1706.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___334_1709.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___332_1706.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___334_1709.FStar_TypeChecker_Env.effects);
+                      (uu___332_1706.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___334_1709.FStar_TypeChecker_Env.generalize);
+                      (uu___332_1706.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___334_1709.FStar_TypeChecker_Env.letrecs);
+                      (uu___332_1706.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___334_1709.FStar_TypeChecker_Env.top_level);
+                      (uu___332_1706.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___334_1709.FStar_TypeChecker_Env.check_uvars);
+                      (uu___332_1706.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___334_1709.FStar_TypeChecker_Env.use_eq);
+                      (uu___332_1706.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___334_1709.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___332_1706.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___334_1709.FStar_TypeChecker_Env.is_iface);
+                      (uu___332_1706.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___334_1709.FStar_TypeChecker_Env.admit);
+                      (uu___332_1706.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax =
-                      (uu___334_1709.FStar_TypeChecker_Env.lax);
+                      (uu___332_1706.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___334_1709.FStar_TypeChecker_Env.lax_universes);
+                      (uu___332_1706.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___334_1709.FStar_TypeChecker_Env.phase1);
+                      (uu___332_1706.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___334_1709.FStar_TypeChecker_Env.failhard);
+                      (uu___332_1706.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___334_1709.FStar_TypeChecker_Env.nosynth);
+                      (uu___332_1706.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___334_1709.FStar_TypeChecker_Env.tc_term);
+                      (uu___332_1706.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___334_1709.FStar_TypeChecker_Env.type_of);
+                      (uu___332_1706.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___334_1709.FStar_TypeChecker_Env.universe_of);
+                      (uu___332_1706.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___334_1709.FStar_TypeChecker_Env.check_type_of);
+                      (uu___332_1706.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___334_1709.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___332_1706.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___334_1709.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___332_1706.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___334_1709.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___332_1706.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___334_1709.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___332_1706.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___334_1709.FStar_TypeChecker_Env.proof_ns);
+                      (uu___332_1706.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___334_1709.FStar_TypeChecker_Env.synth_hook);
+                      (uu___332_1706.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___334_1709.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___332_1706.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___334_1709.FStar_TypeChecker_Env.splice);
+                      (uu___332_1706.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___334_1709.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___332_1706.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___334_1709.FStar_TypeChecker_Env.postprocess);
+                      (uu___332_1706.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___334_1709.FStar_TypeChecker_Env.identifier_info);
+                      (uu___332_1706.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___334_1709.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___332_1706.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___334_1709.FStar_TypeChecker_Env.dsenv);
+                      (uu___332_1706.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___334_1709.FStar_TypeChecker_Env.nbe);
+                      (uu___332_1706.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___334_1709.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___332_1706.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___334_1709.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___332_1706.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___334_1709.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___332_1706.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 let e2 =
-                  let uu___337_1711 = e1 in
+                  let uu___335_1708 = e1 in
                   {
                     FStar_TypeChecker_Env.solver =
-                      (uu___337_1711.FStar_TypeChecker_Env.solver);
+                      (uu___335_1708.FStar_TypeChecker_Env.solver);
                     FStar_TypeChecker_Env.range =
-                      (uu___337_1711.FStar_TypeChecker_Env.range);
+                      (uu___335_1708.FStar_TypeChecker_Env.range);
                     FStar_TypeChecker_Env.curmodule =
-                      (uu___337_1711.FStar_TypeChecker_Env.curmodule);
+                      (uu___335_1708.FStar_TypeChecker_Env.curmodule);
                     FStar_TypeChecker_Env.gamma =
-                      (uu___337_1711.FStar_TypeChecker_Env.gamma);
+                      (uu___335_1708.FStar_TypeChecker_Env.gamma);
                     FStar_TypeChecker_Env.gamma_sig =
-                      (uu___337_1711.FStar_TypeChecker_Env.gamma_sig);
+                      (uu___335_1708.FStar_TypeChecker_Env.gamma_sig);
                     FStar_TypeChecker_Env.gamma_cache =
-                      (uu___337_1711.FStar_TypeChecker_Env.gamma_cache);
+                      (uu___335_1708.FStar_TypeChecker_Env.gamma_cache);
                     FStar_TypeChecker_Env.modules =
-                      (uu___337_1711.FStar_TypeChecker_Env.modules);
+                      (uu___335_1708.FStar_TypeChecker_Env.modules);
                     FStar_TypeChecker_Env.expected_typ =
-                      (uu___337_1711.FStar_TypeChecker_Env.expected_typ);
+                      (uu___335_1708.FStar_TypeChecker_Env.expected_typ);
                     FStar_TypeChecker_Env.sigtab =
-                      (uu___337_1711.FStar_TypeChecker_Env.sigtab);
+                      (uu___335_1708.FStar_TypeChecker_Env.sigtab);
                     FStar_TypeChecker_Env.attrtab =
-                      (uu___337_1711.FStar_TypeChecker_Env.attrtab);
+                      (uu___335_1708.FStar_TypeChecker_Env.attrtab);
                     FStar_TypeChecker_Env.instantiate_imp =
-                      (uu___337_1711.FStar_TypeChecker_Env.instantiate_imp);
+                      (uu___335_1708.FStar_TypeChecker_Env.instantiate_imp);
                     FStar_TypeChecker_Env.effects =
-                      (uu___337_1711.FStar_TypeChecker_Env.effects);
+                      (uu___335_1708.FStar_TypeChecker_Env.effects);
                     FStar_TypeChecker_Env.generalize =
-                      (uu___337_1711.FStar_TypeChecker_Env.generalize);
+                      (uu___335_1708.FStar_TypeChecker_Env.generalize);
                     FStar_TypeChecker_Env.letrecs =
-                      (uu___337_1711.FStar_TypeChecker_Env.letrecs);
+                      (uu___335_1708.FStar_TypeChecker_Env.letrecs);
                     FStar_TypeChecker_Env.top_level =
-                      (uu___337_1711.FStar_TypeChecker_Env.top_level);
+                      (uu___335_1708.FStar_TypeChecker_Env.top_level);
                     FStar_TypeChecker_Env.check_uvars =
-                      (uu___337_1711.FStar_TypeChecker_Env.check_uvars);
+                      (uu___335_1708.FStar_TypeChecker_Env.check_uvars);
                     FStar_TypeChecker_Env.use_eq =
-                      (uu___337_1711.FStar_TypeChecker_Env.use_eq);
+                      (uu___335_1708.FStar_TypeChecker_Env.use_eq);
                     FStar_TypeChecker_Env.use_eq_strict =
-                      (uu___337_1711.FStar_TypeChecker_Env.use_eq_strict);
+                      (uu___335_1708.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
-                      (uu___337_1711.FStar_TypeChecker_Env.is_iface);
+                      (uu___335_1708.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
-                      (uu___337_1711.FStar_TypeChecker_Env.admit);
+                      (uu___335_1708.FStar_TypeChecker_Env.admit);
                     FStar_TypeChecker_Env.lax = true;
                     FStar_TypeChecker_Env.lax_universes =
-                      (uu___337_1711.FStar_TypeChecker_Env.lax_universes);
+                      (uu___335_1708.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
-                      (uu___337_1711.FStar_TypeChecker_Env.phase1);
+                      (uu___335_1708.FStar_TypeChecker_Env.phase1);
                     FStar_TypeChecker_Env.failhard =
-                      (uu___337_1711.FStar_TypeChecker_Env.failhard);
+                      (uu___335_1708.FStar_TypeChecker_Env.failhard);
                     FStar_TypeChecker_Env.nosynth =
-                      (uu___337_1711.FStar_TypeChecker_Env.nosynth);
+                      (uu___335_1708.FStar_TypeChecker_Env.nosynth);
                     FStar_TypeChecker_Env.uvar_subtyping =
-                      (uu___337_1711.FStar_TypeChecker_Env.uvar_subtyping);
+                      (uu___335_1708.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.tc_term =
-                      (uu___337_1711.FStar_TypeChecker_Env.tc_term);
+                      (uu___335_1708.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.type_of =
-                      (uu___337_1711.FStar_TypeChecker_Env.type_of);
+                      (uu___335_1708.FStar_TypeChecker_Env.type_of);
                     FStar_TypeChecker_Env.universe_of =
-                      (uu___337_1711.FStar_TypeChecker_Env.universe_of);
+                      (uu___335_1708.FStar_TypeChecker_Env.universe_of);
                     FStar_TypeChecker_Env.check_type_of =
-                      (uu___337_1711.FStar_TypeChecker_Env.check_type_of);
+                      (uu___335_1708.FStar_TypeChecker_Env.check_type_of);
                     FStar_TypeChecker_Env.use_bv_sorts =
-                      (uu___337_1711.FStar_TypeChecker_Env.use_bv_sorts);
+                      (uu___335_1708.FStar_TypeChecker_Env.use_bv_sorts);
                     FStar_TypeChecker_Env.qtbl_name_and_index =
-                      (uu___337_1711.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      (uu___335_1708.FStar_TypeChecker_Env.qtbl_name_and_index);
                     FStar_TypeChecker_Env.normalized_eff_names =
-                      (uu___337_1711.FStar_TypeChecker_Env.normalized_eff_names);
+                      (uu___335_1708.FStar_TypeChecker_Env.normalized_eff_names);
                     FStar_TypeChecker_Env.fv_delta_depths =
-                      (uu___337_1711.FStar_TypeChecker_Env.fv_delta_depths);
+                      (uu___335_1708.FStar_TypeChecker_Env.fv_delta_depths);
                     FStar_TypeChecker_Env.proof_ns =
-                      (uu___337_1711.FStar_TypeChecker_Env.proof_ns);
+                      (uu___335_1708.FStar_TypeChecker_Env.proof_ns);
                     FStar_TypeChecker_Env.synth_hook =
-                      (uu___337_1711.FStar_TypeChecker_Env.synth_hook);
+                      (uu___335_1708.FStar_TypeChecker_Env.synth_hook);
                     FStar_TypeChecker_Env.try_solve_implicits_hook =
-                      (uu___337_1711.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      (uu___335_1708.FStar_TypeChecker_Env.try_solve_implicits_hook);
                     FStar_TypeChecker_Env.splice =
-                      (uu___337_1711.FStar_TypeChecker_Env.splice);
+                      (uu___335_1708.FStar_TypeChecker_Env.splice);
                     FStar_TypeChecker_Env.mpreprocess =
-                      (uu___337_1711.FStar_TypeChecker_Env.mpreprocess);
+                      (uu___335_1708.FStar_TypeChecker_Env.mpreprocess);
                     FStar_TypeChecker_Env.postprocess =
-                      (uu___337_1711.FStar_TypeChecker_Env.postprocess);
+                      (uu___335_1708.FStar_TypeChecker_Env.postprocess);
                     FStar_TypeChecker_Env.identifier_info =
-                      (uu___337_1711.FStar_TypeChecker_Env.identifier_info);
+                      (uu___335_1708.FStar_TypeChecker_Env.identifier_info);
                     FStar_TypeChecker_Env.tc_hooks =
-                      (uu___337_1711.FStar_TypeChecker_Env.tc_hooks);
+                      (uu___335_1708.FStar_TypeChecker_Env.tc_hooks);
                     FStar_TypeChecker_Env.dsenv =
-                      (uu___337_1711.FStar_TypeChecker_Env.dsenv);
+                      (uu___335_1708.FStar_TypeChecker_Env.dsenv);
                     FStar_TypeChecker_Env.nbe =
-                      (uu___337_1711.FStar_TypeChecker_Env.nbe);
+                      (uu___335_1708.FStar_TypeChecker_Env.nbe);
                     FStar_TypeChecker_Env.strict_args_tab =
-                      (uu___337_1711.FStar_TypeChecker_Env.strict_args_tab);
+                      (uu___335_1708.FStar_TypeChecker_Env.strict_args_tab);
                     FStar_TypeChecker_Env.erasable_types_tab =
-                      (uu___337_1711.FStar_TypeChecker_Env.erasable_types_tab);
+                      (uu___335_1708.FStar_TypeChecker_Env.erasable_types_tab);
                     FStar_TypeChecker_Env.enable_defer_to_tac =
-                      (uu___337_1711.FStar_TypeChecker_Env.enable_defer_to_tac)
+                      (uu___335_1708.FStar_TypeChecker_Env.enable_defer_to_tac)
                   } in
                 try
-                  (fun uu___341_1722 ->
+                  (fun uu___339_1719 ->
                      match () with
                      | () ->
-                         let uu____1731 =
+                         let uu____1728 =
                            FStar_TypeChecker_TcTerm.tc_term e2 t in
-                         FStar_Tactics_Monad.ret uu____1731) ()
+                         FStar_Tactics_Monad.ret uu____1728) ()
                 with
-                | FStar_Errors.Err (uu____1758, msg) ->
-                    let uu____1760 = tts e2 t in
-                    let uu____1761 =
-                      let uu____1762 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_All.pipe_right uu____1762
+                | FStar_Errors.Err (uu____1755, msg) ->
+                    let uu____1757 = tts e2 t in
+                    let uu____1758 =
+                      let uu____1759 = FStar_TypeChecker_Env.all_binders e2 in
+                      FStar_All.pipe_right uu____1759
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1760 uu____1761 msg
-                | FStar_Errors.Error (uu____1769, msg, uu____1771) ->
-                    let uu____1772 = tts e2 t in
-                    let uu____1773 =
-                      let uu____1774 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_All.pipe_right uu____1774
+                      uu____1757 uu____1758 msg
+                | FStar_Errors.Error (uu____1766, msg, uu____1768) ->
+                    let uu____1769 = tts e2 t in
+                    let uu____1770 =
+                      let uu____1771 = FStar_TypeChecker_Env.all_binders e2 in
+                      FStar_All.pipe_right uu____1771
                         (FStar_Syntax_Print.binders_to_string ", ") in
                     fail3 "Cannot type %s in context (%s). Error = (%s)"
-                      uu____1772 uu____1773 msg))
+                      uu____1769 uu____1770 msg))
 let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e ->
     fun t ->
@@ -1223,7 +1126,7 @@ let (istrivial : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
       let t1 = normalize steps e t in is_true t1
 let (get_guard_policy :
   unit -> FStar_Tactics_Types.guard_policy FStar_Tactics_Monad.tac) =
-  fun uu____1801 ->
+  fun uu____1798 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps -> FStar_Tactics_Monad.ret ps.FStar_Tactics_Types.guard_policy)
 let (set_guard_policy :
@@ -1232,31 +1135,31 @@ let (set_guard_policy :
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          FStar_Tactics_Monad.set
-           (let uu___362_1819 = ps in
+           (let uu___360_1816 = ps in
             {
               FStar_Tactics_Types.main_context =
-                (uu___362_1819.FStar_Tactics_Types.main_context);
+                (uu___360_1816.FStar_Tactics_Types.main_context);
               FStar_Tactics_Types.all_implicits =
-                (uu___362_1819.FStar_Tactics_Types.all_implicits);
+                (uu___360_1816.FStar_Tactics_Types.all_implicits);
               FStar_Tactics_Types.goals =
-                (uu___362_1819.FStar_Tactics_Types.goals);
+                (uu___360_1816.FStar_Tactics_Types.goals);
               FStar_Tactics_Types.smt_goals =
-                (uu___362_1819.FStar_Tactics_Types.smt_goals);
+                (uu___360_1816.FStar_Tactics_Types.smt_goals);
               FStar_Tactics_Types.depth =
-                (uu___362_1819.FStar_Tactics_Types.depth);
+                (uu___360_1816.FStar_Tactics_Types.depth);
               FStar_Tactics_Types.__dump =
-                (uu___362_1819.FStar_Tactics_Types.__dump);
+                (uu___360_1816.FStar_Tactics_Types.__dump);
               FStar_Tactics_Types.psc =
-                (uu___362_1819.FStar_Tactics_Types.psc);
+                (uu___360_1816.FStar_Tactics_Types.psc);
               FStar_Tactics_Types.entry_range =
-                (uu___362_1819.FStar_Tactics_Types.entry_range);
+                (uu___360_1816.FStar_Tactics_Types.entry_range);
               FStar_Tactics_Types.guard_policy = pol;
               FStar_Tactics_Types.freshness =
-                (uu___362_1819.FStar_Tactics_Types.freshness);
+                (uu___360_1816.FStar_Tactics_Types.freshness);
               FStar_Tactics_Types.tac_verb_dbg =
-                (uu___362_1819.FStar_Tactics_Types.tac_verb_dbg);
+                (uu___360_1816.FStar_Tactics_Types.tac_verb_dbg);
               FStar_Tactics_Types.local_state =
-                (uu___362_1819.FStar_Tactics_Types.local_state)
+                (uu___360_1816.FStar_Tactics_Types.local_state)
             }))
 let with_policy :
   'a .
@@ -1265,27 +1168,27 @@ let with_policy :
   =
   fun pol ->
     fun t ->
-      let uu____1843 = get_guard_policy () in
-      FStar_Tactics_Monad.bind uu____1843
+      let uu____1840 = get_guard_policy () in
+      FStar_Tactics_Monad.bind uu____1840
         (fun old_pol ->
-           let uu____1849 = set_guard_policy pol in
-           FStar_Tactics_Monad.bind uu____1849
-             (fun uu____1853 ->
+           let uu____1846 = set_guard_policy pol in
+           FStar_Tactics_Monad.bind uu____1846
+             (fun uu____1850 ->
                 FStar_Tactics_Monad.bind t
                   (fun r ->
-                     let uu____1857 = set_guard_policy old_pol in
-                     FStar_Tactics_Monad.bind uu____1857
-                       (fun uu____1861 -> FStar_Tactics_Monad.ret r))))
+                     let uu____1854 = set_guard_policy old_pol in
+                     FStar_Tactics_Monad.bind uu____1854
+                       (fun uu____1858 -> FStar_Tactics_Monad.ret r))))
 let (getopts : FStar_Options.optionstate FStar_Tactics_Monad.tac) =
-  let uu____1864 = trytac FStar_Tactics_Monad.cur_goal in
-  FStar_Tactics_Monad.bind uu____1864
-    (fun uu___0_1873 ->
-       match uu___0_1873 with
+  let uu____1861 = trytac FStar_Tactics_Monad.cur_goal in
+  FStar_Tactics_Monad.bind uu____1861
+    (fun uu___0_1870 ->
+       match uu___0_1870 with
        | FStar_Pervasives_Native.Some g ->
            FStar_Tactics_Monad.ret g.FStar_Tactics_Types.opts
        | FStar_Pervasives_Native.None ->
-           let uu____1879 = FStar_Options.peek () in
-           FStar_Tactics_Monad.ret uu____1879)
+           let uu____1876 = FStar_Options.peek () in
+           FStar_Tactics_Monad.ret uu____1876)
 let (proc_guard :
   Prims.string ->
     env -> FStar_TypeChecker_Common.guard_t -> unit FStar_Tactics_Monad.tac)
@@ -1294,27 +1197,27 @@ let (proc_guard :
     fun e ->
       fun g ->
         FStar_Tactics_Monad.mlog
-          (fun uu____1901 ->
-             let uu____1902 = FStar_TypeChecker_Rel.guard_to_string e g in
-             FStar_Util.print2 "Processing guard (%s:%s)\n" reason uu____1902)
-          (fun uu____1905 ->
-             let uu____1906 =
+          (fun uu____1898 ->
+             let uu____1899 = FStar_TypeChecker_Rel.guard_to_string e g in
+             FStar_Util.print2 "Processing guard (%s:%s)\n" reason uu____1899)
+          (fun uu____1902 ->
+             let uu____1903 =
                FStar_Tactics_Monad.add_implicits
                  g.FStar_TypeChecker_Common.implicits in
-             FStar_Tactics_Monad.bind uu____1906
-               (fun uu____1910 ->
+             FStar_Tactics_Monad.bind uu____1903
+               (fun uu____1907 ->
                   FStar_Tactics_Monad.bind getopts
                     (fun opts ->
-                       let uu____1914 =
-                         let uu____1915 =
+                       let uu____1911 =
+                         let uu____1912 =
                            FStar_TypeChecker_Rel.simplify_guard e g in
-                         uu____1915.FStar_TypeChecker_Common.guard_f in
-                       match uu____1914 with
+                         uu____1912.FStar_TypeChecker_Common.guard_f in
+                       match uu____1911 with
                        | FStar_TypeChecker_Common.Trivial ->
                            FStar_Tactics_Monad.ret ()
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____1919 = istrivial e f in
-                           if uu____1919
+                           let uu____1916 = istrivial e f in
+                           if uu____1916
                            then FStar_Tactics_Monad.ret ()
                            else
                              FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
@@ -1322,127 +1225,127 @@ let (proc_guard :
                                   match ps.FStar_Tactics_Types.guard_policy
                                   with
                                   | FStar_Tactics_Types.Drop ->
-                                      ((let uu____1929 =
-                                          let uu____1934 =
-                                            let uu____1935 =
+                                      ((let uu____1926 =
+                                          let uu____1931 =
+                                            let uu____1932 =
                                               FStar_TypeChecker_Rel.guard_to_string
                                                 e g in
                                             FStar_Util.format1
                                               "Tactics admitted guard <%s>\n\n"
-                                              uu____1935 in
+                                              uu____1932 in
                                           (FStar_Errors.Warning_TacAdmit,
-                                            uu____1934) in
+                                            uu____1931) in
                                         FStar_Errors.log_issue
                                           e.FStar_TypeChecker_Env.range
-                                          uu____1929);
+                                          uu____1926);
                                        FStar_Tactics_Monad.ret ())
                                   | FStar_Tactics_Types.Goal ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1938 ->
-                                           let uu____1939 =
+                                        (fun uu____1935 ->
+                                           let uu____1936 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Making guard (%s:%s) into a goal\n"
-                                             reason uu____1939)
-                                        (fun uu____1942 ->
-                                           let uu____1943 =
+                                             reason uu____1936)
+                                        (fun uu____1939 ->
+                                           let uu____1940 =
                                              FStar_Tactics_Monad.mk_irrelevant_goal
                                                reason e f opts "" in
                                            FStar_Tactics_Monad.bind
-                                             uu____1943
+                                             uu____1940
                                              (fun goal ->
                                                 let goal1 =
-                                                  let uu___391_1950 = goal in
+                                                  let uu___389_1947 = goal in
                                                   {
                                                     FStar_Tactics_Types.goal_main_env
                                                       =
-                                                      (uu___391_1950.FStar_Tactics_Types.goal_main_env);
+                                                      (uu___389_1947.FStar_Tactics_Types.goal_main_env);
                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                       =
-                                                      (uu___391_1950.FStar_Tactics_Types.goal_ctx_uvar);
+                                                      (uu___389_1947.FStar_Tactics_Types.goal_ctx_uvar);
                                                     FStar_Tactics_Types.opts
                                                       =
-                                                      (uu___391_1950.FStar_Tactics_Types.opts);
+                                                      (uu___389_1947.FStar_Tactics_Types.opts);
                                                     FStar_Tactics_Types.is_guard
                                                       = true;
                                                     FStar_Tactics_Types.label
                                                       =
-                                                      (uu___391_1950.FStar_Tactics_Types.label)
+                                                      (uu___389_1947.FStar_Tactics_Types.label)
                                                   } in
                                                 FStar_Tactics_Monad.push_goals
                                                   [goal1]))
                                   | FStar_Tactics_Types.SMT ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1953 ->
-                                           let uu____1954 =
+                                        (fun uu____1950 ->
+                                           let uu____1951 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Sending guard (%s:%s) to SMT goal\n"
-                                             reason uu____1954)
-                                        (fun uu____1957 ->
-                                           let uu____1958 =
+                                             reason uu____1951)
+                                        (fun uu____1954 ->
+                                           let uu____1955 =
                                              FStar_Tactics_Monad.mk_irrelevant_goal
                                                reason e f opts "" in
                                            FStar_Tactics_Monad.bind
-                                             uu____1958
+                                             uu____1955
                                              (fun goal ->
                                                 let goal1 =
-                                                  let uu___398_1965 = goal in
+                                                  let uu___396_1962 = goal in
                                                   {
                                                     FStar_Tactics_Types.goal_main_env
                                                       =
-                                                      (uu___398_1965.FStar_Tactics_Types.goal_main_env);
+                                                      (uu___396_1962.FStar_Tactics_Types.goal_main_env);
                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                       =
-                                                      (uu___398_1965.FStar_Tactics_Types.goal_ctx_uvar);
+                                                      (uu___396_1962.FStar_Tactics_Types.goal_ctx_uvar);
                                                     FStar_Tactics_Types.opts
                                                       =
-                                                      (uu___398_1965.FStar_Tactics_Types.opts);
+                                                      (uu___396_1962.FStar_Tactics_Types.opts);
                                                     FStar_Tactics_Types.is_guard
                                                       = true;
                                                     FStar_Tactics_Types.label
                                                       =
-                                                      (uu___398_1965.FStar_Tactics_Types.label)
+                                                      (uu___396_1962.FStar_Tactics_Types.label)
                                                   } in
                                                 FStar_Tactics_Monad.push_smt_goals
                                                   [goal1]))
                                   | FStar_Tactics_Types.Force ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____1968 ->
-                                           let uu____1969 =
+                                        (fun uu____1965 ->
+                                           let uu____1966 =
                                              FStar_TypeChecker_Rel.guard_to_string
                                                e g in
                                            FStar_Util.print2
                                              "Forcing guard (%s:%s)\n" reason
-                                             uu____1969)
-                                        (fun uu____1971 ->
+                                             uu____1966)
+                                        (fun uu____1968 ->
                                            try
-                                             (fun uu___405_1976 ->
+                                             (fun uu___403_1973 ->
                                                 match () with
                                                 | () ->
-                                                    let uu____1979 =
-                                                      let uu____1980 =
-                                                        let uu____1981 =
+                                                    let uu____1976 =
+                                                      let uu____1977 =
+                                                        let uu____1978 =
                                                           FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                             e g in
                                                         FStar_All.pipe_left
                                                           FStar_TypeChecker_Env.is_trivial
-                                                          uu____1981 in
+                                                          uu____1978 in
                                                       Prims.op_Negation
-                                                        uu____1980 in
-                                                    if uu____1979
+                                                        uu____1977 in
+                                                    if uu____1976
                                                     then
                                                       FStar_Tactics_Monad.mlog
-                                                        (fun uu____1986 ->
-                                                           let uu____1987 =
+                                                        (fun uu____1983 ->
+                                                           let uu____1984 =
                                                              FStar_TypeChecker_Rel.guard_to_string
                                                                e g in
                                                            FStar_Util.print1
                                                              "guard = %s\n"
-                                                             uu____1987)
-                                                        (fun uu____1989 ->
+                                                             uu____1984)
+                                                        (fun uu____1986 ->
                                                            fail1
                                                              "Forcing the guard failed (%s)"
                                                              reason)
@@ -1450,16 +1353,16 @@ let (proc_guard :
                                                       FStar_Tactics_Monad.ret
                                                         ()) ()
                                            with
-                                           | uu___404_1992 ->
+                                           | uu___402_1989 ->
                                                FStar_Tactics_Monad.mlog
-                                                 (fun uu____1997 ->
-                                                    let uu____1998 =
+                                                 (fun uu____1994 ->
+                                                    let uu____1995 =
                                                       FStar_TypeChecker_Rel.guard_to_string
                                                         e g in
                                                     FStar_Util.print1
                                                       "guard = %s\n"
-                                                      uu____1998)
-                                                 (fun uu____2000 ->
+                                                      uu____1995)
+                                                 (fun uu____1997 ->
                                                     fail1
                                                       "Forcing the guard failed (%s)"
                                                       reason))))))
@@ -1470,18 +1373,18 @@ let (tcc :
   =
   fun e ->
     fun t ->
-      let uu____2015 =
-        let uu____2018 = __tc_lax e t in
-        FStar_Tactics_Monad.bind uu____2018
-          (fun uu____2038 ->
-             match uu____2038 with
-             | (uu____2047, lc, uu____2049) ->
-                 let uu____2050 =
-                   let uu____2051 = FStar_TypeChecker_Common.lcomp_comp lc in
-                   FStar_All.pipe_right uu____2051
+      let uu____2012 =
+        let uu____2015 = __tc_lax e t in
+        FStar_Tactics_Monad.bind uu____2015
+          (fun uu____2035 ->
+             match uu____2035 with
+             | (uu____2044, lc, uu____2046) ->
+                 let uu____2047 =
+                   let uu____2048 = FStar_TypeChecker_Common.lcomp_comp lc in
+                   FStar_All.pipe_right uu____2048
                      FStar_Pervasives_Native.fst in
-                 FStar_Tactics_Monad.ret uu____2050) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tcc") uu____2015
+                 FStar_Tactics_Monad.ret uu____2047) in
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tcc") uu____2012
 let (tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -1489,27 +1392,27 @@ let (tc :
   =
   fun e ->
     fun t ->
-      let uu____2078 =
-        let uu____2083 = tcc e t in
-        FStar_Tactics_Monad.bind uu____2083
+      let uu____2075 =
+        let uu____2080 = tcc e t in
+        FStar_Tactics_Monad.bind uu____2080
           (fun c -> FStar_Tactics_Monad.ret (FStar_Syntax_Util.comp_result c)) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tc") uu____2078
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "tc") uu____2075
 let (trivial : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____2106 ->
+  fun uu____2103 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____2112 =
-           let uu____2113 = FStar_Tactics_Types.goal_env goal in
-           let uu____2114 = FStar_Tactics_Types.goal_type goal in
-           istrivial uu____2113 uu____2114 in
-         if uu____2112
+         let uu____2109 =
+           let uu____2110 = FStar_Tactics_Types.goal_env goal in
+           let uu____2111 = FStar_Tactics_Types.goal_type goal in
+           istrivial uu____2110 uu____2111 in
+         if uu____2109
          then solve' goal FStar_Syntax_Util.exp_unit
          else
-           (let uu____2118 =
-              let uu____2119 = FStar_Tactics_Types.goal_env goal in
-              let uu____2120 = FStar_Tactics_Types.goal_type goal in
-              tts uu____2119 uu____2120 in
-            fail1 "Not a trivial goal: %s" uu____2118))
+           (let uu____2115 =
+              let uu____2116 = FStar_Tactics_Types.goal_env goal in
+              let uu____2117 = FStar_Tactics_Types.goal_type goal in
+              tts uu____2116 uu____2117 in
+            fail1 "Not a trivial goal: %s" uu____2115))
 let divide :
   'a 'b .
     FStar_BigInt.t ->
@@ -1521,101 +1424,101 @@ let divide :
       fun r ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun p ->
-             let uu____2169 =
+             let uu____2166 =
                try
-                 (fun uu___456_2192 ->
+                 (fun uu___454_2189 ->
                     match () with
                     | () ->
-                        let uu____2203 =
-                          let uu____2212 = FStar_BigInt.to_int_fs n in
-                          FStar_List.splitAt uu____2212
+                        let uu____2200 =
+                          let uu____2209 = FStar_BigInt.to_int_fs n in
+                          FStar_List.splitAt uu____2209
                             p.FStar_Tactics_Types.goals in
-                        FStar_Tactics_Monad.ret uu____2203) ()
+                        FStar_Tactics_Monad.ret uu____2200) ()
                with
-               | uu___455_2222 ->
+               | uu___453_2219 ->
                    FStar_Tactics_Monad.fail "divide: not enough goals" in
-             FStar_Tactics_Monad.bind uu____2169
-               (fun uu____2258 ->
-                  match uu____2258 with
+             FStar_Tactics_Monad.bind uu____2166
+               (fun uu____2255 ->
+                  match uu____2255 with
                   | (lgs, rgs) ->
                       let lp =
-                        let uu___438_2284 = p in
+                        let uu___436_2281 = p in
                         {
                           FStar_Tactics_Types.main_context =
-                            (uu___438_2284.FStar_Tactics_Types.main_context);
+                            (uu___436_2281.FStar_Tactics_Types.main_context);
                           FStar_Tactics_Types.all_implicits =
-                            (uu___438_2284.FStar_Tactics_Types.all_implicits);
+                            (uu___436_2281.FStar_Tactics_Types.all_implicits);
                           FStar_Tactics_Types.goals = lgs;
                           FStar_Tactics_Types.smt_goals = [];
                           FStar_Tactics_Types.depth =
-                            (uu___438_2284.FStar_Tactics_Types.depth);
+                            (uu___436_2281.FStar_Tactics_Types.depth);
                           FStar_Tactics_Types.__dump =
-                            (uu___438_2284.FStar_Tactics_Types.__dump);
+                            (uu___436_2281.FStar_Tactics_Types.__dump);
                           FStar_Tactics_Types.psc =
-                            (uu___438_2284.FStar_Tactics_Types.psc);
+                            (uu___436_2281.FStar_Tactics_Types.psc);
                           FStar_Tactics_Types.entry_range =
-                            (uu___438_2284.FStar_Tactics_Types.entry_range);
+                            (uu___436_2281.FStar_Tactics_Types.entry_range);
                           FStar_Tactics_Types.guard_policy =
-                            (uu___438_2284.FStar_Tactics_Types.guard_policy);
+                            (uu___436_2281.FStar_Tactics_Types.guard_policy);
                           FStar_Tactics_Types.freshness =
-                            (uu___438_2284.FStar_Tactics_Types.freshness);
+                            (uu___436_2281.FStar_Tactics_Types.freshness);
                           FStar_Tactics_Types.tac_verb_dbg =
-                            (uu___438_2284.FStar_Tactics_Types.tac_verb_dbg);
+                            (uu___436_2281.FStar_Tactics_Types.tac_verb_dbg);
                           FStar_Tactics_Types.local_state =
-                            (uu___438_2284.FStar_Tactics_Types.local_state)
+                            (uu___436_2281.FStar_Tactics_Types.local_state)
                         } in
-                      let uu____2285 = FStar_Tactics_Monad.set lp in
-                      FStar_Tactics_Monad.bind uu____2285
-                        (fun uu____2293 ->
+                      let uu____2282 = FStar_Tactics_Monad.set lp in
+                      FStar_Tactics_Monad.bind uu____2282
+                        (fun uu____2290 ->
                            FStar_Tactics_Monad.bind l
                              (fun a1 ->
                                 FStar_Tactics_Monad.bind
                                   FStar_Tactics_Monad.get
                                   (fun lp' ->
                                      let rp =
-                                       let uu___444_2309 = lp' in
+                                       let uu___442_2306 = lp' in
                                        {
                                          FStar_Tactics_Types.main_context =
-                                           (uu___444_2309.FStar_Tactics_Types.main_context);
+                                           (uu___442_2306.FStar_Tactics_Types.main_context);
                                          FStar_Tactics_Types.all_implicits =
-                                           (uu___444_2309.FStar_Tactics_Types.all_implicits);
+                                           (uu___442_2306.FStar_Tactics_Types.all_implicits);
                                          FStar_Tactics_Types.goals = rgs;
                                          FStar_Tactics_Types.smt_goals = [];
                                          FStar_Tactics_Types.depth =
-                                           (uu___444_2309.FStar_Tactics_Types.depth);
+                                           (uu___442_2306.FStar_Tactics_Types.depth);
                                          FStar_Tactics_Types.__dump =
-                                           (uu___444_2309.FStar_Tactics_Types.__dump);
+                                           (uu___442_2306.FStar_Tactics_Types.__dump);
                                          FStar_Tactics_Types.psc =
-                                           (uu___444_2309.FStar_Tactics_Types.psc);
+                                           (uu___442_2306.FStar_Tactics_Types.psc);
                                          FStar_Tactics_Types.entry_range =
-                                           (uu___444_2309.FStar_Tactics_Types.entry_range);
+                                           (uu___442_2306.FStar_Tactics_Types.entry_range);
                                          FStar_Tactics_Types.guard_policy =
-                                           (uu___444_2309.FStar_Tactics_Types.guard_policy);
+                                           (uu___442_2306.FStar_Tactics_Types.guard_policy);
                                          FStar_Tactics_Types.freshness =
-                                           (uu___444_2309.FStar_Tactics_Types.freshness);
+                                           (uu___442_2306.FStar_Tactics_Types.freshness);
                                          FStar_Tactics_Types.tac_verb_dbg =
-                                           (uu___444_2309.FStar_Tactics_Types.tac_verb_dbg);
+                                           (uu___442_2306.FStar_Tactics_Types.tac_verb_dbg);
                                          FStar_Tactics_Types.local_state =
-                                           (uu___444_2309.FStar_Tactics_Types.local_state)
+                                           (uu___442_2306.FStar_Tactics_Types.local_state)
                                        } in
-                                     let uu____2310 =
+                                     let uu____2307 =
                                        FStar_Tactics_Monad.set rp in
-                                     FStar_Tactics_Monad.bind uu____2310
-                                       (fun uu____2318 ->
+                                     FStar_Tactics_Monad.bind uu____2307
+                                       (fun uu____2315 ->
                                           FStar_Tactics_Monad.bind r
                                             (fun b1 ->
                                                FStar_Tactics_Monad.bind
                                                  FStar_Tactics_Monad.get
                                                  (fun rp' ->
                                                     let p' =
-                                                      let uu___450_2334 = rp' in
+                                                      let uu___448_2331 = rp' in
                                                       {
                                                         FStar_Tactics_Types.main_context
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.main_context);
+                                                          (uu___448_2331.FStar_Tactics_Types.main_context);
                                                         FStar_Tactics_Types.all_implicits
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.all_implicits);
+                                                          (uu___448_2331.FStar_Tactics_Types.all_implicits);
                                                         FStar_Tactics_Types.goals
                                                           =
                                                           (FStar_List.append
@@ -1630,46 +1533,46 @@ let divide :
                                                                 p.FStar_Tactics_Types.smt_goals));
                                                         FStar_Tactics_Types.depth
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.depth);
+                                                          (uu___448_2331.FStar_Tactics_Types.depth);
                                                         FStar_Tactics_Types.__dump
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.__dump);
+                                                          (uu___448_2331.FStar_Tactics_Types.__dump);
                                                         FStar_Tactics_Types.psc
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.psc);
+                                                          (uu___448_2331.FStar_Tactics_Types.psc);
                                                         FStar_Tactics_Types.entry_range
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.entry_range);
+                                                          (uu___448_2331.FStar_Tactics_Types.entry_range);
                                                         FStar_Tactics_Types.guard_policy
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.guard_policy);
+                                                          (uu___448_2331.FStar_Tactics_Types.guard_policy);
                                                         FStar_Tactics_Types.freshness
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.freshness);
+                                                          (uu___448_2331.FStar_Tactics_Types.freshness);
                                                         FStar_Tactics_Types.tac_verb_dbg
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.tac_verb_dbg);
+                                                          (uu___448_2331.FStar_Tactics_Types.tac_verb_dbg);
                                                         FStar_Tactics_Types.local_state
                                                           =
-                                                          (uu___450_2334.FStar_Tactics_Types.local_state)
+                                                          (uu___448_2331.FStar_Tactics_Types.local_state)
                                                       } in
-                                                    let uu____2335 =
+                                                    let uu____2332 =
                                                       FStar_Tactics_Monad.set
                                                         p' in
                                                     FStar_Tactics_Monad.bind
-                                                      uu____2335
-                                                      (fun uu____2343 ->
+                                                      uu____2332
+                                                      (fun uu____2340 ->
                                                          FStar_Tactics_Monad.bind
                                                            FStar_Tactics_Monad.remove_solved_goals
-                                                           (fun uu____2349 ->
+                                                           (fun uu____2346 ->
                                                               FStar_Tactics_Monad.ret
                                                                 (a1, b1)))))))))))
 let focus : 'a . 'a FStar_Tactics_Monad.tac -> 'a FStar_Tactics_Monad.tac =
   fun f ->
-    let uu____2370 = divide FStar_BigInt.one f FStar_Tactics_Monad.idtac in
-    FStar_Tactics_Monad.bind uu____2370
-      (fun uu____2383 ->
-         match uu____2383 with | (a1, ()) -> FStar_Tactics_Monad.ret a1)
+    let uu____2367 = divide FStar_BigInt.one f FStar_Tactics_Monad.idtac in
+    FStar_Tactics_Monad.bind uu____2367
+      (fun uu____2380 ->
+         match uu____2380 with | (a1, ()) -> FStar_Tactics_Monad.ret a1)
 let rec map :
   'a . 'a FStar_Tactics_Monad.tac -> 'a Prims.list FStar_Tactics_Monad.tac =
   fun tau ->
@@ -1677,13 +1580,13 @@ let rec map :
       (fun p ->
          match p.FStar_Tactics_Types.goals with
          | [] -> FStar_Tactics_Monad.ret []
-         | uu____2420::uu____2421 ->
-             let uu____2424 =
-               let uu____2433 = map tau in
-               divide FStar_BigInt.one tau uu____2433 in
-             FStar_Tactics_Monad.bind uu____2424
-               (fun uu____2451 ->
-                  match uu____2451 with
+         | uu____2417::uu____2418 ->
+             let uu____2421 =
+               let uu____2430 = map tau in
+               divide FStar_BigInt.one tau uu____2430 in
+             FStar_Tactics_Monad.bind uu____2421
+               (fun uu____2448 ->
+                  match uu____2448 with
                   | (h, t) -> FStar_Tactics_Monad.ret (h :: t)))
 let (seq :
   unit FStar_Tactics_Monad.tac ->
@@ -1691,168 +1594,168 @@ let (seq :
   =
   fun t1 ->
     fun t2 ->
-      let uu____2492 =
+      let uu____2489 =
         FStar_Tactics_Monad.bind t1
-          (fun uu____2497 ->
-             let uu____2498 = map t2 in
-             FStar_Tactics_Monad.bind uu____2498
-               (fun uu____2506 -> FStar_Tactics_Monad.ret ())) in
-      focus uu____2492
+          (fun uu____2494 ->
+             let uu____2495 = map t2 in
+             FStar_Tactics_Monad.bind uu____2495
+               (fun uu____2503 -> FStar_Tactics_Monad.ret ())) in
+      focus uu____2489
 let (intro : unit -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac) =
-  fun uu____2515 ->
-    let uu____2518 =
+  fun uu____2512 ->
+    let uu____2515 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____2527 =
-             let uu____2534 =
-               let uu____2535 = FStar_Tactics_Types.goal_env goal in
-               let uu____2536 = FStar_Tactics_Types.goal_type goal in
-               whnf uu____2535 uu____2536 in
-             FStar_Syntax_Util.arrow_one uu____2534 in
-           match uu____2527 with
+           let uu____2524 =
+             let uu____2531 =
+               let uu____2532 = FStar_Tactics_Types.goal_env goal in
+               let uu____2533 = FStar_Tactics_Types.goal_type goal in
+               whnf uu____2532 uu____2533 in
+             FStar_Syntax_Util.arrow_one uu____2531 in
+           match uu____2524 with
            | FStar_Pervasives_Native.Some (b, c) ->
-               let uu____2545 =
-                 let uu____2546 = FStar_Syntax_Util.is_total_comp c in
-                 Prims.op_Negation uu____2546 in
-               if uu____2545
+               let uu____2542 =
+                 let uu____2543 = FStar_Syntax_Util.is_total_comp c in
+                 Prims.op_Negation uu____2543 in
+               if uu____2542
                then FStar_Tactics_Monad.fail "Codomain is effectful"
                else
                  (let env' =
-                    let uu____2551 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.push_binders uu____2551 [b] in
+                    let uu____2548 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.push_binders uu____2548 [b] in
                   let typ' = FStar_Syntax_Util.comp_result c in
-                  let uu____2567 =
+                  let uu____2564 =
                     FStar_Tactics_Monad.new_uvar "intro" env' typ' in
-                  FStar_Tactics_Monad.bind uu____2567
-                    (fun uu____2583 ->
-                       match uu____2583 with
+                  FStar_Tactics_Monad.bind uu____2564
+                    (fun uu____2580 ->
+                       match uu____2580 with
                        | (body, ctx_uvar) ->
                            let sol =
                              FStar_Syntax_Util.abs [b] body
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)) in
-                           let uu____2607 = set_solution goal sol in
-                           FStar_Tactics_Monad.bind uu____2607
-                             (fun uu____2613 ->
+                           let uu____2604 = set_solution goal sol in
+                           FStar_Tactics_Monad.bind uu____2604
+                             (fun uu____2610 ->
                                 let g =
                                   FStar_Tactics_Types.mk_goal env' ctx_uvar
                                     goal.FStar_Tactics_Types.opts
                                     goal.FStar_Tactics_Types.is_guard
                                     goal.FStar_Tactics_Types.label in
-                                let uu____2615 =
-                                  let uu____2618 = bnorm_goal g in
-                                  FStar_Tactics_Monad.replace_cur uu____2618 in
-                                FStar_Tactics_Monad.bind uu____2615
-                                  (fun uu____2620 ->
+                                let uu____2612 =
+                                  let uu____2615 = bnorm_goal g in
+                                  FStar_Tactics_Monad.replace_cur uu____2615 in
+                                FStar_Tactics_Monad.bind uu____2612
+                                  (fun uu____2617 ->
                                      FStar_Tactics_Monad.ret b))))
            | FStar_Pervasives_Native.None ->
-               let uu____2625 =
-                 let uu____2626 = FStar_Tactics_Types.goal_env goal in
-                 let uu____2627 = FStar_Tactics_Types.goal_type goal in
-                 tts uu____2626 uu____2627 in
-               fail1 "goal is not an arrow (%s)" uu____2625) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "intro") uu____2518
+               let uu____2622 =
+                 let uu____2623 = FStar_Tactics_Types.goal_env goal in
+                 let uu____2624 = FStar_Tactics_Types.goal_type goal in
+                 tts uu____2623 uu____2624 in
+               fail1 "goal is not an arrow (%s)" uu____2622) in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "intro") uu____2515
 let (intro_rec :
   unit ->
     (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.binder)
       FStar_Tactics_Monad.tac)
   =
-  fun uu____2642 ->
+  fun uu____2639 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Util.print_string
            "WARNING (intro_rec): calling this is known to cause normalizer loops\n";
          FStar_Util.print_string
            "WARNING (intro_rec): proceed at your own risk...\n";
-         (let uu____2663 =
-            let uu____2670 =
-              let uu____2671 = FStar_Tactics_Types.goal_env goal in
-              let uu____2672 = FStar_Tactics_Types.goal_type goal in
-              whnf uu____2671 uu____2672 in
-            FStar_Syntax_Util.arrow_one uu____2670 in
-          match uu____2663 with
+         (let uu____2660 =
+            let uu____2667 =
+              let uu____2668 = FStar_Tactics_Types.goal_env goal in
+              let uu____2669 = FStar_Tactics_Types.goal_type goal in
+              whnf uu____2668 uu____2669 in
+            FStar_Syntax_Util.arrow_one uu____2667 in
+          match uu____2660 with
           | FStar_Pervasives_Native.Some (b, c) ->
-              let uu____2685 =
-                let uu____2686 = FStar_Syntax_Util.is_total_comp c in
-                Prims.op_Negation uu____2686 in
-              if uu____2685
+              let uu____2682 =
+                let uu____2683 = FStar_Syntax_Util.is_total_comp c in
+                Prims.op_Negation uu____2683 in
+              if uu____2682
               then FStar_Tactics_Monad.fail "Codomain is effectful"
               else
                 (let bv =
-                   let uu____2699 = FStar_Tactics_Types.goal_type goal in
+                   let uu____2696 = FStar_Tactics_Types.goal_type goal in
                    FStar_Syntax_Syntax.gen_bv "__recf"
-                     FStar_Pervasives_Native.None uu____2699 in
+                     FStar_Pervasives_Native.None uu____2696 in
                  let bs =
-                   let uu____2709 = FStar_Syntax_Syntax.mk_binder bv in
-                   [uu____2709; b] in
+                   let uu____2706 = FStar_Syntax_Syntax.mk_binder bv in
+                   [uu____2706; b] in
                  let env' =
-                   let uu____2735 = FStar_Tactics_Types.goal_env goal in
-                   FStar_TypeChecker_Env.push_binders uu____2735 bs in
-                 let uu____2736 =
+                   let uu____2732 = FStar_Tactics_Types.goal_env goal in
+                   FStar_TypeChecker_Env.push_binders uu____2732 bs in
+                 let uu____2733 =
                    FStar_Tactics_Monad.new_uvar "intro_rec" env'
                      (FStar_Syntax_Util.comp_result c) in
-                 FStar_Tactics_Monad.bind uu____2736
-                   (fun uu____2761 ->
-                      match uu____2761 with
+                 FStar_Tactics_Monad.bind uu____2733
+                   (fun uu____2758 ->
+                      match uu____2758 with
                       | (u, ctx_uvar_u) ->
                           let lb =
-                            let uu____2775 =
+                            let uu____2772 =
                               FStar_Tactics_Types.goal_type goal in
-                            let uu____2778 =
+                            let uu____2775 =
                               FStar_Syntax_Util.abs [b] u
                                 FStar_Pervasives_Native.None in
                             FStar_Syntax_Util.mk_letbinding
-                              (FStar_Util.Inl bv) [] uu____2775
-                              FStar_Parser_Const.effect_Tot_lid uu____2778 []
+                              (FStar_Util.Inl bv) [] uu____2772
+                              FStar_Parser_Const.effect_Tot_lid uu____2775 []
                               FStar_Range.dummyRange in
                           let body = FStar_Syntax_Syntax.bv_to_name bv in
-                          let uu____2796 =
+                          let uu____2793 =
                             FStar_Syntax_Subst.close_let_rec [lb] body in
-                          (match uu____2796 with
+                          (match uu____2793 with
                            | (lbs, body1) ->
                                let tm =
-                                 let uu____2818 =
-                                   let uu____2819 =
+                                 let uu____2815 =
+                                   let uu____2816 =
                                      FStar_Tactics_Types.goal_witness goal in
-                                   uu____2819.FStar_Syntax_Syntax.pos in
+                                   uu____2816.FStar_Syntax_Syntax.pos in
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_let
-                                      ((true, lbs), body1)) uu____2818 in
-                               let uu____2832 = set_solution goal tm in
-                               FStar_Tactics_Monad.bind uu____2832
-                                 (fun uu____2841 ->
-                                    let uu____2842 =
-                                      let uu____2845 =
+                                      ((true, lbs), body1)) uu____2815 in
+                               let uu____2829 = set_solution goal tm in
+                               FStar_Tactics_Monad.bind uu____2829
+                                 (fun uu____2838 ->
+                                    let uu____2839 =
+                                      let uu____2842 =
                                         bnorm_goal
-                                          (let uu___521_2848 = goal in
+                                          (let uu___519_2845 = goal in
                                            {
                                              FStar_Tactics_Types.goal_main_env
                                                =
-                                               (uu___521_2848.FStar_Tactics_Types.goal_main_env);
+                                               (uu___519_2845.FStar_Tactics_Types.goal_main_env);
                                              FStar_Tactics_Types.goal_ctx_uvar
                                                = ctx_uvar_u;
                                              FStar_Tactics_Types.opts =
-                                               (uu___521_2848.FStar_Tactics_Types.opts);
+                                               (uu___519_2845.FStar_Tactics_Types.opts);
                                              FStar_Tactics_Types.is_guard =
-                                               (uu___521_2848.FStar_Tactics_Types.is_guard);
+                                               (uu___519_2845.FStar_Tactics_Types.is_guard);
                                              FStar_Tactics_Types.label =
-                                               (uu___521_2848.FStar_Tactics_Types.label)
+                                               (uu___519_2845.FStar_Tactics_Types.label)
                                            }) in
                                       FStar_Tactics_Monad.replace_cur
-                                        uu____2845 in
-                                    FStar_Tactics_Monad.bind uu____2842
-                                      (fun uu____2855 ->
-                                         let uu____2856 =
-                                           let uu____2861 =
+                                        uu____2842 in
+                                    FStar_Tactics_Monad.bind uu____2839
+                                      (fun uu____2852 ->
+                                         let uu____2853 =
+                                           let uu____2858 =
                                              FStar_Syntax_Syntax.mk_binder bv in
-                                           (uu____2861, b) in
-                                         FStar_Tactics_Monad.ret uu____2856)))))
+                                           (uu____2858, b) in
+                                         FStar_Tactics_Monad.ret uu____2853)))))
           | FStar_Pervasives_Native.None ->
-              let uu____2870 =
-                let uu____2871 = FStar_Tactics_Types.goal_env goal in
-                let uu____2872 = FStar_Tactics_Types.goal_type goal in
-                tts uu____2871 uu____2872 in
-              fail1 "intro_rec: goal is not an arrow (%s)" uu____2870))
+              let uu____2867 =
+                let uu____2868 = FStar_Tactics_Types.goal_env goal in
+                let uu____2869 = FStar_Tactics_Types.goal_type goal in
+                tts uu____2868 uu____2869 in
+              fail1 "intro_rec: goal is not an arrow (%s)" uu____2867))
 let (norm :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
     unit FStar_Tactics_Monad.tac)
@@ -1861,23 +1764,23 @@ let (norm :
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Tactics_Monad.mlog
-           (fun uu____2894 ->
-              let uu____2895 =
-                let uu____2896 = FStar_Tactics_Types.goal_witness goal in
-                FStar_Syntax_Print.term_to_string uu____2896 in
-              FStar_Util.print1 "norm: witness = %s\n" uu____2895)
-           (fun uu____2901 ->
+           (fun uu____2891 ->
+              let uu____2892 =
+                let uu____2893 = FStar_Tactics_Types.goal_witness goal in
+                FStar_Syntax_Print.term_to_string uu____2893 in
+              FStar_Util.print1 "norm: witness = %s\n" uu____2892)
+           (fun uu____2898 ->
               let steps =
-                let uu____2905 = FStar_TypeChecker_Normalize.tr_norm_steps s in
+                let uu____2902 = FStar_TypeChecker_Normalize.tr_norm_steps s in
                 FStar_List.append
                   [FStar_TypeChecker_Env.Reify;
-                  FStar_TypeChecker_Env.UnfoldTac] uu____2905 in
+                  FStar_TypeChecker_Env.UnfoldTac] uu____2902 in
               let t =
-                let uu____2909 = FStar_Tactics_Types.goal_env goal in
-                let uu____2910 = FStar_Tactics_Types.goal_type goal in
-                normalize steps uu____2909 uu____2910 in
-              let uu____2911 = FStar_Tactics_Types.goal_with_type goal t in
-              FStar_Tactics_Monad.replace_cur uu____2911))
+                let uu____2906 = FStar_Tactics_Types.goal_env goal in
+                let uu____2907 = FStar_Tactics_Types.goal_type goal in
+                normalize steps uu____2906 uu____2907 in
+              let uu____2908 = FStar_Tactics_Types.goal_with_type goal t in
+              FStar_Tactics_Monad.replace_cur uu____2908))
 let (norm_term_env :
   env ->
     FStar_Syntax_Embeddings.norm_step Prims.list ->
@@ -1887,92 +1790,92 @@ let (norm_term_env :
   fun e ->
     fun s ->
       fun t ->
-        let uu____2935 =
+        let uu____2932 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
                let opts =
                  match ps.FStar_Tactics_Types.goals with
-                 | g::uu____2943 -> g.FStar_Tactics_Types.opts
-                 | uu____2946 -> FStar_Options.peek () in
+                 | g::uu____2940 -> g.FStar_Tactics_Types.opts
+                 | uu____2943 -> FStar_Options.peek () in
                FStar_Tactics_Monad.mlog
-                 (fun uu____2951 ->
-                    let uu____2952 = FStar_Syntax_Print.term_to_string t in
-                    FStar_Util.print1 "norm_term_env: t = %s\n" uu____2952)
-                 (fun uu____2955 ->
-                    let uu____2956 = __tc_lax e t in
-                    FStar_Tactics_Monad.bind uu____2956
-                      (fun uu____2977 ->
-                         match uu____2977 with
-                         | (t1, uu____2987, uu____2988) ->
+                 (fun uu____2948 ->
+                    let uu____2949 = FStar_Syntax_Print.term_to_string t in
+                    FStar_Util.print1 "norm_term_env: t = %s\n" uu____2949)
+                 (fun uu____2952 ->
+                    let uu____2953 = __tc_lax e t in
+                    FStar_Tactics_Monad.bind uu____2953
+                      (fun uu____2974 ->
+                         match uu____2974 with
+                         | (t1, uu____2984, uu____2985) ->
                              let steps =
-                               let uu____2992 =
+                               let uu____2989 =
                                  FStar_TypeChecker_Normalize.tr_norm_steps s in
                                FStar_List.append
                                  [FStar_TypeChecker_Env.Reify;
-                                 FStar_TypeChecker_Env.UnfoldTac] uu____2992 in
+                                 FStar_TypeChecker_Env.UnfoldTac] uu____2989 in
                              let t2 =
                                normalize steps
                                  ps.FStar_Tactics_Types.main_context t1 in
                              FStar_Tactics_Monad.mlog
-                               (fun uu____2998 ->
-                                  let uu____2999 =
+                               (fun uu____2995 ->
+                                  let uu____2996 =
                                     FStar_Syntax_Print.term_to_string t2 in
                                   FStar_Util.print1
-                                    "norm_term_env: t' = %s\n" uu____2999)
-                               (fun uu____3001 -> FStar_Tactics_Monad.ret t2)))) in
+                                    "norm_term_env: t' = %s\n" uu____2996)
+                               (fun uu____2998 -> FStar_Tactics_Monad.ret t2)))) in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_term")
-          uu____2935
+          uu____2932
 let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____3012 ->
-    let uu____3015 =
+  fun uu____3009 ->
+    let uu____3012 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____3022 =
-             let uu____3033 = FStar_Tactics_Types.goal_env g in
-             let uu____3034 = FStar_Tactics_Types.goal_type g in
-             FStar_TypeChecker_Rel.base_and_refinement uu____3033 uu____3034 in
-           match uu____3022 with
-           | (uu____3037, FStar_Pervasives_Native.None) ->
+           let uu____3019 =
+             let uu____3030 = FStar_Tactics_Types.goal_env g in
+             let uu____3031 = FStar_Tactics_Types.goal_type g in
+             FStar_TypeChecker_Rel.base_and_refinement uu____3030 uu____3031 in
+           match uu____3019 with
+           | (uu____3034, FStar_Pervasives_Native.None) ->
                FStar_Tactics_Monad.fail "not a refinement"
            | (t, FStar_Pervasives_Native.Some (bv, phi)) ->
                let g1 = FStar_Tactics_Types.goal_with_type g t in
-               let uu____3062 =
-                 let uu____3067 =
-                   let uu____3072 =
-                     let uu____3073 = FStar_Syntax_Syntax.mk_binder bv in
-                     [uu____3073] in
-                   FStar_Syntax_Subst.open_term uu____3072 phi in
-                 match uu____3067 with
+               let uu____3059 =
+                 let uu____3064 =
+                   let uu____3069 =
+                     let uu____3070 = FStar_Syntax_Syntax.mk_binder bv in
+                     [uu____3070] in
+                   FStar_Syntax_Subst.open_term uu____3069 phi in
+                 match uu____3064 with
                  | (bvs, phi1) ->
-                     let uu____3098 =
-                       let uu____3099 = FStar_List.hd bvs in
-                       FStar_Pervasives_Native.fst uu____3099 in
-                     (uu____3098, phi1) in
-               (match uu____3062 with
+                     let uu____3095 =
+                       let uu____3096 = FStar_List.hd bvs in
+                       FStar_Pervasives_Native.fst uu____3096 in
+                     (uu____3095, phi1) in
+               (match uu____3059 with
                 | (bv1, phi1) ->
-                    let uu____3118 =
-                      let uu____3121 = FStar_Tactics_Types.goal_env g in
-                      let uu____3122 =
-                        let uu____3123 =
-                          let uu____3126 =
-                            let uu____3127 =
-                              let uu____3134 =
+                    let uu____3115 =
+                      let uu____3118 = FStar_Tactics_Types.goal_env g in
+                      let uu____3119 =
+                        let uu____3120 =
+                          let uu____3123 =
+                            let uu____3124 =
+                              let uu____3131 =
                                 FStar_Tactics_Types.goal_witness g in
-                              (bv1, uu____3134) in
-                            FStar_Syntax_Syntax.NT uu____3127 in
-                          [uu____3126] in
-                        FStar_Syntax_Subst.subst uu____3123 phi1 in
+                              (bv1, uu____3131) in
+                            FStar_Syntax_Syntax.NT uu____3124 in
+                          [uu____3123] in
+                        FStar_Syntax_Subst.subst uu____3120 phi1 in
                       FStar_Tactics_Monad.mk_irrelevant_goal
-                        "refine_intro refinement" uu____3121 uu____3122
+                        "refine_intro refinement" uu____3118 uu____3119
                         g.FStar_Tactics_Types.opts
                         g.FStar_Tactics_Types.label in
-                    FStar_Tactics_Monad.bind uu____3118
+                    FStar_Tactics_Monad.bind uu____3115
                       (fun g2 ->
                          FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                           (fun uu____3142 ->
+                           (fun uu____3139 ->
                               FStar_Tactics_Monad.add_goals [g1; g2])))) in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "refine_intro")
-      uu____3015
+      uu____3012
 let (__exact_now :
   Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun set_expected_typ ->
@@ -1982,86 +1885,86 @@ let (__exact_now :
            let env1 =
              if set_expected_typ
              then
-               let uu____3166 = FStar_Tactics_Types.goal_env goal in
-               let uu____3167 = FStar_Tactics_Types.goal_type goal in
-               FStar_TypeChecker_Env.set_expected_typ uu____3166 uu____3167
+               let uu____3163 = FStar_Tactics_Types.goal_env goal in
+               let uu____3164 = FStar_Tactics_Types.goal_type goal in
+               FStar_TypeChecker_Env.set_expected_typ uu____3163 uu____3164
              else FStar_Tactics_Types.goal_env goal in
-           let uu____3169 = __tc env1 t in
-           FStar_Tactics_Monad.bind uu____3169
-             (fun uu____3188 ->
-                match uu____3188 with
+           let uu____3166 = __tc env1 t in
+           FStar_Tactics_Monad.bind uu____3166
+             (fun uu____3185 ->
+                match uu____3185 with
                 | (t1, typ, guard) ->
                     FStar_Tactics_Monad.mlog
-                      (fun uu____3203 ->
-                         let uu____3204 =
+                      (fun uu____3200 ->
+                         let uu____3201 =
                            FStar_Syntax_Print.term_to_string typ in
-                         let uu____3205 =
-                           let uu____3206 = FStar_Tactics_Types.goal_env goal in
-                           FStar_TypeChecker_Rel.guard_to_string uu____3206
+                         let uu____3202 =
+                           let uu____3203 = FStar_Tactics_Types.goal_env goal in
+                           FStar_TypeChecker_Rel.guard_to_string uu____3203
                              guard in
                          FStar_Util.print2
                            "__exact_now: got type %s\n__exact_now: and guard %s\n"
-                           uu____3204 uu____3205)
-                      (fun uu____3209 ->
-                         let uu____3210 =
-                           let uu____3213 = FStar_Tactics_Types.goal_env goal in
-                           proc_guard "__exact typing" uu____3213 guard in
-                         FStar_Tactics_Monad.bind uu____3210
-                           (fun uu____3215 ->
+                           uu____3201 uu____3202)
+                      (fun uu____3206 ->
+                         let uu____3207 =
+                           let uu____3210 = FStar_Tactics_Types.goal_env goal in
+                           proc_guard "__exact typing" uu____3210 guard in
+                         FStar_Tactics_Monad.bind uu____3207
+                           (fun uu____3212 ->
                               FStar_Tactics_Monad.mlog
-                                (fun uu____3219 ->
-                                   let uu____3220 =
+                                (fun uu____3216 ->
+                                   let uu____3217 =
                                      FStar_Syntax_Print.term_to_string typ in
-                                   let uu____3221 =
-                                     let uu____3222 =
+                                   let uu____3218 =
+                                     let uu____3219 =
                                        FStar_Tactics_Types.goal_type goal in
                                      FStar_Syntax_Print.term_to_string
-                                       uu____3222 in
+                                       uu____3219 in
                                    FStar_Util.print2
                                      "__exact_now: unifying %s and %s\n"
-                                     uu____3220 uu____3221)
-                                (fun uu____3225 ->
-                                   let uu____3226 =
-                                     let uu____3229 =
+                                     uu____3217 uu____3218)
+                                (fun uu____3222 ->
+                                   let uu____3223 =
+                                     let uu____3226 =
                                        FStar_Tactics_Types.goal_env goal in
-                                     let uu____3230 =
+                                     let uu____3227 =
                                        FStar_Tactics_Types.goal_type goal in
-                                     do_unify uu____3229 typ uu____3230 in
-                                   FStar_Tactics_Monad.bind uu____3226
+                                     do_unify uu____3226 typ uu____3227 in
+                                   FStar_Tactics_Monad.bind uu____3223
                                      (fun b ->
                                         if b
                                         then solve goal t1
                                         else
-                                          (let uu____3236 =
-                                             let uu____3241 =
-                                               let uu____3246 =
+                                          (let uu____3233 =
+                                             let uu____3238 =
+                                               let uu____3243 =
                                                  FStar_Tactics_Types.goal_env
                                                    goal in
-                                               tts uu____3246 in
-                                             let uu____3247 =
+                                               tts uu____3243 in
+                                             let uu____3244 =
                                                FStar_Tactics_Types.goal_type
                                                  goal in
                                              FStar_TypeChecker_Err.print_discrepancy
-                                               uu____3241 typ uu____3247 in
-                                           match uu____3236 with
+                                               uu____3238 typ uu____3244 in
+                                           match uu____3233 with
                                            | (typ1, goalt) ->
-                                               let uu____3252 =
+                                               let uu____3249 =
+                                                 let uu____3250 =
+                                                   FStar_Tactics_Types.goal_env
+                                                     goal in
+                                                 tts uu____3250 t1 in
+                                               let uu____3251 =
+                                                 let uu____3252 =
+                                                   FStar_Tactics_Types.goal_env
+                                                     goal in
                                                  let uu____3253 =
-                                                   FStar_Tactics_Types.goal_env
-                                                     goal in
-                                                 tts uu____3253 t1 in
-                                               let uu____3254 =
-                                                 let uu____3255 =
-                                                   FStar_Tactics_Types.goal_env
-                                                     goal in
-                                                 let uu____3256 =
                                                    FStar_Tactics_Types.goal_witness
                                                      goal in
-                                                 tts uu____3255 uu____3256 in
+                                                 tts uu____3252 uu____3253 in
                                                fail4
                                                  "%s : %s does not exactly solve the goal %s (witness = %s)"
-                                                 uu____3252 typ1 goalt
-                                                 uu____3254)))))))
+                                                 uu____3249 typ1 goalt
+                                                 uu____3251)))))))
 let (t_exact :
   Prims.bool ->
     Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -2069,56 +1972,56 @@ let (t_exact :
   fun try_refine ->
     fun set_expected_typ ->
       fun tm ->
-        let uu____3276 =
+        let uu____3273 =
           FStar_Tactics_Monad.mlog
-            (fun uu____3281 ->
-               let uu____3282 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.print1 "t_exact: tm = %s\n" uu____3282)
-            (fun uu____3285 ->
-               let uu____3286 =
-                 let uu____3293 = __exact_now set_expected_typ tm in
-                 catch uu____3293 in
-               FStar_Tactics_Monad.bind uu____3286
-                 (fun uu___2_3302 ->
-                    match uu___2_3302 with
+            (fun uu____3278 ->
+               let uu____3279 = FStar_Syntax_Print.term_to_string tm in
+               FStar_Util.print1 "t_exact: tm = %s\n" uu____3279)
+            (fun uu____3282 ->
+               let uu____3283 =
+                 let uu____3290 = __exact_now set_expected_typ tm in
+                 catch uu____3290 in
+               FStar_Tactics_Monad.bind uu____3283
+                 (fun uu___2_3299 ->
+                    match uu___2_3299 with
                     | FStar_Util.Inr r -> FStar_Tactics_Monad.ret ()
                     | FStar_Util.Inl e when Prims.op_Negation try_refine ->
                         FStar_Tactics_Monad.traise e
                     | FStar_Util.Inl e ->
                         FStar_Tactics_Monad.mlog
-                          (fun uu____3313 ->
+                          (fun uu____3310 ->
                              FStar_Util.print_string
                                "__exact_now failed, trying refine...\n")
-                          (fun uu____3316 ->
-                             let uu____3317 =
-                               let uu____3324 =
-                                 let uu____3327 =
+                          (fun uu____3313 ->
+                             let uu____3314 =
+                               let uu____3321 =
+                                 let uu____3324 =
                                    norm [FStar_Syntax_Embeddings.Delta] in
-                                 FStar_Tactics_Monad.bind uu____3327
-                                   (fun uu____3332 ->
-                                      let uu____3333 = refine_intro () in
-                                      FStar_Tactics_Monad.bind uu____3333
-                                        (fun uu____3337 ->
+                                 FStar_Tactics_Monad.bind uu____3324
+                                   (fun uu____3329 ->
+                                      let uu____3330 = refine_intro () in
+                                      FStar_Tactics_Monad.bind uu____3330
+                                        (fun uu____3334 ->
                                            __exact_now set_expected_typ tm)) in
-                               catch uu____3324 in
-                             FStar_Tactics_Monad.bind uu____3317
-                               (fun uu___1_3344 ->
-                                  match uu___1_3344 with
+                               catch uu____3321 in
+                             FStar_Tactics_Monad.bind uu____3314
+                               (fun uu___1_3341 ->
+                                  match uu___1_3341 with
                                   | FStar_Util.Inr r ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____3353 ->
+                                        (fun uu____3350 ->
                                            FStar_Util.print_string
                                              "__exact_now: failed after refining too\n")
-                                        (fun uu____3355 ->
+                                        (fun uu____3352 ->
                                            FStar_Tactics_Monad.ret ())
-                                  | FStar_Util.Inl uu____3356 ->
+                                  | FStar_Util.Inl uu____3353 ->
                                       FStar_Tactics_Monad.mlog
-                                        (fun uu____3358 ->
+                                        (fun uu____3355 ->
                                            FStar_Util.print_string
                                              "__exact_now: was not a refinement\n")
-                                        (fun uu____3360 ->
+                                        (fun uu____3357 ->
                                            FStar_Tactics_Monad.traise e))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "exact") uu____3276
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "exact") uu____3273
 let rec (__try_unify_by_application :
   Prims.bool ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual *
@@ -2136,42 +2039,42 @@ let rec (__try_unify_by_application :
         fun ty1 ->
           fun ty2 ->
             let f = if only_match then do_match else do_unify in
-            let uu____3453 = f e ty2 ty1 in
-            FStar_Tactics_Monad.bind uu____3453
-              (fun uu___3_3465 ->
-                 if uu___3_3465
+            let uu____3450 = f e ty2 ty1 in
+            FStar_Tactics_Monad.bind uu____3450
+              (fun uu___3_3462 ->
+                 if uu___3_3462
                  then FStar_Tactics_Monad.ret acc
                  else
-                   (let uu____3484 = FStar_Syntax_Util.arrow_one ty1 in
-                    match uu____3484 with
+                   (let uu____3481 = FStar_Syntax_Util.arrow_one ty1 in
+                    match uu____3481 with
                     | FStar_Pervasives_Native.None ->
-                        let uu____3505 = term_to_string e ty1 in
-                        let uu____3506 = term_to_string e ty2 in
-                        fail2 "Could not instantiate, %s to %s" uu____3505
-                          uu____3506
+                        let uu____3502 = term_to_string e ty1 in
+                        let uu____3503 = term_to_string e ty2 in
+                        fail2 "Could not instantiate, %s to %s" uu____3502
+                          uu____3503
                     | FStar_Pervasives_Native.Some (b, c) ->
-                        let uu____3521 =
-                          let uu____3522 = FStar_Syntax_Util.is_total_comp c in
-                          Prims.op_Negation uu____3522 in
-                        if uu____3521
+                        let uu____3518 =
+                          let uu____3519 = FStar_Syntax_Util.is_total_comp c in
+                          Prims.op_Negation uu____3519 in
+                        if uu____3518
                         then FStar_Tactics_Monad.fail "Codomain is effectful"
                         else
-                          (let uu____3542 =
+                          (let uu____3539 =
                              FStar_Tactics_Monad.new_uvar "apply arg" e
                                (FStar_Pervasives_Native.fst b).FStar_Syntax_Syntax.sort in
-                           FStar_Tactics_Monad.bind uu____3542
-                             (fun uu____3566 ->
-                                match uu____3566 with
+                           FStar_Tactics_Monad.bind uu____3539
+                             (fun uu____3563 ->
+                                match uu____3563 with
                                 | (uvt, uv) ->
                                     FStar_Tactics_Monad.mlog
-                                      (fun uu____3593 ->
-                                         let uu____3594 =
+                                      (fun uu____3590 ->
+                                         let uu____3591 =
                                            FStar_Syntax_Print.ctx_uvar_to_string
                                              uv in
                                          FStar_Util.print1
                                            "t_apply: generated uvar %s\n"
-                                           uu____3594)
-                                      (fun uu____3598 ->
+                                           uu____3591)
+                                      (fun uu____3595 ->
                                          let typ =
                                            FStar_Syntax_Util.comp_result c in
                                          let typ' =
@@ -2203,70 +2106,70 @@ let (t_apply :
   fun uopt ->
     fun only_match ->
       fun tm ->
-        let uu____3680 =
+        let uu____3677 =
           FStar_Tactics_Monad.mlog
+            (fun uu____3682 ->
+               let uu____3683 = FStar_Syntax_Print.term_to_string tm in
+               FStar_Util.print1 "t_apply: tm = %s\n" uu____3683)
             (fun uu____3685 ->
-               let uu____3686 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Util.print1 "t_apply: tm = %s\n" uu____3686)
-            (fun uu____3688 ->
                FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                  (fun goal ->
                     let e = FStar_Tactics_Types.goal_env goal in
                     FStar_Tactics_Monad.mlog
-                      (fun uu____3697 ->
-                         let uu____3698 =
+                      (fun uu____3694 ->
+                         let uu____3695 =
                            FStar_Syntax_Print.term_to_string tm in
-                         let uu____3699 =
+                         let uu____3696 =
                            FStar_Tactics_Printing.goal_to_string_verbose goal in
-                         let uu____3700 =
+                         let uu____3697 =
                            FStar_TypeChecker_Env.print_gamma
                              e.FStar_TypeChecker_Env.gamma in
                          FStar_Util.print3
                            "t_apply: tm = %s\nt_apply: goal = %s\nenv.gamma=%s\n"
-                           uu____3698 uu____3699 uu____3700)
-                      (fun uu____3703 ->
-                         let uu____3704 = __tc e tm in
-                         FStar_Tactics_Monad.bind uu____3704
-                           (fun uu____3725 ->
-                              match uu____3725 with
+                           uu____3695 uu____3696 uu____3697)
+                      (fun uu____3700 ->
+                         let uu____3701 = __tc e tm in
+                         FStar_Tactics_Monad.bind uu____3701
+                           (fun uu____3722 ->
+                              match uu____3722 with
                               | (tm1, typ, guard) ->
                                   let typ1 = bnorm e typ in
-                                  let uu____3738 =
-                                    let uu____3749 =
+                                  let uu____3735 =
+                                    let uu____3746 =
                                       FStar_Tactics_Types.goal_type goal in
                                     try_unify_by_application only_match e
-                                      typ1 uu____3749 in
-                                  FStar_Tactics_Monad.bind uu____3738
+                                      typ1 uu____3746 in
+                                  FStar_Tactics_Monad.bind uu____3735
                                     (fun uvs ->
                                        FStar_Tactics_Monad.mlog
-                                         (fun uu____3770 ->
-                                            let uu____3771 =
+                                         (fun uu____3767 ->
+                                            let uu____3768 =
                                               FStar_Common.string_of_list
-                                                (fun uu____3782 ->
-                                                   match uu____3782 with
-                                                   | (t, uu____3790,
-                                                      uu____3791) ->
+                                                (fun uu____3779 ->
+                                                   match uu____3779 with
+                                                   | (t, uu____3787,
+                                                      uu____3788) ->
                                                        FStar_Syntax_Print.term_to_string
                                                          t) uvs in
                                             FStar_Util.print1
                                               "t_apply: found args = %s\n"
-                                              uu____3771)
-                                         (fun uu____3798 ->
+                                              uu____3768)
+                                         (fun uu____3795 ->
                                             let fix_qual q =
                                               match q with
                                               | FStar_Pervasives_Native.Some
                                                   (FStar_Syntax_Syntax.Meta
-                                                  uu____3813) ->
+                                                  uu____3810) ->
                                                   FStar_Pervasives_Native.Some
                                                     (FStar_Syntax_Syntax.Implicit
                                                        false)
-                                              | uu____3814 -> q in
+                                              | uu____3811 -> q in
                                             let w =
                                               FStar_List.fold_right
-                                                (fun uu____3837 ->
+                                                (fun uu____3834 ->
                                                    fun w ->
-                                                     match uu____3837 with
-                                                     | (uvt, q, uu____3855)
+                                                     match uu____3834 with
+                                                     | (uvt, q, uu____3852)
                                                          ->
                                                          FStar_Syntax_Util.mk_app
                                                            w
@@ -2274,87 +2177,87 @@ let (t_apply :
                                                               (fix_qual q))])
                                                 uvs tm1 in
                                             let uvset =
-                                              let uu____3887 =
+                                              let uu____3884 =
                                                 FStar_Syntax_Free.new_uv_set
                                                   () in
                                               FStar_List.fold_right
-                                                (fun uu____3904 ->
+                                                (fun uu____3901 ->
                                                    fun s ->
-                                                     match uu____3904 with
-                                                     | (uu____3916,
-                                                        uu____3917, uv) ->
-                                                         let uu____3919 =
+                                                     match uu____3901 with
+                                                     | (uu____3913,
+                                                        uu____3914, uv) ->
+                                                         let uu____3916 =
                                                            FStar_Syntax_Free.uvars
                                                              uv.FStar_Syntax_Syntax.ctx_uvar_typ in
                                                          FStar_Util.set_union
-                                                           s uu____3919) uvs
-                                                uu____3887 in
+                                                           s uu____3916) uvs
+                                                uu____3884 in
                                             let free_in_some_goal uv =
                                               FStar_Util.set_mem uv uvset in
-                                            let uu____3928 = solve' goal w in
+                                            let uu____3925 = solve' goal w in
                                             FStar_Tactics_Monad.bind
-                                              uu____3928
-                                              (fun uu____3933 ->
-                                                 let uu____3934 =
+                                              uu____3925
+                                              (fun uu____3930 ->
+                                                 let uu____3931 =
                                                    FStar_Tactics_Monad.mapM
-                                                     (fun uu____3951 ->
-                                                        match uu____3951 with
+                                                     (fun uu____3948 ->
+                                                        match uu____3948 with
                                                         | (uvt, q, uv) ->
-                                                            let uu____3963 =
+                                                            let uu____3960 =
                                                               FStar_Syntax_Unionfind.find
                                                                 uv.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                            (match uu____3963
+                                                            (match uu____3960
                                                              with
                                                              | FStar_Pervasives_Native.Some
-                                                                 uu____3968
+                                                                 uu____3965
                                                                  ->
                                                                  FStar_Tactics_Monad.ret
                                                                    ()
                                                              | FStar_Pervasives_Native.None
                                                                  ->
-                                                                 let uu____3969
+                                                                 let uu____3966
                                                                    =
                                                                    uopt &&
                                                                     (free_in_some_goal
                                                                     uv) in
                                                                  if
-                                                                   uu____3969
+                                                                   uu____3966
                                                                  then
                                                                    FStar_Tactics_Monad.ret
                                                                     ()
                                                                  else
-                                                                   (let uu____3973
+                                                                   (let uu____3970
                                                                     =
-                                                                    let uu____3976
+                                                                    let uu____3973
                                                                     =
                                                                     bnorm_goal
-                                                                    (let uu___684_3979
+                                                                    (let uu___682_3976
                                                                     = goal in
                                                                     {
                                                                     FStar_Tactics_Types.goal_main_env
                                                                     =
-                                                                    (uu___684_3979.FStar_Tactics_Types.goal_main_env);
+                                                                    (uu___682_3976.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     = uv;
                                                                     FStar_Tactics_Types.opts
                                                                     =
-                                                                    (uu___684_3979.FStar_Tactics_Types.opts);
+                                                                    (uu___682_3976.FStar_Tactics_Types.opts);
                                                                     FStar_Tactics_Types.is_guard
                                                                     = false;
                                                                     FStar_Tactics_Types.label
                                                                     =
-                                                                    (uu___684_3979.FStar_Tactics_Types.label)
+                                                                    (uu___682_3976.FStar_Tactics_Types.label)
                                                                     }) in
-                                                                    [uu____3976] in
+                                                                    [uu____3973] in
                                                                     FStar_Tactics_Monad.add_goals
-                                                                    uu____3973)))
+                                                                    uu____3970)))
                                                      uvs in
                                                  FStar_Tactics_Monad.bind
-                                                   uu____3934
-                                                   (fun uu____3983 ->
+                                                   uu____3931
+                                                   (fun uu____3980 ->
                                                       proc_guard
                                                         "apply guard" e guard)))))))) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply") uu____3680
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply") uu____3677
 let (lemma_or_sq :
   FStar_Syntax_Syntax.comp ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)
@@ -2362,37 +2265,37 @@ let (lemma_or_sq :
   =
   fun c ->
     let ct = FStar_Syntax_Util.comp_to_comp_typ_nouniv c in
-    let uu____4008 =
+    let uu____4005 =
       FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
         FStar_Parser_Const.effect_Lemma_lid in
-    if uu____4008
+    if uu____4005
     then
-      let uu____4015 =
+      let uu____4012 =
         match ct.FStar_Syntax_Syntax.effect_args with
-        | pre::post::uu____4030 ->
+        | pre::post::uu____4027 ->
             ((FStar_Pervasives_Native.fst pre),
               (FStar_Pervasives_Native.fst post))
-        | uu____4083 -> failwith "apply_lemma: impossible: not a lemma" in
-      match uu____4015 with
+        | uu____4080 -> failwith "apply_lemma: impossible: not a lemma" in
+      match uu____4012 with
       | (pre, post) ->
           let post1 =
-            let uu____4115 =
-              let uu____4126 =
+            let uu____4112 =
+              let uu____4123 =
                 FStar_Syntax_Syntax.as_arg FStar_Syntax_Util.exp_unit in
-              [uu____4126] in
-            FStar_Syntax_Util.mk_app post uu____4115 in
+              [uu____4123] in
+            FStar_Syntax_Util.mk_app post uu____4112 in
           FStar_Pervasives_Native.Some (pre, post1)
     else
-      (let uu____4156 =
+      (let uu____4153 =
          (FStar_Syntax_Util.is_pure_effect ct.FStar_Syntax_Syntax.effect_name)
            ||
            (FStar_Syntax_Util.is_ghost_effect
               ct.FStar_Syntax_Syntax.effect_name) in
-       if uu____4156
+       if uu____4153
        then
-         let uu____4163 =
+         let uu____4160 =
            FStar_Syntax_Util.un_squash ct.FStar_Syntax_Syntax.result_typ in
-         FStar_Util.map_opt uu____4163
+         FStar_Util.map_opt uu____4160
            (fun post -> (FStar_Syntax_Util.t_true, post))
        else FStar_Pervasives_Native.None)
 let rec fold_left :
@@ -2406,8 +2309,8 @@ let rec fold_left :
         match xs with
         | [] -> FStar_Tactics_Monad.ret e
         | x::xs1 ->
-            let uu____4240 = f x e in
-            FStar_Tactics_Monad.bind uu____4240
+            let uu____4237 = f x e in
+            FStar_Tactics_Monad.bind uu____4237
               (fun e' -> fold_left f e' xs1)
 let (t_apply_lemma :
   Prims.bool ->
@@ -2416,50 +2319,50 @@ let (t_apply_lemma :
   fun noinst ->
     fun noinst_lhs ->
       fun tm ->
-        let uu____4264 =
-          let uu____4267 =
+        let uu____4261 =
+          let uu____4264 =
             FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
               (fun ps ->
                  FStar_Tactics_Monad.mlog
-                   (fun uu____4274 ->
-                      let uu____4275 = FStar_Syntax_Print.term_to_string tm in
-                      FStar_Util.print1 "apply_lemma: tm = %s\n" uu____4275)
-                   (fun uu____4278 ->
+                   (fun uu____4271 ->
+                      let uu____4272 = FStar_Syntax_Print.term_to_string tm in
+                      FStar_Util.print1 "apply_lemma: tm = %s\n" uu____4272)
+                   (fun uu____4275 ->
                       let is_unit_t t =
-                        let uu____4285 =
-                          let uu____4286 = FStar_Syntax_Subst.compress t in
-                          uu____4286.FStar_Syntax_Syntax.n in
-                        match uu____4285 with
+                        let uu____4282 =
+                          let uu____4283 = FStar_Syntax_Subst.compress t in
+                          uu____4283.FStar_Syntax_Syntax.n in
+                        match uu____4282 with
                         | FStar_Syntax_Syntax.Tm_fvar fv when
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.unit_lid
                             -> true
-                        | uu____4290 -> false in
+                        | uu____4287 -> false in
                       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                         (fun goal ->
                            let env1 = FStar_Tactics_Types.goal_env goal in
-                           let uu____4296 = __tc env1 tm in
-                           FStar_Tactics_Monad.bind uu____4296
-                             (fun uu____4319 ->
-                                match uu____4319 with
+                           let uu____4293 = __tc env1 tm in
+                           FStar_Tactics_Monad.bind uu____4293
+                             (fun uu____4316 ->
+                                match uu____4316 with
                                 | (tm1, t, guard) ->
-                                    let uu____4331 =
+                                    let uu____4328 =
                                       FStar_Syntax_Util.arrow_formals_comp t in
-                                    (match uu____4331 with
+                                    (match uu____4328 with
                                      | (bs, comp) ->
-                                         let uu____4340 = lemma_or_sq comp in
-                                         (match uu____4340 with
+                                         let uu____4337 = lemma_or_sq comp in
+                                         (match uu____4337 with
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Tactics_Monad.fail
                                                 "not a lemma or squashed function"
                                           | FStar_Pervasives_Native.Some
                                               (pre, post) ->
-                                              let uu____4359 =
+                                              let uu____4356 =
                                                 fold_left
-                                                  (fun uu____4421 ->
-                                                     fun uu____4422 ->
-                                                       match (uu____4421,
-                                                               uu____4422)
+                                                  (fun uu____4418 ->
+                                                     fun uu____4419 ->
+                                                       match (uu____4418,
+                                                               uu____4419)
                                                        with
                                                        | ((b, aq),
                                                           (uvs, imps, subst))
@@ -2468,9 +2371,9 @@ let (t_apply_lemma :
                                                              FStar_Syntax_Subst.subst
                                                                subst
                                                                b.FStar_Syntax_Syntax.sort in
-                                                           let uu____4573 =
+                                                           let uu____4570 =
                                                              is_unit_t b_t in
-                                                           if uu____4573
+                                                           if uu____4570
                                                            then
                                                              FStar_All.pipe_left
                                                                FStar_Tactics_Monad.ret
@@ -2482,17 +2385,17 @@ let (t_apply_lemma :
                                                                     FStar_Syntax_Util.exp_unit))
                                                                  :: subst))
                                                            else
-                                                             (let uu____4693
+                                                             (let uu____4690
                                                                 =
                                                                 FStar_Tactics_Monad.new_uvar
                                                                   "apply_lemma"
                                                                   env1 b_t in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____4693
+                                                                uu____4690
                                                                 (fun
-                                                                   uu____4729
+                                                                   uu____4726
                                                                    ->
-                                                                   match uu____4729
+                                                                   match uu____4726
                                                                    with
                                                                    | 
                                                                    (t1, u) ->
@@ -2509,9 +2412,9 @@ let (t_apply_lemma :
                                                                     subst)))))
                                                   ([], [], []) bs in
                                               FStar_Tactics_Monad.bind
-                                                uu____4359
-                                                (fun uu____4917 ->
-                                                   match uu____4917 with
+                                                uu____4356
+                                                (fun uu____4914 ->
+                                                   match uu____4914 with
                                                    | (uvs, implicits1, subst)
                                                        ->
                                                        let implicits2 =
@@ -2536,77 +2439,77 @@ let (t_apply_lemma :
                                                            then
                                                              do_match_on_lhs
                                                            else do_unify in
-                                                       let uu____5045 =
-                                                         let uu____5048 =
+                                                       let uu____5042 =
+                                                         let uu____5045 =
                                                            FStar_Tactics_Types.goal_type
                                                              goal in
-                                                         let uu____5049 =
+                                                         let uu____5046 =
                                                            FStar_Syntax_Util.mk_squash
                                                              post_u post1 in
                                                          cmp_func env1
-                                                           uu____5048
-                                                           uu____5049 in
+                                                           uu____5045
+                                                           uu____5046 in
                                                        FStar_Tactics_Monad.bind
-                                                         uu____5045
+                                                         uu____5042
                                                          (fun b ->
                                                             if
                                                               Prims.op_Negation
                                                                 b
                                                             then
-                                                              let uu____5058
+                                                              let uu____5055
                                                                 =
-                                                                let uu____5063
+                                                                let uu____5060
                                                                   =
                                                                   FStar_Syntax_Util.mk_squash
                                                                     post_u
                                                                     post1 in
-                                                                let uu____5064
+                                                                let uu____5061
                                                                   =
                                                                   FStar_Tactics_Types.goal_type
                                                                     goal in
                                                                 FStar_TypeChecker_Err.print_discrepancy
                                                                   (tts env1)
-                                                                  uu____5063
-                                                                  uu____5064 in
-                                                              match uu____5058
+                                                                  uu____5060
+                                                                  uu____5061 in
+                                                              match uu____5055
                                                               with
                                                               | (post2,
                                                                  goalt) ->
-                                                                  let uu____5069
+                                                                  let uu____5066
                                                                     =
                                                                     tts env1
                                                                     tm1 in
                                                                   fail3
                                                                     "Cannot instantiate lemma %s (with postcondition: %s) to match goal (%s)"
-                                                                    uu____5069
+                                                                    uu____5066
                                                                     post2
                                                                     goalt
                                                             else
-                                                              (let uu____5071
+                                                              (let uu____5068
                                                                  =
                                                                  solve' goal
                                                                    FStar_Syntax_Util.exp_unit in
                                                                FStar_Tactics_Monad.bind
-                                                                 uu____5071
+                                                                 uu____5068
                                                                  (fun
-                                                                    uu____5079
+                                                                    uu____5076
                                                                     ->
                                                                     let is_free_uvar
                                                                     uv t1 =
                                                                     let free_uvars
                                                                     =
-                                                                    let uu____5106
+                                                                    let uu____5103
                                                                     =
-                                                                    let uu____5109
+                                                                    let uu____5106
                                                                     =
                                                                     FStar_Syntax_Free.uvars
                                                                     t1 in
                                                                     FStar_Util.set_elements
-                                                                    uu____5109 in
+                                                                    uu____5106 in
                                                                     FStar_List.map
                                                                     (fun x ->
                                                                     x.FStar_Syntax_Syntax.ctx_uvar_head)
-                                                                    uu____5106 in
+                                                                    uu____5103 in
                                                                     FStar_List.existsML
                                                                     (fun u ->
                                                                     FStar_Syntax_Unionfind.equiv
@@ -2618,26 +2521,26 @@ let (t_apply_lemma :
                                                                     FStar_List.existsML
                                                                     (fun g'
                                                                     ->
-                                                                    let uu____5146
+                                                                    let uu____5143
                                                                     =
                                                                     FStar_Tactics_Types.goal_type
                                                                     g' in
                                                                     is_free_uvar
                                                                     uv
-                                                                    uu____5146)
+                                                                    uu____5143)
                                                                     goals in
                                                                     let checkone
                                                                     t1 goals
                                                                     =
-                                                                    let uu____5162
+                                                                    let uu____5159
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     t1 in
-                                                                    match uu____5162
+                                                                    match uu____5159
                                                                     with
                                                                     | 
                                                                     (hd,
-                                                                    uu____5180)
+                                                                    uu____5177)
                                                                     ->
                                                                     (match 
                                                                     hd.FStar_Syntax_Syntax.n
@@ -2645,98 +2548,98 @@ let (t_apply_lemma :
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_uvar
                                                                     (uv,
-                                                                    uu____5206)
+                                                                    uu____5203)
                                                                     ->
                                                                     appears
                                                                     uv.FStar_Syntax_Syntax.ctx_uvar_head
                                                                     goals
                                                                     | 
-                                                                    uu____5223
+                                                                    uu____5220
                                                                     -> false) in
-                                                                    let uu____5224
+                                                                    let uu____5221
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     implicits2
                                                                     (FStar_Tactics_Monad.mapM
                                                                     (fun imp
                                                                     ->
-                                                                    let uu____5265
+                                                                    let uu____5262
                                                                     = imp in
-                                                                    match uu____5265
+                                                                    match uu____5262
                                                                     with
                                                                     | 
                                                                     (term,
                                                                     ctx_uvar)
                                                                     ->
-                                                                    let uu____5276
+                                                                    let uu____5273
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     term in
-                                                                    (match uu____5276
+                                                                    (match uu____5273
                                                                     with
                                                                     | 
                                                                     (hd,
-                                                                    uu____5298)
+                                                                    uu____5295)
                                                                     ->
-                                                                    let uu____5323
+                                                                    let uu____5320
                                                                     =
-                                                                    let uu____5324
+                                                                    let uu____5321
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     hd in
-                                                                    uu____5324.FStar_Syntax_Syntax.n in
-                                                                    (match uu____5323
+                                                                    uu____5321.FStar_Syntax_Syntax.n in
+                                                                    (match uu____5320
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_uvar
                                                                     (ctx_uvar1,
-                                                                    uu____5332)
+                                                                    uu____5329)
                                                                     ->
                                                                     let goal1
                                                                     =
                                                                     bnorm_goal
-                                                                    (let uu___810_5352
+                                                                    (let uu___808_5349
                                                                     = goal in
                                                                     {
                                                                     FStar_Tactics_Types.goal_main_env
                                                                     =
-                                                                    (uu___810_5352.FStar_Tactics_Types.goal_main_env);
+                                                                    (uu___808_5349.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     =
                                                                     ctx_uvar1;
                                                                     FStar_Tactics_Types.opts
                                                                     =
-                                                                    (uu___810_5352.FStar_Tactics_Types.opts);
+                                                                    (uu___808_5349.FStar_Tactics_Types.opts);
                                                                     FStar_Tactics_Types.is_guard
                                                                     =
-                                                                    (uu___810_5352.FStar_Tactics_Types.is_guard);
+                                                                    (uu___808_5349.FStar_Tactics_Types.is_guard);
                                                                     FStar_Tactics_Types.label
                                                                     =
-                                                                    (uu___810_5352.FStar_Tactics_Types.label)
+                                                                    (uu___808_5349.FStar_Tactics_Types.label)
                                                                     }) in
                                                                     FStar_Tactics_Monad.ret
                                                                     [goal1]
                                                                     | 
-                                                                    uu____5355
+                                                                    uu____5352
                                                                     ->
                                                                     FStar_Tactics_Monad.mlog
                                                                     (fun
-                                                                    uu____5361
+                                                                    uu____5358
                                                                     ->
-                                                                    let uu____5362
+                                                                    let uu____5359
                                                                     =
                                                                     FStar_Syntax_Print.uvar_to_string
                                                                     ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                                    let uu____5363
+                                                                    let uu____5360
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     term in
                                                                     FStar_Util.print2
                                                                     "apply_lemma: arg %s unified to (%s)\n"
-                                                                    uu____5362
-                                                                    uu____5363)
+                                                                    uu____5359
+                                                                    uu____5360)
                                                                     (fun
-                                                                    uu____5367
+                                                                    uu____5364
                                                                     ->
                                                                     let g_typ
                                                                     =
@@ -2744,40 +2647,40 @@ let (t_apply_lemma :
                                                                     true env1
                                                                     term
                                                                     ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                                    let uu____5369
+                                                                    let uu____5366
                                                                     =
-                                                                    let uu____5372
+                                                                    let uu____5369
                                                                     =
                                                                     if
                                                                     ps.FStar_Tactics_Types.tac_verb_dbg
                                                                     then
-                                                                    let uu____5373
+                                                                    let uu____5370
                                                                     =
                                                                     FStar_Syntax_Print.ctx_uvar_to_string
                                                                     ctx_uvar in
-                                                                    let uu____5374
+                                                                    let uu____5371
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     term in
                                                                     FStar_Util.format2
                                                                     "apply_lemma solved arg %s to %s\n"
-                                                                    uu____5373
-                                                                    uu____5374
+                                                                    uu____5370
+                                                                    uu____5371
                                                                     else
                                                                     "apply_lemma solved arg" in
                                                                     proc_guard
-                                                                    uu____5372
+                                                                    uu____5369
                                                                     env1
                                                                     g_typ in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5369
+                                                                    uu____5366
                                                                     (fun
-                                                                    uu____5379
+                                                                    uu____5376
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     [])))))) in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5224
+                                                                    uu____5221
                                                                     (fun
                                                                     sub_goals
                                                                     ->
@@ -2793,17 +2696,17 @@ let (t_apply_lemma :
                                                                     [] -> []
                                                                     | 
                                                                     x::xs1 ->
-                                                                    let uu____5441
+                                                                    let uu____5438
                                                                     = f x xs1 in
                                                                     if
-                                                                    uu____5441
+                                                                    uu____5438
                                                                     then
-                                                                    let uu____5444
+                                                                    let uu____5441
                                                                     =
                                                                     filter' f
                                                                     xs1 in x
                                                                     ::
-                                                                    uu____5444
+                                                                    uu____5441
                                                                     else
                                                                     filter' f
                                                                     xs1 in
@@ -2813,51 +2716,51 @@ let (t_apply_lemma :
                                                                     (fun g ->
                                                                     fun goals
                                                                     ->
-                                                                    let uu____5458
+                                                                    let uu____5455
                                                                     =
-                                                                    let uu____5459
+                                                                    let uu____5456
                                                                     =
                                                                     FStar_Tactics_Types.goal_witness
                                                                     g in
                                                                     checkone
-                                                                    uu____5459
+                                                                    uu____5456
                                                                     goals in
                                                                     Prims.op_Negation
-                                                                    uu____5458)
+                                                                    uu____5455)
                                                                     sub_goals1 in
-                                                                    let uu____5460
+                                                                    let uu____5457
                                                                     =
                                                                     proc_guard
                                                                     "apply_lemma guard"
                                                                     env1
                                                                     guard in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5460
+                                                                    uu____5457
                                                                     (fun
-                                                                    uu____5466
+                                                                    uu____5463
                                                                     ->
                                                                     let pre_u
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 pre1 in
+                                                                    let uu____5465
+                                                                    =
                                                                     let uu____5468
                                                                     =
-                                                                    let uu____5471
+                                                                    let uu____5469
                                                                     =
-                                                                    let uu____5472
-                                                                    =
-                                                                    let uu____5473
+                                                                    let uu____5470
                                                                     =
                                                                     FStar_Syntax_Util.mk_squash
                                                                     pre_u
                                                                     pre1 in
                                                                     istrivial
                                                                     env1
-                                                                    uu____5473 in
+                                                                    uu____5470 in
                                                                     Prims.op_Negation
-                                                                    uu____5472 in
+                                                                    uu____5469 in
                                                                     if
-                                                                    uu____5471
+                                                                    uu____5468
                                                                     then
                                                                     FStar_Tactics_Monad.add_irrelevant_goal
                                                                     goal
@@ -2867,15 +2770,15 @@ let (t_apply_lemma :
                                                                     FStar_Tactics_Monad.ret
                                                                     () in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____5468
+                                                                    uu____5465
                                                                     (fun
-                                                                    uu____5478
+                                                                    uu____5475
                                                                     ->
                                                                     FStar_Tactics_Monad.add_goals
                                                                     sub_goals2))))))))))))) in
-          focus uu____4267 in
+          focus uu____4264 in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "apply_lemma")
-          uu____4264
+          uu____4261
 let (split_env :
   FStar_Syntax_Syntax.bv ->
     env ->
@@ -2885,23 +2788,23 @@ let (split_env :
   fun bvar ->
     fun e ->
       let rec aux e1 =
-        let uu____5529 = FStar_TypeChecker_Env.pop_bv e1 in
-        match uu____5529 with
+        let uu____5526 = FStar_TypeChecker_Env.pop_bv e1 in
+        match uu____5526 with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (bv', e') ->
-            let uu____5564 = FStar_Syntax_Syntax.bv_eq bvar bv' in
-            if uu____5564
+            let uu____5561 = FStar_Syntax_Syntax.bv_eq bvar bv' in
+            if uu____5561
             then FStar_Pervasives_Native.Some (e', bv', [])
             else
-              (let uu____5586 = aux e' in
-               FStar_Util.map_opt uu____5586
-                 (fun uu____5617 ->
-                    match uu____5617 with
+              (let uu____5583 = aux e' in
+               FStar_Util.map_opt uu____5583
+                 (fun uu____5614 ->
+                    match uu____5614 with
                     | (e'', bv, bvs) -> (e'', bv, (bv' :: bvs)))) in
-      let uu____5643 = aux e in
-      FStar_Util.map_opt uu____5643
-        (fun uu____5674 ->
-           match uu____5674 with
+      let uu____5640 = aux e in
+      FStar_Util.map_opt uu____5640
+        (fun uu____5671 ->
+           match uu____5671 with
            | (e', bv, bvs) -> (e', bv, (FStar_List.rev bvs)))
 let (push_bvs :
   FStar_TypeChecker_Env.env ->
@@ -2921,39 +2824,39 @@ let (subst_goal :
   fun b1 ->
     fun b2 ->
       fun g ->
-        let uu____5749 =
-          let uu____5760 = FStar_Tactics_Types.goal_env g in
-          split_env b1 uu____5760 in
-        match uu____5749 with
+        let uu____5746 =
+          let uu____5757 = FStar_Tactics_Types.goal_env g in
+          split_env b1 uu____5757 in
+        match uu____5746 with
         | FStar_Pervasives_Native.Some (e0, b11, bvs) ->
             let bs =
               FStar_List.map FStar_Syntax_Syntax.mk_binder (b11 :: bvs) in
             let t = FStar_Tactics_Types.goal_type g in
-            let uu____5800 =
-              let uu____5813 = FStar_Syntax_Subst.close_binders bs in
-              let uu____5822 = FStar_Syntax_Subst.close bs t in
-              (uu____5813, uu____5822) in
-            (match uu____5800 with
+            let uu____5797 =
+              let uu____5810 = FStar_Syntax_Subst.close_binders bs in
+              let uu____5819 = FStar_Syntax_Subst.close bs t in
+              (uu____5810, uu____5819) in
+            (match uu____5797 with
              | (bs', t') ->
                  let bs'1 =
-                   let uu____5866 = FStar_Syntax_Syntax.mk_binder b2 in
-                   let uu____5873 = FStar_List.tail bs' in uu____5866 ::
-                     uu____5873 in
-                 let uu____5894 = FStar_Syntax_Subst.open_term bs'1 t' in
-                 (match uu____5894 with
+                   let uu____5863 = FStar_Syntax_Syntax.mk_binder b2 in
+                   let uu____5870 = FStar_List.tail bs' in uu____5863 ::
+                     uu____5870 in
+                 let uu____5891 = FStar_Syntax_Subst.open_term bs'1 t' in
+                 (match uu____5891 with
                   | (bs'', t'') ->
                       let b21 =
-                        let uu____5910 = FStar_List.hd bs'' in
-                        FStar_Pervasives_Native.fst uu____5910 in
+                        let uu____5907 = FStar_List.hd bs'' in
+                        FStar_Pervasives_Native.fst uu____5907 in
                       let new_env =
-                        let uu____5926 =
+                        let uu____5923 =
                           FStar_List.map FStar_Pervasives_Native.fst bs'' in
-                        push_bvs e0 uu____5926 in
-                      let uu____5937 =
+                        push_bvs e0 uu____5923 in
+                      let uu____5934 =
                         FStar_Tactics_Monad.new_uvar "subst_goal" new_env t'' in
-                      FStar_Tactics_Monad.bind uu____5937
-                        (fun uu____5960 ->
-                           match uu____5960 with
+                      FStar_Tactics_Monad.bind uu____5934
+                        (fun uu____5957 ->
+                           match uu____5957 with
                            | (uvt, uv) ->
                                let goal' =
                                  FStar_Tactics_Types.mk_goal new_env uv
@@ -2961,24 +2864,24 @@ let (subst_goal :
                                    g.FStar_Tactics_Types.is_guard
                                    g.FStar_Tactics_Types.label in
                                let sol =
-                                 let uu____5979 =
+                                 let uu____5976 =
                                    FStar_Syntax_Util.abs bs'' uvt
                                      FStar_Pervasives_Native.None in
-                                 let uu____5982 =
+                                 let uu____5979 =
                                    FStar_List.map
-                                     (fun uu____6003 ->
-                                        match uu____6003 with
+                                     (fun uu____6000 ->
+                                        match uu____6000 with
                                         | (bv, q) ->
-                                            let uu____6016 =
+                                            let uu____6013 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 bv in
                                             FStar_Syntax_Syntax.as_arg
-                                              uu____6016) bs in
-                                 FStar_Syntax_Util.mk_app uu____5979
-                                   uu____5982 in
-                               let uu____6017 = set_solution g sol in
-                               FStar_Tactics_Monad.bind uu____6017
-                                 (fun uu____6027 ->
+                                              uu____6013) bs in
+                                 FStar_Syntax_Util.mk_app uu____5976
+                                   uu____5979 in
+                               let uu____6014 = set_solution g sol in
+                               FStar_Tactics_Monad.bind uu____6014
+                                 (fun uu____6024 ->
                                     FStar_Tactics_Monad.ret
                                       (FStar_Pervasives_Native.Some
                                          (b21, goal'))))))
@@ -2986,82 +2889,82 @@ let (subst_goal :
             FStar_Tactics_Monad.ret FStar_Pervasives_Native.None
 let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun h ->
-    let uu____6065 =
+    let uu____6062 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____6073 = h in
-           match uu____6073 with
-           | (bv, uu____6077) ->
+           let uu____6070 = h in
+           match uu____6070 with
+           | (bv, uu____6074) ->
                FStar_Tactics_Monad.mlog
-                 (fun uu____6085 ->
-                    let uu____6086 = FStar_Syntax_Print.bv_to_string bv in
-                    let uu____6087 =
+                 (fun uu____6082 ->
+                    let uu____6083 = FStar_Syntax_Print.bv_to_string bv in
+                    let uu____6084 =
                       FStar_Syntax_Print.term_to_string
                         bv.FStar_Syntax_Syntax.sort in
-                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu____6086
-                      uu____6087)
-                 (fun uu____6090 ->
-                    let uu____6091 =
-                      let uu____6102 = FStar_Tactics_Types.goal_env goal in
-                      split_env bv uu____6102 in
-                    match uu____6091 with
+                    FStar_Util.print2 "+++Rewrite %s : %s\n" uu____6083
+                      uu____6084)
+                 (fun uu____6087 ->
+                    let uu____6088 =
+                      let uu____6099 = FStar_Tactics_Types.goal_env goal in
+                      split_env bv uu____6099 in
+                    match uu____6088 with
                     | FStar_Pervasives_Native.None ->
                         FStar_Tactics_Monad.fail
                           "binder not found in environment"
                     | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
-                        let uu____6128 =
-                          let uu____6135 =
+                        let uu____6125 =
+                          let uu____6132 =
                             whnf e0 bv1.FStar_Syntax_Syntax.sort in
-                          destruct_eq uu____6135 in
-                        (match uu____6128 with
+                          destruct_eq uu____6132 in
+                        (match uu____6125 with
                          | FStar_Pervasives_Native.Some (x, e) ->
-                             let uu____6144 =
-                               let uu____6145 = FStar_Syntax_Subst.compress x in
-                               uu____6145.FStar_Syntax_Syntax.n in
-                             (match uu____6144 with
+                             let uu____6141 =
+                               let uu____6142 = FStar_Syntax_Subst.compress x in
+                               uu____6142.FStar_Syntax_Syntax.n in
+                             (match uu____6141 with
                               | FStar_Syntax_Syntax.Tm_name x1 ->
                                   let s = [FStar_Syntax_Syntax.NT (x1, e)] in
                                   let t = FStar_Tactics_Types.goal_type goal in
                                   let bs =
                                     FStar_List.map
                                       FStar_Syntax_Syntax.mk_binder bvs in
-                                  let uu____6172 =
-                                    let uu____6177 =
+                                  let uu____6169 =
+                                    let uu____6174 =
                                       FStar_Syntax_Subst.close_binders bs in
-                                    let uu____6178 =
+                                    let uu____6175 =
                                       FStar_Syntax_Subst.close bs t in
-                                    (uu____6177, uu____6178) in
-                                  (match uu____6172 with
+                                    (uu____6174, uu____6175) in
+                                  (match uu____6169 with
                                    | (bs', t') ->
-                                       let uu____6183 =
-                                         let uu____6188 =
+                                       let uu____6180 =
+                                         let uu____6185 =
                                            FStar_Syntax_Subst.subst_binders s
                                              bs' in
-                                         let uu____6189 =
+                                         let uu____6186 =
                                            FStar_Syntax_Subst.subst s t in
-                                         (uu____6188, uu____6189) in
-                                       (match uu____6183 with
+                                         (uu____6185, uu____6186) in
+                                       (match uu____6180 with
                                         | (bs'1, t'1) ->
-                                            let uu____6194 =
+                                            let uu____6191 =
                                               FStar_Syntax_Subst.open_term
                                                 bs'1 t'1 in
-                                            (match uu____6194 with
+                                            (match uu____6191 with
                                              | (bs'', t'') ->
                                                  let new_env =
-                                                   let uu____6204 =
-                                                     let uu____6207 =
+                                                   let uu____6201 =
+                                                     let uu____6204 =
                                                        FStar_List.map
                                                          FStar_Pervasives_Native.fst
                                                          bs'' in
-                                                     bv1 :: uu____6207 in
-                                                   push_bvs e0 uu____6204 in
-                                                 let uu____6218 =
+                                                     bv1 :: uu____6204 in
+                                                   push_bvs e0 uu____6201 in
+                                                 let uu____6215 =
                                                    FStar_Tactics_Monad.new_uvar
                                                      "rewrite" new_env t'' in
                                                  FStar_Tactics_Monad.bind
-                                                   uu____6218
-                                                   (fun uu____6235 ->
-                                                      match uu____6235 with
+                                                   uu____6215
+                                                   (fun uu____6232 ->
+                                                      match uu____6232 with
                                                       | (uvt, uv) ->
                                                           let goal' =
                                                             FStar_Tactics_Types.mk_goal
@@ -3070,172 +2973,172 @@ let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                                               goal.FStar_Tactics_Types.is_guard
                                                               goal.FStar_Tactics_Types.label in
                                                           let sol =
-                                                            let uu____6248 =
+                                                            let uu____6245 =
                                                               FStar_Syntax_Util.abs
                                                                 bs'' uvt
                                                                 FStar_Pervasives_Native.None in
-                                                            let uu____6251 =
+                                                            let uu____6248 =
                                                               FStar_List.map
                                                                 (fun
-                                                                   uu____6272
+                                                                   uu____6269
                                                                    ->
-                                                                   match uu____6272
+                                                                   match uu____6269
                                                                    with
                                                                    | 
                                                                    (bv2,
-                                                                    uu____6280)
+                                                                    uu____6277)
                                                                     ->
-                                                                    let uu____6285
+                                                                    let uu____6282
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv2 in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____6285)
+                                                                    uu____6282)
                                                                 bs in
                                                             FStar_Syntax_Util.mk_app
-                                                              uu____6248
-                                                              uu____6251 in
-                                                          let uu____6286 =
+                                                              uu____6245
+                                                              uu____6248 in
+                                                          let uu____6283 =
                                                             set_solution goal
                                                               sol in
                                                           FStar_Tactics_Monad.bind
-                                                            uu____6286
-                                                            (fun uu____6290
+                                                            uu____6283
+                                                            (fun uu____6287
                                                                ->
                                                                FStar_Tactics_Monad.replace_cur
                                                                  goal')))))
-                              | uu____6291 ->
+                              | uu____6288 ->
                                   FStar_Tactics_Monad.fail
                                     "Not an equality hypothesis with a variable on the LHS")
-                         | uu____6292 ->
+                         | uu____6289 ->
                              FStar_Tactics_Monad.fail
                                "Not an equality hypothesis"))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu____6065
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rewrite") uu____6062
 let (rename_to :
   FStar_Syntax_Syntax.binder ->
     Prims.string -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac)
   =
   fun b ->
     fun s ->
-      let uu____6317 =
+      let uu____6314 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal ->
-             let uu____6339 = b in
-             match uu____6339 with
+             let uu____6336 = b in
+             match uu____6336 with
              | (bv, q) ->
                  let bv' =
-                   let uu____6355 =
-                     let uu___932_6356 = bv in
-                     let uu____6357 =
-                       let uu____6358 =
-                         let uu____6363 =
+                   let uu____6352 =
+                     let uu___930_6353 = bv in
+                     let uu____6354 =
+                       let uu____6355 =
+                         let uu____6360 =
                            FStar_Ident.range_of_id
                              bv.FStar_Syntax_Syntax.ppname in
-                         (s, uu____6363) in
-                       FStar_Ident.mk_ident uu____6358 in
+                         (s, uu____6360) in
+                       FStar_Ident.mk_ident uu____6355 in
                      {
-                       FStar_Syntax_Syntax.ppname = uu____6357;
+                       FStar_Syntax_Syntax.ppname = uu____6354;
                        FStar_Syntax_Syntax.index =
-                         (uu___932_6356.FStar_Syntax_Syntax.index);
+                         (uu___930_6353.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort =
-                         (uu___932_6356.FStar_Syntax_Syntax.sort)
+                         (uu___930_6353.FStar_Syntax_Syntax.sort)
                      } in
-                   FStar_Syntax_Syntax.freshen_bv uu____6355 in
-                 let uu____6364 = subst_goal bv bv' goal in
-                 FStar_Tactics_Monad.bind uu____6364
-                   (fun uu___4_6386 ->
-                      match uu___4_6386 with
+                   FStar_Syntax_Syntax.freshen_bv uu____6352 in
+                 let uu____6361 = subst_goal bv bv' goal in
+                 FStar_Tactics_Monad.bind uu____6361
+                   (fun uu___4_6383 ->
+                      match uu___4_6383 with
                       | FStar_Pervasives_Native.None ->
                           FStar_Tactics_Monad.fail
                             "binder not found in environment"
                       | FStar_Pervasives_Native.Some (bv'1, goal1) ->
-                          let uu____6417 =
+                          let uu____6414 =
                             FStar_Tactics_Monad.replace_cur goal1 in
-                          FStar_Tactics_Monad.bind uu____6417
-                            (fun uu____6427 ->
+                          FStar_Tactics_Monad.bind uu____6414
+                            (fun uu____6424 ->
                                FStar_Tactics_Monad.ret (bv'1, q)))) in
       FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "rename_to")
-        uu____6317
+        uu____6314
 let (binder_retype :
   FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
-    let uu____6461 =
+    let uu____6458 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun goal ->
-           let uu____6470 = b in
-           match uu____6470 with
-           | (bv, uu____6474) ->
-               let uu____6479 =
-                 let uu____6490 = FStar_Tactics_Types.goal_env goal in
-                 split_env bv uu____6490 in
-               (match uu____6479 with
+           let uu____6467 = b in
+           match uu____6467 with
+           | (bv, uu____6471) ->
+               let uu____6476 =
+                 let uu____6487 = FStar_Tactics_Types.goal_env goal in
+                 split_env bv uu____6487 in
+               (match uu____6476 with
                 | FStar_Pervasives_Native.None ->
                     FStar_Tactics_Monad.fail
                       "binder is not present in environment"
                 | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
-                    let uu____6516 = FStar_Syntax_Util.type_u () in
-                    (match uu____6516 with
+                    let uu____6513 = FStar_Syntax_Util.type_u () in
+                    (match uu____6513 with
                      | (ty, u) ->
-                         let uu____6525 =
+                         let uu____6522 =
                            FStar_Tactics_Monad.new_uvar "binder_retype" e0 ty in
-                         FStar_Tactics_Monad.bind uu____6525
-                           (fun uu____6543 ->
-                              match uu____6543 with
+                         FStar_Tactics_Monad.bind uu____6522
+                           (fun uu____6540 ->
+                              match uu____6540 with
                               | (t', u_t') ->
                                   let bv'' =
-                                    let uu___959_6553 = bv1 in
+                                    let uu___957_6550 = bv1 in
                                     {
                                       FStar_Syntax_Syntax.ppname =
-                                        (uu___959_6553.FStar_Syntax_Syntax.ppname);
+                                        (uu___957_6550.FStar_Syntax_Syntax.ppname);
                                       FStar_Syntax_Syntax.index =
-                                        (uu___959_6553.FStar_Syntax_Syntax.index);
+                                        (uu___957_6550.FStar_Syntax_Syntax.index);
                                       FStar_Syntax_Syntax.sort = t'
                                     } in
                                   let s =
-                                    let uu____6557 =
-                                      let uu____6558 =
-                                        let uu____6565 =
+                                    let uu____6554 =
+                                      let uu____6555 =
+                                        let uu____6562 =
                                           FStar_Syntax_Syntax.bv_to_name bv'' in
-                                        (bv1, uu____6565) in
-                                      FStar_Syntax_Syntax.NT uu____6558 in
-                                    [uu____6557] in
+                                        (bv1, uu____6562) in
+                                      FStar_Syntax_Syntax.NT uu____6555 in
+                                    [uu____6554] in
                                   let bvs1 =
                                     FStar_List.map
                                       (fun b1 ->
-                                         let uu___964_6577 = b1 in
-                                         let uu____6578 =
+                                         let uu___962_6574 = b1 in
+                                         let uu____6575 =
                                            FStar_Syntax_Subst.subst s
                                              b1.FStar_Syntax_Syntax.sort in
                                          {
                                            FStar_Syntax_Syntax.ppname =
-                                             (uu___964_6577.FStar_Syntax_Syntax.ppname);
+                                             (uu___962_6574.FStar_Syntax_Syntax.ppname);
                                            FStar_Syntax_Syntax.index =
-                                             (uu___964_6577.FStar_Syntax_Syntax.index);
+                                             (uu___962_6574.FStar_Syntax_Syntax.index);
                                            FStar_Syntax_Syntax.sort =
-                                             uu____6578
+                                             uu____6575
                                          }) bvs in
                                   let env' = push_bvs e0 (bv'' :: bvs1) in
                                   FStar_Tactics_Monad.bind
                                     FStar_Tactics_Monad.dismiss
-                                    (fun uu____6585 ->
+                                    (fun uu____6582 ->
                                        let new_goal =
-                                         let uu____6587 =
+                                         let uu____6584 =
                                            FStar_Tactics_Types.goal_with_env
                                              goal env' in
-                                         let uu____6588 =
-                                           let uu____6589 =
+                                         let uu____6585 =
+                                           let uu____6586 =
                                              FStar_Tactics_Types.goal_type
                                                goal in
                                            FStar_Syntax_Subst.subst s
-                                             uu____6589 in
+                                             uu____6586 in
                                          FStar_Tactics_Types.goal_with_type
-                                           uu____6587 uu____6588 in
-                                       let uu____6590 =
+                                           uu____6584 uu____6585 in
+                                       let uu____6587 =
                                          FStar_Tactics_Monad.add_goals
                                            [new_goal] in
-                                       FStar_Tactics_Monad.bind uu____6590
-                                         (fun uu____6595 ->
-                                            let uu____6596 =
+                                       FStar_Tactics_Monad.bind uu____6587
+                                         (fun uu____6592 ->
+                                            let uu____6593 =
                                               FStar_Syntax_Util.mk_eq2
                                                 (FStar_Syntax_Syntax.U_succ u)
                                                 ty
@@ -3243,91 +3146,91 @@ let (binder_retype :
                                                 t' in
                                             FStar_Tactics_Monad.add_irrelevant_goal
                                               goal "binder_retype equation"
-                                              e0 uu____6596)))))) in
+                                              e0 uu____6593)))))) in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "binder_retype")
-      uu____6461
+      uu____6458
 let (norm_binder_type :
   FStar_Syntax_Embeddings.norm_step Prims.list ->
     FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac)
   =
   fun s ->
     fun b ->
-      let uu____6619 =
+      let uu____6616 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
           (fun goal ->
-             let uu____6628 = b in
-             match uu____6628 with
-             | (bv, uu____6632) ->
-                 let uu____6637 =
-                   let uu____6648 = FStar_Tactics_Types.goal_env goal in
-                   split_env bv uu____6648 in
-                 (match uu____6637 with
+             let uu____6625 = b in
+             match uu____6625 with
+             | (bv, uu____6629) ->
+                 let uu____6634 =
+                   let uu____6645 = FStar_Tactics_Types.goal_env goal in
+                   split_env bv uu____6645 in
+                 (match uu____6634 with
                   | FStar_Pervasives_Native.None ->
                       FStar_Tactics_Monad.fail
                         "binder is not present in environment"
                   | FStar_Pervasives_Native.Some (e0, bv1, bvs) ->
                       let steps =
-                        let uu____6677 =
+                        let uu____6674 =
                           FStar_TypeChecker_Normalize.tr_norm_steps s in
                         FStar_List.append
                           [FStar_TypeChecker_Env.Reify;
-                          FStar_TypeChecker_Env.UnfoldTac] uu____6677 in
+                          FStar_TypeChecker_Env.UnfoldTac] uu____6674 in
                       let sort' =
                         normalize steps e0 bv1.FStar_Syntax_Syntax.sort in
                       let bv' =
-                        let uu___985_6682 = bv1 in
+                        let uu___983_6679 = bv1 in
                         {
                           FStar_Syntax_Syntax.ppname =
-                            (uu___985_6682.FStar_Syntax_Syntax.ppname);
+                            (uu___983_6679.FStar_Syntax_Syntax.ppname);
                           FStar_Syntax_Syntax.index =
-                            (uu___985_6682.FStar_Syntax_Syntax.index);
+                            (uu___983_6679.FStar_Syntax_Syntax.index);
                           FStar_Syntax_Syntax.sort = sort'
                         } in
                       let env' = push_bvs e0 (bv' :: bvs) in
-                      let uu____6684 =
+                      let uu____6681 =
                         FStar_Tactics_Types.goal_with_env goal env' in
-                      FStar_Tactics_Monad.replace_cur uu____6684)) in
+                      FStar_Tactics_Monad.replace_cur uu____6681)) in
       FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "norm_binder_type")
-        uu____6619
+        uu____6616
 let (revert : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____6695 ->
+  fun uu____6692 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____6701 =
-           let uu____6708 = FStar_Tactics_Types.goal_env goal in
-           FStar_TypeChecker_Env.pop_bv uu____6708 in
-         match uu____6701 with
+         let uu____6698 =
+           let uu____6705 = FStar_Tactics_Types.goal_env goal in
+           FStar_TypeChecker_Env.pop_bv uu____6705 in
+         match uu____6698 with
          | FStar_Pervasives_Native.None ->
              FStar_Tactics_Monad.fail "Cannot revert; empty context"
          | FStar_Pervasives_Native.Some (x, env') ->
              let typ' =
-               let uu____6724 =
-                 let uu____6727 = FStar_Tactics_Types.goal_type goal in
-                 FStar_Syntax_Syntax.mk_Total uu____6727 in
+               let uu____6721 =
+                 let uu____6724 = FStar_Tactics_Types.goal_type goal in
+                 FStar_Syntax_Syntax.mk_Total uu____6724 in
                FStar_Syntax_Util.arrow [(x, FStar_Pervasives_Native.None)]
-                 uu____6724 in
-             let uu____6742 = FStar_Tactics_Monad.new_uvar "revert" env' typ' in
-             FStar_Tactics_Monad.bind uu____6742
-               (fun uu____6757 ->
-                  match uu____6757 with
+                 uu____6721 in
+             let uu____6739 = FStar_Tactics_Monad.new_uvar "revert" env' typ' in
+             FStar_Tactics_Monad.bind uu____6739
+               (fun uu____6754 ->
+                  match uu____6754 with
                   | (r, u_r) ->
-                      let uu____6766 =
-                        let uu____6769 =
-                          let uu____6770 =
-                            let uu____6771 =
-                              let uu____6780 =
+                      let uu____6763 =
+                        let uu____6766 =
+                          let uu____6767 =
+                            let uu____6768 =
+                              let uu____6777 =
                                 FStar_Syntax_Syntax.bv_to_name x in
-                              FStar_Syntax_Syntax.as_arg uu____6780 in
-                            [uu____6771] in
-                          let uu____6797 =
-                            let uu____6798 =
+                              FStar_Syntax_Syntax.as_arg uu____6777 in
+                            [uu____6768] in
+                          let uu____6794 =
+                            let uu____6795 =
                               FStar_Tactics_Types.goal_type goal in
-                            uu____6798.FStar_Syntax_Syntax.pos in
-                          FStar_Syntax_Syntax.mk_Tm_app r uu____6770
-                            uu____6797 in
-                        set_solution goal uu____6769 in
-                      FStar_Tactics_Monad.bind uu____6766
-                        (fun uu____6803 ->
+                            uu____6795.FStar_Syntax_Syntax.pos in
+                          FStar_Syntax_Syntax.mk_Tm_app r uu____6767
+                            uu____6794 in
+                        set_solution goal uu____6766 in
+                      FStar_Tactics_Monad.bind uu____6763
+                        (fun uu____6800 ->
                            let g =
                              FStar_Tactics_Types.mk_goal env' u_r
                                goal.FStar_Tactics_Types.opts
@@ -3338,30 +3241,30 @@ let (free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv ->
     fun t ->
-      let uu____6815 = FStar_Syntax_Free.names t in
-      FStar_Util.set_mem bv uu____6815
+      let uu____6812 = FStar_Syntax_Free.names t in
+      FStar_Util.set_mem bv uu____6812
 let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
     let bv = FStar_Pervasives_Native.fst b in
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
          FStar_Tactics_Monad.mlog
-           (fun uu____6835 ->
-              let uu____6836 = FStar_Syntax_Print.binder_to_string b in
-              let uu____6837 =
-                let uu____6838 =
-                  let uu____6839 =
-                    let uu____6848 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.all_binders uu____6848 in
-                  FStar_All.pipe_right uu____6839 FStar_List.length in
-                FStar_All.pipe_right uu____6838 FStar_Util.string_of_int in
+           (fun uu____6832 ->
+              let uu____6833 = FStar_Syntax_Print.binder_to_string b in
+              let uu____6834 =
+                let uu____6835 =
+                  let uu____6836 =
+                    let uu____6845 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.all_binders uu____6845 in
+                  FStar_All.pipe_right uu____6836 FStar_List.length in
+                FStar_All.pipe_right uu____6835 FStar_Util.string_of_int in
               FStar_Util.print2 "Clear of (%s), env has %s binders\n"
-                uu____6836 uu____6837)
-           (fun uu____6865 ->
-              let uu____6866 =
-                let uu____6877 = FStar_Tactics_Types.goal_env goal in
-                split_env bv uu____6877 in
-              match uu____6866 with
+                uu____6833 uu____6834)
+           (fun uu____6862 ->
+              let uu____6863 =
+                let uu____6874 = FStar_Tactics_Types.goal_env goal in
+                split_env bv uu____6874 in
+              match uu____6863 with
               | FStar_Pervasives_Native.None ->
                   FStar_Tactics_Monad.fail
                     "Cannot clear; binder not in environment"
@@ -3370,71 +3273,71 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                     match bvs1 with
                     | [] -> FStar_Tactics_Monad.ret ()
                     | bv'::bvs2 ->
-                        let uu____6921 =
+                        let uu____6918 =
                           free_in bv1 bv'.FStar_Syntax_Syntax.sort in
-                        if uu____6921
+                        if uu____6918
                         then
-                          let uu____6924 =
-                            let uu____6925 =
+                          let uu____6921 =
+                            let uu____6922 =
                               FStar_Syntax_Print.bv_to_string bv' in
                             FStar_Util.format1
                               "Cannot clear; binder present in the type of %s"
-                              uu____6925 in
-                          FStar_Tactics_Monad.fail uu____6924
+                              uu____6922 in
+                          FStar_Tactics_Monad.fail uu____6921
                         else check bvs2 in
-                  let uu____6927 =
-                    let uu____6928 = FStar_Tactics_Types.goal_type goal in
-                    free_in bv1 uu____6928 in
-                  if uu____6927
+                  let uu____6924 =
+                    let uu____6925 = FStar_Tactics_Types.goal_type goal in
+                    free_in bv1 uu____6925 in
+                  if uu____6924
                   then
                     FStar_Tactics_Monad.fail
                       "Cannot clear; binder present in goal"
                   else
-                    (let uu____6932 = check bvs in
-                     FStar_Tactics_Monad.bind uu____6932
-                       (fun uu____6938 ->
+                    (let uu____6929 = check bvs in
+                     FStar_Tactics_Monad.bind uu____6929
+                       (fun uu____6935 ->
                           let env' = push_bvs e' bvs in
-                          let uu____6940 =
-                            let uu____6947 =
+                          let uu____6937 =
+                            let uu____6944 =
                               FStar_Tactics_Types.goal_type goal in
                             FStar_Tactics_Monad.new_uvar "clear.witness" env'
-                              uu____6947 in
-                          FStar_Tactics_Monad.bind uu____6940
-                            (fun uu____6956 ->
-                               match uu____6956 with
+                              uu____6944 in
+                          FStar_Tactics_Monad.bind uu____6937
+                            (fun uu____6953 ->
+                               match uu____6953 with
                                | (ut, uvar_ut) ->
-                                   let uu____6965 = set_solution goal ut in
-                                   FStar_Tactics_Monad.bind uu____6965
-                                     (fun uu____6970 ->
-                                        let uu____6971 =
+                                   let uu____6962 = set_solution goal ut in
+                                   FStar_Tactics_Monad.bind uu____6962
+                                     (fun uu____6967 ->
+                                        let uu____6968 =
                                           FStar_Tactics_Types.mk_goal env'
                                             uvar_ut
                                             goal.FStar_Tactics_Types.opts
                                             goal.FStar_Tactics_Types.is_guard
                                             goal.FStar_Tactics_Types.label in
                                         FStar_Tactics_Monad.replace_cur
-                                          uu____6971))))))
+                                          uu____6968))))))
 let (clear_top : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____6978 ->
+  fun uu____6975 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun goal ->
-         let uu____6984 =
-           let uu____6991 = FStar_Tactics_Types.goal_env goal in
-           FStar_TypeChecker_Env.pop_bv uu____6991 in
-         match uu____6984 with
+         let uu____6981 =
+           let uu____6988 = FStar_Tactics_Types.goal_env goal in
+           FStar_TypeChecker_Env.pop_bv uu____6988 in
+         match uu____6981 with
          | FStar_Pervasives_Native.None ->
              FStar_Tactics_Monad.fail "Cannot clear; empty context"
-         | FStar_Pervasives_Native.Some (x, uu____6999) ->
-             let uu____7004 = FStar_Syntax_Syntax.mk_binder x in
-             clear uu____7004)
+         | FStar_Pervasives_Native.Some (x, uu____6996) ->
+             let uu____7001 = FStar_Syntax_Syntax.mk_binder x in
+             clear uu____7001)
 let (prune : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
          let ctx = FStar_Tactics_Types.goal_env g in
          let ctx' =
-           let uu____7021 = FStar_Ident.path_of_text s in
-           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7021 in
+           let uu____7018 = FStar_Ident.path_of_text s in
+           FStar_TypeChecker_Env.rem_proof_ns ctx uu____7018 in
          let g' = FStar_Tactics_Types.goal_with_env g ctx' in
          FStar_Tactics_Monad.replace_cur g')
 let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
@@ -3443,8 +3346,8 @@ let (addns : Prims.string -> unit FStar_Tactics_Monad.tac) =
       (fun g ->
          let ctx = FStar_Tactics_Types.goal_env g in
          let ctx' =
-           let uu____7039 = FStar_Ident.path_of_text s in
-           FStar_TypeChecker_Env.add_proof_ns ctx uu____7039 in
+           let uu____7036 = FStar_Ident.path_of_text s in
+           FStar_TypeChecker_Env.add_proof_ns ctx uu____7036 in
          let g' = FStar_Tactics_Types.goal_with_env g ctx' in
          FStar_Tactics_Monad.replace_cur g')
 let (_trefl :
@@ -3455,112 +3358,112 @@ let (_trefl :
     fun r ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____7058 =
-             let uu____7061 = FStar_Tactics_Types.goal_env g in
-             do_unify uu____7061 l r in
-           FStar_Tactics_Monad.bind uu____7058
+           let uu____7055 =
+             let uu____7058 = FStar_Tactics_Types.goal_env g in
+             do_unify uu____7058 l r in
+           FStar_Tactics_Monad.bind uu____7055
              (fun b ->
                 if b
                 then solve' g FStar_Syntax_Util.exp_unit
                 else
                   (let l1 =
-                     let uu____7068 = FStar_Tactics_Types.goal_env g in
+                     let uu____7065 = FStar_Tactics_Types.goal_env g in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7068 l in
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7065 l in
                    let r1 =
-                     let uu____7070 = FStar_Tactics_Types.goal_env g in
+                     let uu____7067 = FStar_Tactics_Types.goal_env g in
                      FStar_TypeChecker_Normalize.normalize
                        [FStar_TypeChecker_Env.UnfoldUntil
                           FStar_Syntax_Syntax.delta_constant;
                        FStar_TypeChecker_Env.Primops;
-                       FStar_TypeChecker_Env.UnfoldTac] uu____7070 r in
-                   let uu____7071 =
-                     let uu____7074 = FStar_Tactics_Types.goal_env g in
-                     do_unify uu____7074 l1 r1 in
-                   FStar_Tactics_Monad.bind uu____7071
+                       FStar_TypeChecker_Env.UnfoldTac] uu____7067 r in
+                   let uu____7068 =
+                     let uu____7071 = FStar_Tactics_Types.goal_env g in
+                     do_unify uu____7071 l1 r1 in
+                   FStar_Tactics_Monad.bind uu____7068
                      (fun b1 ->
                         if b1
                         then solve' g FStar_Syntax_Util.exp_unit
                         else
-                          (let uu____7080 =
-                             let uu____7085 =
-                               let uu____7090 =
+                          (let uu____7077 =
+                             let uu____7082 =
+                               let uu____7087 =
                                  FStar_Tactics_Types.goal_env g in
-                               tts uu____7090 in
+                               tts uu____7087 in
                              FStar_TypeChecker_Err.print_discrepancy
-                               uu____7085 l1 r1 in
-                           match uu____7080 with
+                               uu____7082 l1 r1 in
+                           match uu____7077 with
                            | (ls, rs) ->
                                fail2 "not a trivial equality ((%s) vs (%s))"
                                  ls rs)))))
 let (trefl : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7101 ->
-    let uu____7104 =
+  fun uu____7098 ->
+    let uu____7101 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____7112 =
-             let uu____7119 =
-               let uu____7120 = FStar_Tactics_Types.goal_env g in
-               let uu____7121 = FStar_Tactics_Types.goal_type g in
-               whnf uu____7120 uu____7121 in
-             destruct_eq uu____7119 in
-           match uu____7112 with
+           let uu____7109 =
+             let uu____7116 =
+               let uu____7117 = FStar_Tactics_Types.goal_env g in
+               let uu____7118 = FStar_Tactics_Types.goal_type g in
+               whnf uu____7117 uu____7118 in
+             destruct_eq uu____7116 in
+           match uu____7109 with
            | FStar_Pervasives_Native.Some (l, r) -> _trefl l r
            | FStar_Pervasives_Native.None ->
-               let uu____7134 =
-                 let uu____7135 = FStar_Tactics_Types.goal_env g in
-                 let uu____7136 = FStar_Tactics_Types.goal_type g in
-                 tts uu____7135 uu____7136 in
-               fail1 "not an equality (%s)" uu____7134) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7104
+               let uu____7131 =
+                 let uu____7132 = FStar_Tactics_Types.goal_env g in
+                 let uu____7133 = FStar_Tactics_Types.goal_type g in
+                 tts uu____7132 uu____7133 in
+               fail1 "not an equality (%s)" uu____7131) in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "trefl") uu____7101
 let (dup : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7147 ->
+  fun uu____7144 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
          let env1 = FStar_Tactics_Types.goal_env g in
-         let uu____7155 =
-           let uu____7162 = FStar_Tactics_Types.goal_type g in
-           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7162 in
-         FStar_Tactics_Monad.bind uu____7155
-           (fun uu____7171 ->
-              match uu____7171 with
+         let uu____7152 =
+           let uu____7159 = FStar_Tactics_Types.goal_type g in
+           FStar_Tactics_Monad.new_uvar "dup" env1 uu____7159 in
+         FStar_Tactics_Monad.bind uu____7152
+           (fun uu____7168 ->
+              match uu____7168 with
               | (u, u_uvar) ->
                   let g' =
-                    let uu___1071_7181 = g in
+                    let uu___1069_7178 = g in
                     {
                       FStar_Tactics_Types.goal_main_env =
-                        (uu___1071_7181.FStar_Tactics_Types.goal_main_env);
+                        (uu___1069_7178.FStar_Tactics_Types.goal_main_env);
                       FStar_Tactics_Types.goal_ctx_uvar = u_uvar;
                       FStar_Tactics_Types.opts =
-                        (uu___1071_7181.FStar_Tactics_Types.opts);
+                        (uu___1069_7178.FStar_Tactics_Types.opts);
                       FStar_Tactics_Types.is_guard =
-                        (uu___1071_7181.FStar_Tactics_Types.is_guard);
+                        (uu___1069_7178.FStar_Tactics_Types.is_guard);
                       FStar_Tactics_Types.label =
-                        (uu___1071_7181.FStar_Tactics_Types.label)
+                        (uu___1069_7178.FStar_Tactics_Types.label)
                     } in
                   FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                    (fun uu____7185 ->
+                    (fun uu____7182 ->
                        let t_eq =
-                         let uu____7187 =
-                           let uu____7188 = FStar_Tactics_Types.goal_type g in
+                         let uu____7184 =
+                           let uu____7185 = FStar_Tactics_Types.goal_type g in
                            env1.FStar_TypeChecker_Env.universe_of env1
-                             uu____7188 in
-                         let uu____7189 = FStar_Tactics_Types.goal_type g in
-                         let uu____7190 = FStar_Tactics_Types.goal_witness g in
-                         FStar_Syntax_Util.mk_eq2 uu____7187 uu____7189 u
-                           uu____7190 in
-                       let uu____7191 =
+                             uu____7185 in
+                         let uu____7186 = FStar_Tactics_Types.goal_type g in
+                         let uu____7187 = FStar_Tactics_Types.goal_witness g in
+                         FStar_Syntax_Util.mk_eq2 uu____7184 uu____7186 u
+                           uu____7187 in
+                       let uu____7188 =
                          FStar_Tactics_Monad.add_irrelevant_goal g
                            "dup equation" env1 t_eq in
-                       FStar_Tactics_Monad.bind uu____7191
-                         (fun uu____7196 ->
-                            let uu____7197 =
+                       FStar_Tactics_Monad.bind uu____7188
+                         (fun uu____7193 ->
+                            let uu____7194 =
                               FStar_Tactics_Monad.add_goals [g'] in
-                            FStar_Tactics_Monad.bind uu____7197
-                              (fun uu____7201 -> FStar_Tactics_Monad.ret ())))))
+                            FStar_Tactics_Monad.bind uu____7194
+                              (fun uu____7198 -> FStar_Tactics_Monad.ret ())))))
 let longest_prefix :
   'a .
     ('a -> 'a -> Prims.bool) ->
@@ -3573,11 +3476,11 @@ let longest_prefix :
         let rec aux acc l11 l21 =
           match (l11, l21) with
           | (x::xs, y::ys) ->
-              let uu____7324 = f x y in
-              if uu____7324 then aux (x :: acc) xs ys else (acc, xs, ys)
-          | uu____7344 -> (acc, l11, l21) in
-        let uu____7359 = aux [] l1 l2 in
-        match uu____7359 with | (pr, t1, t2) -> ((FStar_List.rev pr), t1, t2)
+              let uu____7321 = f x y in
+              if uu____7321 then aux (x :: acc) xs ys else (acc, xs, ys)
+          | uu____7341 -> (acc, l11, l21) in
+        let uu____7356 = aux [] l1 l2 in
+        match uu____7356 with | (pr, t1, t2) -> ((FStar_List.rev pr), t1, t2)
 let (join_goals :
   FStar_Tactics_Types.goal ->
     FStar_Tactics_Types.goal ->
@@ -3591,13 +3494,13 @@ let (join_goals :
              fun f1 ->
                FStar_Syntax_Util.mk_forall_no_univ
                  (FStar_Pervasives_Native.fst b) f1) bs f in
-      let uu____7464 = FStar_Tactics_Types.get_phi g1 in
-      match uu____7464 with
+      let uu____7461 = FStar_Tactics_Types.get_phi g1 in
+      match uu____7461 with
       | FStar_Pervasives_Native.None ->
           FStar_Tactics_Monad.fail "goal 1 is not irrelevant"
       | FStar_Pervasives_Native.Some phi1 ->
-          let uu____7470 = FStar_Tactics_Types.get_phi g2 in
-          (match uu____7470 with
+          let uu____7467 = FStar_Tactics_Types.get_phi g2 in
+          (match uu____7467 with
            | FStar_Pervasives_Native.None ->
                FStar_Tactics_Monad.fail "goal 2 is not irrelevant"
            | FStar_Pervasives_Native.Some phi2 ->
@@ -3605,221 +3508,221 @@ let (join_goals :
                  (g1.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma in
                let gamma2 =
                  (g2.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma in
-               let uu____7482 =
+               let uu____7479 =
                  longest_prefix FStar_Syntax_Syntax.eq_binding
                    (FStar_List.rev gamma1) (FStar_List.rev gamma2) in
-               (match uu____7482 with
+               (match uu____7479 with
                 | (gamma, r1, r2) ->
                     let t1 =
-                      let uu____7513 =
+                      let uu____7510 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r1) in
-                      close_forall_no_univs uu____7513 phi1 in
+                      close_forall_no_univs uu____7510 phi1 in
                     let t2 =
-                      let uu____7523 =
+                      let uu____7520 =
                         FStar_TypeChecker_Env.binders_of_bindings
                           (FStar_List.rev r2) in
-                      close_forall_no_univs uu____7523 phi2 in
-                    let uu____7532 =
+                      close_forall_no_univs uu____7520 phi2 in
+                    let uu____7529 =
                       set_solution g1 FStar_Syntax_Util.exp_unit in
-                    FStar_Tactics_Monad.bind uu____7532
-                      (fun uu____7537 ->
-                         let uu____7538 =
+                    FStar_Tactics_Monad.bind uu____7529
+                      (fun uu____7534 ->
+                         let uu____7535 =
                            set_solution g2 FStar_Syntax_Util.exp_unit in
-                         FStar_Tactics_Monad.bind uu____7538
-                           (fun uu____7545 ->
+                         FStar_Tactics_Monad.bind uu____7535
+                           (fun uu____7542 ->
                               let ng = FStar_Syntax_Util.mk_conj t1 t2 in
                               let nenv =
-                                let uu___1123_7550 =
+                                let uu___1121_7547 =
                                   FStar_Tactics_Types.goal_env g1 in
-                                let uu____7551 =
+                                let uu____7548 =
                                   FStar_Util.smap_create (Prims.of_int (100)) in
                                 {
                                   FStar_TypeChecker_Env.solver =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.solver);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.solver);
                                   FStar_TypeChecker_Env.range =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.range);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.range);
                                   FStar_TypeChecker_Env.curmodule =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.curmodule);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.curmodule);
                                   FStar_TypeChecker_Env.gamma =
                                     (FStar_List.rev gamma);
                                   FStar_TypeChecker_Env.gamma_sig =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.gamma_sig);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.gamma_sig);
                                   FStar_TypeChecker_Env.gamma_cache =
-                                    uu____7551;
+                                    uu____7548;
                                   FStar_TypeChecker_Env.modules =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.modules);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.modules);
                                   FStar_TypeChecker_Env.expected_typ =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.expected_typ);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.expected_typ);
                                   FStar_TypeChecker_Env.sigtab =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.sigtab);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.sigtab);
                                   FStar_TypeChecker_Env.attrtab =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.attrtab);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.attrtab);
                                   FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.instantiate_imp);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.instantiate_imp);
                                   FStar_TypeChecker_Env.effects =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.effects);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.effects);
                                   FStar_TypeChecker_Env.generalize =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.generalize);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.generalize);
                                   FStar_TypeChecker_Env.letrecs =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.letrecs);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.letrecs);
                                   FStar_TypeChecker_Env.top_level =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.top_level);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.top_level);
                                   FStar_TypeChecker_Env.check_uvars =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.check_uvars);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.check_uvars);
                                   FStar_TypeChecker_Env.use_eq =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.use_eq);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.use_eq);
                                   FStar_TypeChecker_Env.use_eq_strict =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.use_eq_strict);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.is_iface);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.admit);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.admit);
                                   FStar_TypeChecker_Env.lax =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.lax);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.lax_universes);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.phase1);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.phase1);
                                   FStar_TypeChecker_Env.failhard =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.failhard);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.failhard);
                                   FStar_TypeChecker_Env.nosynth =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.nosynth);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.nosynth);
                                   FStar_TypeChecker_Env.uvar_subtyping =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.uvar_subtyping);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.tc_term =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.tc_term);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.type_of =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.type_of);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.type_of);
                                   FStar_TypeChecker_Env.universe_of =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.universe_of);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.universe_of);
                                   FStar_TypeChecker_Env.check_type_of =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.check_type_of);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.check_type_of);
                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.use_bv_sorts);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.qtbl_name_and_index);
                                   FStar_TypeChecker_Env.normalized_eff_names
                                     =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.normalized_eff_names);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.normalized_eff_names);
                                   FStar_TypeChecker_Env.fv_delta_depths =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.fv_delta_depths);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.fv_delta_depths);
                                   FStar_TypeChecker_Env.proof_ns =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.proof_ns);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.proof_ns);
                                   FStar_TypeChecker_Env.synth_hook =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.synth_hook);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.synth_hook);
                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                     =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                   FStar_TypeChecker_Env.splice =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.splice);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.splice);
                                   FStar_TypeChecker_Env.mpreprocess =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.mpreprocess);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.mpreprocess);
                                   FStar_TypeChecker_Env.postprocess =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.postprocess);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.postprocess);
                                   FStar_TypeChecker_Env.identifier_info =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.identifier_info);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.identifier_info);
                                   FStar_TypeChecker_Env.tc_hooks =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.tc_hooks);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.tc_hooks);
                                   FStar_TypeChecker_Env.dsenv =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.dsenv);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.dsenv);
                                   FStar_TypeChecker_Env.nbe =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.nbe);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.strict_args_tab);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.strict_args_tab);
                                   FStar_TypeChecker_Env.erasable_types_tab =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.erasable_types_tab);
+                                    (uu___1121_7547.FStar_TypeChecker_Env.erasable_types_tab);
                                   FStar_TypeChecker_Env.enable_defer_to_tac =
-                                    (uu___1123_7550.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                    (uu___1121_7547.FStar_TypeChecker_Env.enable_defer_to_tac)
                                 } in
-                              let uu____7554 =
+                              let uu____7551 =
                                 FStar_Tactics_Monad.mk_irrelevant_goal
                                   "joined" nenv ng
                                   g1.FStar_Tactics_Types.opts
                                   g1.FStar_Tactics_Types.label in
-                              FStar_Tactics_Monad.bind uu____7554
+                              FStar_Tactics_Monad.bind uu____7551
                                 (fun goal ->
                                    FStar_Tactics_Monad.mlog
-                                     (fun uu____7563 ->
-                                        let uu____7564 =
+                                     (fun uu____7560 ->
+                                        let uu____7561 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g1 in
-                                        let uu____7565 =
+                                        let uu____7562 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             g2 in
-                                        let uu____7566 =
+                                        let uu____7563 =
                                           FStar_Tactics_Printing.goal_to_string_verbose
                                             goal in
                                         FStar_Util.print3
                                           "join_goals of\n(%s)\nand\n(%s)\n= (%s)\n"
-                                          uu____7564 uu____7565 uu____7566)
-                                     (fun uu____7568 ->
+                                          uu____7561 uu____7562 uu____7563)
+                                     (fun uu____7565 ->
                                         FStar_Tactics_Monad.ret goal))))))
 let (join : unit -> unit FStar_Tactics_Monad.tac) =
-  fun uu____7575 ->
+  fun uu____7572 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          match ps.FStar_Tactics_Types.goals with
          | g1::g2::gs ->
-             let uu____7591 =
+             let uu____7588 =
                FStar_Tactics_Monad.set
-                 (let uu___1138_7596 = ps in
+                 (let uu___1136_7593 = ps in
                   {
                     FStar_Tactics_Types.main_context =
-                      (uu___1138_7596.FStar_Tactics_Types.main_context);
+                      (uu___1136_7593.FStar_Tactics_Types.main_context);
                     FStar_Tactics_Types.all_implicits =
-                      (uu___1138_7596.FStar_Tactics_Types.all_implicits);
+                      (uu___1136_7593.FStar_Tactics_Types.all_implicits);
                     FStar_Tactics_Types.goals = gs;
                     FStar_Tactics_Types.smt_goals =
-                      (uu___1138_7596.FStar_Tactics_Types.smt_goals);
+                      (uu___1136_7593.FStar_Tactics_Types.smt_goals);
                     FStar_Tactics_Types.depth =
-                      (uu___1138_7596.FStar_Tactics_Types.depth);
+                      (uu___1136_7593.FStar_Tactics_Types.depth);
                     FStar_Tactics_Types.__dump =
-                      (uu___1138_7596.FStar_Tactics_Types.__dump);
+                      (uu___1136_7593.FStar_Tactics_Types.__dump);
                     FStar_Tactics_Types.psc =
-                      (uu___1138_7596.FStar_Tactics_Types.psc);
+                      (uu___1136_7593.FStar_Tactics_Types.psc);
                     FStar_Tactics_Types.entry_range =
-                      (uu___1138_7596.FStar_Tactics_Types.entry_range);
+                      (uu___1136_7593.FStar_Tactics_Types.entry_range);
                     FStar_Tactics_Types.guard_policy =
-                      (uu___1138_7596.FStar_Tactics_Types.guard_policy);
+                      (uu___1136_7593.FStar_Tactics_Types.guard_policy);
                     FStar_Tactics_Types.freshness =
-                      (uu___1138_7596.FStar_Tactics_Types.freshness);
+                      (uu___1136_7593.FStar_Tactics_Types.freshness);
                     FStar_Tactics_Types.tac_verb_dbg =
-                      (uu___1138_7596.FStar_Tactics_Types.tac_verb_dbg);
+                      (uu___1136_7593.FStar_Tactics_Types.tac_verb_dbg);
                     FStar_Tactics_Types.local_state =
-                      (uu___1138_7596.FStar_Tactics_Types.local_state)
+                      (uu___1136_7593.FStar_Tactics_Types.local_state)
                   }) in
-             FStar_Tactics_Monad.bind uu____7591
-               (fun uu____7599 ->
-                  let uu____7600 = join_goals g1 g2 in
-                  FStar_Tactics_Monad.bind uu____7600
+             FStar_Tactics_Monad.bind uu____7588
+               (fun uu____7596 ->
+                  let uu____7597 = join_goals g1 g2 in
+                  FStar_Tactics_Monad.bind uu____7597
                     (fun g12 -> FStar_Tactics_Monad.add_goals [g12]))
-         | uu____7605 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
+         | uu____7602 -> FStar_Tactics_Monad.fail "join: less than 2 goals")
 let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun s ->
-    let uu____7617 =
+    let uu____7614 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
            FStar_Options.push ();
-           (let uu____7630 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts in
-            FStar_Options.set uu____7630);
+           (let uu____7627 = FStar_Util.smap_copy g.FStar_Tactics_Types.opts in
+            FStar_Options.set uu____7627);
            (let res = FStar_Options.set_options s in
             let opts' = FStar_Options.peek () in
             FStar_Options.pop ();
             (match res with
              | FStar_Getopt.Success ->
                  let g' =
-                   let uu___1149_7637 = g in
+                   let uu___1147_7634 = g in
                    {
                      FStar_Tactics_Types.goal_main_env =
-                       (uu___1149_7637.FStar_Tactics_Types.goal_main_env);
+                       (uu___1147_7634.FStar_Tactics_Types.goal_main_env);
                      FStar_Tactics_Types.goal_ctx_uvar =
-                       (uu___1149_7637.FStar_Tactics_Types.goal_ctx_uvar);
+                       (uu___1147_7634.FStar_Tactics_Types.goal_ctx_uvar);
                      FStar_Tactics_Types.opts = opts';
                      FStar_Tactics_Types.is_guard =
-                       (uu___1149_7637.FStar_Tactics_Types.is_guard);
+                       (uu___1147_7634.FStar_Tactics_Types.is_guard);
                      FStar_Tactics_Types.label =
-                       (uu___1149_7637.FStar_Tactics_Types.label)
+                       (uu___1147_7634.FStar_Tactics_Types.label)
                    } in
                  FStar_Tactics_Monad.replace_cur g'
              | FStar_Getopt.Error err ->
@@ -3827,22 +3730,22 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
              | FStar_Getopt.Help ->
                  fail1 "Setting options `%s` failed (got `Help`?)" s))) in
     FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "set_options")
-      uu____7617
+      uu____7614
 let (top_env : unit -> env FStar_Tactics_Monad.tac) =
-  fun uu____7649 ->
+  fun uu____7646 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
       (fun ps ->
          FStar_All.pipe_left FStar_Tactics_Monad.ret
            ps.FStar_Tactics_Types.main_context)
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
-  fun uu____7662 ->
+  fun uu____7659 ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
       (fun g ->
-         let uu____7668 =
+         let uu____7665 =
            (FStar_Options.lax ()) ||
-             (let uu____7670 = FStar_Tactics_Types.goal_env g in
-              uu____7670.FStar_TypeChecker_Env.lax) in
-         FStar_Tactics_Monad.ret uu____7668)
+             (let uu____7667 = FStar_Tactics_Types.goal_env g in
+              uu____7667.FStar_TypeChecker_Env.lax) in
+         FStar_Tactics_Monad.ret uu____7665)
 let (unquote :
   FStar_Reflection_Data.typ ->
     FStar_Syntax_Syntax.term ->
@@ -3850,42 +3753,42 @@ let (unquote :
   =
   fun ty ->
     fun tm ->
-      let uu____7685 =
+      let uu____7682 =
         FStar_Tactics_Monad.mlog
+          (fun uu____7687 ->
+             let uu____7688 = FStar_Syntax_Print.term_to_string tm in
+             FStar_Util.print1 "unquote: tm = %s\n" uu____7688)
           (fun uu____7690 ->
-             let uu____7691 = FStar_Syntax_Print.term_to_string tm in
-             FStar_Util.print1 "unquote: tm = %s\n" uu____7691)
-          (fun uu____7693 ->
              FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
                (fun goal ->
                   let env1 =
-                    let uu____7699 = FStar_Tactics_Types.goal_env goal in
-                    FStar_TypeChecker_Env.set_expected_typ uu____7699 ty in
-                  let uu____7700 = __tc_ghost env1 tm in
-                  FStar_Tactics_Monad.bind uu____7700
-                    (fun uu____7719 ->
-                       match uu____7719 with
+                    let uu____7696 = FStar_Tactics_Types.goal_env goal in
+                    FStar_TypeChecker_Env.set_expected_typ uu____7696 ty in
+                  let uu____7697 = __tc_ghost env1 tm in
+                  FStar_Tactics_Monad.bind uu____7697
+                    (fun uu____7716 ->
+                       match uu____7716 with
                        | (tm1, typ, guard) ->
                            FStar_Tactics_Monad.mlog
-                             (fun uu____7733 ->
-                                let uu____7734 =
+                             (fun uu____7730 ->
+                                let uu____7731 =
                                   FStar_Syntax_Print.term_to_string tm1 in
                                 FStar_Util.print1 "unquote: tm' = %s\n"
-                                  uu____7734)
-                             (fun uu____7736 ->
+                                  uu____7731)
+                             (fun uu____7733 ->
                                 FStar_Tactics_Monad.mlog
-                                  (fun uu____7739 ->
-                                     let uu____7740 =
+                                  (fun uu____7736 ->
+                                     let uu____7737 =
                                        FStar_Syntax_Print.term_to_string typ in
                                      FStar_Util.print1 "unquote: typ = %s\n"
-                                       uu____7740)
-                                  (fun uu____7743 ->
-                                     let uu____7744 =
+                                       uu____7737)
+                                  (fun uu____7740 ->
+                                     let uu____7741 =
                                        proc_guard "unquote" env1 guard in
-                                     FStar_Tactics_Monad.bind uu____7744
-                                       (fun uu____7748 ->
+                                     FStar_Tactics_Monad.bind uu____7741
+                                       (fun uu____7745 ->
                                           FStar_Tactics_Monad.ret tm1)))))) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____7685
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unquote") uu____7682
 let (uvar_env :
   env ->
     FStar_Reflection_Data.typ FStar_Pervasives_Native.option ->
@@ -3893,148 +3796,148 @@ let (uvar_env :
   =
   fun env1 ->
     fun ty ->
-      let uu____7771 =
+      let uu____7768 =
         match ty with
         | FStar_Pervasives_Native.Some ty1 -> FStar_Tactics_Monad.ret ty1
         | FStar_Pervasives_Native.None ->
-            let uu____7777 =
-              let uu____7784 =
-                let uu____7785 = FStar_Syntax_Util.type_u () in
-                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7785 in
-              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____7784 in
-            FStar_Tactics_Monad.bind uu____7777
-              (fun uu____7801 ->
-                 match uu____7801 with
+            let uu____7774 =
+              let uu____7781 =
+                let uu____7782 = FStar_Syntax_Util.type_u () in
+                FStar_All.pipe_left FStar_Pervasives_Native.fst uu____7782 in
+              FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu____7781 in
+            FStar_Tactics_Monad.bind uu____7774
+              (fun uu____7798 ->
+                 match uu____7798 with
                  | (typ, uvar_typ) -> FStar_Tactics_Monad.ret typ) in
-      FStar_Tactics_Monad.bind uu____7771
+      FStar_Tactics_Monad.bind uu____7768
         (fun typ ->
-           let uu____7813 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ in
-           FStar_Tactics_Monad.bind uu____7813
-             (fun uu____7827 ->
-                match uu____7827 with
+           let uu____7810 = FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ in
+           FStar_Tactics_Monad.bind uu____7810
+             (fun uu____7824 ->
+                match uu____7824 with
                 | (t, uvar_t) -> FStar_Tactics_Monad.ret t))
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
-    let uu____7845 =
+    let uu____7842 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
         (fun ps ->
            let env1 = ps.FStar_Tactics_Types.main_context in
            let opts =
              match ps.FStar_Tactics_Types.goals with
-             | g::uu____7864 -> g.FStar_Tactics_Types.opts
-             | uu____7867 -> FStar_Options.peek () in
-           let uu____7870 = FStar_Syntax_Util.head_and_args t in
-           match uu____7870 with
+             | g::uu____7861 -> g.FStar_Tactics_Types.opts
+             | uu____7864 -> FStar_Options.peek () in
+           let uu____7867 = FStar_Syntax_Util.head_and_args t in
+           match uu____7867 with
            | ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                  (ctx_uvar, uu____7890);
-                FStar_Syntax_Syntax.pos = uu____7891;
-                FStar_Syntax_Syntax.vars = uu____7892;_},
-              uu____7893) ->
+                  (ctx_uvar, uu____7887);
+                FStar_Syntax_Syntax.pos = uu____7888;
+                FStar_Syntax_Syntax.vars = uu____7889;_},
+              uu____7890) ->
                let env2 =
-                 let uu___1203_7935 = env1 in
+                 let uu___1201_7932 = env1 in
                  {
                    FStar_TypeChecker_Env.solver =
-                     (uu___1203_7935.FStar_TypeChecker_Env.solver);
+                     (uu___1201_7932.FStar_TypeChecker_Env.solver);
                    FStar_TypeChecker_Env.range =
-                     (uu___1203_7935.FStar_TypeChecker_Env.range);
+                     (uu___1201_7932.FStar_TypeChecker_Env.range);
                    FStar_TypeChecker_Env.curmodule =
-                     (uu___1203_7935.FStar_TypeChecker_Env.curmodule);
+                     (uu___1201_7932.FStar_TypeChecker_Env.curmodule);
                    FStar_TypeChecker_Env.gamma =
                      (ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_gamma);
                    FStar_TypeChecker_Env.gamma_sig =
-                     (uu___1203_7935.FStar_TypeChecker_Env.gamma_sig);
+                     (uu___1201_7932.FStar_TypeChecker_Env.gamma_sig);
                    FStar_TypeChecker_Env.gamma_cache =
-                     (uu___1203_7935.FStar_TypeChecker_Env.gamma_cache);
+                     (uu___1201_7932.FStar_TypeChecker_Env.gamma_cache);
                    FStar_TypeChecker_Env.modules =
-                     (uu___1203_7935.FStar_TypeChecker_Env.modules);
+                     (uu___1201_7932.FStar_TypeChecker_Env.modules);
                    FStar_TypeChecker_Env.expected_typ =
-                     (uu___1203_7935.FStar_TypeChecker_Env.expected_typ);
+                     (uu___1201_7932.FStar_TypeChecker_Env.expected_typ);
                    FStar_TypeChecker_Env.sigtab =
-                     (uu___1203_7935.FStar_TypeChecker_Env.sigtab);
+                     (uu___1201_7932.FStar_TypeChecker_Env.sigtab);
                    FStar_TypeChecker_Env.attrtab =
-                     (uu___1203_7935.FStar_TypeChecker_Env.attrtab);
+                     (uu___1201_7932.FStar_TypeChecker_Env.attrtab);
                    FStar_TypeChecker_Env.instantiate_imp =
-                     (uu___1203_7935.FStar_TypeChecker_Env.instantiate_imp);
+                     (uu___1201_7932.FStar_TypeChecker_Env.instantiate_imp);
                    FStar_TypeChecker_Env.effects =
-                     (uu___1203_7935.FStar_TypeChecker_Env.effects);
+                     (uu___1201_7932.FStar_TypeChecker_Env.effects);
                    FStar_TypeChecker_Env.generalize =
-                     (uu___1203_7935.FStar_TypeChecker_Env.generalize);
+                     (uu___1201_7932.FStar_TypeChecker_Env.generalize);
                    FStar_TypeChecker_Env.letrecs =
-                     (uu___1203_7935.FStar_TypeChecker_Env.letrecs);
+                     (uu___1201_7932.FStar_TypeChecker_Env.letrecs);
                    FStar_TypeChecker_Env.top_level =
-                     (uu___1203_7935.FStar_TypeChecker_Env.top_level);
+                     (uu___1201_7932.FStar_TypeChecker_Env.top_level);
                    FStar_TypeChecker_Env.check_uvars =
-                     (uu___1203_7935.FStar_TypeChecker_Env.check_uvars);
+                     (uu___1201_7932.FStar_TypeChecker_Env.check_uvars);
                    FStar_TypeChecker_Env.use_eq =
-                     (uu___1203_7935.FStar_TypeChecker_Env.use_eq);
+                     (uu___1201_7932.FStar_TypeChecker_Env.use_eq);
                    FStar_TypeChecker_Env.use_eq_strict =
-                     (uu___1203_7935.FStar_TypeChecker_Env.use_eq_strict);
+                     (uu___1201_7932.FStar_TypeChecker_Env.use_eq_strict);
                    FStar_TypeChecker_Env.is_iface =
-                     (uu___1203_7935.FStar_TypeChecker_Env.is_iface);
+                     (uu___1201_7932.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
-                     (uu___1203_7935.FStar_TypeChecker_Env.admit);
+                     (uu___1201_7932.FStar_TypeChecker_Env.admit);
                    FStar_TypeChecker_Env.lax =
-                     (uu___1203_7935.FStar_TypeChecker_Env.lax);
+                     (uu___1201_7932.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
-                     (uu___1203_7935.FStar_TypeChecker_Env.lax_universes);
+                     (uu___1201_7932.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
-                     (uu___1203_7935.FStar_TypeChecker_Env.phase1);
+                     (uu___1201_7932.FStar_TypeChecker_Env.phase1);
                    FStar_TypeChecker_Env.failhard =
-                     (uu___1203_7935.FStar_TypeChecker_Env.failhard);
+                     (uu___1201_7932.FStar_TypeChecker_Env.failhard);
                    FStar_TypeChecker_Env.nosynth =
-                     (uu___1203_7935.FStar_TypeChecker_Env.nosynth);
+                     (uu___1201_7932.FStar_TypeChecker_Env.nosynth);
                    FStar_TypeChecker_Env.uvar_subtyping =
-                     (uu___1203_7935.FStar_TypeChecker_Env.uvar_subtyping);
+                     (uu___1201_7932.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.tc_term =
-                     (uu___1203_7935.FStar_TypeChecker_Env.tc_term);
+                     (uu___1201_7932.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.type_of =
-                     (uu___1203_7935.FStar_TypeChecker_Env.type_of);
+                     (uu___1201_7932.FStar_TypeChecker_Env.type_of);
                    FStar_TypeChecker_Env.universe_of =
-                     (uu___1203_7935.FStar_TypeChecker_Env.universe_of);
+                     (uu___1201_7932.FStar_TypeChecker_Env.universe_of);
                    FStar_TypeChecker_Env.check_type_of =
-                     (uu___1203_7935.FStar_TypeChecker_Env.check_type_of);
+                     (uu___1201_7932.FStar_TypeChecker_Env.check_type_of);
                    FStar_TypeChecker_Env.use_bv_sorts =
-                     (uu___1203_7935.FStar_TypeChecker_Env.use_bv_sorts);
+                     (uu___1201_7932.FStar_TypeChecker_Env.use_bv_sorts);
                    FStar_TypeChecker_Env.qtbl_name_and_index =
-                     (uu___1203_7935.FStar_TypeChecker_Env.qtbl_name_and_index);
+                     (uu___1201_7932.FStar_TypeChecker_Env.qtbl_name_and_index);
                    FStar_TypeChecker_Env.normalized_eff_names =
-                     (uu___1203_7935.FStar_TypeChecker_Env.normalized_eff_names);
+                     (uu___1201_7932.FStar_TypeChecker_Env.normalized_eff_names);
                    FStar_TypeChecker_Env.fv_delta_depths =
-                     (uu___1203_7935.FStar_TypeChecker_Env.fv_delta_depths);
+                     (uu___1201_7932.FStar_TypeChecker_Env.fv_delta_depths);
                    FStar_TypeChecker_Env.proof_ns =
-                     (uu___1203_7935.FStar_TypeChecker_Env.proof_ns);
+                     (uu___1201_7932.FStar_TypeChecker_Env.proof_ns);
                    FStar_TypeChecker_Env.synth_hook =
-                     (uu___1203_7935.FStar_TypeChecker_Env.synth_hook);
+                     (uu___1201_7932.FStar_TypeChecker_Env.synth_hook);
                    FStar_TypeChecker_Env.try_solve_implicits_hook =
-                     (uu___1203_7935.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                     (uu___1201_7932.FStar_TypeChecker_Env.try_solve_implicits_hook);
                    FStar_TypeChecker_Env.splice =
-                     (uu___1203_7935.FStar_TypeChecker_Env.splice);
+                     (uu___1201_7932.FStar_TypeChecker_Env.splice);
                    FStar_TypeChecker_Env.mpreprocess =
-                     (uu___1203_7935.FStar_TypeChecker_Env.mpreprocess);
+                     (uu___1201_7932.FStar_TypeChecker_Env.mpreprocess);
                    FStar_TypeChecker_Env.postprocess =
-                     (uu___1203_7935.FStar_TypeChecker_Env.postprocess);
+                     (uu___1201_7932.FStar_TypeChecker_Env.postprocess);
                    FStar_TypeChecker_Env.identifier_info =
-                     (uu___1203_7935.FStar_TypeChecker_Env.identifier_info);
+                     (uu___1201_7932.FStar_TypeChecker_Env.identifier_info);
                    FStar_TypeChecker_Env.tc_hooks =
-                     (uu___1203_7935.FStar_TypeChecker_Env.tc_hooks);
+                     (uu___1201_7932.FStar_TypeChecker_Env.tc_hooks);
                    FStar_TypeChecker_Env.dsenv =
-                     (uu___1203_7935.FStar_TypeChecker_Env.dsenv);
+                     (uu___1201_7932.FStar_TypeChecker_Env.dsenv);
                    FStar_TypeChecker_Env.nbe =
-                     (uu___1203_7935.FStar_TypeChecker_Env.nbe);
+                     (uu___1201_7932.FStar_TypeChecker_Env.nbe);
                    FStar_TypeChecker_Env.strict_args_tab =
-                     (uu___1203_7935.FStar_TypeChecker_Env.strict_args_tab);
+                     (uu___1201_7932.FStar_TypeChecker_Env.strict_args_tab);
                    FStar_TypeChecker_Env.erasable_types_tab =
-                     (uu___1203_7935.FStar_TypeChecker_Env.erasable_types_tab);
+                     (uu___1201_7932.FStar_TypeChecker_Env.erasable_types_tab);
                    FStar_TypeChecker_Env.enable_defer_to_tac =
-                     (uu___1203_7935.FStar_TypeChecker_Env.enable_defer_to_tac)
+                     (uu___1201_7932.FStar_TypeChecker_Env.enable_defer_to_tac)
                  } in
                let g =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
-               let uu____7937 = let uu____7940 = bnorm_goal g in [uu____7940] in
-               FStar_Tactics_Monad.add_goals uu____7937
-           | uu____7941 -> FStar_Tactics_Monad.fail "not a uvar") in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____7845
+               let uu____7934 = let uu____7937 = bnorm_goal g in [uu____7937] in
+               FStar_Tactics_Monad.add_goals uu____7934
+           | uu____7938 -> FStar_Tactics_Monad.fail "not a uvar") in
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unshelve") uu____7842
 let (tac_and :
   Prims.bool FStar_Tactics_Monad.tac ->
     Prims.bool FStar_Tactics_Monad.tac -> Prims.bool FStar_Tactics_Monad.tac)
@@ -4044,16 +3947,16 @@ let (tac_and :
       let comp =
         FStar_Tactics_Monad.bind t1
           (fun b ->
-             let uu____7990 = if b then t2 else FStar_Tactics_Monad.ret false in
-             FStar_Tactics_Monad.bind uu____7990
+             let uu____7987 = if b then t2 else FStar_Tactics_Monad.ret false in
+             FStar_Tactics_Monad.bind uu____7987
                (fun b' ->
                   if b'
                   then FStar_Tactics_Monad.ret b'
                   else FStar_Tactics_Monad.fail "")) in
-      let uu____8001 = trytac comp in
-      FStar_Tactics_Monad.bind uu____8001
-        (fun uu___5_8009 ->
-           match uu___5_8009 with
+      let uu____7998 = trytac comp in
+      FStar_Tactics_Monad.bind uu____7998
+        (fun uu___5_8006 ->
+           match uu___5_8006 with
            | FStar_Pervasives_Native.Some (true) ->
                FStar_Tactics_Monad.ret true
            | FStar_Pervasives_Native.Some (false) -> failwith "impossible"
@@ -4066,34 +3969,34 @@ let (match_env :
   fun e ->
     fun t1 ->
       fun t2 ->
-        let uu____8035 =
+        let uu____8032 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
-               let uu____8041 = __tc e t1 in
-               FStar_Tactics_Monad.bind uu____8041
-                 (fun uu____8061 ->
-                    match uu____8061 with
+               let uu____8038 = __tc e t1 in
+               FStar_Tactics_Monad.bind uu____8038
+                 (fun uu____8058 ->
+                    match uu____8058 with
                     | (t11, ty1, g1) ->
-                        let uu____8073 = __tc e t2 in
-                        FStar_Tactics_Monad.bind uu____8073
-                          (fun uu____8093 ->
-                             match uu____8093 with
+                        let uu____8070 = __tc e t2 in
+                        FStar_Tactics_Monad.bind uu____8070
+                          (fun uu____8090 ->
+                             match uu____8090 with
                              | (t21, ty2, g2) ->
-                                 let uu____8105 =
+                                 let uu____8102 =
                                    proc_guard "match_env g1" e g1 in
-                                 FStar_Tactics_Monad.bind uu____8105
-                                   (fun uu____8110 ->
-                                      let uu____8111 =
+                                 FStar_Tactics_Monad.bind uu____8102
+                                   (fun uu____8107 ->
+                                      let uu____8108 =
                                         proc_guard "match_env g2" e g2 in
-                                      FStar_Tactics_Monad.bind uu____8111
-                                        (fun uu____8117 ->
-                                           let uu____8118 =
+                                      FStar_Tactics_Monad.bind uu____8108
+                                        (fun uu____8114 ->
+                                           let uu____8115 =
                                              do_match e ty1 ty2 in
-                                           let uu____8121 =
+                                           let uu____8118 =
                                              do_match e t11 t21 in
-                                           tac_and uu____8118 uu____8121))))) in
+                                           tac_and uu____8115 uu____8118))))) in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "match_env")
-          uu____8035
+          uu____8032
 let (unify_env :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -4102,34 +4005,34 @@ let (unify_env :
   fun e ->
     fun t1 ->
       fun t2 ->
-        let uu____8147 =
+        let uu____8144 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
-               let uu____8153 = __tc e t1 in
-               FStar_Tactics_Monad.bind uu____8153
-                 (fun uu____8173 ->
-                    match uu____8173 with
+               let uu____8150 = __tc e t1 in
+               FStar_Tactics_Monad.bind uu____8150
+                 (fun uu____8170 ->
+                    match uu____8170 with
                     | (t11, ty1, g1) ->
-                        let uu____8185 = __tc e t2 in
-                        FStar_Tactics_Monad.bind uu____8185
-                          (fun uu____8205 ->
-                             match uu____8205 with
+                        let uu____8182 = __tc e t2 in
+                        FStar_Tactics_Monad.bind uu____8182
+                          (fun uu____8202 ->
+                             match uu____8202 with
                              | (t21, ty2, g2) ->
-                                 let uu____8217 =
+                                 let uu____8214 =
                                    proc_guard "unify_env g1" e g1 in
-                                 FStar_Tactics_Monad.bind uu____8217
-                                   (fun uu____8222 ->
-                                      let uu____8223 =
+                                 FStar_Tactics_Monad.bind uu____8214
+                                   (fun uu____8219 ->
+                                      let uu____8220 =
                                         proc_guard "unify_env g2" e g2 in
-                                      FStar_Tactics_Monad.bind uu____8223
-                                        (fun uu____8229 ->
-                                           let uu____8230 =
+                                      FStar_Tactics_Monad.bind uu____8220
+                                        (fun uu____8226 ->
+                                           let uu____8227 =
                                              do_unify e ty1 ty2 in
-                                           let uu____8233 =
+                                           let uu____8230 =
                                              do_unify e t11 t21 in
-                                           tac_and uu____8230 uu____8233))))) in
+                                           tac_and uu____8227 uu____8230))))) in
         FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "unify_env")
-          uu____8147
+          uu____8144
 let (launch_process :
   Prims.string ->
     Prims.string Prims.list ->
@@ -4139,9 +4042,9 @@ let (launch_process :
     fun args ->
       fun input ->
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-          (fun uu____8266 ->
-             let uu____8267 = FStar_Options.unsafe_tactic_exec () in
-             if uu____8267
+          (fun uu____8263 ->
+             let uu____8264 = FStar_Options.unsafe_tactic_exec () in
+             if uu____8264
              then
                let s =
                  FStar_Util.run_process "tactic_launch" prog args
@@ -4158,47 +4061,47 @@ let (fresh_bv_named :
   fun nm ->
     fun t ->
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.idtac
-        (fun uu____8288 ->
-           let uu____8289 =
+        (fun uu____8285 ->
+           let uu____8286 =
              FStar_Syntax_Syntax.gen_bv nm FStar_Pervasives_Native.None t in
-           FStar_Tactics_Monad.ret uu____8289)
+           FStar_Tactics_Monad.ret uu____8286)
 let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
   fun ty ->
-    let uu____8299 =
+    let uu____8296 =
       FStar_Tactics_Monad.mlog
+        (fun uu____8301 ->
+           let uu____8302 = FStar_Syntax_Print.term_to_string ty in
+           FStar_Util.print1 "change: ty = %s\n" uu____8302)
         (fun uu____8304 ->
-           let uu____8305 = FStar_Syntax_Print.term_to_string ty in
-           FStar_Util.print1 "change: ty = %s\n" uu____8305)
-        (fun uu____8307 ->
            FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
              (fun g ->
-                let uu____8311 =
-                  let uu____8320 = FStar_Tactics_Types.goal_env g in
-                  __tc uu____8320 ty in
-                FStar_Tactics_Monad.bind uu____8311
-                  (fun uu____8332 ->
-                     match uu____8332 with
-                     | (ty1, uu____8342, guard) ->
-                         let uu____8344 =
-                           let uu____8347 = FStar_Tactics_Types.goal_env g in
-                           proc_guard "change" uu____8347 guard in
-                         FStar_Tactics_Monad.bind uu____8344
-                           (fun uu____8350 ->
-                              let uu____8351 =
-                                let uu____8354 =
+                let uu____8308 =
+                  let uu____8317 = FStar_Tactics_Types.goal_env g in
+                  __tc uu____8317 ty in
+                FStar_Tactics_Monad.bind uu____8308
+                  (fun uu____8329 ->
+                     match uu____8329 with
+                     | (ty1, uu____8339, guard) ->
+                         let uu____8341 =
+                           let uu____8344 = FStar_Tactics_Types.goal_env g in
+                           proc_guard "change" uu____8344 guard in
+                         FStar_Tactics_Monad.bind uu____8341
+                           (fun uu____8347 ->
+                              let uu____8348 =
+                                let uu____8351 =
                                   FStar_Tactics_Types.goal_env g in
-                                let uu____8355 =
+                                let uu____8352 =
                                   FStar_Tactics_Types.goal_type g in
-                                do_unify uu____8354 uu____8355 ty1 in
-                              FStar_Tactics_Monad.bind uu____8351
+                                do_unify uu____8351 uu____8352 ty1 in
+                              FStar_Tactics_Monad.bind uu____8348
                                 (fun bb ->
                                    if bb
                                    then
-                                     let uu____8361 =
+                                     let uu____8358 =
                                        FStar_Tactics_Types.goal_with_type g
                                          ty1 in
                                      FStar_Tactics_Monad.replace_cur
-                                       uu____8361
+                                       uu____8358
                                    else
                                      (let steps =
                                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -4206,32 +4109,32 @@ let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
                                           FStar_Syntax_Syntax.delta_constant;
                                         FStar_TypeChecker_Env.Primops] in
                                       let ng =
+                                        let uu____8364 =
+                                          FStar_Tactics_Types.goal_env g in
+                                        let uu____8365 =
+                                          FStar_Tactics_Types.goal_type g in
+                                        normalize steps uu____8364 uu____8365 in
+                                      let nty =
                                         let uu____8367 =
                                           FStar_Tactics_Types.goal_env g in
-                                        let uu____8368 =
-                                          FStar_Tactics_Types.goal_type g in
-                                        normalize steps uu____8367 uu____8368 in
-                                      let nty =
-                                        let uu____8370 =
+                                        normalize steps uu____8367 ty1 in
+                                      let uu____8368 =
+                                        let uu____8371 =
                                           FStar_Tactics_Types.goal_env g in
-                                        normalize steps uu____8370 ty1 in
-                                      let uu____8371 =
-                                        let uu____8374 =
-                                          FStar_Tactics_Types.goal_env g in
-                                        do_unify uu____8374 ng nty in
-                                      FStar_Tactics_Monad.bind uu____8371
+                                        do_unify uu____8371 ng nty in
+                                      FStar_Tactics_Monad.bind uu____8368
                                         (fun b ->
                                            if b
                                            then
-                                             let uu____8380 =
+                                             let uu____8377 =
                                                FStar_Tactics_Types.goal_with_type
                                                  g ty1 in
                                              FStar_Tactics_Monad.replace_cur
-                                               uu____8380
+                                               uu____8377
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible"))))))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8299
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "change") uu____8296
 let failwhen :
   'a .
     Prims.bool ->
@@ -4246,66 +4149,66 @@ let (t_destruct :
       FStar_Tactics_Monad.tac)
   =
   fun s_tm ->
-    let uu____8443 =
+    let uu____8440 =
       FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
         (fun g ->
-           let uu____8461 =
-             let uu____8470 = FStar_Tactics_Types.goal_env g in
-             __tc uu____8470 s_tm in
-           FStar_Tactics_Monad.bind uu____8461
-             (fun uu____8488 ->
-                match uu____8488 with
+           let uu____8458 =
+             let uu____8467 = FStar_Tactics_Types.goal_env g in
+             __tc uu____8467 s_tm in
+           FStar_Tactics_Monad.bind uu____8458
+             (fun uu____8485 ->
+                match uu____8485 with
                 | (s_tm1, s_ty, guard) ->
-                    let uu____8506 =
-                      let uu____8509 = FStar_Tactics_Types.goal_env g in
-                      proc_guard "destruct" uu____8509 guard in
-                    FStar_Tactics_Monad.bind uu____8506
-                      (fun uu____8522 ->
+                    let uu____8503 =
+                      let uu____8506 = FStar_Tactics_Types.goal_env g in
+                      proc_guard "destruct" uu____8506 guard in
+                    FStar_Tactics_Monad.bind uu____8503
+                      (fun uu____8519 ->
                          let s_ty1 =
-                           let uu____8524 = FStar_Tactics_Types.goal_env g in
+                           let uu____8521 = FStar_Tactics_Types.goal_env g in
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.UnfoldTac;
                              FStar_TypeChecker_Env.Weak;
                              FStar_TypeChecker_Env.HNF;
                              FStar_TypeChecker_Env.UnfoldUntil
-                               FStar_Syntax_Syntax.delta_constant] uu____8524
+                               FStar_Syntax_Syntax.delta_constant] uu____8521
                              s_ty in
-                         let uu____8525 =
-                           let uu____8540 = FStar_Syntax_Util.unrefine s_ty1 in
-                           FStar_Syntax_Util.head_and_args' uu____8540 in
-                         match uu____8525 with
+                         let uu____8522 =
+                           let uu____8537 = FStar_Syntax_Util.unrefine s_ty1 in
+                           FStar_Syntax_Util.head_and_args' uu____8537 in
+                         match uu____8522 with
                          | (h, args) ->
-                             let uu____8571 =
-                               let uu____8578 =
-                                 let uu____8579 =
+                             let uu____8568 =
+                               let uu____8575 =
+                                 let uu____8576 =
                                    FStar_Syntax_Subst.compress h in
-                                 uu____8579.FStar_Syntax_Syntax.n in
-                               match uu____8578 with
+                                 uu____8576.FStar_Syntax_Syntax.n in
+                               match uu____8575 with
                                | FStar_Syntax_Syntax.Tm_fvar fv ->
                                    FStar_Tactics_Monad.ret (fv, [])
                                | FStar_Syntax_Syntax.Tm_uinst
                                    ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_fvar fv;
-                                      FStar_Syntax_Syntax.pos = uu____8594;
-                                      FStar_Syntax_Syntax.vars = uu____8595;_},
+                                      FStar_Syntax_Syntax.pos = uu____8591;
+                                      FStar_Syntax_Syntax.vars = uu____8592;_},
                                     us)
                                    -> FStar_Tactics_Monad.ret (fv, us)
-                               | uu____8605 ->
+                               | uu____8602 ->
                                    FStar_Tactics_Monad.fail
                                      "type is not an fv" in
-                             FStar_Tactics_Monad.bind uu____8571
-                               (fun uu____8625 ->
-                                  match uu____8625 with
+                             FStar_Tactics_Monad.bind uu____8568
+                               (fun uu____8622 ->
+                                  match uu____8622 with
                                   | (fv, a_us) ->
                                       let t_lid =
                                         FStar_Syntax_Syntax.lid_of_fv fv in
-                                      let uu____8641 =
-                                        let uu____8644 =
+                                      let uu____8638 =
+                                        let uu____8641 =
                                           FStar_Tactics_Types.goal_env g in
                                         FStar_TypeChecker_Env.lookup_sigelt
-                                          uu____8644 t_lid in
-                                      (match uu____8641 with
+                                          uu____8641 t_lid in
+                                      (match uu____8638 with
                                        | FStar_Pervasives_Native.None ->
                                            FStar_Tactics_Monad.fail
                                              "type not found in environment"
@@ -4320,16 +4223,16 @@ let (t_destruct :
                                                   FStar_Syntax_Util.has_attribute
                                                     se.FStar_Syntax_Syntax.sigattrs
                                                     FStar_Parser_Const.erasable_attr in
-                                                let uu____8683 =
+                                                let uu____8680 =
                                                   erasable &&
-                                                    (let uu____8685 =
+                                                    (let uu____8682 =
                                                        FStar_Tactics_Types.is_irrelevant
                                                          g in
                                                      Prims.op_Negation
-                                                       uu____8685) in
-                                                failwhen uu____8683
+                                                       uu____8682) in
+                                                failwhen uu____8680
                                                   "cannot destruct erasable type to solve proof-relevant goal"
-                                                  (fun uu____8693 ->
+                                                  (fun uu____8690 ->
                                                      failwhen
                                                        ((FStar_List.length
                                                            a_us)
@@ -4337,28 +4240,28 @@ let (t_destruct :
                                                           (FStar_List.length
                                                              t_us))
                                                        "t_us don't match?"
-                                                       (fun uu____8705 ->
-                                                          let uu____8706 =
+                                                       (fun uu____8702 ->
+                                                          let uu____8703 =
                                                             FStar_Syntax_Subst.open_term
                                                               t_ps t_ty in
-                                                          match uu____8706
+                                                          match uu____8703
                                                           with
                                                           | (t_ps1, t_ty1) ->
-                                                              let uu____8721
+                                                              let uu____8718
                                                                 =
                                                                 FStar_Tactics_Monad.mapM
                                                                   (fun c_lid
                                                                     ->
-                                                                    let uu____8749
+                                                                    let uu____8746
                                                                     =
-                                                                    let uu____8752
+                                                                    let uu____8749
                                                                     =
                                                                     FStar_Tactics_Types.goal_env
                                                                     g in
                                                                     FStar_TypeChecker_Env.lookup_sigelt
-                                                                    uu____8752
+                                                                    uu____8749
                                                                     c_lid in
-                                                                    match uu____8749
+                                                                    match uu____8746
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
@@ -4392,7 +4295,7 @@ let (t_destruct :
                                                                     c_us))
                                                                     "t_us don't match?"
                                                                     (fun
-                                                                    uu____8825
+                                                                    uu____8822
                                                                     ->
                                                                     let s =
                                                                     FStar_TypeChecker_Env.mk_univ_subst
@@ -4401,26 +4304,26 @@ let (t_destruct :
                                                                     =
                                                                     FStar_Syntax_Subst.subst
                                                                     s c_ty in
-                                                                    let uu____8830
+                                                                    let uu____8827
                                                                     =
                                                                     FStar_TypeChecker_Env.inst_tscheme
                                                                     (c_us,
                                                                     c_ty1) in
-                                                                    match uu____8830
+                                                                    match uu____8827
                                                                     with
                                                                     | 
                                                                     (c_us1,
                                                                     c_ty2) ->
-                                                                    let uu____8853
+                                                                    let uu____8850
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     c_ty2 in
-                                                                    (match uu____8853
+                                                                    (match uu____8850
                                                                     with
                                                                     | 
                                                                     (bs,
                                                                     comp) ->
-                                                                    let uu____8872
+                                                                    let uu____8869
                                                                     =
                                                                     let rename_bv
                                                                     bv =
@@ -4429,123 +4332,123 @@ let (t_destruct :
                                                                     bv.FStar_Syntax_Syntax.ppname in
                                                                     let ppname1
                                                                     =
-                                                                    let uu____8895
+                                                                    let uu____8892
                                                                     =
-                                                                    let uu____8900
+                                                                    let uu____8897
                                                                     =
-                                                                    let uu____8901
+                                                                    let uu____8898
                                                                     =
                                                                     FStar_Ident.string_of_id
                                                                     ppname in
                                                                     Prims.op_Hat
                                                                     "a"
-                                                                    uu____8901 in
-                                                                    let uu____8902
+                                                                    uu____8898 in
+                                                                    let uu____8899
                                                                     =
                                                                     FStar_Ident.range_of_id
                                                                     ppname in
-                                                                    (uu____8900,
-                                                                    uu____8902) in
+                                                                    (uu____8897,
+                                                                    uu____8899) in
                                                                     FStar_Ident.mk_ident
-                                                                    uu____8895 in
+                                                                    uu____8892 in
                                                                     FStar_Syntax_Syntax.freshen_bv
-                                                                    (let uu___1345_8905
+                                                                    (let uu___1343_8902
                                                                     = bv in
                                                                     {
                                                                     FStar_Syntax_Syntax.ppname
                                                                     = ppname1;
                                                                     FStar_Syntax_Syntax.index
                                                                     =
-                                                                    (uu___1345_8905.FStar_Syntax_Syntax.index);
+                                                                    (uu___1343_8902.FStar_Syntax_Syntax.index);
                                                                     FStar_Syntax_Syntax.sort
                                                                     =
-                                                                    (uu___1345_8905.FStar_Syntax_Syntax.sort)
+                                                                    (uu___1343_8902.FStar_Syntax_Syntax.sort)
                                                                     }) in
                                                                     let bs' =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____8931
+                                                                    uu____8928
                                                                     ->
-                                                                    match uu____8931
+                                                                    match uu____8928
                                                                     with
                                                                     | 
                                                                     (bv, aq)
                                                                     ->
-                                                                    let uu____8950
+                                                                    let uu____8947
                                                                     =
                                                                     rename_bv
                                                                     bv in
-                                                                    (uu____8950,
+                                                                    (uu____8947,
                                                                     aq)) bs in
                                                                     let subst
                                                                     =
                                                                     FStar_List.map2
                                                                     (fun
-                                                                    uu____8975
+                                                                    uu____8972
                                                                     ->
                                                                     fun
-                                                                    uu____8976
+                                                                    uu____8973
                                                                     ->
                                                                     match 
-                                                                    (uu____8975,
-                                                                    uu____8976)
+                                                                    (uu____8972,
+                                                                    uu____8973)
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____9002),
+                                                                    uu____8999),
                                                                     (bv',
-                                                                    uu____9004))
+                                                                    uu____9001))
                                                                     ->
-                                                                    let uu____9025
+                                                                    let uu____9022
                                                                     =
-                                                                    let uu____9032
+                                                                    let uu____9029
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     bv' in
                                                                     (bv,
-                                                                    uu____9032) in
+                                                                    uu____9029) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu____9025)
+                                                                    uu____9022)
                                                                     bs bs' in
-                                                                    let uu____9037
+                                                                    let uu____9034
                                                                     =
                                                                     FStar_Syntax_Subst.subst_binders
                                                                     subst bs' in
-                                                                    let uu____9046
+                                                                    let uu____9043
                                                                     =
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subst
                                                                     comp in
-                                                                    (uu____9037,
-                                                                    uu____9046) in
-                                                                    (match uu____8872
+                                                                    (uu____9034,
+                                                                    uu____9043) in
+                                                                    (match uu____8869
                                                                     with
                                                                     | 
                                                                     (bs1,
                                                                     comp1) ->
-                                                                    let uu____9093
+                                                                    let uu____9090
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     bs1 in
-                                                                    (match uu____9093
+                                                                    (match uu____9090
                                                                     with
                                                                     | 
                                                                     (d_ps,
                                                                     bs2) ->
-                                                                    let uu____9166
+                                                                    let uu____9163
                                                                     =
-                                                                    let uu____9167
+                                                                    let uu____9164
                                                                     =
                                                                     FStar_Syntax_Util.is_total_comp
                                                                     comp1 in
                                                                     Prims.op_Negation
-                                                                    uu____9167 in
+                                                                    uu____9164 in
                                                                     failwhen
-                                                                    uu____9166
+                                                                    uu____9163
                                                                     "not total?"
                                                                     (fun
-                                                                    uu____9184
+                                                                    uu____9181
                                                                     ->
                                                                     let mk_pat
                                                                     p =
@@ -4557,24 +4460,24 @@ let (t_destruct :
                                                                     (s_tm1.FStar_Syntax_Syntax.pos)
                                                                     } in
                                                                     let is_imp
-                                                                    uu___6_9200
+                                                                    uu___6_9197
                                                                     =
-                                                                    match uu___6_9200
+                                                                    match uu___6_9197
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
-                                                                    uu____9203)
+                                                                    uu____9200)
                                                                     -> true
                                                                     | 
-                                                                    uu____9204
+                                                                    uu____9201
                                                                     -> false in
-                                                                    let uu____9207
+                                                                    let uu____9204
                                                                     =
                                                                     FStar_List.splitAt
                                                                     nparam
                                                                     args in
-                                                                    match uu____9207
+                                                                    match uu____9204
                                                                     with
                                                                     | 
                                                                     (a_ps,
@@ -4586,7 +4489,7 @@ let (t_destruct :
                                                                     d_ps))
                                                                     "params not match?"
                                                                     (fun
-                                                                    uu____9342
+                                                                    uu____9339
                                                                     ->
                                                                     let d_ps_a_ps
                                                                     =
@@ -4596,15 +4499,15 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9404
+                                                                    uu____9401
                                                                     ->
-                                                                    match uu____9404
+                                                                    match uu____9401
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____9424),
+                                                                    uu____9421),
                                                                     (t,
-                                                                    uu____9426))
+                                                                    uu____9423))
                                                                     ->
                                                                     FStar_Syntax_Syntax.NT
                                                                     (bv, t))
@@ -4616,15 +4519,15 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9494
+                                                                    uu____9491
                                                                     ->
-                                                                    match uu____9494
+                                                                    match uu____9491
                                                                     with
                                                                     | 
                                                                     ((bv,
-                                                                    uu____9520),
+                                                                    uu____9517),
                                                                     (t,
-                                                                    uu____9522))
+                                                                    uu____9519))
                                                                     ->
                                                                     ((mk_pat
                                                                     (FStar_Syntax_Syntax.Pat_dot_term
@@ -4635,9 +4538,9 @@ let (t_destruct :
                                                                     =
                                                                     FStar_List.map
                                                                     (fun
-                                                                    uu____9577
+                                                                    uu____9574
                                                                     ->
-                                                                    match uu____9577
+                                                                    match uu____9574
                                                                     with
                                                                     | 
                                                                     (bv, aq)
@@ -4668,171 +4571,171 @@ let (t_destruct :
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1
                                                                     s_ty1 in
-                                                                    let uu____9627
+                                                                    let uu____9624
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_pat
-                                                                    (let uu___1404_9650
+                                                                    (let uu___1402_9647
                                                                     = env1 in
                                                                     {
                                                                     FStar_TypeChecker_Env.solver
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.solver);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.solver);
                                                                     FStar_TypeChecker_Env.range
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.range);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.range);
                                                                     FStar_TypeChecker_Env.curmodule
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.curmodule);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.curmodule);
                                                                     FStar_TypeChecker_Env.gamma
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.gamma);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma);
                                                                     FStar_TypeChecker_Env.gamma_sig
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.gamma_sig);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma_sig);
                                                                     FStar_TypeChecker_Env.gamma_cache
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.gamma_cache);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.gamma_cache);
                                                                     FStar_TypeChecker_Env.modules
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.modules);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.modules);
                                                                     FStar_TypeChecker_Env.expected_typ
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.expected_typ);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.expected_typ);
                                                                     FStar_TypeChecker_Env.sigtab
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.sigtab);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.sigtab);
                                                                     FStar_TypeChecker_Env.attrtab
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.attrtab);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.attrtab);
                                                                     FStar_TypeChecker_Env.instantiate_imp
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.instantiate_imp);
                                                                     FStar_TypeChecker_Env.effects
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.effects);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.effects);
                                                                     FStar_TypeChecker_Env.generalize
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.generalize);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.generalize);
                                                                     FStar_TypeChecker_Env.letrecs
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.letrecs);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.letrecs);
                                                                     FStar_TypeChecker_Env.top_level
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.top_level);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.top_level);
                                                                     FStar_TypeChecker_Env.check_uvars
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.check_uvars);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.check_uvars);
                                                                     FStar_TypeChecker_Env.use_eq
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.use_eq);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_eq);
                                                                     FStar_TypeChecker_Env.use_eq_strict
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.use_eq_strict);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_eq_strict);
                                                                     FStar_TypeChecker_Env.is_iface
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.is_iface);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.admit);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.admit);
                                                                     FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.lax_universes);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.lax_universes);
                                                                     FStar_TypeChecker_Env.phase1
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.phase1);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.phase1);
                                                                     FStar_TypeChecker_Env.failhard
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.failhard);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.failhard);
                                                                     FStar_TypeChecker_Env.nosynth
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.nosynth);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.nosynth);
                                                                     FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.uvar_subtyping);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.tc_term);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.tc_term);
                                                                     FStar_TypeChecker_Env.type_of
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.type_of);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.type_of);
                                                                     FStar_TypeChecker_Env.universe_of
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.universe_of);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.universe_of);
                                                                     FStar_TypeChecker_Env.check_type_of
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.check_type_of);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.check_type_of);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.use_bv_sorts);
                                                                     FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                     FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.normalized_eff_names);
                                                                     FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.fv_delta_depths);
                                                                     FStar_TypeChecker_Env.proof_ns
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.proof_ns);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.proof_ns);
                                                                     FStar_TypeChecker_Env.synth_hook
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.synth_hook);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.synth_hook);
                                                                     FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                     FStar_TypeChecker_Env.splice
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.splice);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.splice);
                                                                     FStar_TypeChecker_Env.mpreprocess
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.mpreprocess);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.mpreprocess);
                                                                     FStar_TypeChecker_Env.postprocess
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.postprocess);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.postprocess);
                                                                     FStar_TypeChecker_Env.identifier_info
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.identifier_info);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.identifier_info);
                                                                     FStar_TypeChecker_Env.tc_hooks
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.tc_hooks);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.tc_hooks);
                                                                     FStar_TypeChecker_Env.dsenv
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.dsenv);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.dsenv);
                                                                     FStar_TypeChecker_Env.nbe
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.nbe);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.nbe);
                                                                     FStar_TypeChecker_Env.strict_args_tab
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.strict_args_tab);
                                                                     FStar_TypeChecker_Env.erasable_types_tab
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.erasable_types_tab);
                                                                     FStar_TypeChecker_Env.enable_defer_to_tac
                                                                     =
-                                                                    (uu___1404_9650.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                    (uu___1402_9647.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                                     }) s_ty1
                                                                     pat in
-                                                                    match uu____9627
+                                                                    match uu____9624
                                                                     with
                                                                     | 
-                                                                    (uu____9663,
-                                                                    uu____9664,
-                                                                    uu____9665,
-                                                                    uu____9666,
+                                                                    (uu____9660,
+                                                                    uu____9661,
+                                                                    uu____9662,
+                                                                    uu____9663,
                                                                     pat_t,
-                                                                    uu____9668,
+                                                                    uu____9665,
                                                                     _guard_pat,
                                                                     _erasable)
                                                                     ->
                                                                     let eq_b
                                                                     =
-                                                                    let uu____9680
+                                                                    let uu____9677
                                                                     =
-                                                                    let uu____9681
+                                                                    let uu____9678
                                                                     =
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     equ s_ty1
@@ -4840,46 +4743,46 @@ let (t_destruct :
                                                                     pat_t in
                                                                     FStar_Syntax_Util.mk_squash
                                                                     equ
-                                                                    uu____9681 in
+                                                                    uu____9678 in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "breq"
                                                                     FStar_Pervasives_Native.None
-                                                                    uu____9680 in
+                                                                    uu____9677 in
                                                                     let cod1
                                                                     =
-                                                                    let uu____9685
+                                                                    let uu____9682
                                                                     =
-                                                                    let uu____9694
+                                                                    let uu____9691
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     eq_b in
-                                                                    [uu____9694] in
-                                                                    let uu____9713
+                                                                    [uu____9691] in
+                                                                    let uu____9710
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____9685
-                                                                    uu____9713 in
+                                                                    uu____9682
+                                                                    uu____9710 in
                                                                     let nty =
-                                                                    let uu____9719
+                                                                    let uu____9716
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     cod1 in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs3
-                                                                    uu____9719 in
-                                                                    let uu____9722
+                                                                    uu____9716 in
+                                                                    let uu____9719
                                                                     =
                                                                     FStar_Tactics_Monad.new_uvar
                                                                     "destruct branch"
                                                                     env1 nty in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9722
+                                                                    uu____9719
                                                                     (fun
-                                                                    uu____9751
+                                                                    uu____9748
                                                                     ->
-                                                                    match uu____9751
+                                                                    match uu____9748
                                                                     with
                                                                     | 
                                                                     (uvt, uv)
@@ -4895,51 +4798,51 @@ let (t_destruct :
                                                                     uvt bs3 in
                                                                     let brt1
                                                                     =
-                                                                    let uu____9777
+                                                                    let uu____9774
                                                                     =
-                                                                    let uu____9788
+                                                                    let uu____9785
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     FStar_Syntax_Util.exp_unit in
-                                                                    [uu____9788] in
+                                                                    [uu____9785] in
                                                                     FStar_Syntax_Util.mk_app
                                                                     brt
-                                                                    uu____9777 in
+                                                                    uu____9774 in
                                                                     let br =
                                                                     FStar_Syntax_Subst.close_branch
                                                                     (pat,
                                                                     FStar_Pervasives_Native.None,
                                                                     brt1) in
-                                                                    let uu____9824
+                                                                    let uu____9821
                                                                     =
-                                                                    let uu____9835
+                                                                    let uu____9832
                                                                     =
-                                                                    let uu____9840
+                                                                    let uu____9837
                                                                     =
                                                                     FStar_BigInt.of_int_fs
                                                                     (FStar_List.length
                                                                     bs3) in
                                                                     (fv1,
-                                                                    uu____9840) in
+                                                                    uu____9837) in
                                                                     (g', br,
-                                                                    uu____9835) in
+                                                                    uu____9832) in
                                                                     FStar_Tactics_Monad.ret
-                                                                    uu____9824)))))))
+                                                                    uu____9821)))))))
                                                                     | 
-                                                                    uu____9861
+                                                                    uu____9858
                                                                     ->
                                                                     FStar_Tactics_Monad.fail
                                                                     "impossible: not a ctor"))
                                                                   c_lids in
                                                               FStar_Tactics_Monad.bind
-                                                                uu____8721
+                                                                uu____8718
                                                                 (fun goal_brs
                                                                    ->
-                                                                   let uu____9910
+                                                                   let uu____9907
                                                                     =
                                                                     FStar_List.unzip3
                                                                     goal_brs in
-                                                                   match uu____9910
+                                                                   match uu____9907
                                                                    with
                                                                    | 
                                                                    (goals,
@@ -4951,56 +4854,56 @@ let (t_destruct :
                                                                     (s_tm1,
                                                                     brs))
                                                                     s_tm1.FStar_Syntax_Syntax.pos in
-                                                                    let uu____9983
+                                                                    let uu____9980
                                                                     =
                                                                     solve' g
                                                                     w in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9983
+                                                                    uu____9980
                                                                     (fun
-                                                                    uu____9994
+                                                                    uu____9991
                                                                     ->
-                                                                    let uu____9995
+                                                                    let uu____9992
                                                                     =
                                                                     FStar_Tactics_Monad.add_goals
                                                                     goals in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu____9995
+                                                                    uu____9992
                                                                     (fun
-                                                                    uu____10005
+                                                                    uu____10002
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     infos)))))
-                                            | uu____10012 ->
+                                            | uu____10009 ->
                                                 FStar_Tactics_Monad.fail
                                                   "not an inductive type")))))) in
-    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8443
+    FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "destruct") uu____8440
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
     | [] -> failwith "last: empty list"
     | x::[] -> x
-    | uu____10057::xs -> last xs
+    | uu____10054::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
     | [] -> failwith "init: empty list"
     | x::[] -> []
-    | x::xs -> let uu____10085 = init xs in x :: uu____10085
+    | x::xs -> let uu____10082 = init xs in x :: uu____10082
 let rec (inspect :
   FStar_Syntax_Syntax.term ->
     FStar_Reflection_Data.term_view FStar_Tactics_Monad.tac)
   =
   fun t ->
-    let uu____10097 =
-      let uu____10100 = top_env () in
-      FStar_Tactics_Monad.bind uu____10100
+    let uu____10094 =
+      let uu____10097 = top_env () in
+      FStar_Tactics_Monad.bind uu____10097
         (fun e ->
            let t1 = FStar_Syntax_Util.unascribe t in
            let t2 = FStar_Syntax_Util.un_uinst t1 in
            let t3 = FStar_Syntax_Util.unlazy_emb t2 in
            match t3.FStar_Syntax_Syntax.n with
-           | FStar_Syntax_Syntax.Tm_meta (t4, uu____10116) -> inspect t4
+           | FStar_Syntax_Syntax.Tm_meta (t4, uu____10113) -> inspect t4
            | FStar_Syntax_Syntax.Tm_name bv ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Var bv)
@@ -5013,75 +4916,75 @@ let rec (inspect :
            | FStar_Syntax_Syntax.Tm_app (hd, []) ->
                failwith "empty arguments on Tm_app"
            | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-               let uu____10181 = last args in
-               (match uu____10181 with
+               let uu____10178 = last args in
+               (match uu____10178 with
                 | (a, q) ->
                     let q' = FStar_Reflection_Basic.inspect_aqual q in
-                    let uu____10211 =
-                      let uu____10212 =
-                        let uu____10217 =
-                          let uu____10218 = init args in
-                          FStar_Syntax_Syntax.mk_Tm_app hd uu____10218
+                    let uu____10208 =
+                      let uu____10209 =
+                        let uu____10214 =
+                          let uu____10215 = init args in
+                          FStar_Syntax_Syntax.mk_Tm_app hd uu____10215
                             t3.FStar_Syntax_Syntax.pos in
-                        (uu____10217, (a, q')) in
-                      FStar_Reflection_Data.Tv_App uu____10212 in
-                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10211)
-           | FStar_Syntax_Syntax.Tm_abs ([], uu____10229, uu____10230) ->
+                        (uu____10214, (a, q')) in
+                      FStar_Reflection_Data.Tv_App uu____10209 in
+                    FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10208)
+           | FStar_Syntax_Syntax.Tm_abs ([], uu____10226, uu____10227) ->
                failwith "empty arguments on Tm_abs"
            | FStar_Syntax_Syntax.Tm_abs (bs, t4, k) ->
-               let uu____10282 = FStar_Syntax_Subst.open_term bs t4 in
-               (match uu____10282 with
+               let uu____10279 = FStar_Syntax_Subst.open_term bs t4 in
+               (match uu____10279 with
                 | (bs1, t5) ->
                     (match bs1 with
                      | [] -> failwith "impossible"
                      | b::bs2 ->
-                         let uu____10323 =
-                           let uu____10324 =
-                             let uu____10329 = FStar_Syntax_Util.abs bs2 t5 k in
-                             (b, uu____10329) in
-                           FStar_Reflection_Data.Tv_Abs uu____10324 in
+                         let uu____10320 =
+                           let uu____10321 =
+                             let uu____10326 = FStar_Syntax_Util.abs bs2 t5 k in
+                             (b, uu____10326) in
+                           FStar_Reflection_Data.Tv_Abs uu____10321 in
                          FStar_All.pipe_left FStar_Tactics_Monad.ret
-                           uu____10323))
-           | FStar_Syntax_Syntax.Tm_type uu____10332 ->
+                           uu____10320))
+           | FStar_Syntax_Syntax.Tm_type uu____10329 ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Type ())
            | FStar_Syntax_Syntax.Tm_arrow ([], k) ->
                failwith "empty binders on arrow"
-           | FStar_Syntax_Syntax.Tm_arrow uu____10356 ->
-               let uu____10371 = FStar_Syntax_Util.arrow_one t3 in
-               (match uu____10371 with
+           | FStar_Syntax_Syntax.Tm_arrow uu____10353 ->
+               let uu____10368 = FStar_Syntax_Util.arrow_one t3 in
+               (match uu____10368 with
                 | FStar_Pervasives_Native.Some (b, c) ->
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Arrow (b, c))
                 | FStar_Pervasives_Native.None -> failwith "impossible")
            | FStar_Syntax_Syntax.Tm_refine (bv, t4) ->
                let b = FStar_Syntax_Syntax.mk_binder bv in
-               let uu____10401 = FStar_Syntax_Subst.open_term [b] t4 in
-               (match uu____10401 with
+               let uu____10398 = FStar_Syntax_Subst.open_term [b] t4 in
+               (match uu____10398 with
                 | (b', t5) ->
                     let b1 =
                       match b' with
                       | b'1::[] -> b'1
-                      | uu____10454 -> failwith "impossible" in
+                      | uu____10451 -> failwith "impossible" in
                     FStar_All.pipe_left FStar_Tactics_Monad.ret
                       (FStar_Reflection_Data.Tv_Refine
                          ((FStar_Pervasives_Native.fst b1), t5)))
            | FStar_Syntax_Syntax.Tm_constant c ->
-               let uu____10466 =
-                 let uu____10467 = FStar_Reflection_Basic.inspect_const c in
-                 FStar_Reflection_Data.Tv_Const uu____10467 in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10466
+               let uu____10463 =
+                 let uu____10464 = FStar_Reflection_Basic.inspect_const c in
+                 FStar_Reflection_Data.Tv_Const uu____10464 in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10463
            | FStar_Syntax_Syntax.Tm_uvar (ctx_u, s) ->
-               let uu____10488 =
-                 let uu____10489 =
-                   let uu____10494 =
-                     let uu____10495 =
+               let uu____10485 =
+                 let uu____10486 =
+                   let uu____10491 =
+                     let uu____10492 =
                        FStar_Syntax_Unionfind.uvar_id
                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                     FStar_BigInt.of_int_fs uu____10495 in
-                   (uu____10494, (ctx_u, s)) in
-                 FStar_Reflection_Data.Tv_Uvar uu____10489 in
-               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10488
+                     FStar_BigInt.of_int_fs uu____10492 in
+                   (uu____10491, (ctx_u, s)) in
+                 FStar_Reflection_Data.Tv_Uvar uu____10486 in
+               FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10485
            | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), t21) ->
                if lb.FStar_Syntax_Syntax.lbunivs <> []
                then
@@ -5089,18 +4992,18 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____10529 ->
+                  | FStar_Util.Inr uu____10526 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
                       let b = FStar_Syntax_Syntax.mk_binder bv in
-                      let uu____10534 = FStar_Syntax_Subst.open_term [b] t21 in
-                      (match uu____10534 with
+                      let uu____10531 = FStar_Syntax_Subst.open_term [b] t21 in
+                      (match uu____10531 with
                        | (bs, t22) ->
                            let b1 =
                              match bs with
                              | b1::[] -> b1
-                             | uu____10587 ->
+                             | uu____10584 ->
                                  failwith
                                    "impossible: open_term returned different amount of binders" in
                            FStar_All.pipe_left FStar_Tactics_Monad.ret
@@ -5115,18 +5018,18 @@ let rec (inspect :
                    FStar_Reflection_Data.Tv_Unknown
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
-                  | FStar_Util.Inr uu____10623 ->
+                  | FStar_Util.Inr uu____10620 ->
                       FStar_All.pipe_left FStar_Tactics_Monad.ret
                         FStar_Reflection_Data.Tv_Unknown
                   | FStar_Util.Inl bv ->
-                      let uu____10627 =
+                      let uu____10624 =
                         FStar_Syntax_Subst.open_let_rec [lb] t21 in
-                      (match uu____10627 with
+                      (match uu____10624 with
                        | (lbs, t22) ->
                            (match lbs with
                             | lb1::[] ->
                                 (match lb1.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____10647 ->
+                                 | FStar_Util.Inr uu____10644 ->
                                      FStar_Tactics_Monad.ret
                                        FStar_Reflection_Data.Tv_Unknown
                                  | FStar_Util.Inl bv1 ->
@@ -5138,26 +5041,26 @@ let rec (inspect :
                                             bv1,
                                             (lb1.FStar_Syntax_Syntax.lbdef),
                                             t22)))
-                            | uu____10653 ->
+                            | uu____10650 ->
                                 failwith
                                   "impossible: open_term returned different amount of binders")))
            | FStar_Syntax_Syntax.Tm_match (t4, brs) ->
                let rec inspect_pat p =
                  match p.FStar_Syntax_Syntax.v with
                  | FStar_Syntax_Syntax.Pat_constant c ->
-                     let uu____10707 = FStar_Reflection_Basic.inspect_const c in
-                     FStar_Reflection_Data.Pat_Constant uu____10707
+                     let uu____10704 = FStar_Reflection_Basic.inspect_const c in
+                     FStar_Reflection_Data.Pat_Constant uu____10704
                  | FStar_Syntax_Syntax.Pat_cons (fv, ps) ->
-                     let uu____10726 =
-                       let uu____10737 =
+                     let uu____10723 =
+                       let uu____10734 =
                          FStar_List.map
-                           (fun uu____10758 ->
-                              match uu____10758 with
+                           (fun uu____10755 ->
+                              match uu____10755 with
                               | (p1, b) ->
-                                  let uu____10775 = inspect_pat p1 in
-                                  (uu____10775, b)) ps in
-                       (fv, uu____10737) in
-                     FStar_Reflection_Data.Pat_Cons uu____10726
+                                  let uu____10772 = inspect_pat p1 in
+                                  (uu____10772, b)) ps in
+                       (fv, uu____10734) in
+                     FStar_Reflection_Data.Pat_Cons uu____10723
                  | FStar_Syntax_Syntax.Pat_var bv ->
                      FStar_Reflection_Data.Pat_Var bv
                  | FStar_Syntax_Syntax.Pat_wild bv ->
@@ -5167,30 +5070,30 @@ let rec (inspect :
                let brs1 = FStar_List.map FStar_Syntax_Subst.open_branch brs in
                let brs2 =
                  FStar_List.map
-                   (fun uu___7_10869 ->
-                      match uu___7_10869 with
-                      | (pat, uu____10891, t5) ->
-                          let uu____10909 = inspect_pat pat in
-                          (uu____10909, t5)) brs1 in
+                   (fun uu___7_10866 ->
+                      match uu___7_10866 with
+                      | (pat, uu____10888, t5) ->
+                          let uu____10906 = inspect_pat pat in
+                          (uu____10906, t5)) brs1 in
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  (FStar_Reflection_Data.Tv_Match (t4, brs2))
            | FStar_Syntax_Syntax.Tm_unknown ->
                FStar_All.pipe_left FStar_Tactics_Monad.ret
                  FStar_Reflection_Data.Tv_Unknown
-           | uu____10918 ->
-               ((let uu____10920 =
-                   let uu____10925 =
-                     let uu____10926 = FStar_Syntax_Print.tag_of_term t3 in
-                     let uu____10927 = term_to_string e t3 in
+           | uu____10915 ->
+               ((let uu____10917 =
+                   let uu____10922 =
+                     let uu____10923 = FStar_Syntax_Print.tag_of_term t3 in
+                     let uu____10924 = term_to_string e t3 in
                      FStar_Util.format2
                        "inspect: outside of expected syntax (%s, %s)\n"
-                       uu____10926 uu____10927 in
-                   (FStar_Errors.Warning_CantInspect, uu____10925) in
+                       uu____10923 uu____10924 in
+                   (FStar_Errors.Warning_CantInspect, uu____10922) in
                  FStar_Errors.log_issue t3.FStar_Syntax_Syntax.pos
-                   uu____10920);
+                   uu____10917);
                 FStar_All.pipe_left FStar_Tactics_Monad.ret
                   FStar_Reflection_Data.Tv_Unknown)) in
-    FStar_Tactics_Monad.wrap_err "inspect" uu____10097
+    FStar_Tactics_Monad.wrap_err "inspect" uu____10094
 let (pack :
   FStar_Reflection_Data.term_view ->
     FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac)
@@ -5198,72 +5101,72 @@ let (pack :
   fun tv ->
     match tv with
     | FStar_Reflection_Data.Tv_Var bv ->
-        let uu____10940 = FStar_Syntax_Syntax.bv_to_name bv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10940
+        let uu____10937 = FStar_Syntax_Syntax.bv_to_name bv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10937
     | FStar_Reflection_Data.Tv_BVar bv ->
-        let uu____10944 = FStar_Syntax_Syntax.bv_to_tm bv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10944
+        let uu____10941 = FStar_Syntax_Syntax.bv_to_tm bv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10941
     | FStar_Reflection_Data.Tv_FVar fv ->
-        let uu____10948 = FStar_Syntax_Syntax.fv_to_tm fv in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10948
+        let uu____10945 = FStar_Syntax_Syntax.fv_to_tm fv in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10945
     | FStar_Reflection_Data.Tv_App (l, (r, q)) ->
         let q' = FStar_Reflection_Basic.pack_aqual q in
-        let uu____10955 = FStar_Syntax_Util.mk_app l [(r, q')] in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10955
+        let uu____10952 = FStar_Syntax_Util.mk_app l [(r, q')] in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10952
     | FStar_Reflection_Data.Tv_Abs (b, t) ->
-        let uu____10980 =
+        let uu____10977 =
           FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10980
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10977
     | FStar_Reflection_Data.Tv_Arrow (b, c) ->
-        let uu____10997 = FStar_Syntax_Util.arrow [b] c in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10997
+        let uu____10994 = FStar_Syntax_Util.arrow [b] c in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____10994
     | FStar_Reflection_Data.Tv_Type () ->
         FStar_All.pipe_left FStar_Tactics_Monad.ret FStar_Syntax_Util.ktype
     | FStar_Reflection_Data.Tv_Refine (bv, t) ->
-        let uu____11016 = FStar_Syntax_Util.refine bv t in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11016
+        let uu____11013 = FStar_Syntax_Util.refine bv t in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11013
     | FStar_Reflection_Data.Tv_Const c ->
-        let uu____11020 =
-          let uu____11021 =
-            let uu____11022 = FStar_Reflection_Basic.pack_const c in
-            FStar_Syntax_Syntax.Tm_constant uu____11022 in
-          FStar_Syntax_Syntax.mk uu____11021 FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11020
+        let uu____11017 =
+          let uu____11018 =
+            let uu____11019 = FStar_Reflection_Basic.pack_const c in
+            FStar_Syntax_Syntax.Tm_constant uu____11019 in
+          FStar_Syntax_Syntax.mk uu____11018 FStar_Range.dummyRange in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11017
     | FStar_Reflection_Data.Tv_Uvar (_u, ctx_u_s) ->
-        let uu____11027 =
+        let uu____11024 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11027
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11024
     | FStar_Reflection_Data.Tv_Let (false, attrs, bv, t1, t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange in
-        let uu____11039 =
-          let uu____11040 =
-            let uu____11041 =
-              let uu____11054 =
-                let uu____11057 =
-                  let uu____11058 = FStar_Syntax_Syntax.mk_binder bv in
-                  [uu____11058] in
-                FStar_Syntax_Subst.close uu____11057 t2 in
-              ((false, [lb]), uu____11054) in
-            FStar_Syntax_Syntax.Tm_let uu____11041 in
-          FStar_Syntax_Syntax.mk uu____11040 FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11039
+        let uu____11036 =
+          let uu____11037 =
+            let uu____11038 =
+              let uu____11051 =
+                let uu____11054 =
+                  let uu____11055 = FStar_Syntax_Syntax.mk_binder bv in
+                  [uu____11055] in
+                FStar_Syntax_Subst.close uu____11054 t2 in
+              ((false, [lb]), uu____11051) in
+            FStar_Syntax_Syntax.Tm_let uu____11038 in
+          FStar_Syntax_Syntax.mk uu____11037 FStar_Range.dummyRange in
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11036
     | FStar_Reflection_Data.Tv_Let (true, attrs, bv, t1, t2) ->
         let lb =
           FStar_Syntax_Util.mk_letbinding (FStar_Util.Inl bv) []
             bv.FStar_Syntax_Syntax.sort FStar_Parser_Const.effect_Tot_lid t1
             attrs FStar_Range.dummyRange in
-        let uu____11098 = FStar_Syntax_Subst.close_let_rec [lb] t2 in
-        (match uu____11098 with
+        let uu____11095 = FStar_Syntax_Subst.close_let_rec [lb] t2 in
+        (match uu____11095 with
          | (lbs, body) ->
-             let uu____11113 =
+             let uu____11110 =
                FStar_Syntax_Syntax.mk
                  (FStar_Syntax_Syntax.Tm_let ((true, lbs), body))
                  FStar_Range.dummyRange in
-             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11113)
+             FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11110)
     | FStar_Reflection_Data.Tv_Match (t, brs) ->
         let wrap v =
           {
@@ -5273,23 +5176,23 @@ let (pack :
         let rec pack_pat p =
           match p with
           | FStar_Reflection_Data.Pat_Constant c ->
-              let uu____11147 =
-                let uu____11148 = FStar_Reflection_Basic.pack_const c in
-                FStar_Syntax_Syntax.Pat_constant uu____11148 in
-              FStar_All.pipe_left wrap uu____11147
+              let uu____11144 =
+                let uu____11145 = FStar_Reflection_Basic.pack_const c in
+                FStar_Syntax_Syntax.Pat_constant uu____11145 in
+              FStar_All.pipe_left wrap uu____11144
           | FStar_Reflection_Data.Pat_Cons (fv, ps) ->
-              let uu____11163 =
-                let uu____11164 =
-                  let uu____11177 =
+              let uu____11160 =
+                let uu____11161 =
+                  let uu____11174 =
                     FStar_List.map
-                      (fun uu____11198 ->
-                         match uu____11198 with
+                      (fun uu____11195 ->
+                         match uu____11195 with
                          | (p1, b) ->
-                             let uu____11209 = pack_pat p1 in
-                             (uu____11209, b)) ps in
-                  (fv, uu____11177) in
-                FStar_Syntax_Syntax.Pat_cons uu____11164 in
-              FStar_All.pipe_left wrap uu____11163
+                             let uu____11206 = pack_pat p1 in
+                             (uu____11206, b)) ps in
+                  (fv, uu____11174) in
+                FStar_Syntax_Syntax.Pat_cons uu____11161 in
+              FStar_All.pipe_left wrap uu____11160
           | FStar_Reflection_Data.Pat_Var bv ->
               FStar_All.pipe_left wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_Data.Pat_Wild bv ->
@@ -5299,51 +5202,51 @@ let (pack :
                 (FStar_Syntax_Syntax.Pat_dot_term (bv, t1)) in
         let brs1 =
           FStar_List.map
-            (fun uu___8_11255 ->
-               match uu___8_11255 with
+            (fun uu___8_11252 ->
+               match uu___8_11252 with
                | (pat, t1) ->
-                   let uu____11272 = pack_pat pat in
-                   (uu____11272, FStar_Pervasives_Native.None, t1)) brs in
+                   let uu____11269 = pack_pat pat in
+                   (uu____11269, FStar_Pervasives_Native.None, t1)) brs in
         let brs2 = FStar_List.map FStar_Syntax_Subst.close_branch brs1 in
-        let uu____11320 =
+        let uu____11317 =
           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_match (t, brs2))
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11320
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11317
     | FStar_Reflection_Data.Tv_AscribedT (e, t, tacopt) ->
-        let uu____11348 =
+        let uu____11345 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inl t), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11348
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11345
     | FStar_Reflection_Data.Tv_AscribedC (e, c, tacopt) ->
-        let uu____11394 =
+        let uu____11391 =
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_ascribed
                (e, ((FStar_Util.Inr c), tacopt),
                  FStar_Pervasives_Native.None)) FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11394
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11391
     | FStar_Reflection_Data.Tv_Unknown ->
-        let uu____11433 =
+        let uu____11430 =
           FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
             FStar_Range.dummyRange in
-        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11433
+        FStar_All.pipe_left FStar_Tactics_Monad.ret uu____11430
 let (lget :
   FStar_Reflection_Data.typ ->
     Prims.string -> FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac)
   =
   fun ty ->
     fun k ->
-      let uu____11450 =
+      let uu____11447 =
         FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
           (fun ps ->
-             let uu____11456 =
+             let uu____11453 =
                FStar_Util.psmap_try_find ps.FStar_Tactics_Types.local_state k in
-             match uu____11456 with
+             match uu____11453 with
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t) in
-      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____11450
+      FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lget") uu____11447
 let (lset :
   FStar_Reflection_Data.typ ->
     Prims.string -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -5351,41 +5254,41 @@ let (lset :
   fun _ty ->
     fun k ->
       fun t ->
-        let uu____11485 =
+        let uu____11482 =
           FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
             (fun ps ->
                let ps1 =
-                 let uu___1709_11492 = ps in
-                 let uu____11493 =
+                 let uu___1707_11489 = ps in
+                 let uu____11490 =
                    FStar_Util.psmap_add ps.FStar_Tactics_Types.local_state k
                      t in
                  {
                    FStar_Tactics_Types.main_context =
-                     (uu___1709_11492.FStar_Tactics_Types.main_context);
+                     (uu___1707_11489.FStar_Tactics_Types.main_context);
                    FStar_Tactics_Types.all_implicits =
-                     (uu___1709_11492.FStar_Tactics_Types.all_implicits);
+                     (uu___1707_11489.FStar_Tactics_Types.all_implicits);
                    FStar_Tactics_Types.goals =
-                     (uu___1709_11492.FStar_Tactics_Types.goals);
+                     (uu___1707_11489.FStar_Tactics_Types.goals);
                    FStar_Tactics_Types.smt_goals =
-                     (uu___1709_11492.FStar_Tactics_Types.smt_goals);
+                     (uu___1707_11489.FStar_Tactics_Types.smt_goals);
                    FStar_Tactics_Types.depth =
-                     (uu___1709_11492.FStar_Tactics_Types.depth);
+                     (uu___1707_11489.FStar_Tactics_Types.depth);
                    FStar_Tactics_Types.__dump =
-                     (uu___1709_11492.FStar_Tactics_Types.__dump);
+                     (uu___1707_11489.FStar_Tactics_Types.__dump);
                    FStar_Tactics_Types.psc =
-                     (uu___1709_11492.FStar_Tactics_Types.psc);
+                     (uu___1707_11489.FStar_Tactics_Types.psc);
                    FStar_Tactics_Types.entry_range =
-                     (uu___1709_11492.FStar_Tactics_Types.entry_range);
+                     (uu___1707_11489.FStar_Tactics_Types.entry_range);
                    FStar_Tactics_Types.guard_policy =
-                     (uu___1709_11492.FStar_Tactics_Types.guard_policy);
+                     (uu___1707_11489.FStar_Tactics_Types.guard_policy);
                    FStar_Tactics_Types.freshness =
-                     (uu___1709_11492.FStar_Tactics_Types.freshness);
+                     (uu___1707_11489.FStar_Tactics_Types.freshness);
                    FStar_Tactics_Types.tac_verb_dbg =
-                     (uu___1709_11492.FStar_Tactics_Types.tac_verb_dbg);
-                   FStar_Tactics_Types.local_state = uu____11493
+                     (uu___1707_11489.FStar_Tactics_Types.tac_verb_dbg);
+                   FStar_Tactics_Types.local_state = uu____11490
                  } in
                FStar_Tactics_Monad.set ps1) in
-        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____11485
+        FStar_All.pipe_left (FStar_Tactics_Monad.wrap_err "lset") uu____11482
 let (goal_of_goal_ty :
   env ->
     FStar_Reflection_Data.typ ->
@@ -5393,220 +5296,317 @@ let (goal_of_goal_ty :
   =
   fun env1 ->
     fun typ ->
-      let uu____11518 =
+      let uu____11515 =
         FStar_TypeChecker_Env.new_implicit_var_aux "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env1 typ
           FStar_Syntax_Syntax.Allow_untyped FStar_Pervasives_Native.None in
-      match uu____11518 with
+      match uu____11515 with
       | (u, ctx_uvars, g_u) ->
-          let uu____11550 = FStar_List.hd ctx_uvars in
-          (match uu____11550 with
-           | (ctx_uvar, uu____11564) ->
+          let uu____11547 = FStar_List.hd ctx_uvars in
+          (match uu____11547 with
+           | (ctx_uvar, uu____11561) ->
                let g =
-                 let uu____11566 = FStar_Options.peek () in
-                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____11566 false
+                 let uu____11563 = FStar_Options.peek () in
+                 FStar_Tactics_Types.mk_goal env1 ctx_uvar uu____11563 false
                    "" in
                (g, g_u))
 let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env1 ->
-    let uu____11572 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-    match uu____11572 with
-    | (env2, uu____11580) ->
+    let uu____11569 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+    match uu____11569 with
+    | (env2, uu____11577) ->
         let env3 =
-          let uu___1726_11586 = env2 in
+          let uu___1724_11583 = env2 in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1726_11586.FStar_TypeChecker_Env.solver);
+              (uu___1724_11583.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1726_11586.FStar_TypeChecker_Env.range);
+              (uu___1724_11583.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1726_11586.FStar_TypeChecker_Env.curmodule);
+              (uu___1724_11583.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1726_11586.FStar_TypeChecker_Env.gamma);
+              (uu___1724_11583.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1726_11586.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1724_11583.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1726_11586.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1724_11583.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1726_11586.FStar_TypeChecker_Env.modules);
+              (uu___1724_11583.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1726_11586.FStar_TypeChecker_Env.expected_typ);
+              (uu___1724_11583.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1726_11586.FStar_TypeChecker_Env.sigtab);
+              (uu___1724_11583.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1726_11586.FStar_TypeChecker_Env.attrtab);
+              (uu___1724_11583.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp = false;
             FStar_TypeChecker_Env.effects =
-              (uu___1726_11586.FStar_TypeChecker_Env.effects);
+              (uu___1724_11583.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1726_11586.FStar_TypeChecker_Env.generalize);
+              (uu___1724_11583.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1726_11586.FStar_TypeChecker_Env.letrecs);
+              (uu___1724_11583.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1726_11586.FStar_TypeChecker_Env.top_level);
+              (uu___1724_11583.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1726_11586.FStar_TypeChecker_Env.check_uvars);
+              (uu___1724_11583.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1726_11586.FStar_TypeChecker_Env.use_eq);
+              (uu___1724_11583.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1726_11586.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1724_11583.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1726_11586.FStar_TypeChecker_Env.is_iface);
+              (uu___1724_11583.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1726_11586.FStar_TypeChecker_Env.admit);
+              (uu___1724_11583.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1726_11586.FStar_TypeChecker_Env.lax);
+              (uu___1724_11583.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1726_11586.FStar_TypeChecker_Env.lax_universes);
+              (uu___1724_11583.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1726_11586.FStar_TypeChecker_Env.phase1);
+              (uu___1724_11583.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard =
-              (uu___1726_11586.FStar_TypeChecker_Env.failhard);
+              (uu___1724_11583.FStar_TypeChecker_Env.failhard);
             FStar_TypeChecker_Env.nosynth =
-              (uu___1726_11586.FStar_TypeChecker_Env.nosynth);
+              (uu___1724_11583.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1726_11586.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1724_11583.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1726_11586.FStar_TypeChecker_Env.tc_term);
+              (uu___1724_11583.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1726_11586.FStar_TypeChecker_Env.type_of);
+              (uu___1724_11583.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1726_11586.FStar_TypeChecker_Env.universe_of);
+              (uu___1724_11583.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1726_11586.FStar_TypeChecker_Env.check_type_of);
+              (uu___1724_11583.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1726_11586.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1724_11583.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1726_11586.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1724_11583.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1726_11586.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1724_11583.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1726_11586.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1724_11583.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1726_11586.FStar_TypeChecker_Env.proof_ns);
+              (uu___1724_11583.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1726_11586.FStar_TypeChecker_Env.synth_hook);
+              (uu___1724_11583.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1726_11586.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1724_11583.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1726_11586.FStar_TypeChecker_Env.splice);
+              (uu___1724_11583.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1726_11586.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1724_11583.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1726_11586.FStar_TypeChecker_Env.postprocess);
+              (uu___1724_11583.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1726_11586.FStar_TypeChecker_Env.identifier_info);
+              (uu___1724_11583.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1726_11586.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1724_11583.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1726_11586.FStar_TypeChecker_Env.dsenv);
+              (uu___1724_11583.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1726_11586.FStar_TypeChecker_Env.nbe);
+              (uu___1724_11583.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1726_11586.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1724_11583.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1726_11586.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___1724_11583.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___1726_11586.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___1724_11583.FStar_TypeChecker_Env.enable_defer_to_tac)
           } in
         let env4 =
-          let uu___1729_11588 = env3 in
+          let uu___1727_11585 = env3 in
           {
             FStar_TypeChecker_Env.solver =
-              (uu___1729_11588.FStar_TypeChecker_Env.solver);
+              (uu___1727_11585.FStar_TypeChecker_Env.solver);
             FStar_TypeChecker_Env.range =
-              (uu___1729_11588.FStar_TypeChecker_Env.range);
+              (uu___1727_11585.FStar_TypeChecker_Env.range);
             FStar_TypeChecker_Env.curmodule =
-              (uu___1729_11588.FStar_TypeChecker_Env.curmodule);
+              (uu___1727_11585.FStar_TypeChecker_Env.curmodule);
             FStar_TypeChecker_Env.gamma =
-              (uu___1729_11588.FStar_TypeChecker_Env.gamma);
+              (uu___1727_11585.FStar_TypeChecker_Env.gamma);
             FStar_TypeChecker_Env.gamma_sig =
-              (uu___1729_11588.FStar_TypeChecker_Env.gamma_sig);
+              (uu___1727_11585.FStar_TypeChecker_Env.gamma_sig);
             FStar_TypeChecker_Env.gamma_cache =
-              (uu___1729_11588.FStar_TypeChecker_Env.gamma_cache);
+              (uu___1727_11585.FStar_TypeChecker_Env.gamma_cache);
             FStar_TypeChecker_Env.modules =
-              (uu___1729_11588.FStar_TypeChecker_Env.modules);
+              (uu___1727_11585.FStar_TypeChecker_Env.modules);
             FStar_TypeChecker_Env.expected_typ =
-              (uu___1729_11588.FStar_TypeChecker_Env.expected_typ);
+              (uu___1727_11585.FStar_TypeChecker_Env.expected_typ);
             FStar_TypeChecker_Env.sigtab =
-              (uu___1729_11588.FStar_TypeChecker_Env.sigtab);
+              (uu___1727_11585.FStar_TypeChecker_Env.sigtab);
             FStar_TypeChecker_Env.attrtab =
-              (uu___1729_11588.FStar_TypeChecker_Env.attrtab);
+              (uu___1727_11585.FStar_TypeChecker_Env.attrtab);
             FStar_TypeChecker_Env.instantiate_imp =
-              (uu___1729_11588.FStar_TypeChecker_Env.instantiate_imp);
+              (uu___1727_11585.FStar_TypeChecker_Env.instantiate_imp);
             FStar_TypeChecker_Env.effects =
-              (uu___1729_11588.FStar_TypeChecker_Env.effects);
+              (uu___1727_11585.FStar_TypeChecker_Env.effects);
             FStar_TypeChecker_Env.generalize =
-              (uu___1729_11588.FStar_TypeChecker_Env.generalize);
+              (uu___1727_11585.FStar_TypeChecker_Env.generalize);
             FStar_TypeChecker_Env.letrecs =
-              (uu___1729_11588.FStar_TypeChecker_Env.letrecs);
+              (uu___1727_11585.FStar_TypeChecker_Env.letrecs);
             FStar_TypeChecker_Env.top_level =
-              (uu___1729_11588.FStar_TypeChecker_Env.top_level);
+              (uu___1727_11585.FStar_TypeChecker_Env.top_level);
             FStar_TypeChecker_Env.check_uvars =
-              (uu___1729_11588.FStar_TypeChecker_Env.check_uvars);
+              (uu___1727_11585.FStar_TypeChecker_Env.check_uvars);
             FStar_TypeChecker_Env.use_eq =
-              (uu___1729_11588.FStar_TypeChecker_Env.use_eq);
+              (uu___1727_11585.FStar_TypeChecker_Env.use_eq);
             FStar_TypeChecker_Env.use_eq_strict =
-              (uu___1729_11588.FStar_TypeChecker_Env.use_eq_strict);
+              (uu___1727_11585.FStar_TypeChecker_Env.use_eq_strict);
             FStar_TypeChecker_Env.is_iface =
-              (uu___1729_11588.FStar_TypeChecker_Env.is_iface);
+              (uu___1727_11585.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit =
-              (uu___1729_11588.FStar_TypeChecker_Env.admit);
+              (uu___1727_11585.FStar_TypeChecker_Env.admit);
             FStar_TypeChecker_Env.lax =
-              (uu___1729_11588.FStar_TypeChecker_Env.lax);
+              (uu___1727_11585.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
-              (uu___1729_11588.FStar_TypeChecker_Env.lax_universes);
+              (uu___1727_11585.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
-              (uu___1729_11588.FStar_TypeChecker_Env.phase1);
+              (uu___1727_11585.FStar_TypeChecker_Env.phase1);
             FStar_TypeChecker_Env.failhard = true;
             FStar_TypeChecker_Env.nosynth =
-              (uu___1729_11588.FStar_TypeChecker_Env.nosynth);
+              (uu___1727_11585.FStar_TypeChecker_Env.nosynth);
             FStar_TypeChecker_Env.uvar_subtyping =
-              (uu___1729_11588.FStar_TypeChecker_Env.uvar_subtyping);
+              (uu___1727_11585.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.tc_term =
-              (uu___1729_11588.FStar_TypeChecker_Env.tc_term);
+              (uu___1727_11585.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.type_of =
-              (uu___1729_11588.FStar_TypeChecker_Env.type_of);
+              (uu___1727_11585.FStar_TypeChecker_Env.type_of);
             FStar_TypeChecker_Env.universe_of =
-              (uu___1729_11588.FStar_TypeChecker_Env.universe_of);
+              (uu___1727_11585.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.check_type_of =
-              (uu___1729_11588.FStar_TypeChecker_Env.check_type_of);
+              (uu___1727_11585.FStar_TypeChecker_Env.check_type_of);
             FStar_TypeChecker_Env.use_bv_sorts =
-              (uu___1729_11588.FStar_TypeChecker_Env.use_bv_sorts);
+              (uu___1727_11585.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index =
-              (uu___1729_11588.FStar_TypeChecker_Env.qtbl_name_and_index);
+              (uu___1727_11585.FStar_TypeChecker_Env.qtbl_name_and_index);
             FStar_TypeChecker_Env.normalized_eff_names =
-              (uu___1729_11588.FStar_TypeChecker_Env.normalized_eff_names);
+              (uu___1727_11585.FStar_TypeChecker_Env.normalized_eff_names);
             FStar_TypeChecker_Env.fv_delta_depths =
-              (uu___1729_11588.FStar_TypeChecker_Env.fv_delta_depths);
+              (uu___1727_11585.FStar_TypeChecker_Env.fv_delta_depths);
             FStar_TypeChecker_Env.proof_ns =
-              (uu___1729_11588.FStar_TypeChecker_Env.proof_ns);
+              (uu___1727_11585.FStar_TypeChecker_Env.proof_ns);
             FStar_TypeChecker_Env.synth_hook =
-              (uu___1729_11588.FStar_TypeChecker_Env.synth_hook);
+              (uu___1727_11585.FStar_TypeChecker_Env.synth_hook);
             FStar_TypeChecker_Env.try_solve_implicits_hook =
-              (uu___1729_11588.FStar_TypeChecker_Env.try_solve_implicits_hook);
+              (uu___1727_11585.FStar_TypeChecker_Env.try_solve_implicits_hook);
             FStar_TypeChecker_Env.splice =
-              (uu___1729_11588.FStar_TypeChecker_Env.splice);
+              (uu___1727_11585.FStar_TypeChecker_Env.splice);
             FStar_TypeChecker_Env.mpreprocess =
-              (uu___1729_11588.FStar_TypeChecker_Env.mpreprocess);
+              (uu___1727_11585.FStar_TypeChecker_Env.mpreprocess);
             FStar_TypeChecker_Env.postprocess =
-              (uu___1729_11588.FStar_TypeChecker_Env.postprocess);
+              (uu___1727_11585.FStar_TypeChecker_Env.postprocess);
             FStar_TypeChecker_Env.identifier_info =
-              (uu___1729_11588.FStar_TypeChecker_Env.identifier_info);
+              (uu___1727_11585.FStar_TypeChecker_Env.identifier_info);
             FStar_TypeChecker_Env.tc_hooks =
-              (uu___1729_11588.FStar_TypeChecker_Env.tc_hooks);
+              (uu___1727_11585.FStar_TypeChecker_Env.tc_hooks);
             FStar_TypeChecker_Env.dsenv =
-              (uu___1729_11588.FStar_TypeChecker_Env.dsenv);
+              (uu___1727_11585.FStar_TypeChecker_Env.dsenv);
             FStar_TypeChecker_Env.nbe =
-              (uu___1729_11588.FStar_TypeChecker_Env.nbe);
+              (uu___1727_11585.FStar_TypeChecker_Env.nbe);
             FStar_TypeChecker_Env.strict_args_tab =
-              (uu___1729_11588.FStar_TypeChecker_Env.strict_args_tab);
+              (uu___1727_11585.FStar_TypeChecker_Env.strict_args_tab);
             FStar_TypeChecker_Env.erasable_types_tab =
-              (uu___1729_11588.FStar_TypeChecker_Env.erasable_types_tab);
+              (uu___1727_11585.FStar_TypeChecker_Env.erasable_types_tab);
             FStar_TypeChecker_Env.enable_defer_to_tac =
-              (uu___1729_11588.FStar_TypeChecker_Env.enable_defer_to_tac)
+              (uu___1727_11585.FStar_TypeChecker_Env.enable_defer_to_tac)
           } in
-        env4
+        let env5 =
+          let uu___1730_11587 = env4 in
+          {
+            FStar_TypeChecker_Env.solver =
+              (uu___1730_11587.FStar_TypeChecker_Env.solver);
+            FStar_TypeChecker_Env.range =
+              (uu___1730_11587.FStar_TypeChecker_Env.range);
+            FStar_TypeChecker_Env.curmodule =
+              (uu___1730_11587.FStar_TypeChecker_Env.curmodule);
+            FStar_TypeChecker_Env.gamma =
+              (uu___1730_11587.FStar_TypeChecker_Env.gamma);
+            FStar_TypeChecker_Env.gamma_sig =
+              (uu___1730_11587.FStar_TypeChecker_Env.gamma_sig);
+            FStar_TypeChecker_Env.gamma_cache =
+              (uu___1730_11587.FStar_TypeChecker_Env.gamma_cache);
+            FStar_TypeChecker_Env.modules =
+              (uu___1730_11587.FStar_TypeChecker_Env.modules);
+            FStar_TypeChecker_Env.expected_typ =
+              (uu___1730_11587.FStar_TypeChecker_Env.expected_typ);
+            FStar_TypeChecker_Env.sigtab =
+              (uu___1730_11587.FStar_TypeChecker_Env.sigtab);
+            FStar_TypeChecker_Env.attrtab =
+              (uu___1730_11587.FStar_TypeChecker_Env.attrtab);
+            FStar_TypeChecker_Env.instantiate_imp =
+              (uu___1730_11587.FStar_TypeChecker_Env.instantiate_imp);
+            FStar_TypeChecker_Env.effects =
+              (uu___1730_11587.FStar_TypeChecker_Env.effects);
+            FStar_TypeChecker_Env.generalize =
+              (uu___1730_11587.FStar_TypeChecker_Env.generalize);
+            FStar_TypeChecker_Env.letrecs =
+              (uu___1730_11587.FStar_TypeChecker_Env.letrecs);
+            FStar_TypeChecker_Env.top_level =
+              (uu___1730_11587.FStar_TypeChecker_Env.top_level);
+            FStar_TypeChecker_Env.check_uvars =
+              (uu___1730_11587.FStar_TypeChecker_Env.check_uvars);
+            FStar_TypeChecker_Env.use_eq =
+              (uu___1730_11587.FStar_TypeChecker_Env.use_eq);
+            FStar_TypeChecker_Env.use_eq_strict =
+              (uu___1730_11587.FStar_TypeChecker_Env.use_eq_strict);
+            FStar_TypeChecker_Env.is_iface =
+              (uu___1730_11587.FStar_TypeChecker_Env.is_iface);
+            FStar_TypeChecker_Env.admit =
+              (uu___1730_11587.FStar_TypeChecker_Env.admit);
+            FStar_TypeChecker_Env.lax =
+              (uu___1730_11587.FStar_TypeChecker_Env.lax);
+            FStar_TypeChecker_Env.lax_universes =
+              (uu___1730_11587.FStar_TypeChecker_Env.lax_universes);
+            FStar_TypeChecker_Env.phase1 =
+              (uu___1730_11587.FStar_TypeChecker_Env.phase1);
+            FStar_TypeChecker_Env.failhard =
+              (uu___1730_11587.FStar_TypeChecker_Env.failhard);
+            FStar_TypeChecker_Env.nosynth =
+              (uu___1730_11587.FStar_TypeChecker_Env.nosynth);
+            FStar_TypeChecker_Env.uvar_subtyping =
+              (uu___1730_11587.FStar_TypeChecker_Env.uvar_subtyping);
+            FStar_TypeChecker_Env.tc_term =
+              (uu___1730_11587.FStar_TypeChecker_Env.tc_term);
+            FStar_TypeChecker_Env.type_of =
+              (uu___1730_11587.FStar_TypeChecker_Env.type_of);
+            FStar_TypeChecker_Env.universe_of =
+              (uu___1730_11587.FStar_TypeChecker_Env.universe_of);
+            FStar_TypeChecker_Env.check_type_of =
+              (uu___1730_11587.FStar_TypeChecker_Env.check_type_of);
+            FStar_TypeChecker_Env.use_bv_sorts =
+              (uu___1730_11587.FStar_TypeChecker_Env.use_bv_sorts);
+            FStar_TypeChecker_Env.qtbl_name_and_index =
+              (uu___1730_11587.FStar_TypeChecker_Env.qtbl_name_and_index);
+            FStar_TypeChecker_Env.normalized_eff_names =
+              (uu___1730_11587.FStar_TypeChecker_Env.normalized_eff_names);
+            FStar_TypeChecker_Env.fv_delta_depths =
+              (uu___1730_11587.FStar_TypeChecker_Env.fv_delta_depths);
+            FStar_TypeChecker_Env.proof_ns =
+              (uu___1730_11587.FStar_TypeChecker_Env.proof_ns);
+            FStar_TypeChecker_Env.synth_hook =
+              (uu___1730_11587.FStar_TypeChecker_Env.synth_hook);
+            FStar_TypeChecker_Env.try_solve_implicits_hook =
+              (uu___1730_11587.FStar_TypeChecker_Env.try_solve_implicits_hook);
+            FStar_TypeChecker_Env.splice =
+              (uu___1730_11587.FStar_TypeChecker_Env.splice);
+            FStar_TypeChecker_Env.mpreprocess =
+              (uu___1730_11587.FStar_TypeChecker_Env.mpreprocess);
+            FStar_TypeChecker_Env.postprocess =
+              (uu___1730_11587.FStar_TypeChecker_Env.postprocess);
+            FStar_TypeChecker_Env.identifier_info =
+              (uu___1730_11587.FStar_TypeChecker_Env.identifier_info);
+            FStar_TypeChecker_Env.tc_hooks =
+              (uu___1730_11587.FStar_TypeChecker_Env.tc_hooks);
+            FStar_TypeChecker_Env.dsenv =
+              (uu___1730_11587.FStar_TypeChecker_Env.dsenv);
+            FStar_TypeChecker_Env.nbe =
+              (uu___1730_11587.FStar_TypeChecker_Env.nbe);
+            FStar_TypeChecker_Env.strict_args_tab =
+              (uu___1730_11587.FStar_TypeChecker_Env.strict_args_tab);
+            FStar_TypeChecker_Env.erasable_types_tab =
+              (uu___1730_11587.FStar_TypeChecker_Env.erasable_types_tab);
+            FStar_TypeChecker_Env.enable_defer_to_tac = false
+          } in
+        env5
 let (proofstate_of_goals :
   FStar_Range.range ->
     env ->
@@ -5620,10 +5620,10 @@ let (proofstate_of_goals :
         fun imps ->
           let env2 = tac_env env1 in
           let ps =
-            let uu____11619 =
+            let uu____11618 =
               FStar_TypeChecker_Env.debug env2
                 (FStar_Options.Other "TacVerbose") in
-            let uu____11620 = FStar_Util.psmap_empty () in
+            let uu____11619 = FStar_Util.psmap_empty () in
             {
               FStar_Tactics_Types.main_context = env2;
               FStar_Tactics_Types.all_implicits = imps;
@@ -5636,8 +5636,8 @@ let (proofstate_of_goals :
               FStar_Tactics_Types.entry_range = rng;
               FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
               FStar_Tactics_Types.freshness = Prims.int_zero;
-              FStar_Tactics_Types.tac_verb_dbg = uu____11619;
-              FStar_Tactics_Types.local_state = uu____11620
+              FStar_Tactics_Types.tac_verb_dbg = uu____11618;
+              FStar_Tactics_Types.local_state = uu____11619
             } in
           ps
 let (proofstate_of_goal_ty :
@@ -5650,119 +5650,119 @@ let (proofstate_of_goal_ty :
     fun env1 ->
       fun typ ->
         let env2 = tac_env env1 in
-        let uu____11643 = goal_of_goal_ty env2 typ in
-        match uu____11643 with
+        let uu____11642 = goal_of_goal_ty env2 typ in
+        match uu____11642 with
         | (g, g_u) ->
             let ps =
               proofstate_of_goals rng env2 [g]
                 g_u.FStar_TypeChecker_Common.implicits in
-            let uu____11655 = FStar_Tactics_Types.goal_witness g in
-            (ps, uu____11655)
+            let uu____11654 = FStar_Tactics_Types.goal_witness g in
+            (ps, uu____11654)
 let (goal_of_implicit :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Env.implicit -> FStar_Tactics_Types.goal)
   =
   fun env1 ->
     fun i ->
-      let uu____11666 = FStar_Options.peek () in
+      let uu____11665 = FStar_Options.peek () in
       FStar_Tactics_Types.mk_goal
-        (let uu___1748_11669 = env1 in
+        (let uu___1749_11668 = env1 in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___1748_11669.FStar_TypeChecker_Env.solver);
+             (uu___1749_11668.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___1748_11669.FStar_TypeChecker_Env.range);
+             (uu___1749_11668.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___1748_11669.FStar_TypeChecker_Env.curmodule);
+             (uu___1749_11668.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
              ((i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___1748_11669.FStar_TypeChecker_Env.gamma_sig);
+             (uu___1749_11668.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___1748_11669.FStar_TypeChecker_Env.gamma_cache);
+             (uu___1749_11668.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___1748_11669.FStar_TypeChecker_Env.modules);
+             (uu___1749_11668.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___1748_11669.FStar_TypeChecker_Env.expected_typ);
+             (uu___1749_11668.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___1748_11669.FStar_TypeChecker_Env.sigtab);
+             (uu___1749_11668.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___1748_11669.FStar_TypeChecker_Env.attrtab);
+             (uu___1749_11668.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___1748_11669.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___1749_11668.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___1748_11669.FStar_TypeChecker_Env.effects);
+             (uu___1749_11668.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___1748_11669.FStar_TypeChecker_Env.generalize);
+             (uu___1749_11668.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___1748_11669.FStar_TypeChecker_Env.letrecs);
+             (uu___1749_11668.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___1748_11669.FStar_TypeChecker_Env.top_level);
+             (uu___1749_11668.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___1748_11669.FStar_TypeChecker_Env.check_uvars);
+             (uu___1749_11668.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___1748_11669.FStar_TypeChecker_Env.use_eq);
+             (uu___1749_11668.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___1748_11669.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___1749_11668.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___1748_11669.FStar_TypeChecker_Env.is_iface);
+             (uu___1749_11668.FStar_TypeChecker_Env.is_iface);
            FStar_TypeChecker_Env.admit =
-             (uu___1748_11669.FStar_TypeChecker_Env.admit);
+             (uu___1749_11668.FStar_TypeChecker_Env.admit);
            FStar_TypeChecker_Env.lax =
-             (uu___1748_11669.FStar_TypeChecker_Env.lax);
+             (uu___1749_11668.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___1748_11669.FStar_TypeChecker_Env.lax_universes);
+             (uu___1749_11668.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___1748_11669.FStar_TypeChecker_Env.phase1);
+             (uu___1749_11668.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___1748_11669.FStar_TypeChecker_Env.failhard);
+             (uu___1749_11668.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___1748_11669.FStar_TypeChecker_Env.nosynth);
+             (uu___1749_11668.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___1748_11669.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___1749_11668.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___1748_11669.FStar_TypeChecker_Env.tc_term);
+             (uu___1749_11668.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___1748_11669.FStar_TypeChecker_Env.type_of);
+             (uu___1749_11668.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___1748_11669.FStar_TypeChecker_Env.universe_of);
+             (uu___1749_11668.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___1748_11669.FStar_TypeChecker_Env.check_type_of);
+             (uu___1749_11668.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___1748_11669.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___1749_11668.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___1748_11669.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___1749_11668.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___1748_11669.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___1749_11668.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___1748_11669.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___1749_11668.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___1748_11669.FStar_TypeChecker_Env.proof_ns);
+             (uu___1749_11668.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___1748_11669.FStar_TypeChecker_Env.synth_hook);
+             (uu___1749_11668.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___1748_11669.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___1749_11668.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___1748_11669.FStar_TypeChecker_Env.splice);
+             (uu___1749_11668.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___1748_11669.FStar_TypeChecker_Env.mpreprocess);
+             (uu___1749_11668.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___1748_11669.FStar_TypeChecker_Env.postprocess);
+             (uu___1749_11668.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___1748_11669.FStar_TypeChecker_Env.identifier_info);
+             (uu___1749_11668.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___1748_11669.FStar_TypeChecker_Env.tc_hooks);
+             (uu___1749_11668.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___1748_11669.FStar_TypeChecker_Env.dsenv);
+             (uu___1749_11668.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___1748_11669.FStar_TypeChecker_Env.nbe);
+             (uu___1749_11668.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___1748_11669.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___1749_11668.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___1748_11669.FStar_TypeChecker_Env.erasable_types_tab);
+             (uu___1749_11668.FStar_TypeChecker_Env.erasable_types_tab);
            FStar_TypeChecker_Env.enable_defer_to_tac =
-             (uu___1748_11669.FStar_TypeChecker_Env.enable_defer_to_tac)
-         }) i.FStar_TypeChecker_Common.imp_uvar uu____11666 false
+             (uu___1749_11668.FStar_TypeChecker_Env.enable_defer_to_tac)
+         }) i.FStar_TypeChecker_Common.imp_uvar uu____11665 false
         i.FStar_TypeChecker_Common.imp_reason
 let (proofstate_of_all_implicits :
   FStar_Range.range ->
@@ -5776,13 +5776,13 @@ let (proofstate_of_all_implicits :
         let env2 = tac_env env1 in
         let goals = FStar_List.map (goal_of_implicit env2) imps in
         let w =
-          let uu____11694 = FStar_List.hd goals in
-          FStar_Tactics_Types.goal_witness uu____11694 in
+          let uu____11693 = FStar_List.hd goals in
+          FStar_Tactics_Types.goal_witness uu____11693 in
         let ps =
-          let uu____11696 =
+          let uu____11695 =
             FStar_TypeChecker_Env.debug env2
               (FStar_Options.Other "TacVerbose") in
-          let uu____11697 = FStar_Util.psmap_empty () in
+          let uu____11696 = FStar_Util.psmap_empty () in
           {
             FStar_Tactics_Types.main_context = env2;
             FStar_Tactics_Types.all_implicits = imps;
@@ -5796,7 +5796,7 @@ let (proofstate_of_all_implicits :
             FStar_Tactics_Types.entry_range = rng;
             FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;
             FStar_Tactics_Types.freshness = Prims.int_zero;
-            FStar_Tactics_Types.tac_verb_dbg = uu____11696;
-            FStar_Tactics_Types.local_state = uu____11697
+            FStar_Tactics_Types.tac_verb_dbg = uu____11695;
+            FStar_Tactics_Types.local_state = uu____11696
           } in
         (ps, w)

--- a/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
@@ -298,341 +298,350 @@ let (solve_deferred_to_tactic_goals :
   =
   fun env ->
     fun g ->
-      let deferred = g.FStar_TypeChecker_Common.deferred_to_tac in
-      let prob_as_implicit uu____683 =
-        match uu____683 with
-        | (reason, prob) ->
-            (match prob with
-             | FStar_TypeChecker_Common.TProb tp when
-                 tp.FStar_TypeChecker_Common.relation =
-                   FStar_TypeChecker_Common.EQ
-                 ->
-                 let uu____701 = FStar_TypeChecker_Env.clear_expected_typ env in
-                 (match uu____701 with
-                  | (env1, uu____713) ->
-                      let env2 =
-                        let uu___89_719 = env1 in
-                        {
-                          FStar_TypeChecker_Env.solver =
-                            (uu___89_719.FStar_TypeChecker_Env.solver);
-                          FStar_TypeChecker_Env.range =
-                            (uu___89_719.FStar_TypeChecker_Env.range);
-                          FStar_TypeChecker_Env.curmodule =
-                            (uu___89_719.FStar_TypeChecker_Env.curmodule);
-                          FStar_TypeChecker_Env.gamma =
-                            ((tp.FStar_TypeChecker_Common.logical_guard_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma);
-                          FStar_TypeChecker_Env.gamma_sig =
-                            (uu___89_719.FStar_TypeChecker_Env.gamma_sig);
-                          FStar_TypeChecker_Env.gamma_cache =
-                            (uu___89_719.FStar_TypeChecker_Env.gamma_cache);
-                          FStar_TypeChecker_Env.modules =
-                            (uu___89_719.FStar_TypeChecker_Env.modules);
-                          FStar_TypeChecker_Env.expected_typ =
-                            (uu___89_719.FStar_TypeChecker_Env.expected_typ);
-                          FStar_TypeChecker_Env.sigtab =
-                            (uu___89_719.FStar_TypeChecker_Env.sigtab);
-                          FStar_TypeChecker_Env.attrtab =
-                            (uu___89_719.FStar_TypeChecker_Env.attrtab);
-                          FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___89_719.FStar_TypeChecker_Env.instantiate_imp);
-                          FStar_TypeChecker_Env.effects =
-                            (uu___89_719.FStar_TypeChecker_Env.effects);
-                          FStar_TypeChecker_Env.generalize =
-                            (uu___89_719.FStar_TypeChecker_Env.generalize);
-                          FStar_TypeChecker_Env.letrecs =
-                            (uu___89_719.FStar_TypeChecker_Env.letrecs);
-                          FStar_TypeChecker_Env.top_level =
-                            (uu___89_719.FStar_TypeChecker_Env.top_level);
-                          FStar_TypeChecker_Env.check_uvars =
-                            (uu___89_719.FStar_TypeChecker_Env.check_uvars);
-                          FStar_TypeChecker_Env.use_eq =
-                            (uu___89_719.FStar_TypeChecker_Env.use_eq);
-                          FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___89_719.FStar_TypeChecker_Env.use_eq_strict);
-                          FStar_TypeChecker_Env.is_iface =
-                            (uu___89_719.FStar_TypeChecker_Env.is_iface);
-                          FStar_TypeChecker_Env.admit =
-                            (uu___89_719.FStar_TypeChecker_Env.admit);
-                          FStar_TypeChecker_Env.lax =
-                            (uu___89_719.FStar_TypeChecker_Env.lax);
-                          FStar_TypeChecker_Env.lax_universes =
-                            (uu___89_719.FStar_TypeChecker_Env.lax_universes);
-                          FStar_TypeChecker_Env.phase1 =
-                            (uu___89_719.FStar_TypeChecker_Env.phase1);
-                          FStar_TypeChecker_Env.failhard =
-                            (uu___89_719.FStar_TypeChecker_Env.failhard);
-                          FStar_TypeChecker_Env.nosynth =
-                            (uu___89_719.FStar_TypeChecker_Env.nosynth);
-                          FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___89_719.FStar_TypeChecker_Env.uvar_subtyping);
-                          FStar_TypeChecker_Env.tc_term =
-                            (uu___89_719.FStar_TypeChecker_Env.tc_term);
-                          FStar_TypeChecker_Env.type_of =
-                            (uu___89_719.FStar_TypeChecker_Env.type_of);
-                          FStar_TypeChecker_Env.universe_of =
-                            (uu___89_719.FStar_TypeChecker_Env.universe_of);
-                          FStar_TypeChecker_Env.check_type_of =
-                            (uu___89_719.FStar_TypeChecker_Env.check_type_of);
-                          FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___89_719.FStar_TypeChecker_Env.use_bv_sorts);
-                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___89_719.FStar_TypeChecker_Env.qtbl_name_and_index);
-                          FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___89_719.FStar_TypeChecker_Env.normalized_eff_names);
-                          FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___89_719.FStar_TypeChecker_Env.fv_delta_depths);
-                          FStar_TypeChecker_Env.proof_ns =
-                            (uu___89_719.FStar_TypeChecker_Env.proof_ns);
-                          FStar_TypeChecker_Env.synth_hook =
-                            (uu___89_719.FStar_TypeChecker_Env.synth_hook);
-                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___89_719.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                          FStar_TypeChecker_Env.splice =
-                            (uu___89_719.FStar_TypeChecker_Env.splice);
-                          FStar_TypeChecker_Env.mpreprocess =
-                            (uu___89_719.FStar_TypeChecker_Env.mpreprocess);
-                          FStar_TypeChecker_Env.postprocess =
-                            (uu___89_719.FStar_TypeChecker_Env.postprocess);
-                          FStar_TypeChecker_Env.identifier_info =
-                            (uu___89_719.FStar_TypeChecker_Env.identifier_info);
-                          FStar_TypeChecker_Env.tc_hooks =
-                            (uu___89_719.FStar_TypeChecker_Env.tc_hooks);
-                          FStar_TypeChecker_Env.dsenv =
-                            (uu___89_719.FStar_TypeChecker_Env.dsenv);
-                          FStar_TypeChecker_Env.nbe =
-                            (uu___89_719.FStar_TypeChecker_Env.nbe);
-                          FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___89_719.FStar_TypeChecker_Env.strict_args_tab);
-                          FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___89_719.FStar_TypeChecker_Env.erasable_types_tab);
-                          FStar_TypeChecker_Env.enable_defer_to_tac =
-                            (uu___89_719.FStar_TypeChecker_Env.enable_defer_to_tac)
-                        } in
-                      let env_lax =
-                        let uu___92_721 = env2 in
-                        {
-                          FStar_TypeChecker_Env.solver =
-                            (uu___92_721.FStar_TypeChecker_Env.solver);
-                          FStar_TypeChecker_Env.range =
-                            (uu___92_721.FStar_TypeChecker_Env.range);
-                          FStar_TypeChecker_Env.curmodule =
-                            (uu___92_721.FStar_TypeChecker_Env.curmodule);
-                          FStar_TypeChecker_Env.gamma =
-                            (uu___92_721.FStar_TypeChecker_Env.gamma);
-                          FStar_TypeChecker_Env.gamma_sig =
-                            (uu___92_721.FStar_TypeChecker_Env.gamma_sig);
-                          FStar_TypeChecker_Env.gamma_cache =
-                            (uu___92_721.FStar_TypeChecker_Env.gamma_cache);
-                          FStar_TypeChecker_Env.modules =
-                            (uu___92_721.FStar_TypeChecker_Env.modules);
-                          FStar_TypeChecker_Env.expected_typ =
-                            (uu___92_721.FStar_TypeChecker_Env.expected_typ);
-                          FStar_TypeChecker_Env.sigtab =
-                            (uu___92_721.FStar_TypeChecker_Env.sigtab);
-                          FStar_TypeChecker_Env.attrtab =
-                            (uu___92_721.FStar_TypeChecker_Env.attrtab);
-                          FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___92_721.FStar_TypeChecker_Env.instantiate_imp);
-                          FStar_TypeChecker_Env.effects =
-                            (uu___92_721.FStar_TypeChecker_Env.effects);
-                          FStar_TypeChecker_Env.generalize =
-                            (uu___92_721.FStar_TypeChecker_Env.generalize);
-                          FStar_TypeChecker_Env.letrecs =
-                            (uu___92_721.FStar_TypeChecker_Env.letrecs);
-                          FStar_TypeChecker_Env.top_level =
-                            (uu___92_721.FStar_TypeChecker_Env.top_level);
-                          FStar_TypeChecker_Env.check_uvars =
-                            (uu___92_721.FStar_TypeChecker_Env.check_uvars);
-                          FStar_TypeChecker_Env.use_eq =
-                            (uu___92_721.FStar_TypeChecker_Env.use_eq);
-                          FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___92_721.FStar_TypeChecker_Env.use_eq_strict);
-                          FStar_TypeChecker_Env.is_iface =
-                            (uu___92_721.FStar_TypeChecker_Env.is_iface);
-                          FStar_TypeChecker_Env.admit =
-                            (uu___92_721.FStar_TypeChecker_Env.admit);
-                          FStar_TypeChecker_Env.lax = true;
-                          FStar_TypeChecker_Env.lax_universes =
-                            (uu___92_721.FStar_TypeChecker_Env.lax_universes);
-                          FStar_TypeChecker_Env.phase1 =
-                            (uu___92_721.FStar_TypeChecker_Env.phase1);
-                          FStar_TypeChecker_Env.failhard =
-                            (uu___92_721.FStar_TypeChecker_Env.failhard);
-                          FStar_TypeChecker_Env.nosynth =
-                            (uu___92_721.FStar_TypeChecker_Env.nosynth);
-                          FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___92_721.FStar_TypeChecker_Env.uvar_subtyping);
-                          FStar_TypeChecker_Env.tc_term =
-                            (uu___92_721.FStar_TypeChecker_Env.tc_term);
-                          FStar_TypeChecker_Env.type_of =
-                            (uu___92_721.FStar_TypeChecker_Env.type_of);
-                          FStar_TypeChecker_Env.universe_of =
-                            (uu___92_721.FStar_TypeChecker_Env.universe_of);
-                          FStar_TypeChecker_Env.check_type_of =
-                            (uu___92_721.FStar_TypeChecker_Env.check_type_of);
-                          FStar_TypeChecker_Env.use_bv_sorts = true;
-                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___92_721.FStar_TypeChecker_Env.qtbl_name_and_index);
-                          FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___92_721.FStar_TypeChecker_Env.normalized_eff_names);
-                          FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___92_721.FStar_TypeChecker_Env.fv_delta_depths);
-                          FStar_TypeChecker_Env.proof_ns =
-                            (uu___92_721.FStar_TypeChecker_Env.proof_ns);
-                          FStar_TypeChecker_Env.synth_hook =
-                            (uu___92_721.FStar_TypeChecker_Env.synth_hook);
-                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___92_721.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                          FStar_TypeChecker_Env.splice =
-                            (uu___92_721.FStar_TypeChecker_Env.splice);
-                          FStar_TypeChecker_Env.mpreprocess =
-                            (uu___92_721.FStar_TypeChecker_Env.mpreprocess);
-                          FStar_TypeChecker_Env.postprocess =
-                            (uu___92_721.FStar_TypeChecker_Env.postprocess);
-                          FStar_TypeChecker_Env.identifier_info =
-                            (uu___92_721.FStar_TypeChecker_Env.identifier_info);
-                          FStar_TypeChecker_Env.tc_hooks =
-                            (uu___92_721.FStar_TypeChecker_Env.tc_hooks);
-                          FStar_TypeChecker_Env.dsenv =
-                            (uu___92_721.FStar_TypeChecker_Env.dsenv);
-                          FStar_TypeChecker_Env.nbe =
-                            (uu___92_721.FStar_TypeChecker_Env.nbe);
-                          FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___92_721.FStar_TypeChecker_Env.strict_args_tab);
-                          FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___92_721.FStar_TypeChecker_Env.erasable_types_tab);
-                          FStar_TypeChecker_Env.enable_defer_to_tac =
-                            (uu___92_721.FStar_TypeChecker_Env.enable_defer_to_tac)
-                        } in
-                      let uu____722 =
-                        let uu____729 =
-                          is_flex tp.FStar_TypeChecker_Common.lhs in
-                        if uu____729
-                        then
-                          env2.FStar_TypeChecker_Env.type_of env_lax
-                            tp.FStar_TypeChecker_Common.lhs
-                        else
-                          env2.FStar_TypeChecker_Env.type_of env_lax
-                            tp.FStar_TypeChecker_Common.rhs in
-                      (match uu____722 with
-                       | (uu____741, t_eq, uu____743) ->
-                           let goal_ty =
-                             let uu____745 =
-                               env2.FStar_TypeChecker_Env.universe_of env_lax
-                                 t_eq in
-                             FStar_Syntax_Util.mk_eq2 uu____745 t_eq
+      if Prims.op_Negation env.FStar_TypeChecker_Env.enable_defer_to_tac
+      then g
+      else
+        (let deferred = g.FStar_TypeChecker_Common.deferred_to_tac in
+         let prob_as_implicit uu____684 =
+           match uu____684 with
+           | (reason, prob) ->
+               (match prob with
+                | FStar_TypeChecker_Common.TProb tp when
+                    tp.FStar_TypeChecker_Common.relation =
+                      FStar_TypeChecker_Common.EQ
+                    ->
+                    let uu____702 =
+                      FStar_TypeChecker_Env.clear_expected_typ env in
+                    (match uu____702 with
+                     | (env1, uu____714) ->
+                         let env2 =
+                           let uu___90_720 = env1 in
+                           {
+                             FStar_TypeChecker_Env.solver =
+                               (uu___90_720.FStar_TypeChecker_Env.solver);
+                             FStar_TypeChecker_Env.range =
+                               (uu___90_720.FStar_TypeChecker_Env.range);
+                             FStar_TypeChecker_Env.curmodule =
+                               (uu___90_720.FStar_TypeChecker_Env.curmodule);
+                             FStar_TypeChecker_Env.gamma =
+                               ((tp.FStar_TypeChecker_Common.logical_guard_uvar).FStar_Syntax_Syntax.ctx_uvar_gamma);
+                             FStar_TypeChecker_Env.gamma_sig =
+                               (uu___90_720.FStar_TypeChecker_Env.gamma_sig);
+                             FStar_TypeChecker_Env.gamma_cache =
+                               (uu___90_720.FStar_TypeChecker_Env.gamma_cache);
+                             FStar_TypeChecker_Env.modules =
+                               (uu___90_720.FStar_TypeChecker_Env.modules);
+                             FStar_TypeChecker_Env.expected_typ =
+                               (uu___90_720.FStar_TypeChecker_Env.expected_typ);
+                             FStar_TypeChecker_Env.sigtab =
+                               (uu___90_720.FStar_TypeChecker_Env.sigtab);
+                             FStar_TypeChecker_Env.attrtab =
+                               (uu___90_720.FStar_TypeChecker_Env.attrtab);
+                             FStar_TypeChecker_Env.instantiate_imp =
+                               (uu___90_720.FStar_TypeChecker_Env.instantiate_imp);
+                             FStar_TypeChecker_Env.effects =
+                               (uu___90_720.FStar_TypeChecker_Env.effects);
+                             FStar_TypeChecker_Env.generalize =
+                               (uu___90_720.FStar_TypeChecker_Env.generalize);
+                             FStar_TypeChecker_Env.letrecs =
+                               (uu___90_720.FStar_TypeChecker_Env.letrecs);
+                             FStar_TypeChecker_Env.top_level =
+                               (uu___90_720.FStar_TypeChecker_Env.top_level);
+                             FStar_TypeChecker_Env.check_uvars =
+                               (uu___90_720.FStar_TypeChecker_Env.check_uvars);
+                             FStar_TypeChecker_Env.use_eq =
+                               (uu___90_720.FStar_TypeChecker_Env.use_eq);
+                             FStar_TypeChecker_Env.use_eq_strict =
+                               (uu___90_720.FStar_TypeChecker_Env.use_eq_strict);
+                             FStar_TypeChecker_Env.is_iface =
+                               (uu___90_720.FStar_TypeChecker_Env.is_iface);
+                             FStar_TypeChecker_Env.admit =
+                               (uu___90_720.FStar_TypeChecker_Env.admit);
+                             FStar_TypeChecker_Env.lax =
+                               (uu___90_720.FStar_TypeChecker_Env.lax);
+                             FStar_TypeChecker_Env.lax_universes =
+                               (uu___90_720.FStar_TypeChecker_Env.lax_universes);
+                             FStar_TypeChecker_Env.phase1 =
+                               (uu___90_720.FStar_TypeChecker_Env.phase1);
+                             FStar_TypeChecker_Env.failhard =
+                               (uu___90_720.FStar_TypeChecker_Env.failhard);
+                             FStar_TypeChecker_Env.nosynth =
+                               (uu___90_720.FStar_TypeChecker_Env.nosynth);
+                             FStar_TypeChecker_Env.uvar_subtyping =
+                               (uu___90_720.FStar_TypeChecker_Env.uvar_subtyping);
+                             FStar_TypeChecker_Env.tc_term =
+                               (uu___90_720.FStar_TypeChecker_Env.tc_term);
+                             FStar_TypeChecker_Env.type_of =
+                               (uu___90_720.FStar_TypeChecker_Env.type_of);
+                             FStar_TypeChecker_Env.universe_of =
+                               (uu___90_720.FStar_TypeChecker_Env.universe_of);
+                             FStar_TypeChecker_Env.check_type_of =
+                               (uu___90_720.FStar_TypeChecker_Env.check_type_of);
+                             FStar_TypeChecker_Env.use_bv_sorts =
+                               (uu___90_720.FStar_TypeChecker_Env.use_bv_sorts);
+                             FStar_TypeChecker_Env.qtbl_name_and_index =
+                               (uu___90_720.FStar_TypeChecker_Env.qtbl_name_and_index);
+                             FStar_TypeChecker_Env.normalized_eff_names =
+                               (uu___90_720.FStar_TypeChecker_Env.normalized_eff_names);
+                             FStar_TypeChecker_Env.fv_delta_depths =
+                               (uu___90_720.FStar_TypeChecker_Env.fv_delta_depths);
+                             FStar_TypeChecker_Env.proof_ns =
+                               (uu___90_720.FStar_TypeChecker_Env.proof_ns);
+                             FStar_TypeChecker_Env.synth_hook =
+                               (uu___90_720.FStar_TypeChecker_Env.synth_hook);
+                             FStar_TypeChecker_Env.try_solve_implicits_hook =
+                               (uu___90_720.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                             FStar_TypeChecker_Env.splice =
+                               (uu___90_720.FStar_TypeChecker_Env.splice);
+                             FStar_TypeChecker_Env.mpreprocess =
+                               (uu___90_720.FStar_TypeChecker_Env.mpreprocess);
+                             FStar_TypeChecker_Env.postprocess =
+                               (uu___90_720.FStar_TypeChecker_Env.postprocess);
+                             FStar_TypeChecker_Env.identifier_info =
+                               (uu___90_720.FStar_TypeChecker_Env.identifier_info);
+                             FStar_TypeChecker_Env.tc_hooks =
+                               (uu___90_720.FStar_TypeChecker_Env.tc_hooks);
+                             FStar_TypeChecker_Env.dsenv =
+                               (uu___90_720.FStar_TypeChecker_Env.dsenv);
+                             FStar_TypeChecker_Env.nbe =
+                               (uu___90_720.FStar_TypeChecker_Env.nbe);
+                             FStar_TypeChecker_Env.strict_args_tab =
+                               (uu___90_720.FStar_TypeChecker_Env.strict_args_tab);
+                             FStar_TypeChecker_Env.erasable_types_tab =
+                               (uu___90_720.FStar_TypeChecker_Env.erasable_types_tab);
+                             FStar_TypeChecker_Env.enable_defer_to_tac =
+                               (uu___90_720.FStar_TypeChecker_Env.enable_defer_to_tac)
+                           } in
+                         let env_lax =
+                           let uu___93_722 = env2 in
+                           {
+                             FStar_TypeChecker_Env.solver =
+                               (uu___93_722.FStar_TypeChecker_Env.solver);
+                             FStar_TypeChecker_Env.range =
+                               (uu___93_722.FStar_TypeChecker_Env.range);
+                             FStar_TypeChecker_Env.curmodule =
+                               (uu___93_722.FStar_TypeChecker_Env.curmodule);
+                             FStar_TypeChecker_Env.gamma =
+                               (uu___93_722.FStar_TypeChecker_Env.gamma);
+                             FStar_TypeChecker_Env.gamma_sig =
+                               (uu___93_722.FStar_TypeChecker_Env.gamma_sig);
+                             FStar_TypeChecker_Env.gamma_cache =
+                               (uu___93_722.FStar_TypeChecker_Env.gamma_cache);
+                             FStar_TypeChecker_Env.modules =
+                               (uu___93_722.FStar_TypeChecker_Env.modules);
+                             FStar_TypeChecker_Env.expected_typ =
+                               (uu___93_722.FStar_TypeChecker_Env.expected_typ);
+                             FStar_TypeChecker_Env.sigtab =
+                               (uu___93_722.FStar_TypeChecker_Env.sigtab);
+                             FStar_TypeChecker_Env.attrtab =
+                               (uu___93_722.FStar_TypeChecker_Env.attrtab);
+                             FStar_TypeChecker_Env.instantiate_imp =
+                               (uu___93_722.FStar_TypeChecker_Env.instantiate_imp);
+                             FStar_TypeChecker_Env.effects =
+                               (uu___93_722.FStar_TypeChecker_Env.effects);
+                             FStar_TypeChecker_Env.generalize =
+                               (uu___93_722.FStar_TypeChecker_Env.generalize);
+                             FStar_TypeChecker_Env.letrecs =
+                               (uu___93_722.FStar_TypeChecker_Env.letrecs);
+                             FStar_TypeChecker_Env.top_level =
+                               (uu___93_722.FStar_TypeChecker_Env.top_level);
+                             FStar_TypeChecker_Env.check_uvars =
+                               (uu___93_722.FStar_TypeChecker_Env.check_uvars);
+                             FStar_TypeChecker_Env.use_eq =
+                               (uu___93_722.FStar_TypeChecker_Env.use_eq);
+                             FStar_TypeChecker_Env.use_eq_strict =
+                               (uu___93_722.FStar_TypeChecker_Env.use_eq_strict);
+                             FStar_TypeChecker_Env.is_iface =
+                               (uu___93_722.FStar_TypeChecker_Env.is_iface);
+                             FStar_TypeChecker_Env.admit =
+                               (uu___93_722.FStar_TypeChecker_Env.admit);
+                             FStar_TypeChecker_Env.lax = true;
+                             FStar_TypeChecker_Env.lax_universes =
+                               (uu___93_722.FStar_TypeChecker_Env.lax_universes);
+                             FStar_TypeChecker_Env.phase1 =
+                               (uu___93_722.FStar_TypeChecker_Env.phase1);
+                             FStar_TypeChecker_Env.failhard =
+                               (uu___93_722.FStar_TypeChecker_Env.failhard);
+                             FStar_TypeChecker_Env.nosynth =
+                               (uu___93_722.FStar_TypeChecker_Env.nosynth);
+                             FStar_TypeChecker_Env.uvar_subtyping =
+                               (uu___93_722.FStar_TypeChecker_Env.uvar_subtyping);
+                             FStar_TypeChecker_Env.tc_term =
+                               (uu___93_722.FStar_TypeChecker_Env.tc_term);
+                             FStar_TypeChecker_Env.type_of =
+                               (uu___93_722.FStar_TypeChecker_Env.type_of);
+                             FStar_TypeChecker_Env.universe_of =
+                               (uu___93_722.FStar_TypeChecker_Env.universe_of);
+                             FStar_TypeChecker_Env.check_type_of =
+                               (uu___93_722.FStar_TypeChecker_Env.check_type_of);
+                             FStar_TypeChecker_Env.use_bv_sorts = true;
+                             FStar_TypeChecker_Env.qtbl_name_and_index =
+                               (uu___93_722.FStar_TypeChecker_Env.qtbl_name_and_index);
+                             FStar_TypeChecker_Env.normalized_eff_names =
+                               (uu___93_722.FStar_TypeChecker_Env.normalized_eff_names);
+                             FStar_TypeChecker_Env.fv_delta_depths =
+                               (uu___93_722.FStar_TypeChecker_Env.fv_delta_depths);
+                             FStar_TypeChecker_Env.proof_ns =
+                               (uu___93_722.FStar_TypeChecker_Env.proof_ns);
+                             FStar_TypeChecker_Env.synth_hook =
+                               (uu___93_722.FStar_TypeChecker_Env.synth_hook);
+                             FStar_TypeChecker_Env.try_solve_implicits_hook =
+                               (uu___93_722.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                             FStar_TypeChecker_Env.splice =
+                               (uu___93_722.FStar_TypeChecker_Env.splice);
+                             FStar_TypeChecker_Env.mpreprocess =
+                               (uu___93_722.FStar_TypeChecker_Env.mpreprocess);
+                             FStar_TypeChecker_Env.postprocess =
+                               (uu___93_722.FStar_TypeChecker_Env.postprocess);
+                             FStar_TypeChecker_Env.identifier_info =
+                               (uu___93_722.FStar_TypeChecker_Env.identifier_info);
+                             FStar_TypeChecker_Env.tc_hooks =
+                               (uu___93_722.FStar_TypeChecker_Env.tc_hooks);
+                             FStar_TypeChecker_Env.dsenv =
+                               (uu___93_722.FStar_TypeChecker_Env.dsenv);
+                             FStar_TypeChecker_Env.nbe =
+                               (uu___93_722.FStar_TypeChecker_Env.nbe);
+                             FStar_TypeChecker_Env.strict_args_tab =
+                               (uu___93_722.FStar_TypeChecker_Env.strict_args_tab);
+                             FStar_TypeChecker_Env.erasable_types_tab =
+                               (uu___93_722.FStar_TypeChecker_Env.erasable_types_tab);
+                             FStar_TypeChecker_Env.enable_defer_to_tac =
+                               (uu___93_722.FStar_TypeChecker_Env.enable_defer_to_tac)
+                           } in
+                         let uu____723 =
+                           let uu____730 =
+                             is_flex tp.FStar_TypeChecker_Common.lhs in
+                           if uu____730
+                           then
+                             env2.FStar_TypeChecker_Env.type_of env_lax
                                tp.FStar_TypeChecker_Common.lhs
+                           else
+                             env2.FStar_TypeChecker_Env.type_of env_lax
                                tp.FStar_TypeChecker_Common.rhs in
-                           let uu____746 =
-                             FStar_TypeChecker_Env.new_implicit_var_aux
-                               reason
-                               (tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos
-                               env2 goal_ty FStar_Syntax_Syntax.Strict
-                               FStar_Pervasives_Native.None in
-                           (match uu____746 with
-                            | (goal, ctx_uvar, uu____765) ->
-                                let imp =
-                                  let uu____779 =
-                                    let uu____780 = FStar_List.hd ctx_uvar in
-                                    FStar_Pervasives_Native.fst uu____780 in
-                                  {
-                                    FStar_TypeChecker_Common.imp_reason = "";
-                                    FStar_TypeChecker_Common.imp_uvar =
-                                      uu____779;
-                                    FStar_TypeChecker_Common.imp_tm = goal;
-                                    FStar_TypeChecker_Common.imp_range =
-                                      ((tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos)
-                                  } in
-                                let sigelt =
-                                  let uu____792 =
-                                    is_flex tp.FStar_TypeChecker_Common.lhs in
-                                  if uu____792
-                                  then
-                                    let uu____795 =
-                                      flex_uvar_head
-                                        tp.FStar_TypeChecker_Common.lhs in
-                                    find_user_tac_for_uvar env2 uu____795
-                                  else
-                                    (let uu____797 =
+                         (match uu____723 with
+                          | (uu____742, t_eq, uu____744) ->
+                              let goal_ty =
+                                let uu____746 =
+                                  env2.FStar_TypeChecker_Env.universe_of
+                                    env_lax t_eq in
+                                FStar_Syntax_Util.mk_eq2 uu____746 t_eq
+                                  tp.FStar_TypeChecker_Common.lhs
+                                  tp.FStar_TypeChecker_Common.rhs in
+                              let uu____747 =
+                                FStar_TypeChecker_Env.new_implicit_var_aux
+                                  reason
+                                  (tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos
+                                  env2 goal_ty FStar_Syntax_Syntax.Strict
+                                  FStar_Pervasives_Native.None in
+                              (match uu____747 with
+                               | (goal, ctx_uvar, uu____766) ->
+                                   let imp =
+                                     let uu____780 =
+                                       let uu____781 = FStar_List.hd ctx_uvar in
+                                       FStar_Pervasives_Native.fst uu____781 in
+                                     {
+                                       FStar_TypeChecker_Common.imp_reason =
+                                         "";
+                                       FStar_TypeChecker_Common.imp_uvar =
+                                         uu____780;
+                                       FStar_TypeChecker_Common.imp_tm = goal;
+                                       FStar_TypeChecker_Common.imp_range =
+                                         ((tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos)
+                                     } in
+                                   let sigelt =
+                                     let uu____793 =
                                        is_flex
-                                         tp.FStar_TypeChecker_Common.rhs in
-                                     if uu____797
+                                         tp.FStar_TypeChecker_Common.lhs in
+                                     if uu____793
                                      then
-                                       let uu____800 =
+                                       let uu____796 =
                                          flex_uvar_head
-                                           tp.FStar_TypeChecker_Common.rhs in
-                                       find_user_tac_for_uvar env2 uu____800
-                                     else FStar_Pervasives_Native.None) in
-                                (match sigelt with
-                                 | FStar_Pervasives_Native.None ->
-                                     failwith
-                                       "Impossible: No tactic associated with deferred problem"
-                                 | FStar_Pervasives_Native.Some se ->
-                                     (imp, se)))))
-             | uu____811 -> failwith "Unexpected problem deferred to tactic") in
-      let eqs =
-        FStar_List.map prob_as_implicit
-          g.FStar_TypeChecker_Common.deferred_to_tac in
-      let uu____831 =
-        FStar_List.fold_right
-          (fun imp ->
-             fun uu____863 ->
-               match uu____863 with
-               | (more, imps) ->
-                   let uu____906 =
-                     FStar_Syntax_Unionfind.find
-                       (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                   (match uu____906 with
-                    | FStar_Pervasives_Native.Some uu____921 ->
-                        (more, (imp :: imps))
-                    | FStar_Pervasives_Native.None ->
-                        let se =
-                          find_user_tac_for_uvar env
-                            imp.FStar_TypeChecker_Common.imp_uvar in
-                        (match se with
+                                           tp.FStar_TypeChecker_Common.lhs in
+                                       find_user_tac_for_uvar env2 uu____796
+                                     else
+                                       (let uu____798 =
+                                          is_flex
+                                            tp.FStar_TypeChecker_Common.rhs in
+                                        if uu____798
+                                        then
+                                          let uu____801 =
+                                            flex_uvar_head
+                                              tp.FStar_TypeChecker_Common.rhs in
+                                          find_user_tac_for_uvar env2
+                                            uu____801
+                                        else FStar_Pervasives_Native.None) in
+                                   (match sigelt with
+                                    | FStar_Pervasives_Native.None ->
+                                        failwith
+                                          "Impossible: No tactic associated with deferred problem"
+                                    | FStar_Pervasives_Native.Some se ->
+                                        (imp, se)))))
+                | uu____812 ->
+                    failwith "Unexpected problem deferred to tactic") in
+         let eqs =
+           FStar_List.map prob_as_implicit
+             g.FStar_TypeChecker_Common.deferred_to_tac in
+         let uu____832 =
+           FStar_List.fold_right
+             (fun imp ->
+                fun uu____864 ->
+                  match uu____864 with
+                  | (more, imps) ->
+                      let uu____907 =
+                        FStar_Syntax_Unionfind.find
+                          (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                      (match uu____907 with
+                       | FStar_Pervasives_Native.Some uu____922 ->
+                           (more, (imp :: imps))
+                       | FStar_Pervasives_Native.None ->
+                           let se =
+                             find_user_tac_for_uvar env
+                               imp.FStar_TypeChecker_Common.imp_uvar in
+                           (match se with
+                            | FStar_Pervasives_Native.None ->
+                                (more, (imp :: imps))
+                            | FStar_Pervasives_Native.Some se1 ->
+                                (((imp, se1) :: more), imps))))
+             g.FStar_TypeChecker_Common.implicits ([], []) in
+         match uu____832 with
+         | (more, imps) ->
+             let bucketize is =
+               let map = FStar_Util.smap_create (Prims.of_int (17)) in
+               FStar_List.iter
+                 (fun uu____1047 ->
+                    match uu____1047 with
+                    | (i, s) ->
+                        let uu____1054 = FStar_Syntax_Util.lid_of_sigelt s in
+                        (match uu____1054 with
                          | FStar_Pervasives_Native.None ->
-                             (more, (imp :: imps))
-                         | FStar_Pervasives_Native.Some se1 ->
-                             (((imp, se1) :: more), imps))))
-          g.FStar_TypeChecker_Common.implicits ([], []) in
-      match uu____831 with
-      | (more, imps) ->
-          let bucketize is =
-            let map = FStar_Util.smap_create (Prims.of_int (17)) in
-            FStar_List.iter
-              (fun uu____1046 ->
-                 match uu____1046 with
-                 | (i, s) ->
-                     let uu____1053 = FStar_Syntax_Util.lid_of_sigelt s in
-                     (match uu____1053 with
-                      | FStar_Pervasives_Native.None ->
-                          failwith "Unexpected: tactic without a name"
-                      | FStar_Pervasives_Native.Some l ->
-                          let lstr = FStar_Ident.string_of_lid l in
-                          let uu____1058 = FStar_Util.smap_try_find map lstr in
-                          (match uu____1058 with
-                           | FStar_Pervasives_Native.None ->
-                               FStar_Util.smap_add map lstr ([i], s)
-                           | FStar_Pervasives_Native.Some (is1, s1) ->
-                               (FStar_Util.smap_remove map lstr;
-                                FStar_Util.smap_add map lstr ((i :: is1), s1)))))
-              is;
-            FStar_Util.smap_fold map
-              (fun uu____1105 -> fun is1 -> fun out -> is1 :: out) [] in
-          let buckets = bucketize (FStar_List.append eqs more) in
-          (FStar_List.iter
-             (fun uu____1145 ->
-                match uu____1145 with
-                | (imps1, sigel) -> solve_goals_with_tac env g imps1 sigel)
-             buckets;
-           (let uu___153_1152 = g in
-            {
-              FStar_TypeChecker_Common.guard_f =
-                (uu___153_1152.FStar_TypeChecker_Common.guard_f);
-              FStar_TypeChecker_Common.deferred_to_tac = [];
-              FStar_TypeChecker_Common.deferred =
-                (uu___153_1152.FStar_TypeChecker_Common.deferred);
-              FStar_TypeChecker_Common.univ_ineqs =
-                (uu___153_1152.FStar_TypeChecker_Common.univ_ineqs);
-              FStar_TypeChecker_Common.implicits = imps
-            }))
+                             failwith "Unexpected: tactic without a name"
+                         | FStar_Pervasives_Native.Some l ->
+                             let lstr = FStar_Ident.string_of_lid l in
+                             let uu____1059 =
+                               FStar_Util.smap_try_find map lstr in
+                             (match uu____1059 with
+                              | FStar_Pervasives_Native.None ->
+                                  FStar_Util.smap_add map lstr ([i], s)
+                              | FStar_Pervasives_Native.Some (is1, s1) ->
+                                  (FStar_Util.smap_remove map lstr;
+                                   FStar_Util.smap_add map lstr
+                                     ((i :: is1), s1))))) is;
+               FStar_Util.smap_fold map
+                 (fun uu____1106 -> fun is1 -> fun out -> is1 :: out) [] in
+             let buckets = bucketize (FStar_List.append eqs more) in
+             (FStar_List.iter
+                (fun uu____1146 ->
+                   match uu____1146 with
+                   | (imps1, sigel) -> solve_goals_with_tac env g imps1 sigel)
+                buckets;
+              (let uu___154_1153 = g in
+               {
+                 FStar_TypeChecker_Common.guard_f =
+                   (uu___154_1153.FStar_TypeChecker_Common.guard_f);
+                 FStar_TypeChecker_Common.deferred_to_tac = [];
+                 FStar_TypeChecker_Common.deferred =
+                   (uu___154_1153.FStar_TypeChecker_Common.deferred);
+                 FStar_TypeChecker_Common.univ_ineqs =
+                   (uu___154_1153.FStar_TypeChecker_Common.univ_ineqs);
+                 FStar_TypeChecker_Common.implicits = imps
+               })))

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -180,7 +180,7 @@ let do_unify env t1 t2 : tac<bool> =
         let _ = Options.set_options "--debug_level Rel --debug_level RelCheck" in
         ()
     );
-    bind (__do_unify ({env with enable_defer_to_tac=false}) t1 t2) (fun r ->
+    bind (__do_unify env t1 t2) (fun r ->
     if Env.debug env (Options.Other "1346") then
         Options.pop ();
     (* bind compress_implicits (fun _ -> *)
@@ -1637,6 +1637,7 @@ let tac_env (env:Env.env) : Env.env =
     let env, _ = Env.clear_expected_typ env in
     let env = { env with Env.instantiate_imp = false } in
     let env = { env with failhard = true } in
+    let env = { env with enable_defer_to_tac = false } in
     env
 
 let proofstate_of_goals rng env goals imps =

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -180,7 +180,7 @@ let do_unify env t1 t2 : tac<bool> =
         let _ = Options.set_options "--debug_level Rel --debug_level RelCheck" in
         ()
     );
-    bind (__do_unify env t1 t2) (fun r ->
+    bind (__do_unify ({env with enable_defer_to_tac=false}) t1 t2) (fun r ->
     if Env.debug env (Options.Other "1346") then
         Options.pop ();
     (* bind compress_implicits (fun _ -> *)

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fs
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fs
@@ -116,6 +116,7 @@ let solve_goals_with_tac env g (deferred_goals:implicits) (tac:sigelt) =
 (** This functions is called in Rel.force_trivial_guard to solve all
     goals in a guard that were deferred to a tactic *)
 let solve_deferred_to_tactic_goals env g =
+    if not env.enable_defer_to_tac then g else
     let deferred = g.deferred_to_tac in
     (** A unification problem between two terms is presented to
         a tactic as an equality goal between the terms. *)


### PR DESCRIPTION
The issue arose when applying `trefl` on a goal such as `?u1 == f ?u2`, if ?u2 is tagged with a defer_to_implicit attribute.

`trefl` runs the unifier, and adds the remaining unresolved implicits to the current proofstate. In this example, it would see `?u2` as tagged and try to solve it instead with the associated tactic in a new proofstate, that would not contain constraints on the original `?u2`

This fix prevents deferral to tactics when calling `trefl`. We are already in a tactic context, implicits generated should be added to the current proofstate instead.